### PR TITLE
Pin super-linter to specific version

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -13,13 +13,14 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Lint Code Base
-        uses: github/super-linter@v3
+        uses: docker://github/super-linter:v3.12.0
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_BASH: false
           VALIDATE_PYTHON: false
           VALIDATE_PYTHON_FLAKE8: false
           VALIDATE_PYTHON_BLACK: false
+          VALIDATE_KUBERNETES_KUBEVAL: false
           VALIDATE_YAML: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Linter is failing in https://github.com/prometheus-community/helm-charts/pull/178/checks?check_run_id=1224114982

Looks like the GitHub action is using always the latest version.

The GitHub action refers to the v3 tag of the docker image:

```yaml
name: 'Super-Linter'
author: 'GitHub'
description: 'It is a simple combination of various linters, written in bash, to help validate your source code.'
runs:
  using: 'docker'
  image: 'docker://ghcr.io/github/super-linter:v3'
branding:
  icon: 'check-square'
  color: 'white'
```
https://github.com/github/super-linter/blob/master/action.yml


It's a floating tag as one can check in https://hub.docker.com/r/github/super-linter/tags

Kubeval was added in https://github.com/github/super-linter/releases/tag/v3.11.0

This PR does two things:
- it disables the newly added Kubeval validation and specifies a specific version of the linter so that it's on us to decide when to update.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
