### PR TITLE
[kube-prometheus-stack] Update chart dependencies

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -17,7 +17,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 10.3.4
+version: 10.3.5
 appVersion: 0.42.1
 tillerVersion: ">=2.12.0"
 kubeVersion: ">=1.16.0-0"

--- a/charts/kube-prometheus-stack/requirements.yaml
+++ b/charts/kube-prometheus-stack/requirements.yaml
@@ -1,12 +1,12 @@
 dependencies:
 
   - name: kube-state-metrics
-    version: "2.8.*"
+    version: "2.9.*"
     repository: https://charts.helm.sh/stable
     condition: kubeStateMetrics.enabled
 
   - name: prometheus-node-exporter
-    version: "1.11.*"
+    version: "1.12.*"
     repository: https://prometheus-community.github.io/helm-charts
     condition: nodeExporter.enabled
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Updates chart dependencies to new minor. 
Can't upgrade Grafana chart, which moved to helm-v3 only chart in 6.x

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
