### PR TITLE
[kube-prometheus-stack] Allow autoTagVersion for hyperkube image

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -17,7 +17,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-operator/kube-prometheus
   - https://github.com/prometheus-operator/prometheus-operator
-version: 9.3.4
+version: 9.4.0
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/cleanup-crds.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/cleanup-crds.yaml
@@ -24,7 +24,9 @@ spec:
     {{- end }}
       containers:
         - name: kubectl
-          {{- if .Values.prometheusOperator.hyperkubeImage.sha }}
+          {{- if .Values.prometheusOperator.hyperkubeImage.autoTagVersion}}
+           image: "{{ .Values.prometheusOperator.hyperkubeImage.repository }}:{{ .Capabilities.KubeVersion.GitVersion }}"
+          {{- else if .Values.prometheusOperator.hyperkubeImage.sha }}
           image: {{ .Values.prometheusOperator.hyperkubeImage.repository }}:{{ .Values.prometheusOperator.hyperkubeImage.tag }}@sha256:{{ .Values.prometheusOperator.hyperkubeImage.sha }}
           {{- else }}
           image: "{{ .Values.prometheusOperator.hyperkubeImage.repository }}:{{ .Values.prometheusOperator.hyperkubeImage.tag }}"

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1366,6 +1366,9 @@ prometheusOperator:
   ##
   hyperkubeImage:
     repository: k8s.gcr.io/hyperkube
+    ## When autoTagVersion is enabled, tag will default to the deployed Kubernetes version
+    ##
+    autoTagVersion: false
     tag: v1.16.12
     sha: ""
     pullPolicy: IfNotPresent


### PR DESCRIPTION
Valentin Zayash <valioozz@gmail.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
This PR will allow to conditionally set image tag for `hyperkube` depending on installed Kubernetes version using Helm's built-in `Capabilities`.

https://v2.helm.sh/docs/chart_template_guide/#built-in-objects
> `Capabilities.KubeVersion` provides a way to look up the Kubernetes version. It has the following values: `Major`, `Minor`, `GitVersion`, `GitCommit`, `GitTreeState`, `BuildDate`, `GoVersion`, `Compiler`, and `Platform`.

It will be really useful to avoid manual reconfiguration across clusters with different versions.
It won't affect existing installation until `autoTagVersion` will be set to `true`

#### Special notes for your reviewer:
This PR was previously opened to the `stable/chart` - [#23590](https://github.com/helm/charts/pull/23590)
#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
