### PR TITLE
fix: correcting asset urls

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -28,7 +28,7 @@ entries:
     - https://github.com/prometheus/node_exporter
     - https://github.com/kubernetes/kube-state-metrics
     urls:
-    - https://github.com/scottrigby/prometheus-helm-charts/releases/download/prometheus-11.12.1/prometheus-11.12.1.tgz
+    - https://github.com/prometheus-community/helm-charts/releases/download/prometheus-11.12.1/prometheus-11.12.1.tgz
     version: 11.12.1
   prometheus-adapter:
   - apiVersion: v1
@@ -53,7 +53,7 @@ entries:
     - https://github.com/kubernetes/charts
     - https://github.com/DirectXMan12/k8s-prometheus-adapter
     urls:
-    - https://github.com/scottrigby/prometheus-helm-charts/releases/download/prometheus-adapter-2.5.1/prometheus-adapter-2.5.1.tgz
+    - https://github.com/prometheus-community/helm-charts/releases/download/prometheus-adapter-2.5.1/prometheus-adapter-2.5.1.tgz
     version: 2.5.1
   prometheus-blackbox-exporter:
   - apiVersion: v1
@@ -77,7 +77,7 @@ entries:
     sources:
     - https://github.com/prometheus/blackbox_exporter
     urls:
-    - https://github.com/scottrigby/prometheus-helm-charts/releases/download/prometheus-blackbox-exporter-4.3.1/prometheus-blackbox-exporter-4.3.1.tgz
+    - https://github.com/prometheus-community/helm-charts/releases/download/prometheus-blackbox-exporter-4.3.1/prometheus-blackbox-exporter-4.3.1.tgz
     version: 4.3.1
   prometheus-cloudwatch-exporter:
   - apiVersion: v1
@@ -102,7 +102,7 @@ entries:
     sources:
     - https://github.com/prometheus/cloudwatch_exporter
     urls:
-    - https://github.com/scottrigby/prometheus-helm-charts/releases/download/prometheus-cloudwatch-exporter-0.8.4/prometheus-cloudwatch-exporter-0.8.4.tgz
+    - https://github.com/prometheus-community/helm-charts/releases/download/prometheus-cloudwatch-exporter-0.8.4/prometheus-cloudwatch-exporter-0.8.4.tgz
     version: 0.8.4
   prometheus-consul-exporter:
   - apiVersion: v1
@@ -120,7 +120,7 @@ entries:
       name: timm088
     name: prometheus-consul-exporter
     urls:
-    - https://github.com/scottrigby/prometheus-helm-charts/releases/download/prometheus-consul-exporter-0.1.6/prometheus-consul-exporter-0.1.6.tgz
+    - https://github.com/prometheus-community/helm-charts/releases/download/prometheus-consul-exporter-0.1.6/prometheus-consul-exporter-0.1.6.tgz
     version: 0.1.6
   prometheus-couchdb-exporter:
   - apiVersion: v1
@@ -138,7 +138,7 @@ entries:
     sources:
     - https://github.com/gesellix/couchdb-prometheus-exporter
     urls:
-    - https://github.com/scottrigby/prometheus-helm-charts/releases/download/prometheus-couchdb-exporter-0.1.2/prometheus-couchdb-exporter-0.1.2.tgz
+    - https://github.com/prometheus-community/helm-charts/releases/download/prometheus-couchdb-exporter-0.1.2/prometheus-couchdb-exporter-0.1.2.tgz
     version: 0.1.2
   prometheus-mongodb-exporter:
   - apiVersion: v1
@@ -159,7 +159,7 @@ entries:
     sources:
     - https://github.com/percona/mongodb_exporter
     urls:
-    - https://github.com/scottrigby/prometheus-helm-charts/releases/download/prometheus-mongodb-exporter-2.8.1/prometheus-mongodb-exporter-2.8.1.tgz
+    - https://github.com/prometheus-community/helm-charts/releases/download/prometheus-mongodb-exporter-2.8.1/prometheus-mongodb-exporter-2.8.1.tgz
     version: 2.8.1
   prometheus-mysql-exporter:
   - apiVersion: v1
@@ -177,7 +177,7 @@ entries:
     sources:
     - https://github.com/prometheus/mysqld_exporter
     urls:
-    - https://github.com/scottrigby/prometheus-helm-charts/releases/download/prometheus-mysql-exporter-0.7.1/prometheus-mysql-exporter-0.7.1.tgz
+    - https://github.com/prometheus-community/helm-charts/releases/download/prometheus-mysql-exporter-0.7.1/prometheus-mysql-exporter-0.7.1.tgz
     version: 0.7.1
   prometheus-nats-exporter:
   - apiVersion: v1
@@ -199,7 +199,7 @@ entries:
     sources:
     - https://github.com/nats-io/prometheus-nats-exporter
     urls:
-    - https://github.com/scottrigby/prometheus-helm-charts/releases/download/prometheus-nats-exporter-2.5.1/prometheus-nats-exporter-2.5.1.tgz
+    - https://github.com/prometheus-community/helm-charts/releases/download/prometheus-nats-exporter-2.5.1/prometheus-nats-exporter-2.5.1.tgz
     version: 2.5.1
   prometheus-node-exporter:
   - apiVersion: v1
@@ -220,7 +220,7 @@ entries:
     sources:
     - https://github.com/prometheus/node_exporter/
     urls:
-    - https://github.com/scottrigby/prometheus-helm-charts/releases/download/prometheus-node-exporter-1.11.2/prometheus-node-exporter-1.11.2.tgz
+    - https://github.com/prometheus-community/helm-charts/releases/download/prometheus-node-exporter-1.11.2/prometheus-node-exporter-1.11.2.tgz
     version: 1.11.2
   prometheus-operator:
   - apiVersion: v1
@@ -253,7 +253,7 @@ entries:
     - https://github.com/coreos/prometheus-operator
     - https://coreos.com/operators/prometheus
     urls:
-    - https://github.com/scottrigby/prometheus-helm-charts/releases/download/prometheus-operator-9.3.2/prometheus-operator-9.3.2.tgz
+    - https://github.com/prometheus-community/helm-charts/releases/download/prometheus-operator-9.3.2/prometheus-operator-9.3.2.tgz
     version: 9.3.2
   prometheus-postgres-exporter:
   - apiVersion: v1
@@ -273,7 +273,7 @@ entries:
     sources:
     - https://github.com/wrouesnel/postgres_exporter
     urls:
-    - https://github.com/scottrigby/prometheus-helm-charts/releases/download/prometheus-postgres-exporter-1.3.1/prometheus-postgres-exporter-1.3.1.tgz
+    - https://github.com/prometheus-community/helm-charts/releases/download/prometheus-postgres-exporter-1.3.1/prometheus-postgres-exporter-1.3.1.tgz
     version: 1.3.1
   prometheus-pushgateway:
   - apiVersion: v1
@@ -294,7 +294,7 @@ entries:
     sources:
     - https://github.com/prometheus/pushgateway
     urls:
-    - https://github.com/scottrigby/prometheus-helm-charts/releases/download/prometheus-pushgateway-1.4.2/prometheus-pushgateway-1.4.2.tgz
+    - https://github.com/prometheus-community/helm-charts/releases/download/prometheus-pushgateway-1.4.2/prometheus-pushgateway-1.4.2.tgz
     version: 1.4.2
   prometheus-rabbitmq-exporter:
   - apiVersion: v1
@@ -310,7 +310,7 @@ entries:
     sources:
     - https://github.com/kbudde/rabbitmq_exporter
     urls:
-    - https://github.com/scottrigby/prometheus-helm-charts/releases/download/prometheus-rabbitmq-exporter-0.5.6/prometheus-rabbitmq-exporter-0.5.6.tgz
+    - https://github.com/prometheus-community/helm-charts/releases/download/prometheus-rabbitmq-exporter-0.5.6/prometheus-rabbitmq-exporter-0.5.6.tgz
     version: 0.5.6
   prometheus-redis-exporter:
   - apiVersion: v1
@@ -329,7 +329,7 @@ entries:
     sources:
     - https://github.com/oliver006/redis_exporter
     urls:
-    - https://github.com/scottrigby/prometheus-helm-charts/releases/download/prometheus-redis-exporter-3.5.1/prometheus-redis-exporter-3.5.1.tgz
+    - https://github.com/prometheus-community/helm-charts/releases/download/prometheus-redis-exporter-3.5.1/prometheus-redis-exporter-3.5.1.tgz
     version: 3.5.1
   prometheus-snmp-exporter:
   - apiVersion: v1
@@ -349,7 +349,7 @@ entries:
     sources:
     - https://github.com/prometheus/snmp_exporter
     urls:
-    - https://github.com/scottrigby/prometheus-helm-charts/releases/download/prometheus-snmp-exporter-0.0.6/prometheus-snmp-exporter-0.0.6.tgz
+    - https://github.com/prometheus-community/helm-charts/releases/download/prometheus-snmp-exporter-0.0.6/prometheus-snmp-exporter-0.0.6.tgz
     version: 0.0.6
   prometheus-to-sd:
   - apiVersion: v1
@@ -366,6 +366,6 @@ entries:
       name: acondrat
     name: prometheus-to-sd
     urls:
-    - https://github.com/scottrigby/prometheus-helm-charts/releases/download/prometheus-to-sd-0.3.1/prometheus-to-sd-0.3.1.tgz
+    - https://github.com/prometheus-community/helm-charts/releases/download/prometheus-to-sd-0.3.1/prometheus-to-sd-0.3.1.tgz
     version: 0.3.1
 generated: "2020-08-20T11:30:13.463619786Z"


### PR DESCRIPTION
Signed-off-by: gkarthiks <github.gkarthiks@gmail.com>

This PR is to change the URL for the charts to the `prometheus-community` GH Pages.

Fixes: https://github.com/prometheus-community/helm-charts/issues/35

/cc @scottrigby 