### PR TITLE
[kube-prometheus-stack] set crd api version with template crd.apiVersion

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -17,7 +17,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 9.4.8
+version: 9.5.0
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/crds/crd-alertmanager.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-alertmanager.yaml
@@ -1,5 +1,5 @@
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: {{ template "crds.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/charts/kube-prometheus-stack/crds/crd-podmonitor.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-podmonitor.yaml
@@ -1,5 +1,5 @@
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: {{ template "crds.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/charts/kube-prometheus-stack/crds/crd-prometheus.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-prometheus.yaml
@@ -1,5 +1,5 @@
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: {{ template "crds.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/charts/kube-prometheus-stack/crds/crd-prometheusrules.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-prometheusrules.yaml
@@ -1,5 +1,5 @@
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: {{ template "crds.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/charts/kube-prometheus-stack/crds/crd-servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-servicemonitor.yaml
@@ -1,5 +1,5 @@
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: {{ template "crds.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/charts/kube-prometheus-stack/crds/crd-thanosrulers.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-thanosrulers.yaml
@@ -1,5 +1,5 @@
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-0.38/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: {{ template "crds.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/charts/kube-prometheus-stack/templates/_helpers.tpl
+++ b/charts/kube-prometheus-stack/templates/_helpers.tpl
@@ -91,3 +91,14 @@ Allow the release namespace to be overridden for multi-namespace deployments in 
     {{- .Release.Namespace -}}
   {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for custom resource definition.
+*/}}
+{{- define "crds.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1" }}
+{{- print "apiextensions.k8s.io/v1" -}}
+{{- else -}}
+{{- print "apiextensions.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/crds.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/crds.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.prometheusOperator.enabled .Values.prometheusOperator.createCustomResource -}}
 {{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
-{{ $.Files.Get $path }}
+{{ tpl ($.Files.Get $path) $ }}
 ---
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: John Chen <johnchen456@gmail.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
To successfully lint the helm chart with the latest version of Helm the CustomResourceDefinition `apiVersion` needs to be returned as `apiextensions.k8s.io/v1`, since `apiextensions.k8s.io/v1beta1` is marked for deprecation.
 
#### Which issue this PR fixes

#### Special notes for your reviewer:
The work done in this PR is similar to #66. 

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
