### PR TITLE
[prometheus] Use Alertmanager API port only for kubernetes_sd.

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 11.16.8
+version: 11.16.9
 appVersion: 2.21.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/templates/server/cm.yaml
+++ b/charts/prometheus/templates/server/cm.yaml
@@ -72,8 +72,8 @@ data:
           regex: {{ index $root.Values.alertmanager.podAnnotations "prometheus.io/probe" | default ".*" }}
           action: keep
         - source_labels: [__meta_kubernetes_pod_container_port_number]
-          regex:
-          action: drop
+          regex: "9093"
+          action: keep
 {{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Signed-off-by: Anas <anas.oubrahim@commercetools.com>

#### What this PR does / why we need it:
Avoid sending alerts to Alertmanager Peering port.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
In this PR : https://github.com/prometheus-community/helm-charts/pull/179 the mesh peering port was explicitly defined for Alertmanager pods, as a result `kubernetes_sd` will list it as a target for Prometheus to send alerts to.
This leads to the following error on Prometheus spamming the logs:
```json
{"alertmanager":"http://10.35.102.55:6783/api/v1/alerts","caller":"notifier.go:527","component":"notifier","count":2,"err":"Post \"http://10.35.102.55:6783/api/v1/alerts\": EOF","level":"error","msg":"Error sending alert","ts":"2020-11-12T16:45:09.526Z"}
```

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
