### PR TITLE
[kube-prometheus-stack] add secret-field-selector

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -17,7 +17,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-operator/kube-prometheus
   - https://github.com/prometheus-operator/prometheus-operator
-version: 9.3.4
+version: 9.3.5
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -75,6 +75,9 @@ spec:
             {{- end }}
             - --config-reloader-cpu={{ .Values.prometheusOperator.configReloaderCpu }}
             - --config-reloader-memory={{ .Values.prometheusOperator.configReloaderMemory }}
+            {{- if .Values.prometheusOperator.secretFieldSelector }}
+            - --secret-field-selector={{ .Values.prometheusOperator.secretFieldSelector }}
+            {{- end }}
           ports:
             - containerPort: 8080
               name: http

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1362,6 +1362,10 @@ prometheusOperator:
   ##
   configReloaderMemory: 25Mi
 
+  ## Set a Field Selector to filter watched secrets
+  ##
+  secretFieldSelector: ""
+
   ## Hyperkube image to use when cleaning up
   ##
   hyperkubeImage:


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

Following prometheus-operator/prometheus-operator#3355, add support for this new option. This should be released in v0.41.0.
This option is used to filter out secrets that are usually watched by the operator but not useful. This includes filtering out Helm V3 secrets which can cause significant CPU and Memory usage or to select only Prometheus Secret if you want to tag them all with a type (or any Field Selector actually).

Old PR: helm/charts#23330

#### Which issue this PR fixes

None

#### Special notes for your reviewer:

This should not introduce any breaking change and should work (not enable the option but not crash the operator) before v0.41.0. I did not version-gate the option for this reason.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
