### PR TITLE
[gh-pages] Artifact Hub verified fix repositoryID

### DIFF
--- a/artifacthub-repo.yaml
+++ b/artifacthub-repo.yaml
@@ -1,5 +1,5 @@
 # Artifact Hub repository metadata file
-repositoryID: prometheus-community
+repositoryID: 61b55c4e-f8ef-4a51-9595-695560540ca3
 owners:
   - name: scottrigby
     email: scott@r6by.com


### PR DESCRIPTION
Fixes #75

format was incorrect. repositoryID is a UUID. See https://github.com/artifacthub/hub/blob/master/docs/chart/artifacthub-repo.yml