### PR TITLE
[kube-prometheus-stack] Add details to access dashboards

### DIFF
--- a/charts/kube-prometheus-stack/README.md
+++ b/charts/kube-prometheus-stack/README.md
@@ -35,6 +35,25 @@ _See [configuration](#configuration) below._
 
 _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
 
+## Access Dashboards
+**Access Prometheus Dashboard**
+```console
+$ kubectl  port-forward svc/my-release-kube-prom-prometheus 9090:9090
+```
+Then you can access the dashboard on http://localhost:9090
+
+**Access Grafana Dashboard**
+```console
+$ kubectl  port-forward svc/my-release-grafana 3000:80
+```
+Use the **`username: admin` and `password: prom-operator`** to access the dashboard on http://localhost:3000
+
+**Access Alert Manager Dashboard**
+```console
+$ kubectl  port-forward svc/my-release-kube-prom-alertmanager  9093:9093
+```
+Then you can access the dashboard on http://localhost:9093
+
 ## Dependencies
 
 By default this chart installs additional, dependent charts:


### PR DESCRIPTION
Added the necessary commands and credentials to access the prometheus, grafana and alert-manager dashboards

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [x] Title of the PR starts with chart name
