### PR TITLE
Improve README for main and gh pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prometheus Community Kubernetes Helm Charts
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Release Charts](https://github.com/prometheus-community/helm-charts/workflows/Release%20Charts/badge.svg?branch=main)
 
 This functionality is in beta and is subject to change. The code is provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ You can then run `helm search repo prometheus-community` to see the charts.
 
 ## Contributing
 
-We'd love to have you contribute! Please refer to our [contribution guidelines](CONTRIBUTING.md) for details.
+<!-- Keep full URL links to repo files because this README syncs from main to gh-pages.  -->
+We'd love to have you contribute! Please refer to our [contribution guidelines](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md) for details.
 
 ## License
 
-[Apache 2.0 License](./LICENSE).
+<!-- Keep full URL links to repo files because this README syncs from main to gh-pages.  -->
+[Apache 2.0 License](https://github.com/prometheus-community/helm-charts/blob/main/LICENSE).


### PR DESCRIPTION
Follow up to #41 
Also see https://github.com/prometheus-community/helm-charts/pull/39#issuecomment-687616250

To be clear, changes to the README in `main` now auto-sync to the `gh-pages` branch, so users will be able to see human-readable help and info about this helm repo if they decide to visit the helm repo URL.

I didn't add an additional link to the source code location, since the CONTRIBUTING file links directly there, with explicit instructions for forking etc.

Thanks to @monotek for getting the ball rolling with this in #39 