### PR TITLE
[prometheus-blackbox-exporter] Allow custom labels for pods. Add service labels to values.yaml.

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 4.5.2
+version: 4.5.3
 appVersion: 0.17.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 4.5.3
+version: 4.6.0
 appVersion: 0.17.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/charts/prometheus-blackbox-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/daemonset.yaml
@@ -20,6 +20,9 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         helm.sh/chart: {{ include "prometheus-blackbox-exporter.chart" . }}
+        {{- if .Values.pod.labels }}
+{{ toYaml .Values.pod.labels | indent 8 }}
+        {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}

--- a/charts/prometheus-blackbox-exporter/templates/deployment.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/deployment.yaml
@@ -23,6 +23,9 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         helm.sh/chart: {{ include "prometheus-blackbox-exporter.chart" . }}
+        {{- if .Values.pod.labels }}
+{{ toYaml .Values.pod.labels | indent 8 }}
+        {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -85,6 +85,7 @@ priorityClassName: ""
 
 service:
   annotations: {}
+  labels: {}
   type: ClusterIP
   port: 9115
 
@@ -115,6 +116,9 @@ ingress:
     #     - chart-example.local
 
 podAnnotations: {}
+
+pods:
+  labels: {}
 
 extraArgs: []
 #  --history.limit=1000

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -117,7 +117,7 @@ ingress:
 
 podAnnotations: {}
 
-pods:
+pod:
   labels: {}
 
 extraArgs: []


### PR DESCRIPTION
#### What this PR does / why we need it:
Allow custom labels for pods. Also adds label option to service entry in values.yaml that was missed in commit [d696fd4c388fdece1026491248be0b45412c163a](https://github.com/prometheus-community/helm-charts/commit/d696fd4c388fdece1026491248be0b45412c163a)

#### Special notes for your reviewer:
I created a top-level `pods` entry in `values.yaml` to mimic other top-level resource values such as `service`, `ingress`, etc. However, there is currently a top-level entry named podAnnotations that I feel should fit under it. I however didn't change that key to be under `pods` as it would be a breaking change.

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
