### PR TITLE
[kube-prometheus-stack] add ingressclass support

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -17,7 +17,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 11.0.3
+version: 11.0.4
 appVersion: 0.43.1
 tillerVersion: ">=2.12.0"
 kubeVersion: ">=1.16.0-0"

--- a/charts/kube-prometheus-stack/templates/alertmanager/ingress.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/ingress.yaml
@@ -23,8 +23,10 @@ metadata:
 {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
+  {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass") (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/IngressClass") }}
   {{- if .Values.alertmanager.ingress.ingressClassName }}
   ingressClassName: {{ .Values.alertmanager.ingress.ingressClassName }}
+  {{- end }}
   {{- end }}
   rules:
   {{- if .Values.alertmanager.ingress.hosts }}

--- a/charts/kube-prometheus-stack/templates/alertmanager/ingress.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/ingress.yaml
@@ -23,6 +23,9 @@ metadata:
 {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
+  {{- if .Values.alertmanager.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.alertmanager.ingress.ingressClassName }}
+  {{- end }}
   rules:
   {{- if .Values.alertmanager.ingress.hosts }}
   {{- range $host := .Values.alertmanager.ingress.hosts }}

--- a/charts/kube-prometheus-stack/templates/alertmanager/ingressperreplica.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/ingressperreplica.yaml
@@ -29,6 +29,9 @@ items:
 {{ toYaml $ingressValues.annotations | indent 8 }}
       {{- end }}
     spec:
+      {{- if $ingressValues.ingressClassName }}
+      ingressClassName: {{ $ingressValues.ingressClassName }}
+      {{- end }}
       rules:
         - host: {{ $ingressValues.hostPrefix }}-{{ $i }}.{{ $ingressValues.hostDomain }}
           http:

--- a/charts/kube-prometheus-stack/templates/alertmanager/ingressperreplica.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/ingressperreplica.yaml
@@ -29,8 +29,10 @@ items:
 {{ toYaml $ingressValues.annotations | indent 8 }}
       {{- end }}
     spec:
+      {{- if or ($.Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass") ($.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/IngressClass") }}
       {{- if $ingressValues.ingressClassName }}
       ingressClassName: {{ $ingressValues.ingressClassName }}
+      {{- end }}
       {{- end }}
       rules:
         - host: {{ $ingressValues.hostPrefix }}-{{ $i }}.{{ $ingressValues.hostDomain }}

--- a/charts/kube-prometheus-stack/templates/prometheus/ingress.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/ingress.yaml
@@ -23,8 +23,10 @@ metadata:
 {{ toYaml .Values.prometheus.ingress.labels | indent 4 }}
 {{- end }}
 spec:
+  {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass") (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/IngressClass") }}
   {{- if .Values.prometheus.ingress.ingressClassName }}
   ingressClassName: {{ .Values.prometheus.ingress.ingressClassName }}
+  {{- end }}
   {{- end }}
   rules:
   {{- if .Values.prometheus.ingress.hosts }}

--- a/charts/kube-prometheus-stack/templates/prometheus/ingress.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/ingress.yaml
@@ -23,6 +23,9 @@ metadata:
 {{ toYaml .Values.prometheus.ingress.labels | indent 4 }}
 {{- end }}
 spec:
+  {{- if .Values.prometheus.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.prometheus.ingress.ingressClassName }}
+  {{- end }}
   rules:
   {{- if .Values.prometheus.ingress.hosts }}
   {{- range $host := .Values.prometheus.ingress.hosts }}

--- a/charts/kube-prometheus-stack/templates/prometheus/ingressThanosSidecar.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/ingressThanosSidecar.yaml
@@ -18,8 +18,10 @@ metadata:
 {{ toYaml .Values.prometheus.thanosIngress.labels | indent 4 }}
 {{- end }}
 spec:
+  {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass") (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/IngressClass") }}
   {{- if .Values.prometheus.thanosIngress.ingressClassName }}
   ingressClassName: {{ .Values.prometheus.thanosIngress.ingressClassName }}
+  {{- end }}
   {{- end }}
   rules:
   {{- if .Values.prometheus.thanosIngress.hosts }}

--- a/charts/kube-prometheus-stack/templates/prometheus/ingressThanosSidecar.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/ingressThanosSidecar.yaml
@@ -18,6 +18,9 @@ metadata:
 {{ toYaml .Values.prometheus.thanosIngress.labels | indent 4 }}
 {{- end }}
 spec:
+  {{- if .Values.prometheus.thanosIngress.ingressClassName }}
+  ingressClassName: {{ .Values.prometheus.thanosIngress.ingressClassName }}
+  {{- end }}
   rules:
   {{- if .Values.prometheus.thanosIngress.hosts }}
   {{- range $host := .Values.prometheus.thanosIngress.hosts }}

--- a/charts/kube-prometheus-stack/templates/prometheus/ingressperreplica.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/ingressperreplica.yaml
@@ -29,6 +29,9 @@ items:
 {{ toYaml $ingressValues.annotations | indent 8 }}
       {{- end }}
     spec:
+      {{- if $ingressValues.ingressClassName }}
+      ingressClassName: {{ $ingressValues.ingressClassName }}
+      {{- end }}
       rules:
         - host: {{ $ingressValues.hostPrefix }}-{{ $i }}.{{ $ingressValues.hostDomain }}
           http:

--- a/charts/kube-prometheus-stack/templates/prometheus/ingressperreplica.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/ingressperreplica.yaml
@@ -29,8 +29,10 @@ items:
 {{ toYaml $ingressValues.annotations | indent 8 }}
       {{- end }}
     spec:
+      {{- if or ($.Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass") ($.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/IngressClass") }}
       {{- if $ingressValues.ingressClassName }}
       ingressClassName: {{ $ingressValues.ingressClassName }}
+      {{- end }}
       {{- end }}
       rules:
         - host: {{ $ingressValues.hostPrefix }}-{{ $i }}.{{ $ingressValues.hostDomain }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -196,6 +196,10 @@ alertmanager:
   ingress:
     enabled: false
 
+    # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+    # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
+    # ingressClassName: nginx
+
     annotations: {}
 
     labels: {}
@@ -228,6 +232,11 @@ alertmanager:
   ##
   ingressPerReplica:
     enabled: false
+
+    # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+    # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
+    # ingressClassName: nginx
+
     annotations: {}
     labels: {}
 
@@ -1471,6 +1480,11 @@ prometheus:
 # Ingress exposes thanos sidecar outside the clsuter
   thanosIngress:
     enabled: false
+
+    # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+    # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
+    # ingressClassName: nginx
+
     annotations: {}
     labels: {}
     servicePort: 10901
@@ -1494,6 +1508,11 @@ prometheus:
 
   ingress:
     enabled: false
+
+    # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+    # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
+    # ingressClassName: nginx
+
     annotations: {}
     labels: {}
 
@@ -1522,6 +1541,11 @@ prometheus:
   ##
   ingressPerReplica:
     enabled: false
+
+    # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+    # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
+    # ingressClassName: nginx
+
     annotations: {}
     labels: {}
 


### PR DESCRIPTION
Signed-off-by: Christian Niehoff <mail@christian-niehoff.com>

#### What this PR does / why we need it:

The annotation `kubernetes.io/ingress.class` will be deprecated.

Instead you have to specify the class of your ingress-controller via the new field `ingressClassName`

#### Which issue this PR fixes

  - fixes #265 

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
