### PR TITLE
[kube-prometheus-stack] Update README.md

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -17,7 +17,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-operator/kube-prometheus
   - https://github.com/prometheus-operator/prometheus-operator
-version: 9.4.0
+version: 9.4.1
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/hack/README.md
+++ b/charts/kube-prometheus-stack/hack/README.md
@@ -13,7 +13,7 @@ Currently following imported:
 
      ```bash
      jb update
-     make generate-in-docker
+     make generate
      ```
 
     - prepare and merge PR with imported changes into `prometheus-operator/kube-prometheus` master and/or release branch
@@ -38,7 +38,7 @@ Currently following imported:
 
      ```bash
      jb update
-     make generate-in-docker
+     make generate
      ```
 
     - prepare and merge PR with imported changes into `prometheus-operator/kube-prometheus` master and/or release branch


### PR DESCRIPTION
### What this PR does / why we need it:

Looks like the generate command was renamed here https://github.com/prometheus-operator/kube-prometheus/commit/0f6cd6d0a8881ad7e80f2817c597dab8345f8790#diff-b67911656ef5d18c4ae36cb6741b7965

#### Checklist
I don't think we need to bump version number here. 

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped 
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
