### PR TITLE
[kube-prometheus-stack] #356 add support for multicluster in grafana dashboards

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 12.7.0
+version: 12.8.0
 appVersion: 0.44.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/hack/sync_grafana_dashboards.py
+++ b/charts/kube-prometheus-stack/hack/sync_grafana_dashboards.py
@@ -101,6 +101,10 @@ def escape(s):
     return s.replace("{{", "{{`{{").replace("}}", "}}`}}").replace("{{`{{", "{{`{{`}}").replace("}}`}}", "{{`}}`}}")
 
 
+def unescape(s):
+    return s.replace("\{\{", "{{").replace("\}\}", "}}")
+
+
 def yaml_str_repr(struct, indent=2):
     """represent yaml as a string"""
     text = yaml.dump(
@@ -109,8 +113,50 @@ def yaml_str_repr(struct, indent=2):
         default_flow_style=False  # to disable multiple items on single line
     )
     text = escape(text)  # escape {{ and }} for helm
+    text = unescape(text)  # unescape \{\{ and \}\} for templating
     text = textwrap.indent(text, ' ' * indent)
     return text
+
+
+def patch_json_for_multicluster_configuration(content):
+    try:
+        content_struct = json.loads(content)
+        overwrite_list = []
+        for variable in content_struct['templating']['list']:
+            if variable['name'] == 'cluster':
+                variable['hide'] = ':multicluster:'
+            overwrite_list.append(variable)
+        content_struct['templating']['list'] = overwrite_list
+        content_array = []
+        original_content_lines = content.split('\n')
+        for i, line in enumerate(json.dumps(content_struct, indent=4).split('\n')):
+            if ('[]' not in line and '{}' not in line) or line == original_content_lines[i]:
+                content_array.append(line)
+                continue
+
+            append = ''
+            if line.endswith(','):
+                line = line[:-1]
+                append = ','
+
+            if line.endswith('{}') or line.endswith('[]'):
+                content_array.append(line[:-1])
+                content_array.append('')
+                content_array.append(' ' * (len(line) - len(line.lstrip())) + line[-1] + append)
+
+        content = '\n'.join(content_array)
+
+        multicluster = content.find(':multicluster:')
+        if multicluster != -1:
+            content = ''.join((
+                content[:multicluster-1],
+                '\{\{ if .Values.grafana.sidecar.dashboards.multicluster \}\}0\{\{ else \}\}2\{\{ end \}\}',
+                content[multicluster + 15:]
+            ))
+    except (ValueError, KeyError):
+        pass
+
+    return content
 
 
 def write_group_to_file(resource_name, content, url, destination, min_kubernetes, max_kubernetes):
@@ -122,6 +168,8 @@ def write_group_to_file(resource_name, content, url, destination, min_kubernetes
         'min_kubernetes': min_kubernetes,
         'max_kubernetes': max_kubernetes
     }
+
+    content = patch_json_for_multicluster_configuration(content)
 
     filename_struct = {resource_name + '.json': (LiteralStr(content))}
     # rules themselves

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/apiserver.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/apiserver.yaml
@@ -1662,7 +1662,7 @@ data:
 
                     },
                     "datasource": "$datasource",
-                    "hide": 2,
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": "cluster",
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/etcd.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/etcd.yaml
@@ -1060,7 +1060,7 @@ data:
                         "value": "prod"
                     },
                     "datasource": "$datasource",
-                    "hide": 0,
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": "cluster",
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-cluster.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-cluster.yaml
@@ -2523,7 +2523,7 @@ data:
                         "value": ""
                     },
                     "datasource": "$datasource",
-                    "hide": 2,
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": null,
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-namespace.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-namespace.yaml
@@ -2200,7 +2200,7 @@ data:
                         "value": ""
                     },
                     "datasource": "$datasource",
-                    "hide": 2,
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": null,
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-node.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-node.yaml
@@ -892,7 +892,7 @@ data:
                         "value": ""
                     },
                     "datasource": "$datasource",
-                    "hide": 2,
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": null,
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-pod.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-pod.yaml
@@ -1659,7 +1659,7 @@ data:
                         "value": ""
                     },
                     "datasource": "$datasource",
-                    "hide": 2,
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": null,
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-workload.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-workload.yaml
@@ -1894,7 +1894,7 @@ data:
                         "value": ""
                     },
                     "datasource": "$datasource",
-                    "hide": 2,
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": null,
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-workloads-namespace.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-workloads-namespace.yaml
@@ -2109,7 +2109,7 @@ data:
                         "value": ""
                     },
                     "datasource": "$datasource",
-                    "hide": 2,
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": null,
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/kubelet.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/kubelet.yaml
@@ -2448,7 +2448,7 @@ data:
 
                     },
                     "datasource": "$datasource",
-                    "hide": 2,
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": "cluster",
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/persistentvolumesusage.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/persistentvolumesusage.yaml
@@ -466,7 +466,7 @@ data:
 
                     },
                     "datasource": "$datasource",
-                    "hide": 2,
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": "cluster",
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/prometheus-remote-write.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/prometheus-remote-write.yaml
@@ -1586,7 +1586,7 @@ data:
                         }
                     },
                     "datasource": "$datasource",
-                    "hide": 0,
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
                     "includeAll": true,
                     "label": null,
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/statefulset.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/statefulset.yaml
@@ -817,7 +817,7 @@ data:
 
                     },
                     "datasource": "$datasource",
-                    "hide": 2,
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": "cluster",
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards/etcd.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards/etcd.yaml
@@ -1060,7 +1060,7 @@ data:
                         "value": "prod"
                     },
                     "datasource": "$datasource",
-                    "hide": 0,
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": "cluster",
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards/k8s-cluster-rsrc-use.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards/k8s-cluster-rsrc-use.yaml
@@ -900,7 +900,7 @@ data:
                         "value": "prod"
                     },
                     "datasource": "$datasource",
-                    "hide": 2,
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": "cluster",
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards/k8s-node-rsrc-use.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards/k8s-node-rsrc-use.yaml
@@ -900,7 +900,7 @@ data:
                         "value": "prod"
                     },
                     "datasource": "$datasource",
-                    "hide": 2,
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": "cluster",
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards/k8s-resources-cluster.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards/k8s-resources-cluster.yaml
@@ -1420,7 +1420,7 @@ data:
                         "value": "prod"
                     },
                     "datasource": "$datasource",
-                    "hide": 2,
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": "cluster",
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards/k8s-resources-namespace.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards/k8s-resources-namespace.yaml
@@ -877,7 +877,7 @@ data:
                         "value": "prod"
                     },
                     "datasource": "$datasource",
-                    "hide": 2,
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": "cluster",
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards/k8s-resources-pod.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards/k8s-resources-pod.yaml
@@ -893,7 +893,7 @@ data:
                         "value": "prod"
                     },
                     "datasource": "$datasource",
-                    "hide": 2,
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": "cluster",
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards/k8s-resources-workload.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards/k8s-resources-workload.yaml
@@ -796,7 +796,7 @@ data:
                         "value": "prod"
                     },
                     "datasource": "$datasource",
-                    "hide": 2,
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": "cluster",
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards/k8s-resources-workloads-namespace.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards/k8s-resources-workloads-namespace.yaml
@@ -886,7 +886,7 @@ data:
                         "value": "prod"
                     },
                     "datasource": "$datasource",
-                    "hide": 2,
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": "cluster",
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards/nodes.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards/nodes.yaml
@@ -1298,7 +1298,7 @@ data:
 
                     },
                     "datasource": "$datasource",
-                    "hide": 2,
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": "cluster",
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards/persistentvolumesusage.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards/persistentvolumesusage.yaml
@@ -462,7 +462,7 @@ data:
 
                     },
                     "datasource": "$datasource",
-                    "hide": 2,
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": "cluster",
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards/pods.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards/pods.yaml
@@ -543,7 +543,7 @@ data:
 
                     },
                     "datasource": "$datasource",
-                    "hide": 2,
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": "cluster",
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards/statefulset.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards/statefulset.yaml
@@ -815,7 +815,7 @@ data:
 
                     },
                     "datasource": "$datasource",
-                    "hide": 2,
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": "cluster",
                     "multi": false,

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -623,6 +623,7 @@ grafana:
       ## Annotations for Grafana dashboard configmaps
       ##
       annotations: {}
+      multicluster: false
     datasources:
       enabled: true
       defaultDatasourceEnabled: true


### PR DESCRIPTION
#### What this PR does / why we need it:
These changes enable to configure Grafana's dashboard to support multi cluster configuration.
Additionally, PR updates dashboards.

#### Which issue this PR fixes
  - fixes #356

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
