### PR TITLE
[kube-prometheus-stack] Add hint for zero downtime migration from stable/prometheus-operator

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -17,7 +17,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 10.1.0
+version: 10.1.1
 appVersion: 0.42.1
 tillerVersion: ">=2.12.0"
 kubeVersion: ">=1.16.0-0"

--- a/charts/kube-prometheus-stack/README.md
+++ b/charts/kube-prometheus-stack/README.md
@@ -220,7 +220,7 @@ To do so, you can set `prometheus.prometheusSpec.podMonitorSelectorNilUsesHelmVa
 
 ## Migrating from stable/prometheus-operator chart
 
-## Without downtime
+## Zero downtime
 
 Since `kube-prometheus-stack` is fully compatible with the `stable/prometheus-operator` chart a migration without downtime can be achieved.
 However the old name prefix needs to be kept. If you want the new name please follow the step by step guide bellow (with downtime).
@@ -228,7 +228,7 @@ However the old name prefix needs to be kept. If you want the new name please fo
 You can override the fullname to achieve this:
 
 ```
-helm upgrade prometheus-operator prometheus-community/kube-prometheus -n monitoring --set nameOverride=prometheus-operator --set fullnameOverride=prometheus-operator
+helm upgrade prometheus-operator prometheus-community/kube-prometheus-stack -n monitoring --set nameOverride=prometheus-operator --set fullnameOverride=prometheus-operator
 ```
 
 ## Redeploy with new name (downtime)

--- a/charts/kube-prometheus-stack/README.md
+++ b/charts/kube-prometheus-stack/README.md
@@ -227,9 +227,11 @@ However the old name prefix needs to be kept. If you want the new name please fo
 
 You can override the fullname to achieve this:
 
+```console
+helm upgrade prometheus-operator prometheus-community/kube-prometheus-stack -n monitoring --reuse-values --set nameOverride=prometheus-operator --set fullnameOverride=prometheus-operator
 ```
-helm upgrade prometheus-operator prometheus-community/kube-prometheus-stack -n monitoring --set nameOverride=prometheus-operator --set fullnameOverride=prometheus-operator
-```
+
+**Note**: It is recommended to run this first with `--dry-run --debug`.
 
 ## Redeploy with new name (downtime)
 

--- a/charts/kube-prometheus-stack/README.md
+++ b/charts/kube-prometheus-stack/README.md
@@ -220,6 +220,19 @@ To do so, you can set `prometheus.prometheusSpec.podMonitorSelectorNilUsesHelmVa
 
 ## Migrating from stable/prometheus-operator chart
 
+## Without downtime
+
+Since `kube-prometheus-stack` is fully compatible with the `stable/prometheus-operator` chart a migration without downtime can be achieved.
+However the old name prefix needs to be kept. If you want the new name please follow the step by step guide bellow (with downtime).
+
+You can override the fullname to achieve this:
+
+```
+helm upgrade prometheus-operator prometheus-community/kube-prometheus -n monitoring --set nameOverride=prometheus-operator --set fullnameOverride=prometheus-operator
+```
+
+## Redeploy with new name (downtime)
+
 If the **prometheus-operator** values are compatible with the new **kube-prometheus-stack** chart, please follow the below steps for migration:
 
 > The guide presumes that chart is deployed in `monitoring` namespace and the deployments are running there. If in other namespace, please replace the `monitoring` to the deployed namespace.


### PR DESCRIPTION
Signed-off-by: Raffael Sahli <raffael.sahli@doodle.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
The current description to migrate from stable/prometheus-operator only covers a migration path with downtime. In most cases people want a zero downtime migration.

This fairly small pr adds a simple hint to cover the fullnameOverride option.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
