### PR TITLE
[kube-prometheus-stack] Add "xtigyro" as Maintainer for "kube-prometheus-stack"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 # Unless a later match takes precedence, they will be requested for review when someone opens a pull request.
 * @prometheus-community/helm-charts-admins
 
-/charts/kube-prometheus-stack/ @vsliouniaev @bismarck @gianrubio @gkarthiks @scottrigby
+/charts/kube-prometheus-stack/ @vsliouniaev @bismarck @gianrubio @gkarthiks @scottrigby @Xtigyro
 /charts/prometheus/ @gianrubio @zanhsieh @Xtigyro @monotek @naseemkullah
 /charts/prometheus-adapter/ @mattiasgees @steven-sheehy @hectorj2f
 /charts/prometheus-blackbox-exporter/ @desaintmartin @gianrubio @monotek @rsotnychenko

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -11,11 +11,13 @@ maintainers:
     email: github.gkarthiks@gmail.com
   - name: scottrigby
     email: scott@r6by.com
+  - name: Xtigyro
+    email: miroslav.hadzhiev@gmail.com
 name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-operator/kube-prometheus
   - https://github.com/prometheus-operator/prometheus-operator
-version: 9.3.3
+version: 9.3.4
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/prometheus-operator/kube-prometheus


### PR DESCRIPTION
Signed-off-by: Xtigyro <miroslav.hadzhiev@gmail.com>

#### What this PR does / why we need it:

Adds @Xtigyro as a maintainer of the `kube-prometheus-stack` chart.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
