### PR TITLE
[prometheus-blackbox-exporter] Added support of sidecars and extraVolumes

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 4.7.0
+version: 4.8.0
 appVersion: 0.17.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/charts/prometheus-blackbox-exporter/templates/deployment.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/deployment.yaml
@@ -90,7 +90,7 @@ spec:
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           ports:
-            - containerPort: {{ .Values.port }}
+            - containerPort: {{ .Values.service.port }}
               name: http
           livenessProbe:
             {{- toYaml .Values.livenessProbe | trim | nindent 12 }}

--- a/charts/prometheus-blackbox-exporter/templates/deployment.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/deployment.yaml
@@ -58,6 +58,9 @@ spec:
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
       containers:
+        {{- if .Values.extraContainers }}
+{{ toYaml .Values.extraContainers | indent 8 }}
+        {{- end }}      
         - name: blackbox-exporter
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -87,7 +90,7 @@ spec:
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           ports:
-            - containerPort: {{ .Values.service.port }}
+            - containerPort: {{ .Values.port }}
               name: http
           livenessProbe:
             {{- toYaml .Values.livenessProbe | trim | nindent 12 }}
@@ -116,6 +119,9 @@ spec:
         {{- toYaml .Values.dnsConfig | nindent 8 }}
 {{- end }}
       volumes:
+    {{- if .Values.extraVolumes }}      
+{{ toYaml .Values.extraVolumes | indent 8 }}      
+    {{- end }}      
         - name: config
 {{- if .Values.secretConfig }}
           secret:

--- a/charts/prometheus-blackbox-exporter/templates/service.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/service.yaml
@@ -19,6 +19,7 @@ spec:
   ports:
     - name: http
       port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
 {{- if .Values.service.externalIPs }}
   externalIPs:

--- a/charts/prometheus-blackbox-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/servicemonitor.yaml
@@ -16,7 +16,15 @@ metadata:
 spec:
   endpoints:
   - port: http
-    scheme: http
+    {{- if .Values.serviceMonitor.scheme }}
+    scheme: {{ .Values.serviceMonitor.scheme }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.bearerTokenFile }}
+    bearerTokenFile: {{ .Values.serviceMonitor.bearerTokenFile }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.tlsConfig }}
+    tlsConfig: {{ toYaml .Values.serviceMonitor.tlsConfig | nindent 6 }}
+    {{- end }}
     path: "/probe"
     interval: {{ .interval | default $.Values.serviceMonitor.defaults.interval }}
     scrapeTimeout: {{ .scrapeTimeout | default $.Values.serviceMonitor.defaults.scrapeTimeout }}

--- a/charts/prometheus-blackbox-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/servicemonitor.yaml
@@ -22,7 +22,7 @@ spec:
     {{- end }}
     {{- if $.Values.serviceMonitor.tlsConfig }}
     tlsConfig: {{ toYaml $.Values.serviceMonitor.tlsConfig | nindent 6 }}
-    {{- end }}
+    {{- end -}}
     path: "/probe"
     interval: {{ .interval | default $.Values.serviceMonitor.defaults.interval }}
     scrapeTimeout: {{ .scrapeTimeout | default $.Values.serviceMonitor.defaults.scrapeTimeout }}

--- a/charts/prometheus-blackbox-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/servicemonitor.yaml
@@ -16,14 +16,12 @@ metadata:
 spec:
   endpoints:
   - port: http
-    {{- if .Values.serviceMonitor.scheme }}
-    scheme: {{ .Values.serviceMonitor.scheme }}
+    scheme: {{ $.Values.serviceMonitor.scheme }}
+    {{- if $.Values.serviceMonitor.bearerTokenFile }}
+    bearerTokenFile: {{ $.Values.serviceMonitor.bearerTokenFile }}
     {{- end }}
-    {{- if .Values.serviceMonitor.bearerTokenFile }}
-    bearerTokenFile: {{ .Values.serviceMonitor.bearerTokenFile }}
-    {{- end }}
-    {{- if .Values.serviceMonitor.tlsConfig }}
-    tlsConfig: {{ toYaml .Values.serviceMonitor.tlsConfig | nindent 6 }}
+    {{- if $.Values.serviceMonitor.tlsConfig }}
+    tlsConfig: {{ toYaml $.Values.serviceMonitor.tlsConfig | nindent 6 }}
     {{- end }}
     path: "/probe"
     interval: {{ .interval | default $.Values.serviceMonitor.defaults.interval }}

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -68,7 +68,6 @@ runAsUser: 1000
 readOnlyRootFilesystem: true
 runAsNonRoot: true
 
-port: 9115
 
 livenessProbe:
   httpGet:
@@ -127,7 +126,7 @@ service:
   labels: {}
   type: ClusterIP
   port: 9115
-
+  targetPort: 9115
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -13,6 +13,35 @@ podDisruptionBudget: {}
 ##   NO_PROXY: "localhost,127.0.0.1"
 extraEnv: {}
 
+extraVolumes: []
+  # - name: secret-blackbox-oauth-htpasswd
+  #   secret:
+  #     defaultMode: 420
+  #     secretName: blackbox-oauth-htpasswd
+  # - name: storage-volume
+  #   persistentVolumeClaim:
+  #     claimName: example
+extraContainers: []
+  # - name: oAuth2-proxy
+  #   args:
+  #     - -https-address=:9116
+  #     - -upstream=http://localhost:9115
+  #     - -skip-auth-regex=^/metrics
+  #     - -openshift-delegate-urls={"/":{"group":"monitoring.coreos.com","resource":"prometheuses","verb":"get"}}
+  #   image: openshift/oauth-proxy:v1.1.0
+  #   ports:
+  #       - containerPort: 9116
+  #         name: proxy
+  #   resources:
+  #       limits:
+  #         memory: 16Mi
+  #       requests:
+  #         memory: 4Mi
+  #         cpu: 20m
+  #   volumeMounts:
+  #     - mountPath: /etc/prometheus/secrets/blackbox-tls
+  #       name: secret-blackbox-tls
+
 ## Enable pod security policy
 pspEnabled: true
 
@@ -38,6 +67,8 @@ image:
 runAsUser: 1000
 readOnlyRootFilesystem: true
 runAsNonRoot: true
+
+port: 9115
 
 livenessProbe:
   httpGet:
@@ -146,6 +177,14 @@ serviceMonitor:
     interval: 30s
     scrapeTimeout: 30s
     module: http_2xx
+  ## scheme: HTTP scheme to use for scraping. Can be used with `tlsConfig` for example if using istio mTLS.
+  scheme: ""
+  ## tlsConfig: TLS configuration to use when scraping the endpoint. For example if using istio mTLS.
+  ## Of type: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#tlsconfig
+  tlsConfig: {}
+  bearerTokenFile:
+
+
 
   targets:
 #    - name: example                    # Human readable URL that will appear in Prometheus / AlertManager

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -21,6 +21,7 @@ extraVolumes: []
   # - name: storage-volume
   #   persistentVolumeClaim:
   #     claimName: example
+
 extraContainers: []
   # - name: oAuth2-proxy
   #   args:

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -178,7 +178,7 @@ serviceMonitor:
     scrapeTimeout: 30s
     module: http_2xx
   ## scheme: HTTP scheme to use for scraping. Can be used with `tlsConfig` for example if using istio mTLS.
-  scheme: ""
+  scheme: http
   ## tlsConfig: TLS configuration to use when scraping the endpoint. For example if using istio mTLS.
   ## Of type: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#tlsconfig
   tlsConfig: {}

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -184,8 +184,6 @@ serviceMonitor:
   tlsConfig: {}
   bearerTokenFile:
 
-
-
   targets:
 #    - name: example                    # Human readable URL that will appear in Prometheus / AlertManager
 #      url: http://example.com/healthz  # The URL that blackbox will scrape


### PR DESCRIPTION
Signed-off-by: Philippe Bürgisser <philippe.burgisser@camptocamp.com>

#### What this PR does / why we need it:
- Adding support of multiple container in the same pod (side car, like oAuth-proxy)
- Adding support of multiple secret (necessary for oauth)
- Adding support of annotation on service, service account
- Adding support of authenticated Service Monitor

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)