### PR TITLE
[kube-prometheus-stack] Allow use of Prometheus Operator master image tag

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -17,7 +17,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 10.1.2
+version: 10.2.0
 appVersion: 0.42.1
 tillerVersion: ">=2.12.0"
 kubeVersion: ">=1.16.0-0"

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -39,7 +39,8 @@ spec:
           {{- end }}
           imagePullPolicy: "{{ .Values.prometheusOperator.image.pullPolicy }}"
           args:
-            {{- if semverCompare "< v0.39.0" .Values.prometheusOperator.image.tag }}
+            {{- if eq .Values.prometheusOperator.image.tag "master" -}}
+            {{- else if (semverCompare "< v0.39.0" .Values.prometheusOperator.image.tag) -}}
             - --manage-crds={{ .Values.prometheusOperator.manageCrds }}
             {{- end }}
             {{- if .Values.prometheusOperator.kubeletService.enabled }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -39,7 +39,7 @@ spec:
           {{- end }}
           imagePullPolicy: "{{ .Values.prometheusOperator.image.pullPolicy }}"
           args:
-            {{- if eq .Values.prometheusOperator.image.tag "master" -}}
+            {{- if regexMatch "master.*" .Values.prometheusOperator.image.tag -}}
             {{- else if (semverCompare "< v0.39.0" .Values.prometheusOperator.image.tag) -}}
             - --manage-crds={{ .Values.prometheusOperator.manageCrds }}
             {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -39,6 +39,7 @@ spec:
           {{- end }}
           imagePullPolicy: "{{ .Values.prometheusOperator.image.pullPolicy }}"
           args:
+            # Empty if statement to catch non-semver master tags that do not need the --manage-crds flag
             {{- if regexMatch "master.*" .Values.prometheusOperator.image.tag -}}
             {{- else if (semverCompare "< v0.39.0" .Values.prometheusOperator.image.tag) -}}
             - --manage-crds={{ .Values.prometheusOperator.manageCrds }}


### PR DESCRIPTION
Signed-off-by: Sally Lehman <slehman@ripple.com>

#### What this PR does / why we need it:

The latest master build of the prometheus-operator chart cannot currently be used with kube-prometheus-stack because the deployment.yaml restricts customization only to release numbers.

This modification allows for releases, as well as the latest [master build of prometheus operator](https://quay.io/repository/prometheus-operator/prometheus-operator?tab=tags
) to be used with the chart.

cc'ing chart maintainers mentioned in Chart.yaml, as recommended in the Pull request guidelines:
@vsliouniaev @bismarck @gianrubio @gkarthiks @scottrigby @Xtigyro 

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
