### PR TITLE
[WIP][kube-prometheus-stack] Support native TLS in prometheus-operator

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -17,7 +17,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 10.1.3
+version: 10.3.1
 appVersion: 0.42.1
 tillerVersion: ">=2.12.0"
 kubeVersion: ">=1.16.0-0"

--- a/charts/kube-prometheus-stack/README.md
+++ b/charts/kube-prometheus-stack/README.md
@@ -86,6 +86,10 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 
 A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an incompatible breaking change needing manual actions.
 
+### From 10.x to 11.x
+
+Version 11 will remove the deprecated tlsProxy via ghostunnel in favor of native TLS support the prometheus-operator has gained with v0.39.0.
+
 ### From 9.x to 10.x
 
 Version 10 upgrades prometheus-operator to from 0.38.x 0.42.x. Starting with 0.40.x an additional `Probes` CRD is introduced. Helm does not automatically upgrade or install new CRDs on a chart upgrade, so you have to install the CRD manually before updating:

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -87,14 +87,30 @@ spec:
             {{- if .Values.prometheusOperator.secretFieldSelector }}
             - --secret-field-selector={{ .Values.prometheusOperator.secretFieldSelector }}
             {{- end }}
+            {{- if .Values.prometheusOperator.tls.enabled }}
+            - --web.enable-tls=true
+            - --web.cert-file=cert/cert
+            - --web.key-file=cert/key
+            - --web.listen-address=:8443
+          ports:
+            - containerPort: 8443
+              name: https
+          {{- else }}
           ports:
             - containerPort: 8080
               name: http
+          {{- end }}
           resources:
 {{ toYaml .Values.prometheusOperator.resources | indent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+          {{- if .Values.prometheusOperator.tls.enabled }}
+          volumeMounts:
+            - name: tls-proxy-secret
+              mountPath: /cert
+              readOnly: true
+          {{- end }}
         {{- if .Values.prometheusOperator.tlsProxy.enabled }}
         - name: tls-proxy
           {{- if .Values.prometheusOperator.tlsProxy.image.sha }}
@@ -123,7 +139,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         {{- end }}
-{{- if .Values.prometheusOperator.tlsProxy.enabled }}
+{{- if or .Values.prometheusOperator.tlsProxy.enabled .Values.prometheusOperator.tls.enabled }}
       volumes:
         - name: tls-proxy-secret
           secret:

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/service.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/service.yaml
@@ -32,13 +32,15 @@ spec:
   {{- end }}
 {{- end }}
   ports:
+  {{- if not .Values.prometheusOperator.tls.enabled }}
   - name: http
     {{- if eq .Values.prometheusOperator.service.type "NodePort" }}
     nodePort: {{ .Values.prometheusOperator.service.nodePort }}
     {{- end }}
     port: 8080
     targetPort: http
-  {{- if .Values.prometheusOperator.tlsProxy.enabled }}
+  {{- end }}
+  {{- if or .Values.prometheusOperator.tlsProxy.enabled .Values.prometheusOperator.tls.enabled }}
   - name: https
     {{- if eq .Values.prometheusOperator.service.type "NodePort"}}
     nodePort: {{ .Values.prometheusOperator.service.nodePortTls }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/servicemonitor.yaml
@@ -9,7 +9,19 @@ metadata:
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
   endpoints:
+  {{- if .Values.prometheusOperator.tls.enabled }}
+  - port: https
+    scheme: https
+    tlsConfig:
+      serverName: {{ template "kube-prometheus-stack.operator.fullname" . }}
+      ca:
+        secret:
+          name: {{ template "kube-prometheus-stack.fullname" . }}-admission
+          key: ca
+          optional: false
+  {{- else }}
   - port: http
+  {{- end }}
     honorLabels: true
     {{- if .Values.prometheusOperator.serviceMonitor.interval }}
     interval: {{ .Values.prometheusOperator.serviceMonitor.interval }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1158,6 +1158,7 @@ prometheusOperator:
   # Only for prometheusOperator.image.tag < v0.39.0
   manageCrds: true
 
+  # This is deprecated and will be removed in v11 of the chart. Please use native TLS support below.
   tlsProxy:
     enabled: true
     image:
@@ -1166,6 +1167,10 @@ prometheusOperator:
       sha: ""
       pullPolicy: IfNotPresent
     resources: {}
+
+  # Prometheus-Operator v0.39.0 and later support TLS natively. To preserve compatibility with tlsProxy, the secret tls-proxy-secret is reused
+  tls:
+    enabled: false
 
   ## Admission webhook support for PrometheusRules resources added in Prometheus Operator 0.30 can be enabled to prevent incorrectly formatted
   ## rules from making their way into prometheus and potentially preventing the container from starting


### PR DESCRIPTION
#### What this PR does / why we need it:
Allow native TLS supported by prometheus-operator v0.39.0 and later 

#### Special notes for your reviewer:
This is not tested yet and still WIP. 
To be discussed: Deprecate tlsproxy to simplify chart?

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
