### PR TITLE
[prometheus] Change helm stable repo in docs

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 11.16.6
+version: 11.16.7
 appVersion: 2.21.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/README.md
+++ b/charts/prometheus/README.md
@@ -12,7 +12,7 @@ This chart bootstraps a [Prometheus](https://prometheus.io/) deployment on a [Ku
 
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo add stable https://charts.helm.sh/stable
 helm repo update
 ```
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Actualize docs

#### Special notes for your reviewer:
New URL for [stable](https://helm.sh/docs/intro/quickstart/#initialize-a-helm-chart-repository) helm chart

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)

Аfter closing https://github.com/prometheus-community/helm-charts/pull/283