### PR TITLE
Changed ghostunnel repo to include 1.5.3 (arm64)

### DIFF
--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1161,8 +1161,8 @@ prometheusOperator:
   tlsProxy:
     enabled: true
     image:
-      repository: squareup/ghostunnel
-      tag: v1.5.2
+      repository: ghostunnel/ghostunnel
+      tag: v1.5.3
       sha: ""
       pullPolicy: IfNotPresent
     resources: {}


### PR DESCRIPTION
Signed-off-by: Ben Thomas <benjamesthomas@gmail.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

The `kube-prometheus-stack` manifest currently pulls version 1.5.2 of squareup/ghostunnel image. This version was released in Nov 2019 before they supported the arm64 architecture. Version 1.5.3 at ghostunnel/ghostunnel now supports arm64.

I have tested this change by editing the top-level `values.yaml` of the `prometheus-community/kube-prometheus-stack` Helm Chart to reflect the same image name change as this PR.

Before:
```
$ kubectl --namespace monitoring get pods -l "release=prom-graf"
NAME                                                  READY   STATUS    RESTARTS   AGE
prom-graf-kube-prometheus-operator-68b49c6688-c6cl7   1/2     Error     2          39s
prom-graf-prometheus-node-exporter-5w8vw              1/1     Running   0          39s

$ kubectl logs prom-graf-kube-prometheus-operator-68b49c6688-c6cl7 -n monitoring tls-proxy
standard_init_linux.go:211: exec user process caused "exec format error"
```
After:

```
$ kubectl --namespace monitoring get pods -l "release=prom-graf"
NAME                                                  READY   STATUS    RESTARTS   AGE
prom-graf-kube-prometheus-operator-85bddb9c6b-lwtbj   2/2     Running   0          47m
prom-graf-prometheus-node-exporter-88nrp              1/1     Running   0          47m
prom-graf-prometheus-node-exporter-djbqr              1/1     Running   0          47m
```

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

https://github.com/helm/charts/issues/23405

This ticket discusses the problem of arm64 images, but was closed when the project was renamed.

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
