### PR TITLE
[kube-prometheus-stack] Add instance namespaces arguments for prometheus-operator deployment

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -17,7 +17,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 10.0.2
+version: 10.1.0
 appVersion: 0.42.1
 tillerVersion: ">=2.12.0"
 kubeVersion: ">=1.16.0-0"

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -75,6 +75,15 @@ spec:
             {{- end }}
             - --config-reloader-cpu={{ .Values.prometheusOperator.configReloaderCpu }}
             - --config-reloader-memory={{ .Values.prometheusOperator.configReloaderMemory }}
+            {{- if .Values.prometheusOperator.alertmanagerInstanceNamespaces }}
+            - --alertmanager-instance-namespaces={{ .Values.prometheusOperator.alertmanagerInstanceNamespaces | join "," }}
+            {{- end }}
+            {{- if .Values.prometheusOperator.prometheusInstanceNamespaces }}
+            - --prometheus-instance-namespaces={{ .Values.prometheusOperator.prometheusInstanceNamespaces | join "," }}
+            {{- end }}
+            {{- if .Values.prometheusOperator.thanosInstanceNamespaces }}
+            - --thanos-instance-namespaces={{ .Values.prometheusOperator.thanosInstanceNamespaces | join "," }}
+            {{- end }}
             {{- if .Values.prometheusOperator.secretFieldSelector }}
             - --secret-field-selector={{ .Values.prometheusOperator.secretFieldSelector }}
             {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -39,28 +39,28 @@ spec:
           {{- end }}
           imagePullPolicy: "{{ .Values.prometheusOperator.image.pullPolicy }}"
           args:
-          {{- if semverCompare "< v0.39.0" .Values.prometheusOperator.image.tag }}
+            {{- if semverCompare "< v0.39.0" .Values.prometheusOperator.image.tag }}
             - --manage-crds={{ .Values.prometheusOperator.manageCrds }}
-          {{- end }}
-          {{- if .Values.prometheusOperator.kubeletService.enabled }}
+            {{- end }}
+            {{- if .Values.prometheusOperator.kubeletService.enabled }}
             - --kubelet-service={{ .Values.prometheusOperator.kubeletService.namespace }}/{{ template "kube-prometheus-stack.fullname" . }}-kubelet
-          {{- end }}
-          {{- if .Values.prometheusOperator.logFormat }}
+            {{- end }}
+            {{- if .Values.prometheusOperator.logFormat }}
             - --log-format={{ .Values.prometheusOperator.logFormat }}
-          {{- end }}
-          {{- if .Values.prometheusOperator.logLevel }}
+            {{- end }}
+            {{- if .Values.prometheusOperator.logLevel }}
             - --log-level={{ .Values.prometheusOperator.logLevel }}
-          {{- end }}
-          {{- if .Values.prometheusOperator.denyNamespaces }}
+            {{- end }}
+            {{- if .Values.prometheusOperator.denyNamespaces }}
             - --deny-namespaces={{ .Values.prometheusOperator.denyNamespaces | join "," }}
-          {{- end }}
-          {{- with $.Values.prometheusOperator.namespaces }}
-          {{ $ns := .additional }}
-          {{- if .releaseNamespace }}
-          {{- $ns = append $ns $namespace }}
-          {{- end }}
+            {{- end }}
+            {{- with $.Values.prometheusOperator.namespaces }}
+            {{ $ns := .additional }}
+            {{- if .releaseNamespace }}
+            {{- $ns = append $ns $namespace }}
+            {{- end }}
             - --namespaces={{ $ns | join "," }}
-          {{- end }}
+            {{- end }}
             - --logtostderr=true
             - --localhost=127.0.0.1
             {{- if .Values.prometheusOperator.prometheusConfigReloaderImage.sha }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1204,6 +1204,12 @@ prometheusOperator:
   ##
   denyNamespaces: []
 
+  ## Filter namespaces to look for prometheus-operator custom resources
+  ##
+  alertmanagerInstanceNamespaces: []
+  prometheusInstanceNamespaces: []
+  thanosInstanceNamespaces: []
+
   ## Service account for Alertmanager to use.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
   ##


### PR DESCRIPTION
#### What this PR does / why we need it:
Allow configuring namespaces where prometheus-operator searches for custom resources to deploy. This allows narrowing the scope of permissions for prometheus-operator service account.

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:
The flags can be consulted here https://github.com/prometheus-operator/prometheus-operator/blob/master/cmd/operator/main.go#L177.

Original [PR](https://github.com/helm/charts/pull/23667).

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
