### PR TITLE
[kube-prometheus-stack] Allow setting persistence settings for grafana

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -17,7 +17,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 11.0.4
+version: 11.0.5
 appVersion: 0.43.1
 tillerVersion: ">=2.12.0"
 kubeVersion: ">=1.16.0-0"

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -636,6 +636,19 @@ grafana:
     #   replacement: $1
     #   action: replace
 
+  persistence:
+    type: pvc
+    enabled: false
+    # storageClassName: default
+    accessModes:
+      - ReadWriteOnce
+    size: 10Gi
+    # annotations: {}
+    finalizers:
+      - kubernetes.io/pvc-protection
+    # subPath: ""
+    # existingClaim:
+
 ## Component scraping the kube api server
 ##
 kubeApiServer:


### PR DESCRIPTION
#### What this PR does / why we need it:
Allows persisting grafana storage to a PV - meaning that no dashboard setups get lost when pods get deleted.

#### Notes to reviewers
Relevent options in grafana helm chart https://github.com/grafana/helm-charts/blob/main/charts/grafana/values.yaml#L230-L244 

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
