### PR TITLE
[kube-prometheus-stack] Add cluster settings to Alertmanager that were introduced in prom operator version to 0.43.3

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -17,8 +17,8 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 11.1.1
-appVersion: 0.43.2
+version: 11.1.2
+appVersion: 0.43.3
 tillerVersion: ">=2.12.0"
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/alertmanager/alertmanager.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/alertmanager.yaml
@@ -126,3 +126,12 @@ spec:
 {{- if .Values.alertmanager.alertmanagerSpec.clusterAdvertiseAddress }}
   clusterAdvertiseAddress: {{ .Values.alertmanager.alertmanagerSpec.clusterAdvertiseAddress }}
 {{- end }}
+{{- if .Values.alertmanager.alertmanagerSpec.clusterGossipInterval }}
+  clusterGossipInterval: {{ .Values.alertmanager.alertmanagerSpec.clusterGossipInterval }}
+{{- end }}
+{{- if .Values.alertmanager.alertmanagerSpec.clusterPushpullInterval }}
+  clusterPushpullInterval: {{ .Values.alertmanager.alertmanagerSpec.clusterPushpullInterval }}
+{{- end }}
+{{- if .Values.alertmanager.alertmanagerSpec.clusterPeerTimeout }}
+  clusterPeerTimeout: {{ .Values.alertmanager.alertmanagerSpec.clusterPeerTimeout }}
+{{- end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -551,6 +551,18 @@ alertmanager:
     ##
     clusterAdvertiseAddress: false
 
+    ## Interval between gossip attempts.
+    ##
+    clusterGossipInterval: ""
+
+    ## Interval between pushpull attempts.
+    ##
+    clusterPushpullInterval: ""
+
+    ## Timeout for cluster peering.
+    ##
+    clusterPeerTimeout: ""
+
 
 ## Using default values from https://github.com/grafana/helm-charts/blob/main/charts/grafana/values.yaml
 ##
@@ -1397,7 +1409,7 @@ prometheusOperator:
   ##
   image:
     repository: quay.io/prometheus-operator/prometheus-operator
-    tag: v0.43.2
+    tag: v0.43.3
     sha: ""
     pullPolicy: IfNotPresent
 
@@ -1412,7 +1424,7 @@ prometheusOperator:
   ##
   prometheusConfigReloaderImage:
     repository: quay.io/prometheus-operator/prometheus-config-reloader
-    tag: v0.43.2
+    tag: v0.43.3
     sha: ""
 
   ## Set the prometheus config reloader side-car CPU limit


### PR DESCRIPTION
Signed-off-by: hacktastic <jackson.coakley@gmail.com>

#### What this PR does / why we need it:
This PR adds three setting to AlertmanagerSpec that were added in prometheus operator v0.43.3:
- clusterGossipInterval
- clusterPushpullInterval
- clusterPeerTimeout
These settings allow the user to control the corresponding flags (e.g. --cluster.gossip-interval) on the alertmanager Pod.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
