### PR TITLE
[prometheus] Create PSP only when corresponding components enabled

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 11.16.2
+version: 11.16.3
 appVersion: 2.21.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/templates/alertmanager/psp.yaml
+++ b/charts/prometheus/templates/alertmanager/psp.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.rbac.create }}
-{{- if .Values.podSecurityPolicy.enabled }}
+{{- if and .Values.alertmanager.enabled .Values.rbac.create .Values.podSecurityPolicy.enabled }}
 apiVersion: {{ template "prometheus.podSecurityPolicy.apiVersion" . }}
 kind: PodSecurityPolicy
 metadata:
@@ -44,5 +43,4 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: true
-{{- end }}
 {{- end }}

--- a/charts/prometheus/templates/node-exporter/psp.yaml
+++ b/charts/prometheus/templates/node-exporter/psp.yaml
@@ -1,5 +1,4 @@
-{{- if and .Values.nodeExporter.enabled .Values.rbac.create }}
-{{- if .Values.podSecurityPolicy.enabled }}
+{{- if and .Values.nodeExporter.enabled .Values.rbac.create .Values.podSecurityPolicy.enabled }}
 apiVersion: {{ template "prometheus.podSecurityPolicy.apiVersion" . }}
 kind: PodSecurityPolicy
 metadata:
@@ -51,5 +50,4 @@ spec:
   hostPorts:
     - min: 1
       max: 65535
-{{- end }}
 {{- end }}

--- a/charts/prometheus/templates/pushgateway/psp.yaml
+++ b/charts/prometheus/templates/pushgateway/psp.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.rbac.create }}
-{{- if .Values.podSecurityPolicy.enabled }}
+{{- if and .Values.pushgateway.enabled .Values.rbac.create .Values.podSecurityPolicy.enabled }}
 apiVersion: {{ template "prometheus.podSecurityPolicy.apiVersion" . }}
 kind: PodSecurityPolicy
 metadata:
@@ -40,5 +39,4 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: true
-{{- end }}
 {{- end }}

--- a/charts/prometheus/templates/server/psp.yaml
+++ b/charts/prometheus/templates/server/psp.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.rbac.create }}
-{{- if .Values.podSecurityPolicy.enabled }}
+{{- if and .Values.server.enabled .Values.rbac.create .Values.podSecurityPolicy.enabled }}
 apiVersion: {{ template "prometheus.podSecurityPolicy.apiVersion" . }}
 kind: PodSecurityPolicy
 metadata:
@@ -49,5 +48,4 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
-{{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Qiu Yu <unicell@gmail.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

Currently once `.Values.podSecurityPolicy.enabled` is set to true, PSPs will be created for all components (server, alertmanager, pushgateway) regardless of their enabling states. This PR fixes that by adding additional checks.

#### Which issue this PR fixes

n/a

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
