### PR TITLE
[kube-prometheus-stack] Add a UID to the prometheus grafana chart

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -17,7 +17,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 9.4.4
+version: 9.4.5
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/prometheus.yaml
@@ -1221,7 +1221,7 @@ data:
         },
         "timezone": "utc",
         "title": "Prometheus Overview",
-        "uid": "",
+        "uid": "k3Mmw3dMk",
         "version": 0
     }
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Chris Jowett <cryptk@gmail.com>
#### What this PR does / why we need it:
Adds a UID to the prometheus dashboard so the URL will remain consistent across container restarts

#### Which issue this PR fixes
No open issue currently, but I can open one if you like

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
