### PR TITLE
[prometheus] set rbac api version with template rbac.apiVersion

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 11.13.1
+version: 11.13.2
 appVersion: 2.20.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 11.13.2
+version: 11.14.0
 appVersion: 2.20.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/templates/_helpers.tpl
+++ b/charts/prometheus/templates/_helpers.tpl
@@ -192,6 +192,16 @@ Return the appropriate apiVersion for podsecuritypolicy.
 {{- print "policy/v1beta1" -}}
 {{- end -}}
 {{- end -}}
+{{/*
+Return the appropriate apiVersion for rbac.
+*/}}
+{{- define "rbac.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
+{{- print "rbac.authorization.k8s.io/v1" -}}
+{{- else -}}
+{{- print "rbac.authorization.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}
 
 {{/*
 Create the name of the service account to use for the alertmanager component

--- a/charts/prometheus/templates/rbac/alertmanager-clusterrole.yaml
+++ b/charts/prometheus/templates/rbac/alertmanager-clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.alertmanager.enabled .Values.rbac.create .Values.alertmanager.useClusterRole (not .Values.alertmanager.useExistingRole) -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   labels:

--- a/charts/prometheus/templates/rbac/alertmanager-clusterrolebinding.yaml
+++ b/charts/prometheus/templates/rbac/alertmanager-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.alertmanager.enabled .Values.rbac.create .Values.alertmanager.useClusterRole -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   labels:

--- a/charts/prometheus/templates/rbac/alertmanager-role.yaml
+++ b/charts/prometheus/templates/rbac/alertmanager-role.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.alertmanager.enabled .Values.rbac.create (eq .Values.alertmanager.useClusterRole false) (not .Values.alertmanager.useExistingRole) -}}
 {{- range $.Values.alertmanager.namespaces }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: {{ template "rbac.apiVersion" . }}
 kind: Role
 metadata:
   labels:

--- a/charts/prometheus/templates/rbac/alertmanager-rolebinding.yaml
+++ b/charts/prometheus/templates/rbac/alertmanager-rolebinding.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.alertmanager.enabled .Values.rbac.create (eq .Values.alertmanager.useClusterRole false) -}}
 {{ range $.Values.alertmanager.namespaces }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: {{ template "rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   labels:

--- a/charts/prometheus/templates/rbac/node-exporter-role.yaml
+++ b/charts/prometheus/templates/rbac/node-exporter-role.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.nodeExporter.enabled .Values.rbac.create }}
 {{- if or (default .Values.nodeExporter.podSecurityPolicy.enabled false) (.Values.podSecurityPolicy.enabled) }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: {{ template "rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ template "prometheus.nodeExporter.fullname" . }}

--- a/charts/prometheus/templates/rbac/node-exporter-rolebinding.yaml
+++ b/charts/prometheus/templates/rbac/node-exporter-rolebinding.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.nodeExporter.enabled .Values.rbac.create }}
 {{- if .Values.podSecurityPolicy.enabled }}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ template "rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   name: {{ template "prometheus.nodeExporter.fullname" . }}

--- a/charts/prometheus/templates/rbac/pushgateway-clusterrole.yaml
+++ b/charts/prometheus/templates/rbac/pushgateway-clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.pushgateway.enabled .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   labels:

--- a/charts/prometheus/templates/rbac/pushgateway-clusterrolebinding.yaml
+++ b/charts/prometheus/templates/rbac/pushgateway-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.pushgateway.enabled .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   labels:

--- a/charts/prometheus/templates/rbac/server-clusterrole.yaml
+++ b/charts/prometheus/templates/rbac/server-clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.server.enabled .Values.rbac.create (empty .Values.server.useExistingClusterRoleName) -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   labels:

--- a/charts/prometheus/templates/rbac/server-clusterrolebinding.yaml
+++ b/charts/prometheus/templates/rbac/server-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.server.enabled .Values.rbac.create (empty .Values.server.namespaces) (empty .Values.server.useExistingClusterRoleName) -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   labels:

--- a/charts/prometheus/templates/rbac/server-rolebinding.yaml
+++ b/charts/prometheus/templates/rbac/server-rolebinding.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.server.enabled .Values.rbac.create .Values.server.useExistingClusterRoleName .Values.server.namespaces -}}
 {{ range $.Values.server.namespaces -}}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: {{ template "rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   labels:


### PR DESCRIPTION
Signed-off-by: Jorrit Salverda <jsalverda@travix.com>

#### What this PR does / why we need it:

To successfully lint the helm chart with the latest version of Helm the rbac apiVersion needs to be returned as `rbac.authorization.k8s.io/v1`, since `rbac.authorization.k8s.io/v1beta1` is marked for deprecation.

#### Which issue this PR fixes
  - fixes #65 

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
