### PR TITLE
[prometheus-stackdriver-exporter] Add dropDelegatedProjects to stackdriver-exporter

### DIFF
--- a/charts/prometheus-stackdriver-exporter/Chart.yaml
+++ b/charts/prometheus-stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: prometheus-stackdriver-exporter
-version: 1.4.1
+version: 1.5.0
 appVersion: 0.6.0
 home: https://www.stackdriver.com/
 sources:

--- a/charts/prometheus-stackdriver-exporter/Chart.yaml
+++ b/charts/prometheus-stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: prometheus-stackdriver-exporter
-version: 1.4.0
+version: 1.4.1
 appVersion: 0.6.0
 home: https://www.stackdriver.com/
 sources:

--- a/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
@@ -81,6 +81,8 @@ spec:
               value: {{ .Values.stackdriver.backoffJitter | quote }}
             - name: STACKDRIVER_EXPORTER_RETRY_STATUSES
               value: {{ .Values.stackdriver.retryStatuses | quote}}
+            - name: STACKDRIVER_EXPORTER_DROP_DELEGATED_PROJECTS
+              value: {{ .Values.stackdriver.dropDelegatedProjects | quote}}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           ports:

--- a/charts/prometheus-stackdriver-exporter/values.yaml
+++ b/charts/prometheus-stackdriver-exporter/values.yaml
@@ -39,6 +39,8 @@ stackdriver:
   backoffJitter: 1s
   # The HTTP statuses that should trigger a retry
   retryStatuses: 503
+  # Drop metrics from attached projects and fetch `project_id` only
+  dropDelegatedProjects: false
   metrics:
     # The prefixes to gather metrics for, we default to just CPU metrics.
     typePrefixes: 'compute.googleapis.com/instance/cpu'


### PR DESCRIPTION
Allow for enabling the ability to drop delegated projects from the scraped data in stackdriver-exporter using the STACKDRIVER_EXPORTER_DROP_DELEGATED_PROJECTS env var.

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

Adds the ability to drop delegated projects from scraped data using the STACKDRIVER_EXPORTER_DROP_DELEGATED_PROJECTS env var.

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
