### PR TITLE
[prometheus-cloudwatch-exporter] Allow Helm variables in config

### DIFF
--- a/charts/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/charts/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.8.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.9.0
+version: 0.10.0
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/charts/prometheus-cloudwatch-exporter/templates/configmap.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/configmap.yaml
@@ -9,4 +9,4 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   config.yml: |
-{{ printf .Values.config | indent 4 }}
+{{ tpl .Values.config . | indent 4 }}

--- a/charts/prometheus-cloudwatch-exporter/templates/configmap.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/configmap.yaml
@@ -9,4 +9,4 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   config.yml: |
-{{ tpl .Values.config . | indent 4 }}
+    {{ tpl .Values.config . | nindent 4 }}

--- a/charts/prometheus-cloudwatch-exporter/values.yaml
+++ b/charts/prometheus-cloudwatch-exporter/values.yaml
@@ -76,6 +76,7 @@ rbac:
   # Specifies whether RBAC resources should be created
   create: true
 
+# Configuration is rendered with `tpl` function, therefore you can use any Helm variables and/or templates here
 config: |-
   # This is the default configuration for prometheus-cloudwatch-exporter
   region: eu-west-1


### PR DESCRIPTION
Signed-off-by: Rostyslav Sotnychenko <me@sota.sh>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
One might want to collect the exact same set of metrics in different environments, with a difference only in tag filter value (`metrics.*.aws_tag_select.tag_selections.someLabel=XXXX`).
Given that definition of what metrics to collect takes most of the configuration file, it's handy to have an ability to change a single variable instead of overwriting the whole config from scratch. 

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
