### PR TITLE
update URL for stable repository

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Add dependency chart repos
         run: |
-          helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+          helm repo add stable https://charts.helm.sh/stable
           helm repo add grafana https://grafana.github.io/helm-charts
 
       - name: Run chart-releaser

--- a/ct.yaml
+++ b/ct.yaml
@@ -4,7 +4,7 @@ target-branch: main
 chart-dirs:
   - charts
 chart-repos:
-  - stable=https://kubernetes-charts.storage.googleapis.com/
+  - stable=https://charts.helm.sh/stable
   - prometheus-community=https://prometheus-community.github.io/helm-charts
   - grafana=https://grafana.github.io/helm-charts
 helm-extra-args: --timeout 600s


### PR DESCRIPTION
#### What this PR does / why we need it:

https://github.com/prometheus-community/helm-charts/pull/183#issuecomment-716725104
Release failed as the URL to stable repository needs to be updated.

#### Special notes for your reviewer:

kube-prometheus-stack and prometheus also reference the old URL. I think it't best to merge this first and have separate PRs for those charts.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
