### PR TITLE
[prometheus] Fix rolebinding apiVersion

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 11.16.5
+version: 11.16.6
 appVersion: 2.21.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/requirements.yaml
+++ b/charts/prometheus/requirements.yaml
@@ -2,6 +2,6 @@ dependencies:
 
   - name: kube-state-metrics
     version: "2.8.*"
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable/
     condition: kubeStateMetrics.enabled
 

--- a/charts/prometheus/templates/server/rolebinding.yaml
+++ b/charts/prometheus/templates/server/rolebinding.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.server.enabled .Values.rbac.create .Values.server.useExistingClusterRoleName .Values.server.namespaces -}}
 {{ range $.Values.server.namespaces -}}
 ---
-apiVersion: {{ template "rbac.apiVersion" . }}
+apiVersion: {{ template "rbac.apiVersion" $ }}
 kind: RoleBinding
 metadata:
   labels:


### PR DESCRIPTION
#### What this PR does / why we need it:
Setting `server.useExistingClusterRoleName` and `server.namespaces` results in an error upon deployment:

    Error: template: prometheus/templates/_helpers.tpl:199:20: executing "rbac.apiVersion" at <.Capabilities.APIVersions.Has>: can't evaluate field Capabilities in type string

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
