### PR TITLE
[alertmanager] Add support change default config

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: v0.21.0
 maintainers:
   - name: naseemkullah

--- a/charts/alertmanager/templates/configmap.yaml
+++ b/charts/alertmanager/templates/configmap.yaml
@@ -5,5 +5,5 @@ metadata:
   labels:
     {{- include "alertmanager.labels" . | nindent 4 }}
 data:
-  alertmanager.yml: |
+  {{ .Values.configFileName }}: |
     {{- toYaml .Values.config | default "{}" | nindent 4 }}

--- a/charts/alertmanager/templates/configmap.yaml
+++ b/charts/alertmanager/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.config }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -5,5 +6,6 @@ metadata:
   labels:
     {{- include "alertmanager.labels" . | nindent 4 }}
 data:
-  {{ .Values.configFileName }}: |
+  alertmanager.yml: |
     {{- toYaml .Values.config | default "{}" | nindent 4 }}
+{{- end }}

--- a/charts/alertmanager/templates/configmap.yaml
+++ b/charts/alertmanager/templates/configmap.yaml
@@ -5,5 +5,5 @@ metadata:
   labels:
     {{- include "alertmanager.labels" . | nindent 4 }}
 data:
-  config.yml: |
+  alertmanager.yml: |
     {{- toYaml .Values.config | default "{}" | nindent 4 }}

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -28,15 +28,14 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if or .Values.extraArgs .Values.configFileName }}
           args: 
-            {{- range $key, $value := .Values.extraArgs }}
-            - --{{ $key }}={{ $value }}
-            {{- end }}
+            --storage.path=/alertmanager
             {{- if .Values.configFileName }}
             - --config.file=/etc/alertmanager/{{ .Values.configFileName }}
             {{- end }}
-          {{- end }}
+            {{- range $key, $value := .Values.extraArgs }}
+            - --{{ $key }}={{ $value }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 9093

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -28,6 +28,15 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if or .Values.extraArgs .Values.configFileName }}
+          args: 
+            {{- range $key, $value := .Values.extraArgs }}
+            - --{{ $key }}={{ $value }}
+            {{- end }}
+            {{- if .Values.configFileName }}
+            - --config.file=/etc/alertmanager/{{ .Values.configFileName }}
+            {{- end }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 9093
@@ -44,8 +53,8 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - name: config
-              mountPath: /etc/alertmanager/config.yml
-              subPath: config.yml
+              mountPath: /etc/alertmanager/{{ .Values.configFileName }}
+              subPath: {{ .Values.configFileName }}
             - name: storage
               mountPath: /alertmanager
       volumes:

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -29,7 +29,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: 
-            --storage.path=/alertmanager
+            - --storage.path=/alertmanager
             {{- if .Values.configFileName }}
             - --config.file=/etc/alertmanager/{{ .Values.configFileName }}
             {{- end }}

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -30,9 +30,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: 
             - --storage.path=/alertmanager
-            {{- if .Values.configFileName }}
-            - --config.file=/etc/alertmanager/{{ .Values.configFileName }}
-            {{- end }}
+            - --config.file=/etc/alertmanager/alertmanager.yml
             {{- range $key, $value := .Values.extraArgs }}
             - --{{ $key }}={{ $value }}
             {{- end }}
@@ -51,15 +49,19 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
+            {{- if .Values.config }}
             - name: config
-              mountPath: /etc/alertmanager/{{ .Values.configFileName }}
-              subPath: {{ .Values.configFileName }}
+              mountPath: /etc/alertmanager/alertmanager.yml
+              subPath: alertmanager.yml
+            {{- end }}
             - name: storage
               mountPath: /alertmanager
+      {{- if .Values.config }}
       volumes:
         - name: config
           configMap:
             name: {{ include "alertmanager.fullname" . }}
+      {{- end }}
 {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -9,7 +9,7 @@ image:
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
-  
+
 extraArgs: {}
 
 imagePullSecrets: []

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -9,6 +9,8 @@ image:
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
+  
+extraArgs: {}
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -81,6 +81,7 @@ persistence:
     - ReadWriteOnce
   size: 50Mi
 
+configFileName: alertmanager.yml
 config:
   global: {}
     # slack_api_url: ''

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -83,7 +83,6 @@ persistence:
     - ReadWriteOnce
   size: 50Mi
 
-configFileName: config.yml
 config:
   global: {}
     # slack_api_url: ''

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -83,7 +83,7 @@ persistence:
     - ReadWriteOnce
   size: 50Mi
 
-configFileName: alertmanager.yml
+configFileName: config.yml
 config:
   global: {}
     # slack_api_url: ''


### PR DESCRIPTION
#### What this PR does / why we need it:
Default image prom/alertmanager use configfile called `alertmanager.yml`, but in the chart we use configfile with name `config.yml`.
Configuration from `.Values.config` is rendered correctly but it doesn't matter because we don't use this configfile.
Also, we don't have an option how to say alertmanager to use our configfile.
This PR allows us to:
* use this configuration file (fix)
* configure the name of the configuration file.
* add some extra args if it needed.

#### Special notes for your reviewer:
We have added `configFileName` as param just in case when someone uses a custom image and default alertmanager.yml contains some kind of reference configurations or examples.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
