### PR TITLE
[kube-prometheus-stack] Add option to add headless svc for thanos sidecar

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -17,7 +17,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 11.0.1
+version: 11.1.0
 appVersion: 0.43.1
 tillerVersion: ">=2.12.0"
 kubeVersion: ">=1.16.0-0"

--- a/charts/kube-prometheus-stack/templates/prometheus/serviceThanosSIdecar.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/serviceThanosSIdecar.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.prometheus.enabled .Values.prometheus.thanosService.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "kube-prometheus-stack.fullname" . }}-thanos-discovery
+  namespace: {{ template "kube-prometheus-stack.namespace" . }}
+  labels:
+    app: {{ template "kube-prometheus-stack.name" . }}-thanos-discovery
+{{ include "kube-prometheus-stack.labels" . | indent 4 }}
+{{- if .Values.prometheus.thanosService.labels }}
+{{ toYaml .Values.prometheus.thanosService.labels | indent 4 }}
+{{- end }}
+{{- if .Values.prometheus.thanosService.annotations }}
+  annotations:
+{{ toYaml .Values.prometheus.thanosService.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: {{ .Values.prometheus.thanosService.portName }}
+    port: {{ .Values.prometheus.thanosService.port }}
+    targetPort: {{ .Values.prometheus.thanosService.targetPort }}
+  selector:
+    app: prometheus
+    prometheus: {{ template "kube-prometheus-stack.fullname" . }}-prometheus
+{{- end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1406,6 +1406,19 @@ prometheus:
     create: true
     name: ""
 
+  # Service for thanos service discovery on sidecar
+  # Enable this can make Thanos Query can use
+  # `--store=dnssrv+_grpc._tcp.${kube-prometheus-stack.fullname}-thanos-discovery.${namespace}.svc.cluster.local` to discovery
+  # Thanos sidecar on prometheus nodes
+  # (Please remember to change ${kube-prometheus-stack.fullname} and ${namespace}. Not just copy and paste!)
+  thanosService:
+    enabled: false
+    annotations: {}
+    labels: {}
+    portName: grpc
+    port: 10901
+    targetPort: "grpc"
+
   ## Configuration for Prometheus service
   ##
   service:


### PR DESCRIPTION
## What this PR does / why we need it:
Add option to add headless svc for Thanos sidecar. Let Thanos Query can use `--store=dnssrv+_grpc._tcp.${kube-prometheus-stack.fullname}-thanos-discovery.infra.svc.cluster.local` to discovery Thanos sidecar.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
