### PR TITLE
[prometheus] Make emptyDir settings consistent across components

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 11.16.3
+version: 11.16.4
 appVersion: 2.21.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/templates/alertmanager/deploy.yaml
+++ b/charts/prometheus/templates/alertmanager/deploy.yaml
@@ -144,6 +144,11 @@ spec:
           persistentVolumeClaim:
             claimName: {{ if .Values.alertmanager.persistentVolume.existingClaim }}{{ .Values.alertmanager.persistentVolume.existingClaim }}{{- else }}{{ template "prometheus.alertmanager.fullname" . }}{{- end }}
         {{- else }}
-          emptyDir: {}
+          emptyDir:
+          {{- if .Values.alertmanager.emptyDir.sizeLimit }}
+            sizeLimit: {{ .Values.alertmanager.emptyDir.sizeLimit }}
+          {{- else }}
+            {}
+          {{- end -}}
         {{- end -}}
 {{- end }}

--- a/charts/prometheus/templates/alertmanager/sts.yaml
+++ b/charts/prometheus/templates/alertmanager/sts.yaml
@@ -168,6 +168,11 @@ spec:
       {{- end }}
 {{- else }}
         - name: storage-volume
-          emptyDir: {}
+          emptyDir:
+          {{- if .Values.alertmanager.emptyDir.sizeLimit }}
+            sizeLimit: {{ .Values.alertmanager.emptyDir.sizeLimit }}
+          {{- else }}
+            {}
+          {{- end -}}
 {{- end }}
 {{- end }}

--- a/charts/prometheus/templates/server/sts.yaml
+++ b/charts/prometheus/templates/server/sts.yaml
@@ -234,7 +234,12 @@ spec:
       {{- end }}
 {{- else }}
         - name: storage-volume
-          emptyDir: {}
+          emptyDir:
+          {{- if .Values.server.emptyDir.sizeLimit }}
+            sizeLimit: {{ .Values.server.emptyDir.sizeLimit }}
+          {{- else }}
+            {}
+          {{- end -}}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -224,6 +224,11 @@ alertmanager:
     ##
     subPath: ""
 
+  emptyDir:
+    ## alertmanager emptyDir volume size limit
+    ##
+    sizeLimit: ""
+
   ## Annotations to be added to alertmanager pods
   ##
   podAnnotations: {}
@@ -821,6 +826,8 @@ server:
     subPath: ""
 
   emptyDir:
+    ## Prometheus server emptyDir volume size limit
+    ##
     sizeLimit: ""
 
   ## Annotations to be added to Prometheus server pods
@@ -1114,7 +1121,6 @@ pushgateway:
 
   persistentVolume:
     ## If true, pushgateway will create/use a Persistent Volume Claim
-    ## If false, use emptyDir
     ##
     enabled: false
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Currently only prometheus server takes `emptyDir.sizeLimit` for
`deployment` but not for `statefulset`. And alertmanager has no notion
about `emptyDir.sizeLimit` at all.

This change fixes that by following existing pattern of prometheus
server deployment spec, to allow `sizeLimit` to be set for both `server`
and `alertmanager`, regardless it is a deployment spec or statefulset.

On the pushgateway side, existing comment string in `values.yaml`
suggests if `persistentVolume.enabled` set to false, `emptyDir` will be
used. But that's actually not the case. Since the existing pushgateway
deployment spec by default has persistent volume turned off and doesn't
specify emptyDir at all (neither in volume nor  volumeMount), this
change fixes the inconsistency by updating the comment string in
values.yaml

#### Which issue this PR fixes

Described above.

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
