### PR TITLE
added github repo link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ You can then run `helm search repo prometheus-community` to see the charts.
 
 ## Contributing
 
+The source code of all [Prometheus](https://prometheus.io) community [Helm](https://helm.sh) charts can be found on Github: <https://github.com/prometheus-community/helm-charts/>
+
 <!-- Keep full URL links to repo files because this README syncs from main to gh-pages.  -->
 We'd love to have you contribute! Please refer to our [contribution guidelines](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md) for details.
 


### PR DESCRIPTION
Signed-off-by: André Bauer <monotek23@gmail.com>

Added github repo link to readme.md. 
This might look redundant but imho its nice to have a link to the repo from the index.html generated by gh-pages.