### PR TITLE
[prometheus-postgres-exporter] add extraVolumeMounts and examples

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.8.0"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 1.3.2
+version: 1.3.3
 home: https://github.com/wrouesnel/postgres_exporter
 sources:
 - https://github.com/wrouesnel/postgres_exporter

--- a/charts/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/charts/prometheus-postgres-exporter/templates/deployment.yaml
@@ -91,6 +91,9 @@ spec:
             - name: queries
               mountPath: /etc/config.yaml
               subPath: config.yaml
+{{- with .Values.extraVolumeMounts }}
+{{ tpl . $ | indent 12 }}
+{{- end }}
 {{- with .Values.extraContainers }}
 {{ tpl . $ | indent 8 }}
 {{- end }}

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -319,8 +319,6 @@ extraVolumes: |
 #        path: ca-certificates.crt
 #      secretName: ssl-certs
 
-
-
 # Additional volume mounts
 extraVolumeMounts: | 
 

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -320,7 +320,7 @@ extraVolumes: |
 #      secretName: ssl-certs
 
 # Additional volume mounts
-extraVolumeMounts: | 
+extraVolumeMounts: |
 
 # Uncomment for mounting custom ca-certificates file into container
 #  - name: ssl-certs

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -309,3 +309,22 @@ extraContainers: |
 
 # Additional volumes, e. g. for secrets used in an extraContainer
 extraVolumes: |
+
+# Uncomment for mounting custom ca-certificates
+#  - name: ssl-certs
+#    secret:
+#      defaultMode: 420
+#      items:
+#      - key: ca-certificates.crt
+#        path: ca-certificates.crt
+#      secretName: ssl-certs
+
+
+
+# Additional volume mounts
+extraVolumeMounts: | 
+
+# Uncomment for mounting custom ca-certificates file into container
+#  - name: ssl-certs
+#    mountPath: /etc/ssl/certs/ca-certificates.crt
+#    subPath: ca-certificates.crt


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

adds an extra volume mount so an extra volume can actually be mounted into the pod.

adds an example how to mount a custom ca-certificates files to allow SSL connections to postgres databases

#### Which issue this PR fixes

none

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
