### PR TITLE
kube-prometheus-stack/alertmanager Added more options for AlertManager ServiceMonitoring

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -17,7 +17,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 9.4.5
+version: 9.4.6
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/alertmanager/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/servicemonitor.yaml
@@ -21,6 +21,15 @@ spec:
     {{- if .Values.alertmanager.serviceMonitor.interval }}
     interval: {{ .Values.alertmanager.serviceMonitor.interval }}
     {{- end }}
+    {{- if .Values.alertmanager.serviceMonitor.scheme }}
+    scheme: {{ .Values.alertmanager.serviceMonitor.scheme }}
+    {{- end }}
+    {{- if .Values.alertmanager.serviceMonitor.bearerTokenFile }}
+    bearerTokenFile: {{ .Values.alertmanager.serviceMonitor.bearerTokenFile }}
+    {{- end }}
+    {{- if .Values.alertmanager.serviceMonitor.tlsConfig }}
+    tlsConfig: {{ toYaml .Values.alertmanager.serviceMonitor.tlsConfig | nindent 6 }}
+    {{- end }}
     path: "{{ trimSuffix "/" .Values.alertmanager.alertmanagerSpec.routePrefix }}/metrics"
 {{- if .Values.alertmanager.serviceMonitor.metricRelabelings }}
     metricRelabelings:

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -315,6 +315,15 @@ alertmanager:
     interval: ""
     selfMonitor: true
 
+    ## scheme: HTTP scheme to use for scraping. Can be used with `tlsConfig` for example if using istio mTLS.
+    scheme: ""
+
+    ## tlsConfig: TLS configuration to use when scraping the endpoint. For example if using istio mTLS.
+    ## Of type: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#tlsconfig
+    tlsConfig: {}
+
+    bearerTokenFile:
+
     ## 	metric relabel configs to apply to samples before ingestion.
     ##
     metricRelabelings: []


### PR DESCRIPTION
Signed-off-by: Philippe Bürgisser <philippe.burgisser@camptocamp.com>
#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)