### PR TITLE
feat: replacing grafana rom stable to its own repo + additional chart maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # See https://github.com/scottrigby/prometheus-helm-charts/issues/12
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-charts/kube-prometheus-stack/ @vsliouniaev @bismarck @gianrubio
+charts/kube-prometheus-stack/ @vsliouniaev @bismarck @gianrubio @gkarthiks
 charts/prometheus/ @gianrubio @zanhsieh @Xtigyro
 charts/prometheus-adapter/ @mattiasgees @steven-sheehy @hectorj2f
 charts/prometheus-blackbox-exporter/ @desaintmartin @gianrubio

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Add dependency chart repos
         run: |
           helm repo add stable https://kubernetes-charts.storage.googleapis.com/
-          helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
+          helm repo add grafana https://grafana.github.io/helm-charts
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.0.0

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -7,11 +7,13 @@ maintainers:
   - name: bismarck
   - name: gianrubio
     email: gianrubio@gmail.com
+  - name: gkarthiks
+    email: github.gkarthiks@gmail.com
 name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-operator/kube-prometheus
   - https://github.com/prometheus-operator/prometheus-operator
-version: 9.3.2
+version: 9.3.3
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/README.md
+++ b/charts/kube-prometheus-stack/README.md
@@ -217,7 +217,7 @@ You can check out the tickets for this change [here](https://github.com/promethe
 The chart has added 3 [dependencies](#dependencies).
 
 - Node-Exporter, Kube-State-Metrics: These components are loaded as dependencies into the chart, and are relatively simple components
-- Grafana: The Grafana chart is more feature-rich than this chart - it contains a sidecar that is able to load data sources and dashboards from configmaps deployed into the same cluster. For more information check out the [documentation for the chart](https://github.com/grafana/helm-charts/tree/main/charts/grafana)
+- Grafana: The Grafana chart is more feature-rich that contains a sidecar that is able to load data sources and dashboards from configmaps deployed into the same cluster and more information on that can be found by visiting the [documentation for the chart](https://github.com/grafana/helm-charts/tree/main/charts/grafana)
 
 #### CoreOS CRDs
 

--- a/charts/kube-prometheus-stack/README.md
+++ b/charts/kube-prometheus-stack/README.md
@@ -41,7 +41,7 @@ By default this chart installs additional, dependent charts:
 
 - [stable/kube-state-metrics](https://github.com/helm/charts/tree/master/stable/kube-state-metrics)
 - [stable/prometheus-node-exporter](https://github.com/prometheus-community/helm-charts/tree/main/prometheus-node-exporter)
-- [stable/grafana](https://github.com/helm/charts/tree/master/stable/grafana)
+- [grafana/grafana](https://github.com/grafana/helm-charts/tree/main/charts/grafana)
 
 To disable dependencies during installation, see [multiple releases](#multiple-releases) below.
 
@@ -192,7 +192,7 @@ For more in-depth documentation of configuration options meanings, please see
 
 - [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator)
 - [Prometheus](https://prometheus.io/docs/introduction/overview/)
-- [Grafana](https://github.com/helm/charts/tree/master/stable/grafana#grafana-helm-chart)
+- [Grafana](https://github.com/grafana/helm-charts/tree/main/charts/grafana#grafana-helm-chart)
 
 ## prometheus.io/scrape
 
@@ -217,7 +217,7 @@ You can check out the tickets for this change [here](https://github.com/promethe
 The chart has added 3 [dependencies](#dependencies).
 
 - Node-Exporter, Kube-State-Metrics: These components are loaded as dependencies into the chart, and are relatively simple components
-- Grafana: The Grafana chart is more feature-rich than this chart - it contains a sidecar that is able to load data sources and dashboards from configmaps deployed into the same cluster. For more information check out the [documentation for the chart](https://github.com/helm/charts/tree/master/stable/grafana)
+- Grafana: The Grafana chart is more feature-rich than this chart - it contains a sidecar that is able to load data sources and dashboards from configmaps deployed into the same cluster. For more information check out the [documentation for the chart](https://github.com/grafana/helm-charts/tree/main/charts/grafana)
 
 #### CoreOS CRDs
 

--- a/charts/kube-prometheus-stack/README.md
+++ b/charts/kube-prometheus-stack/README.md
@@ -217,7 +217,7 @@ You can check out the tickets for this change [here](https://github.com/promethe
 The chart has added 3 [dependencies](#dependencies).
 
 - Node-Exporter, Kube-State-Metrics: These components are loaded as dependencies into the chart, and are relatively simple components
-- Grafana: The Grafana chart is more feature-rich that contains a sidecar that is able to load data sources and dashboards from configmaps deployed into the same cluster and more information on that can be found by visiting the [documentation for the chart](https://github.com/grafana/helm-charts/tree/main/charts/grafana)
+- Grafana: The Grafana chart is more feature-rich than this chart - it contains a sidecar that is able to load data sources and dashboards from configmaps deployed into the same cluster. For more information check out the [documentation for the chart](https://github.com/helm/charts/tree/master/stable/grafana)
 
 #### CoreOS CRDs
 

--- a/charts/kube-prometheus-stack/requirements.yaml
+++ b/charts/kube-prometheus-stack/requirements.yaml
@@ -11,6 +11,6 @@ dependencies:
     condition: nodeExporter.enabled
 
   - name: grafana
-    version: "5.3.*"
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    version: "5.6.*"
+    repository: https://grafana.github.io/helm-charts
     condition: grafana.enabled

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -486,8 +486,8 @@ alertmanager:
 grafana:
   ## Override the deployment namespace
   namespaceOverride: ""
-  
-  replicas: 1  
+
+  replicas: 1
   ## See `kubectl explain deployment.spec.strategy` for more
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
   deploymentStrategy:

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -484,541 +484,122 @@ alertmanager:
 ## Using default values from https://github.com/grafana/helm-charts/blob/main/charts/grafana/values.yaml
 ##
 grafana:
-  ## Override the deployment namespace
+  enabled: true
   namespaceOverride: ""
 
-  replicas: 1
-  ## See `kubectl explain deployment.spec.strategy` for more
-  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
-  deploymentStrategy:
-    type: RollingUpdate
-
-  rbac:
-    create: true
-    pspEnabled: true
-    pspUseAppArmor: true
-    namespaced: false
-    extraRoleRules: []
-    # - apiGroups: []
-    #   resources: []
-    #   verbs: []
-    extraClusterRoleRules: []
-    # - apiGroups: []
-    #   resources: []
-    #   verbs: []
-  serviceAccount:
-    create: true
-    name:
-    nameTest:
-  #  annotations:
-
-  ## See `kubectl explain poddisruptionbudget.spec` for more
-  ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
-  podDisruptionBudget: {}
-  #  minAvailable: 1
-  #  maxUnavailable: 1
-
-  readinessProbe:
-    httpGet:
-      path: /api/health
-      port: 3000
-
-  livenessProbe:
-    httpGet:
-      path: /api/health
-      port: 3000
-    initialDelaySeconds: 60
-    timeoutSeconds: 30
-    failureThreshold: 10
-
-  ## Use an alternate scheduler, e.g. "stork".
-  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ## Deploy default dashboards.
   ##
-  # schedulerName: "default-scheduler"
+  defaultDashboardsEnabled: true
 
-  image:
-    repository: grafana/grafana
-    tag: 7.1.1
-    sha: ""
-    pullPolicy: IfNotPresent
-
-    ## Optionally specify an array of imagePullSecrets.
-    ## Secrets must be manually created in the namespace.
-    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    ##
-    # pullSecrets:
-    #   - myRegistrKeySecretName
-
-  testFramework:
-    enabled: true
-    image: "bats/bats"
-    tag: "v1.1.0"
-    imagePullPolicy: IfNotPresent
-    securityContext: {}
-
-  securityContext:
-    runAsUser: 472
-    runAsGroup: 472
-    fsGroup: 472
-
-
-  extraConfigmapMounts: []
-    # - name: certs-configmap
-    #   mountPath: /etc/grafana/ssl/
-    #   subPath: certificates.crt # (optional)
-    #   configMap: certs-configmap
-    #   readOnly: true
-
-
-  extraEmptyDirMounts: []
-    # - name: provisioning-notifiers
-    #   mountPath: /etc/grafana/provisioning/notifiers
-
-
-  ## Assign a PriorityClassName to pods if set
-  # priorityClassName:
-
-  downloadDashboardsImage:
-    repository: curlimages/curl
-    tag: 7.70.0
-    sha: ""
-    pullPolicy: IfNotPresent
-
-  downloadDashboards:
-    env: {}
-    resources: {}
-
-  ## Pod Annotations
-  # podAnnotations: {}
-
-  ## Pod Labels
-  # podLabels: {}
-
-  podPortName: grafana
-
-  ## Deployment annotations
-  # annotations: {}
-
-  ## Expose the grafana service to be accessed from outside the cluster (LoadBalancer service).
-  ## or access it from within the cluster (ClusterIP service). Set the service type and the port to serve it.
-  ## ref: http://kubernetes.io/docs/user-guide/services/
-  ##
-  service:
-    type: ClusterIP
-    port: 80
-    targetPort: 3000
-      # targetPort: 4181 To be used with a proxy extraContainer
-    annotations: {}
-    labels: {}
-    portName: service
-
-  extraExposePorts: []
-  # - name: keycloak
-  #   port: 8080
-  #   targetPort: 8080
-  #   type: ClusterIP
-
-  # overrides pod.spec.hostAliases in the grafana deployment's pods
-  hostAliases: []
-    # - ip: "1.2.3.4"
-    #   hostnames:
-    #     - "my.host.com"
+  adminPassword: prom-operator
 
   ingress:
+    ## If true, Grafana Ingress will be created
+    ##
     enabled: false
-    # Values can be templated
+
+    ## Annotations for Grafana Ingress
+    ##
     annotations: {}
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
+
+    ## Labels to be added to the Ingress
+    ##
     labels: {}
+
+    ## Hostnames.
+    ## Must be provided if Ingress is enable.
+    ##
+    # hosts:
+    #   - grafana.domain.com
+    hosts: []
+
+    ## Path for grafana ingress
     path: /
-    hosts:
-      - chart-example.local
-    ## Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
-    extraPaths: []
-    # - path: /*
-    #   backend:
-    #     serviceName: ssl-redirect
-    #     servicePort: use-annotation
+
+    ## TLS configuration for grafana Ingress
+    ## Secret must be manually created in the namespace
+    ##
     tls: []
-    #  - secretName: chart-example-tls
-    #    hosts:
-    #      - chart-example.local
+    # - secretName: grafana-general-tls
+    #   hosts:
+    #   - grafana.example.com
 
-  resources: {}
-  #  limits:
-  #    cpu: 100m
-  #    memory: 128Mi
-  #  requests:
-  #    cpu: 100m
-  #    memory: 128Mi
-
-  ## Node labels for pod assignment
-  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
-  #
-  nodeSelector: {}
-
-  ## Tolerations for pod assignment
-  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-  ##
-  tolerations: []
-
-  ## Affinity for pod assignment
-  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
-  ##
-  affinity: {}
-
-  extraInitContainers: []
-
-  ## Enable an Specify container in extraContainers. This is meant to allow adding an authentication proxy to a grafana pod
-  extraContainers: |
-  # - name: proxy
-  #   image: quay.io/gambol99/keycloak-proxy:latest
-  #   args:
-  #   - -provider=github
-  #   - -client-id=
-  #   - -client-secret=
-  #   - -github-org=<ORG_NAME>
-  #   - -email-domain=*
-  #   - -cookie-secret=
-  #   - -http-address=http://0.0.0.0:4181
-  #   - -upstream-url=http://127.0.0.1:3000
-  #   ports:
-  #     - name: proxy-web
-  #       containerPort: 4181
-
-  ## Volumes that can be used in init containers that will not be mounted to deployment pods
-  extraContainerVolumes: []
-  #  - name: volume-from-secret
-  #    secret:
-  #      secretName: secret-to-mount
-  #  - name: empty-dir-volume
-  #    emptyDir: {}
-
-  ## Enable persistence using Persistent Volume Claims
-  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
-  ##
-  persistence:
-    type: pvc
-    enabled: false
-    # storageClassName: default
-    accessModes:
-      - ReadWriteOnce
-    size: 10Gi
-    # annotations: {}
-    finalizers:
-      - kubernetes.io/pvc-protection
-    # subPath: ""
-    # existingClaim:
-
-  initChownData:
-    ## If false, data ownership will not be reset at startup
-    ## This allows the prometheus-server to be run with an arbitrary user
-    ##
-    enabled: true
-
-    ## initChownData container image
-    ##
-    image:
-      repository: busybox
-      tag: "1.31.1"
-      sha: ""
-      pullPolicy: IfNotPresent
-
-    ## initChownData resource requests and limits
-    ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
-    ##
-    resources: {}
-    #  limits:
-    #    cpu: 100m
-    #    memory: 128Mi
-    #  requests:
-    #    cpu: 100m
-    #    memory: 128Mi
-
-
-  # Administrator credentials when not using an existing secret (see below)
-  adminUser: admin
-  # adminPassword: strongpassword
-
-  # Use an existing secret for the admin user.
-  admin:
-    existingSecret: ""
-    userKey: admin-user
-    passwordKey: admin-password
-
-  ## Define command to be executed at startup by grafana container
-  ## Needed if using `vault-env` to manage secrets (ref: https://banzaicloud.com/blog/inject-secrets-into-pods-vault/)
-  ## Default is "run.sh" as defined in grafana's Dockerfile
-  # command:
-  # - "sh"
-  # - "/run.sh"
-
-  ## Use an alternate scheduler, e.g. "stork".
-  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
-  ##
-  # schedulerName:
-
-  ## Extra environment variables that will be pass onto deployment pods
-  env: {}
-
-  ## "valueFrom" environment variable references that will be added to deployment pods
-  ## ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#envvarsource-v1-core
-  ## Renders in container spec as:
-  ##   env:
-  ##     ...
-  ##     - name: <key>
-  ##       valueFrom:
-  ##         <value rendered as YAML>
-  envValueFrom: {}
-
-  ## The name of a secret in the same kubernetes namespace which contain values to be added to the environment
-  ## This can be useful for auth tokens, etc. Value is templated.
-  envFromSecret: ""
-
-  ## Sensible environment variables that will be rendered as new secret object
-  ## This can be useful for auth tokens, etc
-  envRenderSecret: {}
-
-  ## Additional grafana server secret mounts
-  # Defines additional mounts with secrets. Secrets must be manually created in the namespace.
-  extraSecretMounts: []
-    # - name: secret-files
-    #   mountPath: /etc/secrets
-    #   secretName: grafana-secret-files
-    #   readOnly: true
-    #   subPath: ""
-
-  ## Additional grafana server volume mounts
-  # Defines additional volume mounts.
-  extraVolumeMounts: []
-    # - name: extra-volume
-    #   mountPath: /mnt/volume
-    #   readOnly: true
-    #   existingClaim: volume-claim
-
-  ## Pass the plugins you want installed as a list.
-  ##
-  plugins: []
-    # - digrich-bubblechart-panel
-    # - grafana-clock-panel
-
-  ## Configure grafana datasources
-  ## ref: http://docs.grafana.org/administration/provisioning/#datasources
-  ##
-  datasources: {}
-  #  datasources.yaml:
-  #    apiVersion: 1
-  #    datasources:
-  #    - name: Prometheus
-  #      type: prometheus
-  #      url: http://prometheus-prometheus-server
-  #      access: proxy
-  #      isDefault: true
-
-  ## Configure notifiers
-  ## ref: http://docs.grafana.org/administration/provisioning/#alert-notification-channels
-  ##
-  notifiers: {}
-  #  notifiers.yaml:
-  #    notifiers:
-  #    - name: email-notifier
-  #      type: email
-  #      uid: email1
-  #      # either:
-  #      org_id: 1
-  #      # or
-  #      org_name: Main Org.
-  #      is_default: true
-  #      settings:
-  #        addresses: an_email_address@example.com
-  #    delete_notifiers:
-
-  ## Configure grafana dashboard providers
-  ## ref: http://docs.grafana.org/administration/provisioning/#dashboards
-  ##
-  ## `path` must be /var/lib/grafana/dashboards/<provider_name>
-  ##
-  dashboardProviders: {}
-  #  dashboardproviders.yaml:
-  #    apiVersion: 1
-  #    providers:
-  #    - name: 'default'
-  #      orgId: 1
-  #      folder: ''
-  #      type: file
-  #      disableDeletion: false
-  #      editable: true
-  #      options:
-  #        path: /var/lib/grafana/dashboards/default
-
-  ## Configure grafana dashboard to import
-  ## NOTE: To use dashboards you must also enable/configure dashboardProviders
-  ## ref: https://grafana.com/dashboards
-  ##
-  ## dashboards per provider, use provider name as key.
-  ##
-  dashboards: {}
-    # default:
-    #   some-dashboard:
-    #     json: |
-    #       $RAW_JSON
-    #   custom-dashboard:
-    #     file: dashboards/custom-dashboard.json
-    #   prometheus-stats:
-    #     gnetId: 2
-    #     revision: 2
-    #     datasource: Prometheus
-    #   local-dashboard:
-    #     url: https://example.com/repository/test.json
-    #   local-dashboard-base64:
-    #     url: https://example.com/repository/test-b64.json
-    #     b64content: true
-
-  ## Reference to external ConfigMap per provider. Use provider name as key and ConfigMap name as value.
-  ## A provider dashboards must be defined either by external ConfigMaps or in values.yaml, not in both.
-  ## ConfigMap data example:
-  ##
-  ## data:
-  ##   example-dashboard.json: |
-  ##     RAW_JSON
-  ##
-  dashboardsConfigMaps: {}
-  #  default: ""
-
-  ## Grafana's primary configuration
-  ## NOTE: values in map will be converted to ini format
-  ## ref: http://docs.grafana.org/installation/configuration/
-  ##
-  grafana.ini:
-    paths:
-      data: /var/lib/grafana/data
-      logs: /var/log/grafana
-      plugins: /var/lib/grafana/plugins
-      provisioning: /etc/grafana/provisioning
-    analytics:
-      check_for_updates: true
-    log:
-      mode: console
-    grafana_net:
-      url: https://grafana.net
-  ## grafana Authentication can be enabled with the following values on grafana.ini
-  # server:
-        # The full public facing url you use in browser, used for redirects and emails
-  #    root_url:
-  # https://grafana.com/docs/grafana/latest/auth/github/#enable-github-in-grafana
-  # auth.github:
-  #    enabled: false
-  #    allow_sign_up: false
-  #    scopes: user:email,read:org
-  #    auth_url: https://github.com/login/oauth/authorize
-  #    token_url: https://github.com/login/oauth/access_token
-  #    api_url: https://github.com/user
-  #    team_ids:
-  #    allowed_organizations:
-  #    client_id:
-  #    client_secret:
-  ## LDAP Authentication can be enabled with the following values on grafana.ini
-  ## NOTE: Grafana will fail to start if the value for ldap.toml is invalid
-    # auth.ldap:
-    #   enabled: true
-    #   allow_sign_up: true
-    #   config_file: /etc/grafana/ldap.toml
-
-  ## Grafana's LDAP configuration
-  ## Templated by the template in _helpers.tpl
-  ## NOTE: To enable the grafana.ini must be configured with auth.ldap.enabled
-  ## ref: http://docs.grafana.org/installation/configuration/#auth-ldap
-  ## ref: http://docs.grafana.org/installation/ldap/#configuration
-  ldap:
-    enabled: false
-    # `existingSecret` is a reference to an existing secret containing the ldap configuration
-    # for Grafana in a key `ldap-toml`.
-    existingSecret: ""
-    # `config` is the content of `ldap.toml` that will be stored in the created secret
-    config: ""
-    # config: |-
-    #   verbose_logging = true
-
-    #   [[servers]]
-    #   host = "my-ldap-server"
-    #   port = 636
-    #   use_ssl = true
-    #   start_tls = false
-    #   ssl_skip_verify = false
-    #   bind_dn = "uid=%s,ou=users,dc=myorg,dc=com"
-
-  ## Grafana's SMTP configuration
-  ## NOTE: To enable, grafana.ini must be configured with smtp.enabled
-  ## ref: http://docs.grafana.org/installation/configuration/#smtp
-  smtp:
-    # `existingSecret` is a reference to an existing secret containing the smtp configuration
-    # for Grafana.
-    existingSecret: ""
-    userKey: "user"
-    passwordKey: "password"
-
-  ## Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders
-  ## Requires at least Grafana 5 to work and can't be used together with parameters dashboardProviders, datasources and dashboards
   sidecar:
-    image:
-      repository: kiwigrid/k8s-sidecar
-      tag: 0.1.151
-      sha: ""
-    imagePullPolicy: IfNotPresent
-    resources: {}
-  #   limits:
-  #     cpu: 100m
-  #     memory: 100Mi
-  #   requests:
-  #     cpu: 50m
-  #     memory: 50Mi
-    # skipTlsVerify Set to true to skip tls verification for kube api calls
-    # skipTlsVerify: true
-    enableUniqueFilenames: false
     dashboards:
-      enabled: false
-      SCProvider: true
-      # label that the configmaps with dashboards are marked with
+      enabled: true
       label: grafana_dashboard
-      # folder in the pod that should hold the collected dashboards (unless `defaultFolderName` is set)
-      folder: /tmp/dashboards
-      # The default folder name, it will create a subfolder under the `folder` and put dashboards in there instead
-      defaultFolderName: null
-      # If specified, the sidecar will search for dashboard config-maps inside this namespace.
-      # Otherwise the namespace in which the sidecar is running will be used.
-      # It's also possible to specify ALL to search in all namespaces
-      searchNamespace: null
-      # provider configuration that lets grafana manage the dashboards
-      provider:
-        # name of the provider, should be unique
-        name: sidecarProvider
-        # orgid as configured in grafana
-        orgid: 1
-        # folder in which the dashboards should be imported in grafana
-        folder: ''
-        # type of the provider
-        type: file
-        # disableDelete to activate a import-only behaviour
-        disableDelete: false
-        # allow updating provisioned dashboards from the UI
-        allowUiUpdates: false
+
+      ## Annotations for Grafana dashboard configmaps
+      ##
+      annotations: {}
     datasources:
-      enabled: false
-      # label that the configmaps with datasources are marked with
+      enabled: true
+      defaultDatasourceEnabled: true
+
+      ## Annotations for Grafana datasource configmaps
+      ##
+      annotations: {}
+
+      ## Create datasource for each Pod of Prometheus StatefulSet;
+      ## this uses headless service `prometheus-operated` which is
+      ## created by Prometheus Operator
+      ## ref: https://git.io/fjaBS
+      createPrometheusReplicasDatasources: false
       label: grafana_datasource
-      # If specified, the sidecar will search for datasource config-maps inside this namespace.
-      # Otherwise the namespace in which the sidecar is running will be used.
-      # It's also possible to specify ALL to search in all namespaces
-      searchNamespace: null
-    notifiers:
-      enabled: false
-      # label that the configmaps with notifiers are marked with
-      label: grafana_notifier
-      # If specified, the sidecar will search for notifier config-maps inside this namespace.
-      # Otherwise the namespace in which the sidecar is running will be used.
-      # It's also possible to specify ALL to search in all namespaces
-      searchNamespace: null
+
+  extraConfigmapMounts: []
+  # - name: certs-configmap
+  #   mountPath: /etc/grafana/ssl/
+  #   configMap: certs-configmap
+  #   readOnly: true
+
+  ## Configure additional grafana datasources (passed through tpl)
+  ## ref: http://docs.grafana.org/administration/provisioning/#datasources
+  additionalDataSources: []
+  # - name: prometheus-sample
+  #   access: proxy
+  #   basicAuth: true
+  #   basicAuthPassword: pass
+  #   basicAuthUser: daco
+  #   editable: false
+  #   jsonData:
+  #       tlsSkipVerify: true
+  #   orgId: 1
+  #   type: prometheus
+  #   url: https://{{ printf "%s-prometheus.svc" .Release.Name }}:9090
+  #   version: 1
+
+  ## Passed to grafana subchart and used by servicemonitor below
+  ##
+  service:
+    portName: service
+
+  ## If true, create a serviceMonitor for grafana
+  ##
+  serviceMonitor:
+    ## Scrape interval. If not set, the Prometheus default scrape interval is used.
+    ##
+    interval: ""
+    selfMonitor: true
+
+    ## 	metric relabel configs to apply to samples before ingestion.
+    ##
+    metricRelabelings: []
+    # - action: keep
+    #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
+    #   sourceLabels: [__name__]
+
+    # 	relabel configs to apply to samples before ingestion.
+    ##
+    relabelings: []
+    # - sourceLabels: [__meta_kubernetes_pod_node_name]
+    #   separator: ;
+    #   regex: ^(.*)$
+    #   targetLabel: nodename
+    #   replacement: $1
+    #   action: replace
 
 ## Component scraping the kube api server
 ##

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -481,125 +481,544 @@ alertmanager:
     portName: "web"
 
 
-## Using default values from https://github.com/helm/charts/blob/master/stable/grafana/values.yaml
+## Using default values from https://github.com/grafana/helm-charts/blob/main/charts/grafana/values.yaml
 ##
 grafana:
-  enabled: true
+  ## Override the deployment namespace
   namespaceOverride: ""
+  
+  replicas: 1  
+  ## See `kubectl explain deployment.spec.strategy` for more
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  deploymentStrategy:
+    type: RollingUpdate
 
-  ## Deploy default dashboards.
+  rbac:
+    create: true
+    pspEnabled: true
+    pspUseAppArmor: true
+    namespaced: false
+    extraRoleRules: []
+    # - apiGroups: []
+    #   resources: []
+    #   verbs: []
+    extraClusterRoleRules: []
+    # - apiGroups: []
+    #   resources: []
+    #   verbs: []
+  serviceAccount:
+    create: true
+    name:
+    nameTest:
+  #  annotations:
+
+  ## See `kubectl explain poddisruptionbudget.spec` for more
+  ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+  podDisruptionBudget: {}
+  #  minAvailable: 1
+  #  maxUnavailable: 1
+
+  readinessProbe:
+    httpGet:
+      path: /api/health
+      port: 3000
+
+  livenessProbe:
+    httpGet:
+      path: /api/health
+      port: 3000
+    initialDelaySeconds: 60
+    timeoutSeconds: 30
+    failureThreshold: 10
+
+  ## Use an alternate scheduler, e.g. "stork".
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
   ##
-  defaultDashboardsEnabled: true
+  # schedulerName: "default-scheduler"
 
-  adminPassword: prom-operator
+  image:
+    repository: grafana/grafana
+    tag: 7.1.1
+    sha: ""
+    pullPolicy: IfNotPresent
+
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistrKeySecretName
+
+  testFramework:
+    enabled: true
+    image: "bats/bats"
+    tag: "v1.1.0"
+    imagePullPolicy: IfNotPresent
+    securityContext: {}
+
+  securityContext:
+    runAsUser: 472
+    runAsGroup: 472
+    fsGroup: 472
+
+
+  extraConfigmapMounts: []
+    # - name: certs-configmap
+    #   mountPath: /etc/grafana/ssl/
+    #   subPath: certificates.crt # (optional)
+    #   configMap: certs-configmap
+    #   readOnly: true
+
+
+  extraEmptyDirMounts: []
+    # - name: provisioning-notifiers
+    #   mountPath: /etc/grafana/provisioning/notifiers
+
+
+  ## Assign a PriorityClassName to pods if set
+  # priorityClassName:
+
+  downloadDashboardsImage:
+    repository: curlimages/curl
+    tag: 7.70.0
+    sha: ""
+    pullPolicy: IfNotPresent
+
+  downloadDashboards:
+    env: {}
+    resources: {}
+
+  ## Pod Annotations
+  # podAnnotations: {}
+
+  ## Pod Labels
+  # podLabels: {}
+
+  podPortName: grafana
+
+  ## Deployment annotations
+  # annotations: {}
+
+  ## Expose the grafana service to be accessed from outside the cluster (LoadBalancer service).
+  ## or access it from within the cluster (ClusterIP service). Set the service type and the port to serve it.
+  ## ref: http://kubernetes.io/docs/user-guide/services/
+  ##
+  service:
+    type: ClusterIP
+    port: 80
+    targetPort: 3000
+      # targetPort: 4181 To be used with a proxy extraContainer
+    annotations: {}
+    labels: {}
+    portName: service
+
+  extraExposePorts: []
+  # - name: keycloak
+  #   port: 8080
+  #   targetPort: 8080
+  #   type: ClusterIP
+
+  # overrides pod.spec.hostAliases in the grafana deployment's pods
+  hostAliases: []
+    # - ip: "1.2.3.4"
+    #   hostnames:
+    #     - "my.host.com"
 
   ingress:
-    ## If true, Grafana Ingress will be created
-    ##
     enabled: false
-
-    ## Annotations for Grafana Ingress
-    ##
+    # Values can be templated
     annotations: {}
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
-
-    ## Labels to be added to the Ingress
-    ##
     labels: {}
-
-    ## Hostnames.
-    ## Must be provided if Ingress is enable.
-    ##
-    # hosts:
-    #   - grafana.domain.com
-    hosts: []
-
-    ## Path for grafana ingress
     path: /
-
-    ## TLS configuration for grafana Ingress
-    ## Secret must be manually created in the namespace
-    ##
+    hosts:
+      - chart-example.local
+    ## Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
+    extraPaths: []
+    # - path: /*
+    #   backend:
+    #     serviceName: ssl-redirect
+    #     servicePort: use-annotation
     tls: []
-    # - secretName: grafana-general-tls
-    #   hosts:
-    #   - grafana.example.com
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
 
-  sidecar:
-    dashboards:
-      enabled: true
-      label: grafana_dashboard
+  resources: {}
+  #  limits:
+  #    cpu: 100m
+  #    memory: 128Mi
+  #  requests:
+  #    cpu: 100m
+  #    memory: 128Mi
 
-      ## Annotations for Grafana dashboard configmaps
-      ##
-      annotations: {}
-    datasources:
-      enabled: true
-      defaultDatasourceEnabled: true
+  ## Node labels for pod assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  #
+  nodeSelector: {}
 
-      ## Annotations for Grafana datasource configmaps
-      ##
-      annotations: {}
+  ## Tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
 
-      ## Create datasource for each Pod of Prometheus StatefulSet;
-      ## this uses headless service `prometheus-operated` which is
-      ## created by Prometheus Operator
-      ## ref: https://git.io/fjaBS
-      createPrometheusReplicasDatasources: false
-      label: grafana_datasource
+  ## Affinity for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  affinity: {}
 
-  extraConfigmapMounts: []
-  # - name: certs-configmap
-  #   mountPath: /etc/grafana/ssl/
-  #   configMap: certs-configmap
-  #   readOnly: true
+  extraInitContainers: []
 
-  ## Configure additional grafana datasources (passed through tpl)
+  ## Enable an Specify container in extraContainers. This is meant to allow adding an authentication proxy to a grafana pod
+  extraContainers: |
+  # - name: proxy
+  #   image: quay.io/gambol99/keycloak-proxy:latest
+  #   args:
+  #   - -provider=github
+  #   - -client-id=
+  #   - -client-secret=
+  #   - -github-org=<ORG_NAME>
+  #   - -email-domain=*
+  #   - -cookie-secret=
+  #   - -http-address=http://0.0.0.0:4181
+  #   - -upstream-url=http://127.0.0.1:3000
+  #   ports:
+  #     - name: proxy-web
+  #       containerPort: 4181
+
+  ## Volumes that can be used in init containers that will not be mounted to deployment pods
+  extraContainerVolumes: []
+  #  - name: volume-from-secret
+  #    secret:
+  #      secretName: secret-to-mount
+  #  - name: empty-dir-volume
+  #    emptyDir: {}
+
+  ## Enable persistence using Persistent Volume Claims
+  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+  ##
+  persistence:
+    type: pvc
+    enabled: false
+    # storageClassName: default
+    accessModes:
+      - ReadWriteOnce
+    size: 10Gi
+    # annotations: {}
+    finalizers:
+      - kubernetes.io/pvc-protection
+    # subPath: ""
+    # existingClaim:
+
+  initChownData:
+    ## If false, data ownership will not be reset at startup
+    ## This allows the prometheus-server to be run with an arbitrary user
+    ##
+    enabled: true
+
+    ## initChownData container image
+    ##
+    image:
+      repository: busybox
+      tag: "1.31.1"
+      sha: ""
+      pullPolicy: IfNotPresent
+
+    ## initChownData resource requests and limits
+    ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
+    ##
+    resources: {}
+    #  limits:
+    #    cpu: 100m
+    #    memory: 128Mi
+    #  requests:
+    #    cpu: 100m
+    #    memory: 128Mi
+
+
+  # Administrator credentials when not using an existing secret (see below)
+  adminUser: admin
+  # adminPassword: strongpassword
+
+  # Use an existing secret for the admin user.
+  admin:
+    existingSecret: ""
+    userKey: admin-user
+    passwordKey: admin-password
+
+  ## Define command to be executed at startup by grafana container
+  ## Needed if using `vault-env` to manage secrets (ref: https://banzaicloud.com/blog/inject-secrets-into-pods-vault/)
+  ## Default is "run.sh" as defined in grafana's Dockerfile
+  # command:
+  # - "sh"
+  # - "/run.sh"
+
+  ## Use an alternate scheduler, e.g. "stork".
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  # schedulerName:
+
+  ## Extra environment variables that will be pass onto deployment pods
+  env: {}
+
+  ## "valueFrom" environment variable references that will be added to deployment pods
+  ## ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#envvarsource-v1-core
+  ## Renders in container spec as:
+  ##   env:
+  ##     ...
+  ##     - name: <key>
+  ##       valueFrom:
+  ##         <value rendered as YAML>
+  envValueFrom: {}
+
+  ## The name of a secret in the same kubernetes namespace which contain values to be added to the environment
+  ## This can be useful for auth tokens, etc. Value is templated.
+  envFromSecret: ""
+
+  ## Sensible environment variables that will be rendered as new secret object
+  ## This can be useful for auth tokens, etc
+  envRenderSecret: {}
+
+  ## Additional grafana server secret mounts
+  # Defines additional mounts with secrets. Secrets must be manually created in the namespace.
+  extraSecretMounts: []
+    # - name: secret-files
+    #   mountPath: /etc/secrets
+    #   secretName: grafana-secret-files
+    #   readOnly: true
+    #   subPath: ""
+
+  ## Additional grafana server volume mounts
+  # Defines additional volume mounts.
+  extraVolumeMounts: []
+    # - name: extra-volume
+    #   mountPath: /mnt/volume
+    #   readOnly: true
+    #   existingClaim: volume-claim
+
+  ## Pass the plugins you want installed as a list.
+  ##
+  plugins: []
+    # - digrich-bubblechart-panel
+    # - grafana-clock-panel
+
+  ## Configure grafana datasources
   ## ref: http://docs.grafana.org/administration/provisioning/#datasources
-  additionalDataSources: []
-  # - name: prometheus-sample
-  #   access: proxy
-  #   basicAuth: true
-  #   basicAuthPassword: pass
-  #   basicAuthUser: daco
-  #   editable: false
-  #   jsonData:
-  #       tlsSkipVerify: true
-  #   orgId: 1
-  #   type: prometheus
-  #   url: https://{{ printf "%s-prometheus.svc" .Release.Name }}:9090
-  #   version: 1
-
-  ## Passed to grafana subchart and used by servicemonitor below
   ##
-  service:
-    portName: service
+  datasources: {}
+  #  datasources.yaml:
+  #    apiVersion: 1
+  #    datasources:
+  #    - name: Prometheus
+  #      type: prometheus
+  #      url: http://prometheus-prometheus-server
+  #      access: proxy
+  #      isDefault: true
 
-  ## If true, create a serviceMonitor for grafana
+  ## Configure notifiers
+  ## ref: http://docs.grafana.org/administration/provisioning/#alert-notification-channels
   ##
-  serviceMonitor:
-    ## Scrape interval. If not set, the Prometheus default scrape interval is used.
-    ##
-    interval: ""
-    selfMonitor: true
+  notifiers: {}
+  #  notifiers.yaml:
+  #    notifiers:
+  #    - name: email-notifier
+  #      type: email
+  #      uid: email1
+  #      # either:
+  #      org_id: 1
+  #      # or
+  #      org_name: Main Org.
+  #      is_default: true
+  #      settings:
+  #        addresses: an_email_address@example.com
+  #    delete_notifiers:
 
-    ## 	metric relabel configs to apply to samples before ingestion.
-    ##
-    metricRelabelings: []
-    # - action: keep
-    #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
-    #   sourceLabels: [__name__]
+  ## Configure grafana dashboard providers
+  ## ref: http://docs.grafana.org/administration/provisioning/#dashboards
+  ##
+  ## `path` must be /var/lib/grafana/dashboards/<provider_name>
+  ##
+  dashboardProviders: {}
+  #  dashboardproviders.yaml:
+  #    apiVersion: 1
+  #    providers:
+  #    - name: 'default'
+  #      orgId: 1
+  #      folder: ''
+  #      type: file
+  #      disableDeletion: false
+  #      editable: true
+  #      options:
+  #        path: /var/lib/grafana/dashboards/default
 
-    # 	relabel configs to apply to samples before ingestion.
-    ##
-    relabelings: []
-    # - sourceLabels: [__meta_kubernetes_pod_node_name]
-    #   separator: ;
-    #   regex: ^(.*)$
-    #   targetLabel: nodename
-    #   replacement: $1
-    #   action: replace
+  ## Configure grafana dashboard to import
+  ## NOTE: To use dashboards you must also enable/configure dashboardProviders
+  ## ref: https://grafana.com/dashboards
+  ##
+  ## dashboards per provider, use provider name as key.
+  ##
+  dashboards: {}
+    # default:
+    #   some-dashboard:
+    #     json: |
+    #       $RAW_JSON
+    #   custom-dashboard:
+    #     file: dashboards/custom-dashboard.json
+    #   prometheus-stats:
+    #     gnetId: 2
+    #     revision: 2
+    #     datasource: Prometheus
+    #   local-dashboard:
+    #     url: https://example.com/repository/test.json
+    #   local-dashboard-base64:
+    #     url: https://example.com/repository/test-b64.json
+    #     b64content: true
+
+  ## Reference to external ConfigMap per provider. Use provider name as key and ConfigMap name as value.
+  ## A provider dashboards must be defined either by external ConfigMaps or in values.yaml, not in both.
+  ## ConfigMap data example:
+  ##
+  ## data:
+  ##   example-dashboard.json: |
+  ##     RAW_JSON
+  ##
+  dashboardsConfigMaps: {}
+  #  default: ""
+
+  ## Grafana's primary configuration
+  ## NOTE: values in map will be converted to ini format
+  ## ref: http://docs.grafana.org/installation/configuration/
+  ##
+  grafana.ini:
+    paths:
+      data: /var/lib/grafana/data
+      logs: /var/log/grafana
+      plugins: /var/lib/grafana/plugins
+      provisioning: /etc/grafana/provisioning
+    analytics:
+      check_for_updates: true
+    log:
+      mode: console
+    grafana_net:
+      url: https://grafana.net
+  ## grafana Authentication can be enabled with the following values on grafana.ini
+  # server:
+        # The full public facing url you use in browser, used for redirects and emails
+  #    root_url:
+  # https://grafana.com/docs/grafana/latest/auth/github/#enable-github-in-grafana
+  # auth.github:
+  #    enabled: false
+  #    allow_sign_up: false
+  #    scopes: user:email,read:org
+  #    auth_url: https://github.com/login/oauth/authorize
+  #    token_url: https://github.com/login/oauth/access_token
+  #    api_url: https://github.com/user
+  #    team_ids:
+  #    allowed_organizations:
+  #    client_id:
+  #    client_secret:
+  ## LDAP Authentication can be enabled with the following values on grafana.ini
+  ## NOTE: Grafana will fail to start if the value for ldap.toml is invalid
+    # auth.ldap:
+    #   enabled: true
+    #   allow_sign_up: true
+    #   config_file: /etc/grafana/ldap.toml
+
+  ## Grafana's LDAP configuration
+  ## Templated by the template in _helpers.tpl
+  ## NOTE: To enable the grafana.ini must be configured with auth.ldap.enabled
+  ## ref: http://docs.grafana.org/installation/configuration/#auth-ldap
+  ## ref: http://docs.grafana.org/installation/ldap/#configuration
+  ldap:
+    enabled: false
+    # `existingSecret` is a reference to an existing secret containing the ldap configuration
+    # for Grafana in a key `ldap-toml`.
+    existingSecret: ""
+    # `config` is the content of `ldap.toml` that will be stored in the created secret
+    config: ""
+    # config: |-
+    #   verbose_logging = true
+
+    #   [[servers]]
+    #   host = "my-ldap-server"
+    #   port = 636
+    #   use_ssl = true
+    #   start_tls = false
+    #   ssl_skip_verify = false
+    #   bind_dn = "uid=%s,ou=users,dc=myorg,dc=com"
+
+  ## Grafana's SMTP configuration
+  ## NOTE: To enable, grafana.ini must be configured with smtp.enabled
+  ## ref: http://docs.grafana.org/installation/configuration/#smtp
+  smtp:
+    # `existingSecret` is a reference to an existing secret containing the smtp configuration
+    # for Grafana.
+    existingSecret: ""
+    userKey: "user"
+    passwordKey: "password"
+
+  ## Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders
+  ## Requires at least Grafana 5 to work and can't be used together with parameters dashboardProviders, datasources and dashboards
+  sidecar:
+    image:
+      repository: kiwigrid/k8s-sidecar
+      tag: 0.1.151
+      sha: ""
+    imagePullPolicy: IfNotPresent
+    resources: {}
+  #   limits:
+  #     cpu: 100m
+  #     memory: 100Mi
+  #   requests:
+  #     cpu: 50m
+  #     memory: 50Mi
+    # skipTlsVerify Set to true to skip tls verification for kube api calls
+    # skipTlsVerify: true
+    enableUniqueFilenames: false
+    dashboards:
+      enabled: false
+      SCProvider: true
+      # label that the configmaps with dashboards are marked with
+      label: grafana_dashboard
+      # folder in the pod that should hold the collected dashboards (unless `defaultFolderName` is set)
+      folder: /tmp/dashboards
+      # The default folder name, it will create a subfolder under the `folder` and put dashboards in there instead
+      defaultFolderName: null
+      # If specified, the sidecar will search for dashboard config-maps inside this namespace.
+      # Otherwise the namespace in which the sidecar is running will be used.
+      # It's also possible to specify ALL to search in all namespaces
+      searchNamespace: null
+      # provider configuration that lets grafana manage the dashboards
+      provider:
+        # name of the provider, should be unique
+        name: sidecarProvider
+        # orgid as configured in grafana
+        orgid: 1
+        # folder in which the dashboards should be imported in grafana
+        folder: ''
+        # type of the provider
+        type: file
+        # disableDelete to activate a import-only behaviour
+        disableDelete: false
+        # allow updating provisioned dashboards from the UI
+        allowUiUpdates: false
+    datasources:
+      enabled: false
+      # label that the configmaps with datasources are marked with
+      label: grafana_datasource
+      # If specified, the sidecar will search for datasource config-maps inside this namespace.
+      # Otherwise the namespace in which the sidecar is running will be used.
+      # It's also possible to specify ALL to search in all namespaces
+      searchNamespace: null
+    notifiers:
+      enabled: false
+      # label that the configmaps with notifiers are marked with
+      label: grafana_notifier
+      # If specified, the sidecar will search for notifier config-maps inside this namespace.
+      # Otherwise the namespace in which the sidecar is running will be used.
+      # It's also possible to specify ALL to search in all namespaces
+      searchNamespace: null
 
 ## Component scraping the kube api server
 ##

--- a/ct.yaml
+++ b/ct.yaml
@@ -6,6 +6,7 @@ chart-dirs:
 chart-repos:
   - stable=https://kubernetes-charts.storage.googleapis.com/
   - prometheus-community=https://prometheus-community.github.io/helm-charts
+  - grafana=https://grafana.github.io/helm-charts
 helm-extra-args: --timeout 600s
 excluded-charts:
   # If not running on GCE, will error: "Failed to get GCE config"


### PR DESCRIPTION
Signed-off-by: gkarthiks <github.gkarthiks@gmail.com>

This PR is to update the Grafana's dependent repository from **`stable`** to **`grafana`**.

## ⚠️  Major Changes
👉  Version of Grafana chart has been upgraded from `5.3.*` to `5.6.*`
👉  `values.yaml` file's default value for Grafana has been same even after the bump of grafana chart.

### Addresses: https://github.com/prometheus-community/helm-charts/issues/30



/cc @bismarck @gianrubio @vsliouniaev 
🗒️  I also added myself as an additional maintainer to the chart.