### PR TITLE
[kube-prometheus-stack] Show tmpfs option for Prometheus storageSpec

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -17,7 +17,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 11.1.2
+version: 11.1.3
 appVersion: 0.43.2
 tillerVersion: ">=2.12.0"
 kubeVersion: ">=1.16.0-0"

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1936,6 +1936,8 @@ prometheus:
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/user-guides/storage.md
     ##
     storageSpec: {}
+    ## Using PersistentVolumeClaim
+    ##
     #  volumeClaimTemplate:
     #    spec:
     #      storageClassName: gluster
@@ -1944,6 +1946,11 @@ prometheus:
     #        requests:
     #          storage: 50Gi
     #    selector: {}
+    
+    ## Using tmpfs volume
+    ##
+    #  emptyDir:
+    #    medium: Memory
 
     # Additional volumes on the output StatefulSet definition.
     volumes: []

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1946,7 +1946,7 @@ prometheus:
     #        requests:
     #          storage: 50Gi
     #    selector: {}
-    
+
     ## Using tmpfs volume
     ##
     #  emptyDir:


### PR DESCRIPTION
Did some digging for how to configure the default emptyDir for the `/prometheus` mount and I found https://github.com/prometheus-community/helm-charts/blob/3ab7f9b04e1ab5abd6c0b35268368422436ae3a6/charts/kube-prometheus-stack/crds/crd-prometheuses.yaml#L4502

Adding comment to storageSpec in case future folks want to use a tmpfs mount for metrics (useful for short-term/ephemeral things, fast queries, or for not ruining a RaspberryPi microSD card).

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name
