### PR TITLE
[kube-prometheus-stack] Fix some GitHub broken links on 'hack/README.md'

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 12.0.1
+version: 12.0.2
 appVersion: 0.43.2
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/hack/README.md
+++ b/charts/kube-prometheus-stack/hack/README.md
@@ -6,7 +6,7 @@ This script generates prometheus rules set for alertmanager from any properly fo
 
 Currently following imported:
 
-- [prometheus-operator/kube-prometheus rules set](https://github.com/prometheus-operator/kube-prometheus/master/manifests/prometheus-rules.yaml)
+- [prometheus-operator/kube-prometheus rules set](https://github.com/prometheus-operator/kube-prometheus/tree/master/manifests/prometheus-rules.yaml)
   - In order to modify these rules:
     - prepare and merge PR into [kubernetes-mixin](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/rules) master and/or release branch
     - run import inside your fork of [prometheus-operator/kube-prometheus](https://github.com/prometheus-operator/kube-prometheus/tree/master)
@@ -19,7 +19,7 @@ Currently following imported:
     - prepare and merge PR with imported changes into `prometheus-operator/kube-prometheus` master and/or release branch
     - run sync_prometheus_rules.py inside your fork of this repo
     - send PR with changes to this repo
-- [etcd-io/etc rules set](https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/etcd3_alert.rules.yml)
+- [etcd-io/etcd rules set](https://github.com/etcd-io/etcd/blob/master/Documentation/etcd-mixin/README.md)
   - In order to modify these rules:
     - prepare and merge PR into [etcd-io/etcd](https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/grafana.json) repo
     - run sync_prometheus_rules.py inside your fork of this repo
@@ -31,10 +31,10 @@ This script generates grafana dashboards from json files, splitting them to sepa
 
 Currently following imported:
 
-- [prometheus-operator/kube-prometheus dashboards](https://github.com/prometheus-operator/kube-prometheus/manifests/grafana-deployment.yaml)
+- [prometheus-operator/kube-prometheus dashboards](https://github.com/prometheus-operator/kube-prometheus/tree/master/manifests/grafana-deployment.yaml)
   - In order to modify these dashboards:
     - prepare and merge PR into [kubernetes-mixin](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/dashboards) master and/or release branch
-    - run import inside your fork of [prometheus-operator/kube-prometheus](https://github.com/kube-prometheus/kube-prometheus/tree/master)
+    - run import inside your fork of [prometheus-operator/kube-prometheus](https://github.com/prometheus-operator/kube-prometheus/tree/master)
 
      ```bash
      jb update


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

Was reading through [`charts/kube-prometheus-stack/hack`](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack) and noticed some links were broken or outdated.

This includes pointing to new etcd-io/etcd rules set (after https://github.com/etcd-io/etcd/commit/4160b8396ddf21b0727c189017e5e71b25c3e5c5). I think these changes have been already synced in this repo, as the intermediate artifact (https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/grafana.json) stayed the same. It was just a matter of updating the procedure in the docs.

#### Special notes for your reviewer:

I don't think the chart version needs to be bumped for documentation nitpicks, but let me know otherwise.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
