### PR TITLE
[prometheus-kafka-exporter] Helpful cosmetic tweaks to comments and notes.

### DIFF
--- a/charts/prometheus-kafka-exporter/Chart.yaml
+++ b/charts/prometheus-kafka-exporter/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v1.2.0"
 description: A Helm chart to export the metrics from Kafka in Prometheus format using the kafka-exporter from https://github.com/danielqsj/kafka_exporter
 name: prometheus-kafka-exporter
 home: https://github.com/danielqsj/kafka_exporter
-version: 0.1.4
+version: 0.1.6
 sources:
   - https://gkarthiks.github.io/helm-charts/charts/prometheus-kafka-exporter
 keywords:

--- a/charts/prometheus-kafka-exporter/templates/NOTES.txt
+++ b/charts/prometheus-kafka-exporter/templates/NOTES.txt
@@ -10,6 +10,6 @@
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "prometheus-kafka-exporter.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:80
+  echo "Visit http://127.0.0.1:9308/metrics to view Kafka metrics."
+  kubectl port-forward $POD_NAME 9308
 {{- end }}

--- a/charts/prometheus-kafka-exporter/values.yaml
+++ b/charts/prometheus-kafka-exporter/values.yaml
@@ -23,6 +23,9 @@ service:
   type: ClusterIP
   port: 9308
   annotations: {}
+  #  prometheus.io/scrape: "true"
+  #  prometheus.io/path: /metrics
+  #  prometheus.io/port: "9308"
 
 liveness:
   enabled: false


### PR DESCRIPTION
#### What this PR does / why we need it:

There are no functionality changes, just comments/notes that I thought would be helpful to others:
- Added commented-out annotation values that would enable discovery by Prometheus server.
- Adjusted default NOTES.txt that referenced port number that is not relevant.

#### Which issue this PR fixes

n/a

#### Special notes for your reviewer:

I changed chart version to 0.1.6 because I used 0.1.5 in https://github.com/prometheus-community/helm-charts/pull/288. We'll need to adjust them if we end up merging in a different order.

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
