### PR TITLE
[kube-prometheus-stack] Add support for ProbeSelector and ProbeNamespaceSelector

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -17,7 +17,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 10.1.0
+version: 10.1.1
 appVersion: 0.42.1
 tillerVersion: ">=2.12.0"
 kubeVersion: ">=1.16.0-0"

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -130,6 +130,22 @@ spec:
 {{ else }}
   podMonitorNamespaceSelector: {}
 {{- end }}
+{{- if .Values.prometheus.prometheusSpec.probeSelector }}
+  probeSelector:
+{{ toYaml .Values.prometheus.prometheusSpec.probeSelector | indent 4 }}
+{{ else if .Values.prometheus.prometheusSpec.probeSelectorNilUsesHelmValues  }}
+  probeSelector:
+    matchLabels:
+      release: {{ $.Release.Name | quote }}
+{{ else }}
+  probeSelector: {}
+{{- end }}
+{{- if .Values.prometheus.prometheusSpec.probeNamespaceSelector }}
+  probeNamespaceSelector:
+{{ toYaml .Values.prometheus.prometheusSpec.probeNamespaceSelector | indent 4 }}
+{{ else }}
+  probeNamespaceSelector: {}
+{{- end }}
 {{- if .Values.prometheus.prometheusSpec.remoteRead }}
   remoteRead:
 {{ toYaml .Values.prometheus.prometheusSpec.remoteRead | indent 4 }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1788,6 +1788,26 @@ prometheus:
     ##
     podMonitorNamespaceSelector: {}
 
+    ## If true, a nil or {} value for prometheus.prometheusSpec.probeSelector will cause the
+    ## prometheus resource to be created with selectors based on values in the helm deployment,
+    ## which will also match the podmonitors created
+    ##
+    probeSelectorNilUsesHelmValues: true
+
+    ## Probes to be selected for target discovery.
+    ## If {}, select all Probes
+    ##
+    probeSelector: {}
+    ## Example which selects Probes with label "prometheus" set to "somelabel"
+    # probeSelector:
+    #   matchLabels:
+    #     prometheus: somelabel
+
+    ## Namespaces to be selected for Probe discovery.
+    ## See https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#namespaceselector for usage
+    ##
+    probeNamespaceSelector: {}
+
     ## How long to retain metrics
     ##
     retention: 10d


### PR DESCRIPTION
#### What this PR does / why we need it:
Add probe properties in prometheus template and default values.

#### Which issue this PR fixes
  - fixes #235

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
