### PR TITLE
[prometheus-node-exporter] Add rootfs mount by default

### DIFF
--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.1
 description: A Helm chart for prometheus node-exporter
 name: prometheus-node-exporter
-version: 1.11.2
+version: 1.11.3
 home: https://github.com/prometheus/node_exporter/
 sources:
 - https://github.com/prometheus/node_exporter/

--- a/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -38,6 +38,7 @@ spec:
           args:
             - --path.procfs=/host/proc
             - --path.sysfs=/host/sys
+            - --path.rootfs=/host/root
             - --web.listen-address=$(HOST_IP):{{ .Values.service.port }}
 {{- if .Values.extraArgs }}
 {{ toYaml .Values.extraArgs | indent 12 }}
@@ -72,6 +73,10 @@ spec:
               readOnly:  true
             - name: sys
               mountPath: /host/sys
+              readOnly: true
+            - name: root
+              mountPath: /host/root
+              mountPropagation: HostToContainer
               readOnly: true
             {{- if .Values.extraHostVolumeMounts }}
             {{- range $_, $mount := .Values.extraHostVolumeMounts }}
@@ -128,6 +133,9 @@ spec:
         - name: sys
           hostPath:
             path: /sys
+        - name: root
+          hostPath:
+            path: /
         {{- if .Values.extraHostVolumeMounts }}
         {{- range $_, $mount := .Values.extraHostVolumeMounts }}
         - name: {{ $mount.name }}


### PR DESCRIPTION
Signed-off-by: Dan Jones <dan@palm93.com>

@gianrubio 
@vsliouniaev 

#### What this PR does / why we need it:
Adds rootfs mount by default, resolving an issue where root filesystem metrics are incorrectly reported if the container runtime storage is not on the host root filesystem.

#### Which issue this PR fixes
issue from old repo: https://github.com/helm/charts/issues/22905

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
