### PR TITLE
[kube-prometheus-stack] Disable scraping kubelet resource metrics endpoint

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -17,7 +17,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 11.0.1
+version: 11.0.2
 appVersion: 0.43.1
 tillerVersion: ">=2.12.0"
 kubeVersion: ">=1.16.0-0"

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -689,8 +689,9 @@ kubelet:
     probes: true
 
     ## Enable scraping /metrics/resource from kubelet's service
+    ## This is disabled by default because container metrics are already exposed by cAdvisor
     ##
-    resource: true
+    resource: false
     # From kubernetes 1.18, /metrics/resource/v1alpha1 renamed to /metrics/resource
     resourcePath: "/metrics/resource/v1alpha1"
     ## Metric relabellings to apply to samples before ingestion
@@ -1630,7 +1631,7 @@ prometheus:
     ##
     image:
       repository: quay.io/prometheus/prometheus
-      tag: v2.22.0
+      tag: v2.22.1
       sha: ""
 
     ## Tolerations for use with node taints


### PR DESCRIPTION
#### What this PR does / why we need it:
Based on the [KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/kubelet-resource-metrics-endpoint.md) for the Kubelet Resource Metrics Endpoint, I don't believe we should be scraping this endpoint. In the past, it's caused [issues](https://github.com/kubernetes-monitoring/kubernetes-mixin/issues/458) with some of the metrics reported by cAdvisor. Also, the kube-prometheus project (which this chart is based on) [does not scrape](https://github.com/prometheus-operator/kube-prometheus/blob/master/manifests/prometheus-serviceMonitorKubelet.yaml) this endpoint.

Also, bumping the prometheus to v2.22.1 because it has fixes for a [retention size bug](https://github.com/prometheus/prometheus/pull/8139).
#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
