### PR TITLE
[kube-prometheus-stack] Add missing parameter scrapetimeout

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 12.0.0
+version: 12.0.1
 appVersion: 0.43.2
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -72,6 +72,9 @@ spec:
 {{- if .Values.prometheus.prometheusSpec.scrapeInterval }}
   scrapeInterval: {{ .Values.prometheus.prometheusSpec.scrapeInterval }}
 {{- end }}
+{{- if .Values.prometheus.prometheusSpec.scrapeTimeout }}
+  scrapeTimeout: {{ .Values.prometheus.prometheusSpec.scrapeTimeout }}
+{{- end }}
 {{- if .Values.prometheus.prometheusSpec.evaluationInterval }}
   evaluationInterval: {{ .Values.prometheus.prometheusSpec.evaluationInterval }}
 {{- end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1669,6 +1669,10 @@ prometheus:
     ##
     scrapeInterval: ""
 
+    ## Number of seconds to wait for target to respond before
+    ##
+    scrapeTimeout: ""
+
     ## Interval between consecutive evaluations.
     ##
     evaluationInterval: ""

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1669,7 +1669,7 @@ prometheus:
     ##
     scrapeInterval: ""
 
-    ## Number of seconds to wait for target to respond before
+    ## Number of seconds to wait for target to respond before erroring
     ##
     scrapeTimeout: ""
 


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
The parameter `scrapeTimeout` is missing from the [values.yaml](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml)  and from the [prometheus template](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml). This parameter is present on the CRD [prometheuses.yaml](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/crds/crd-prometheuses.yaml).

This value is to customize the number of seconds to wait for target to respond before erroring, and currently the only way to change it is to added after deploy the chart by editing the pometheus object or creating a new one with the parameter and value in the spec. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
