### PR TITLE
[prometheus-blackbox-exporter] fix service monitor template

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 4.9.0
+version: 4.9.1
 appVersion: 0.18.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/charts/prometheus-blackbox-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/servicemonitor.yaml
@@ -22,7 +22,7 @@ spec:
     {{- end }}
     {{- if $.Values.serviceMonitor.tlsConfig }}
     tlsConfig: {{ toYaml $.Values.serviceMonitor.tlsConfig | nindent 6 }}
-    {{- end -}}
+    {{- end }}
     path: "/probe"
     interval: {{ .interval | default $.Values.serviceMonitor.defaults.interval }}
     scrapeTimeout: {{ .scrapeTimeout | default $.Values.serviceMonitor.defaults.scrapeTimeout }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Following 1d66906e0f792372e0f76e7e058a5dd507778fe4 the chart fails to render with the following error:
```
Error: YAML parse error on prometheus-blackbox-exporter/templates/servicemonitor.yaml: error converting YAML to JSON: yaml: line 12: mapping values are not allowed in this context
```

Issue replicate with the following vals:
```yaml
serviceMonitor:
  enabled: true
  targets:
    - name: example
      url: https://example.com
```

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
