### PR TITLE
[prometheus-adapter] Add missing namespace fields to custom-metric resources to allow install dedicated ns

### DIFF
--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 2.7.0
+version: 2.7.1
 appVersion: v0.7.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/charts/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
+++ b/charts/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   name: {{ template "k8s-prometheus-adapter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:

--- a/charts/prometheus-adapter/templates/custom-metrics-apiserver-service-account.yaml
+++ b/charts/prometheus-adapter/templates/custom-metrics-apiserver-service-account.yaml
@@ -8,4 +8,5 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   name: {{ template "k8s-prometheus-adapter.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/charts/prometheus-adapter/templates/custom-metrics-apiserver-service.yaml
+++ b/charts/prometheus-adapter/templates/custom-metrics-apiserver-service.yaml
@@ -9,6 +9,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   name: {{ template "k8s-prometheus-adapter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - port: {{ .Values.service.port }}

--- a/charts/prometheus-adapter/templates/custom-metrics-configmap.yaml
+++ b/charts/prometheus-adapter/templates/custom-metrics-configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "k8s-prometheus-adapter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "k8s-prometheus-adapter.name" . }}
     chart: {{ template "k8s-prometheus-adapter.chart" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Fix for deploying the adapter in a custom namespace like monitoring.

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
