### PR TITLE
[prometheus-blackbox-exporter] fix linting failure due to deprecated api version (see issue #56)

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 4.3.1
+version: 4.3.2
 appVersion: 0.16.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/charts/prometheus-blackbox-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-blackbox-exporter/templates/_helpers.tpl
@@ -40,3 +40,14 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for rbac.
+*/}}
+{{- define "rbac.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
+{{- print "rbac.authorization.k8s.io/v1" -}}
+{{- else -}}
+{{- print "rbac.authorization.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/prometheus-blackbox-exporter/templates/role.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.pspEnabled }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:

--- a/charts/prometheus-blackbox-exporter/templates/role.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.pspEnabled }}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ template "rbac.apiVersion" . }}
 kind: Role
 metadata:
   labels:

--- a/charts/prometheus-blackbox-exporter/templates/rolebinding.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.pspEnabled }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:

--- a/charts/prometheus-blackbox-exporter/templates/rolebinding.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.pspEnabled }}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ template "rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   labels:


### PR DESCRIPTION
Signed-off-by: Jorrit Salverda <jsalverda@travix.com>

#### Is this a new chart

No

#### What this PR does / why we need it:

To fix `helm lint` from failing on deprecated api versions in `role` and `rolebinding`

#### Which issue this PR fixes

  - fixes #56

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)