### PR TITLE
[kube-prometheus-stack] Fix Chart Name and Rm Whitespaces in "NOTES.txt"

### DIFF
--- a/charts/kube-prometheus-stack/templates/NOTES.txt
+++ b/charts/kube-prometheus-stack/templates/NOTES.txt
@@ -1,4 +1,4 @@
-kube-prometheus has been installed. Check its status by running:
+{{ $.Chart.Name }} has been installed. Check its status by running:
   kubectl --namespace {{ template "kube-prometheus-stack.namespace" . }} get pods -l "release={{ $.Release.Name }}"
 
 Visit https://github.com/prometheus-operator/kube-prometheus for instructions on how

--- a/charts/kube-prometheus-stack/templates/NOTES.txt
+++ b/charts/kube-prometheus-stack/templates/NOTES.txt
@@ -1,5 +1,4 @@
 {{ $.Chart.Name }} has been installed. Check its status by running:
   kubectl --namespace {{ template "kube-prometheus-stack.namespace" . }} get pods -l "release={{ $.Release.Name }}"
 
-Visit https://github.com/prometheus-operator/kube-prometheus for instructions on how
-to create & configure Alertmanager and Prometheus instances using the Operator.
+Visit https://github.com/prometheus-operator/kube-prometheus for instructions on how to create & configure Alertmanager and Prometheus instances using the Operator.


### PR DESCRIPTION
Signed-off-by: Xtigyro <miroslav.hadzhiev@gmail.com>

#### What this PR does / why we need it:

Fixes the name of the chart and removes whitespaces in `templates/NOTES.txt`.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [already done in original PR] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
