### PR TITLE
[prometheus-druid-exporter] update CODEOWNERS to reflect maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,7 @@
 /charts/prometheus-cloudwatch-exporter/ @asherf @gianrubio @torstenwalter
 /charts/prometheus-consul-exporter/ @gkarthiks @timm088
 /charts/prometheus-couchdb-exporter/ @gkarthiks
-/charts/prometheus-druid-exporter/ @iamabhishek-dubey
+/charts/prometheus-druid-exporter/ @iamabhishek-dubey @sandy724
 /charts/prometheus-elasticsearch-exporter/ @caarlos0 @desaintmartin @svenmueller
 /charts/prometheus-kafka-exporter/ @gkarthiks @golgoth31
 /charts/prometheus-mongodb-exporter/ @steven-sheehy


### PR DESCRIPTION
#### What this PR does / why we need it:

@sandy724 is a maintainer of that chart according to:
https://github.com/prometheus-community/helm-charts/blob/18ce04ce2dd84ea0884251745256e5405ad6b77d/charts/prometheus-druid-exporter/Chart.yaml#L9-L13

This PR reflects that in CODEOWNERS

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
