### PR TITLE
[kube-prometheus-stack] Bump prometheus-operator to 0.43.1

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -17,8 +17,8 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 11.0.0
-appVersion: 0.43.0
+version: 11.0.1
+appVersion: 0.43.1
 tillerVersion: ">=2.12.0"
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1351,7 +1351,7 @@ prometheusOperator:
   ##
   image:
     repository: quay.io/prometheus-operator/prometheus-operator
-    tag: v0.43.0
+    tag: v0.43.1
     sha: ""
     pullPolicy: IfNotPresent
 
@@ -1366,7 +1366,7 @@ prometheusOperator:
   ##
   prometheusConfigReloaderImage:
     repository: quay.io/prometheus-operator/prometheus-config-reloader
-    tag: v0.43.0
+    tag: v0.43.1
     sha: ""
 
   ## Set the prometheus config reloader side-car CPU limit


### PR DESCRIPTION
#### What this PR does / why we need it:
Bumps prometheus-operator to 0.43.1

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
