### PR TITLE
[kube-prometheus-stack] Fix indentation for applying labels to per-replica ingress

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -17,7 +17,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 11.1.1
+version: 11.1.2
 appVersion: 0.43.2
 tillerVersion: ">=2.12.0"
 kubeVersion: ">=1.16.0-0"

--- a/charts/kube-prometheus-stack/templates/alertmanager/ingressperreplica.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/ingressperreplica.yaml
@@ -22,7 +22,7 @@ items:
         app: {{ include "kube-prometheus-stack.name" $ }}-alertmanager
 {{ include "kube-prometheus-stack.labels" $ | indent 8 }}
       {{- if $ingressValues.labels }}
-      {{ toYaml $ingressValues.labels | indent 8 }}
+{{ toYaml $ingressValues.labels | indent 8 }}
       {{- end }}
       {{- if $ingressValues.annotations }}
       annotations:

--- a/charts/kube-prometheus-stack/templates/prometheus/ingressperreplica.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/ingressperreplica.yaml
@@ -22,7 +22,7 @@ items:
         app: {{ include "kube-prometheus-stack.name" $ }}-prometheus
 {{ include "kube-prometheus-stack.labels" $ | indent 8 }}
       {{- if $ingressValues.labels }}
-      {{ toYaml $ingressValues.labels | indent 8 }}
+{{ toYaml $ingressValues.labels | indent 8 }}
       {{- end }}
       {{- if $ingressValues.annotations }}
       annotations:


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR fixes ingress-per-replica labels. 

Currently when attempting to add labels to per-replica ingresses you'll get some variation of this error:

```
Error: YAML parse error on kube-prometheus-stack/templates/alertmanager/ingressperreplica.yaml: error converting YAML to JSON: yaml: line 18: did not find expected key
```

This is because the indent is set incorrectly in the template. I imagine it's a very seldom used feature which might explain why it's been like this for a while.

#### Which issue this PR fixes

No issue was reported, as it was a small, quick fix.

#### Special notes for your reviewer:

@bismarck @vsliouniaev @gianrubio @gkarthiks @scottrigby @Xtigyro For review please.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
