### PR TITLE
[kube-prometheus-stack] Replacing hyperkube image with kubectl image from bitnami

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -17,7 +17,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 9.4.6
+version: 9.4.7
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/cleanup-crds.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/cleanup-crds.yaml
@@ -24,12 +24,12 @@ spec:
     {{- end }}
       containers:
         - name: kubectl
-          {{- if .Values.prometheusOperator.hyperkubeImage.sha }}
-          image: {{ .Values.prometheusOperator.hyperkubeImage.repository }}:{{ .Values.prometheusOperator.hyperkubeImage.tag }}@sha256:{{ .Values.prometheusOperator.hyperkubeImage.sha }}
+          {{- if .Values.prometheusOperator.kubectlImage.sha }}
+          image: "{{ .Values.prometheusOperator.kubectlImage.repository }}:{{ .Values.prometheusOperator.kubectlImage.tag }}@sha256:{{ .Values.prometheusOperator.kubectlImage.sha }}"
           {{- else }}
-          image: "{{ .Values.prometheusOperator.hyperkubeImage.repository }}:{{ .Values.prometheusOperator.hyperkubeImage.tag }}"
+          image: "{{ .Values.prometheusOperator.kubectlImage.repository }}:{{ .Values.prometheusOperator.kubectlImage.tag }}"
           {{- end }}
-          imagePullPolicy: "{{ .Values.prometheusOperator.hyperkubeImage.pullPolicy }}"
+          imagePullPolicy: "{{ .Values.prometheusOperator.kubectlImage.pullPolicy }}"
           command:
           - /bin/sh
           - -c

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1385,11 +1385,11 @@ prometheusOperator:
   ##
   secretFieldSelector: ""
 
-  ## Hyperkube image to use when cleaning up
+  ## kubectl image to use when cleaning up
   ##
-  hyperkubeImage:
-    repository: k8s.gcr.io/hyperkube
-    tag: v1.16.12
+  kubectlImage:
+    repository: docker.io/bitnami/kubectl
+    tag: 1.16.15
     sha: ""
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
#### What this PR does / why we need it:
The hypercube image has been deprecated and will no longer be built. Replacing with the kubectl image from the bitnami repository

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #156 

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
