### PR TITLE
prometheus statsd exporter: migrate from niclic chart repository

### DIFF
--- a/charts/prometheus-statsd-exporter/.helmignore
+++ b/charts/prometheus-statsd-exporter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/prometheus-statsd-exporter/Chart.yaml
+++ b/charts/prometheus-statsd-exporter/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: prometheus-statsd-exporter
+home: https://github.com/prometheus/statsd_exporter
+description: StatsD to Prometheus metrics exporter.
+type: application
+version: 0.2.0
+appVersion: 0.16.0
+keywords:
+- statsd
+- prometheus
+- metrics
+- graphite
+maintainers:
+- name: niclic
+  email: git@niclic.com

--- a/charts/prometheus-statsd-exporter/Chart.yaml
+++ b/charts/prometheus-statsd-exporter/Chart.yaml
@@ -4,7 +4,7 @@ home: https://github.com/prometheus/statsd_exporter
 description: StatsD to Prometheus metrics exporter.
 type: application
 version: 0.2.0
-appVersion: 0.16.0
+appVersion: 0.18.0
 keywords:
 - statsd
 - prometheus

--- a/charts/prometheus-statsd-exporter/Chart.yaml
+++ b/charts/prometheus-statsd-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: prometheus-statsd-exporter
 home: https://github.com/prometheus/statsd_exporter
 description: StatsD to Prometheus metrics exporter.
 type: application
-version: 0.2.0
+version: 1.0.0
 appVersion: 0.18.0
 keywords:
 - statsd

--- a/charts/prometheus-statsd-exporter/README.md
+++ b/charts/prometheus-statsd-exporter/README.md
@@ -1,0 +1,101 @@
+# prometheus-statsd-exporter
+
+The [prometheus-statsd-exporter](https://github.com/prometheus/statsd_exporter) receives StatsD metrics and exports them as Prometheus metrics.
+
+## Introduction
+
+This chart creates a `prometheus-statsd-exporter` deployment using the [Helm](https://helm.sh) package manager.
+
+
+## Prerequisites
+
+- Kubernetes 1.16 or above
+- `prometheus-statsd-exporter` `v0.16.0`
+
+
+## Installing the Chart
+
+The `prometheus-statsd-exporter` chart is stored in the `niclic` repository.
+
+Add the `niclic` repository to your list of helm repositories.
+
+```sh
+helm repo add niclic https://niclic.github.com/helm-charts
+
+# review the list of avaialble charts
+helm search repo niclic
+NAME                              CHART VERSION APP VERSION DESCRIPTION                           
+niclic/prometheus-statsd-exporter 0.1.0         0.16.0      StatsD to Prometheus metrics exporter.
+```
+
+To install the chart with the release name `prometheus-statsd-exporter` and default values:
+
+```sh
+helm install prometheus-statsd-exporter niclic/prometheus-statsd-exporter
+```
+
+
+## Testing the Chart.
+
+To run the tests for this chart.
+
+```sh
+helm test prometheus-statsd-exporter
+```
+
+
+## Uninstalling the Chart
+
+To uninstall `prometheus-statsd-exporter`:
+
+```sh
+helm uninstall prometheus-statsd-exporter
+```
+
+
+## Configuration
+
+The following table lists the configurable parameters of the `prometheus-statsd-exporter` chart and their default values.
+
+
+|             Parameter               |            Description                   |                    Default                |
+|-------------------------------------|------------------------------------------|-------------------------------------------|
+| `replicaCount`                      | Number of pods to run                    | `1`                                       |
+| `image.repository`                  | The docker image to run                  | `prom/statsd-exporter`                    |
+| `image.tag`                         | The image tag to pull                    | `v0.16.0`                                 |
+| `image.pullPolicy`                  | Image pull policy                        | `IfNotPresent`                            |
+| `imagePullSecrets`                  | Image pull secrets                       | `[]`                                      |
+| `serviceAccount.create`             | Create a service account                 | `true`                                    |
+| `podAnnotations`                    | Annotations to add to pods               | `{}`                                      |
+| `priorityClassName`                 | Priority class name                      | `""`                                      |
+| `podSecurityContext`                | Security settings for the pod            | `{}`                                      |
+| `securityContext`                   | Security settings for the container      | `{}`                                      |
+| `service.type`                      | Type of kubernetes service               | `ClusterIP`                               |
+| `webPort`                           | Web port for metrics endpoint            | `9102`                                    |
+| `udpPort`                           | UDP port to receive statsd metrics       | `9125`                                    |
+| `tcpPort`                           | TCP port to receive statsd metrics       | `9125`                                    |
+| `ingress.enabled`                   | Create an ingress resource               | `false`                                   |
+| `resources`                         | Pod resource requests & limits           | `{}`                                      |
+| `nodeSelector`                      | Node labels for pod assignment           | `{}`                                      |
+| `affinity`                          | Node affinity for pod assignment         | `{}`                                      |
+| `tolerations`                       | Node tolerations for pod assignment      | `[]`                                      |
+| `statsdMappingConfig`               | `statsd-exporter` mappings               | `timer_type: histogram`                   |
+
+
+Specify each parameter you'd like to override using a YAML file.
+
+```sh
+helm install prometheus-statsd-exporter niclic/prometheus-statsd-exporter -f values.yaml
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+You can also override specific values by using the `--set key=value[,key=value]` argument to `helm install`. For example, to change the `udpPort` to `8125`:
+
+```sh
+helm install prometheus-statsd-exporter niclic/prometheus-statsd-exporter --set udpPort=8125
+```
+
+
+## Metric Mapping and Configuration
+This chart provides a minimal default configuration. To create a custom mapping configuration and review default settings, consult the [official docs](https://github.com/prometheus/statsd_exporter#metric-mapping-and-configuration).

--- a/charts/prometheus-statsd-exporter/README.md
+++ b/charts/prometheus-statsd-exporter/README.md
@@ -2,100 +2,79 @@
 
 The [prometheus-statsd-exporter](https://github.com/prometheus/statsd_exporter) receives StatsD metrics and exports them as Prometheus metrics.
 
-## Introduction
-
 This chart creates a `prometheus-statsd-exporter` deployment using the [Helm](https://helm.sh) package manager.
-
 
 ## Prerequisites
 
 - Kubernetes 1.16 or above
-- `prometheus-statsd-exporter` `v0.16.0`
 
+## Get Repo Info
 
-## Installing the Chart
-
-The `prometheus-statsd-exporter` chart is stored in the `niclic` repository.
-
-Add the `niclic` repository to your list of helm repositories.
-
-```sh
-helm repo add niclic https://niclic.github.com/helm-charts
-
-# review the list of avaialble charts
-helm search repo niclic
-NAME                              CHART VERSION APP VERSION DESCRIPTION                           
-niclic/prometheus-statsd-exporter 0.1.0         0.16.0      StatsD to Prometheus metrics exporter.
+```console
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+help repo update
 ```
 
-To install the chart with the release name `prometheus-statsd-exporter` and default values:
+_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
 
-```sh
-helm install prometheus-statsd-exporter niclic/prometheus-statsd-exporter
+## Install Chart
+
+```console
+# Helm 3
+$ helm install [RELEASE_NAME] prometheus-community/prometheus-statsd-exporter
+
+# Helm 2
+$ helm install --name [RELEASE_NAME] prometheus-community/prometheus-statsd-exporter
 ```
 
+_See [configuration](#configuration) below._
 
-## Testing the Chart.
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
 
-To run the tests for this chart.
+## Test Chart
 
 ```sh
 helm test prometheus-statsd-exporter
 ```
 
+_See [helm test](https://helm.sh/docs/helm/helm_test/) for command documentation._
 
-## Uninstalling the Chart
+## Uninstall Chart
 
-To uninstall `prometheus-statsd-exporter`:
+```console
+# Helm 3
+$ helm uninstall [RELEASE_NAME]
 
-```sh
-helm uninstall prometheus-statsd-exporter
+# Helm 2
+$ helm delete --purge [RELEASE_NAME]
 ```
+
+This removes all the Kubernetes components associated with the chart and deletes the release.
+
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+
+
+## Upgrading Chart
+
+```console
+# Helm 3 or 2
+$ helm upgrade [RELEASE_NAME] [CHART] --install
+```
+
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
 
 ## Configuration
 
-The following table lists the configurable parameters of the `prometheus-statsd-exporter` chart and their default values.
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
 
+```console
+# Helm 2
+$ helm inspect values prometheus-community/prometheus-statsd-exporter
 
-|             Parameter               |            Description                   |                    Default                |
-|-------------------------------------|------------------------------------------|-------------------------------------------|
-| `replicaCount`                      | Number of pods to run                    | `1`                                       |
-| `image.repository`                  | The docker image to run                  | `prom/statsd-exporter`                    |
-| `image.tag`                         | The image tag to pull                    | `v0.16.0`                                 |
-| `image.pullPolicy`                  | Image pull policy                        | `IfNotPresent`                            |
-| `imagePullSecrets`                  | Image pull secrets                       | `[]`                                      |
-| `serviceAccount.create`             | Create a service account                 | `true`                                    |
-| `podAnnotations`                    | Annotations to add to pods               | `{}`                                      |
-| `priorityClassName`                 | Priority class name                      | `""`                                      |
-| `podSecurityContext`                | Security settings for the pod            | `{}`                                      |
-| `securityContext`                   | Security settings for the container      | `{}`                                      |
-| `service.type`                      | Type of kubernetes service               | `ClusterIP`                               |
-| `webPort`                           | Web port for metrics endpoint            | `9102`                                    |
-| `udpPort`                           | UDP port to receive statsd metrics       | `9125`                                    |
-| `tcpPort`                           | TCP port to receive statsd metrics       | `9125`                                    |
-| `ingress.enabled`                   | Create an ingress resource               | `false`                                   |
-| `resources`                         | Pod resource requests & limits           | `{}`                                      |
-| `nodeSelector`                      | Node labels for pod assignment           | `{}`                                      |
-| `affinity`                          | Node affinity for pod assignment         | `{}`                                      |
-| `tolerations`                       | Node tolerations for pod assignment      | `[]`                                      |
-| `statsdMappingConfig`               | `statsd-exporter` mappings               | `timer_type: histogram`                   |
-
-
-Specify each parameter you'd like to override using a YAML file.
-
-```sh
-helm install prometheus-statsd-exporter niclic/prometheus-statsd-exporter -f values.yaml
+# Helm 3
+$ helm show values prometheus-community/prometheus-statsd-exporter
 ```
-
-> **Tip**: You can use the default [values.yaml](values.yaml)
-
-You can also override specific values by using the `--set key=value[,key=value]` argument to `helm install`. For example, to change the `udpPort` to `8125`:
-
-```sh
-helm install prometheus-statsd-exporter niclic/prometheus-statsd-exporter --set udpPort=8125
-```
-
 
 ## Metric Mapping and Configuration
 This chart provides a minimal default configuration. To create a custom mapping configuration and review default settings, consult the [official docs](https://github.com/prometheus/statsd_exporter#metric-mapping-and-configuration).

--- a/charts/prometheus-statsd-exporter/templates/NOTES.txt
+++ b/charts/prometheus-statsd-exporter/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "prometheus-statsd-exporter.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "prometheus-statsd-exporter.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "prometheus-statsd-exporter.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.webPort }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "prometheus-statsd-exporter.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:{{ .Values.webPort }}
+{{- end }}

--- a/charts/prometheus-statsd-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-statsd-exporter/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "prometheus-statsd-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "prometheus-statsd-exporter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "prometheus-statsd-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "prometheus-statsd-exporter.labels" -}}
+helm.sh/chart: {{ include "prometheus-statsd-exporter.chart" . }}
+{{ include "prometheus-statsd-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "prometheus-statsd-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "prometheus-statsd-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "prometheus-statsd-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "prometheus-statsd-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/prometheus-statsd-exporter/templates/configmap.yaml
+++ b/charts/prometheus-statsd-exporter/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "prometheus-statsd-exporter.fullname" . }}-mapping-config
+  labels:
+    {{- include "prometheus-statsd-exporter.labels" . | nindent 4 }}
+data:
+  statsd-mapping.conf: |-
+{{ .Values.statsdMappingConfig | indent 4 }}

--- a/charts/prometheus-statsd-exporter/templates/deployment.yaml
+++ b/charts/prometheus-statsd-exporter/templates/deployment.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "prometheus-statsd-exporter.fullname" . }}
+  labels:
+    {{- include "prometheus-statsd-exporter.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "prometheus-statsd-exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+        {{- end}}
+      labels:
+        {{- include "prometheus-statsd-exporter.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "prometheus-statsd-exporter.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}        
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - --web.listen-address=:{{ .Values.webPort }}
+            - --web.telemetry-path=/metrics
+            - --statsd.listen-udp=:{{ .Values.udpPort }}
+            - --statsd.listen-tcp=:{{ .Values.tcpPort }}
+            - --statsd.mapping-config=/etc/{{ template "prometheus-statsd-exporter.name" . }}/statsd-mapping.conf
+          ports:
+            - name: web
+              containerPort: {{ .Values.webPort }}
+              protocol: TCP
+            - name: statsd-udp
+              containerPort: {{ .Values.udpPort }}
+              protocol: UDP
+            - name: statsd-tcp
+              containerPort: {{ .Values.tcpPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: web
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: statsd-mapping-config
+              mountPath: /etc/{{ template "prometheus-statsd-exporter.name" . }}
+      volumes:
+        - name: statsd-mapping-config
+          configMap:
+            name: {{ template "prometheus-statsd-exporter.fullname" . }}-mapping-config
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/prometheus-statsd-exporter/templates/ingress.yaml
+++ b/charts/prometheus-statsd-exporter/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "prometheus-statsd-exporter.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "prometheus-statsd-exporter.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/charts/prometheus-statsd-exporter/templates/ingress.yaml
+++ b/charts/prometheus-statsd-exporter/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "prometheus-statsd-exporter.fullname" . -}}
-{{- $svcPort := .Values.service.port -}}
+{{- $svcPort := .Values.webPort -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
@@ -31,11 +31,9 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
-          - path: {{ . }}
+          - path: /metrics
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
-          {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/prometheus-statsd-exporter/templates/service.yaml
+++ b/charts/prometheus-statsd-exporter/templates/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "prometheus-statsd-exporter.fullname" . }}
+  labels:
+    {{- include "prometheus-statsd-exporter.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: web
+      port: {{ .Values.webPort }}
+      protocol: TCP
+      targetPort: {{ .Values.webPort }}
+    - name: statsd-udp
+      port: {{ .Values.udpPort }}
+      protocol: UDP
+      targetPort: {{ .Values.udpPort }}
+    - name: statsd-tcp
+      port: {{ .Values.tcpPort }}
+      protocol: TCP
+      targetPort: {{ .Values.tcpPort }}
+  selector:
+    {{- include "prometheus-statsd-exporter.selectorLabels" . | nindent 4 }}

--- a/charts/prometheus-statsd-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-statsd-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "prometheus-statsd-exporter.serviceAccountName" . }}
+  labels:
+    {{- include "prometheus-statsd-exporter.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/prometheus-statsd-exporter/templates/tests/test-metrics-endpoint.yaml
+++ b/charts/prometheus-statsd-exporter/templates/tests/test-metrics-endpoint.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "prometheus-statsd-exporter.fullname" . }}-test-metrics-endpoint"
+  labels:
+    {{- include "prometheus-statsd-exporter.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['--spider', '{{ include "prometheus-statsd-exporter.fullname" . }}:{{ .Values.webPort }}/metrics']
+  restartPolicy: Never

--- a/charts/prometheus-statsd-exporter/templates/tests/test-metrics-publish.yaml
+++ b/charts/prometheus-statsd-exporter/templates/tests/test-metrics-publish.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "prometheus-statsd-exporter.fullname" . }}-test-metrics-publish"
+  labels:
+    {{- include "prometheus-statsd-exporter.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded    
+spec:
+  containers:
+    - name: netcat
+      image: busybox:1.28
+      command: ['/bin/sh']
+      args: ['-c', 'for i in 1 2 3 4 5;do echo "foo:$i|c" | nc -w 1 {{ include "prometheus-statsd-exporter.fullname" . }} {{ .Values.udpPort }} && echo "published foo:$i|c metric";done']
+  restartPolicy: Never

--- a/charts/prometheus-statsd-exporter/values.yaml
+++ b/charts/prometheus-statsd-exporter/values.yaml
@@ -1,0 +1,50 @@
+# Default values for prometheus-statsd-exporter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: prom/statsd-exporter
+  tag: v0.16.0
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+
+priorityClassName: ""
+
+podSecurityContext: {}
+
+securityContext: {}
+
+service:
+  type: ClusterIP
+
+webPort: 9102
+udpPort: 9125
+tcpPort: 9125
+
+ingress:
+  enabled: false
+  annotations: {}
+  hosts: []
+  tls: []
+
+resources: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+statsdMappingConfig: |-
+  defaults:
+    timer_type: histogram

--- a/charts/prometheus-statsd-exporter/values.yaml
+++ b/charts/prometheus-statsd-exporter/values.yaml
@@ -20,31 +20,46 @@ podAnnotations: {}
 
 priorityClassName: ""
 
+# Security settings for the pod
 podSecurityContext: {}
 
+# Security settings for the container
 securityContext: {}
 
 service:
   type: ClusterIP
 
+# statsd-exporter port settings
+# https://github.com/prometheus/statsd_exporter
+
+# Web port for /metrics endpoint
 webPort: 9102
+# UDP port to receive statsd metrics
 udpPort: 9125
+# TCP port to receive statsd metrics
 tcpPort: 9125
 
+# Settings for ingress resource
 ingress:
   enabled: false
   annotations: {}
   hosts: []
   tls: []
 
+# Pod resource requests & limits 
 resources: {}
 
+# Node labels for pod assignment
 nodeSelector: {}
 
+# Node tolerations for pod assignment
 tolerations: []
 
+# Node affinity for pod assignment
 affinity: {}
 
+# statsd-exporter mappings
+# https://github.com/prometheus/statsd_exporter#metric-mapping-and-configuration
 statsdMappingConfig: |-
   defaults:
     timer_type: histogram

--- a/charts/prometheus-statsd-exporter/values.yaml
+++ b/charts/prometheus-statsd-exporter/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: prom/statsd-exporter
-  tag: v0.16.0
+  tag: v0.18.0
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/prometheus-statsd-exporter/values.yaml
+++ b/charts/prometheus-statsd-exporter/values.yaml
@@ -20,45 +20,38 @@ podAnnotations: {}
 
 priorityClassName: ""
 
-# Security settings for the pod
 podSecurityContext: {}
 
-# Security settings for the container
 securityContext: {}
 
 service:
   type: ClusterIP
 
-# statsd-exporter port settings
+# statsd-exporter listener settings
 # https://github.com/prometheus/statsd_exporter
 
-# Web port for /metrics endpoint
+# webPort is the address on which to expose the /metrics web endpoint
 webPort: 9102
-# UDP port to receive statsd metrics
+# udpPort is the UDP address on which to receive statsd metrics
 udpPort: 9125
-# TCP port to receive statsd metrics
+# tcpPort is the TCP address on which to receive statsd metrics
 tcpPort: 9125
 
-# Settings for ingress resource
 ingress:
   enabled: false
   annotations: {}
   hosts: []
   tls: []
 
-# Pod resource requests & limits 
 resources: {}
 
-# Node labels for pod assignment
 nodeSelector: {}
 
-# Node tolerations for pod assignment
 tolerations: []
 
-# Node affinity for pod assignment
 affinity: {}
 
-# statsd-exporter mappings
+# statsdMappingConfig contains statsd-exporter metric mappings
 # https://github.com/prometheus/statsd_exporter#metric-mapping-and-configuration
 statsdMappingConfig: |-
   defaults:


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

Adds a prometheus-statsd-exporter chart.

#### Which issue this PR fixes

As per niclic/helm-charts/issues/3, this PR migrates a prometheus-statsd-exporter chart from [niclic](https://github.com/niclic/helm-charts) to [prometheus-community](https://github.com/prometheus-community/helm-charts).

See commit messages for details of changes made to the chart.

#### Special notes for your reviewer:

Future enhancements:
1. Add Service Monitor resource, as per niclic/helm-charts/pull/1
2. Figure out how to handle Ingress for statsd-exporter.

Currently, the ingress resource in this chart only supports exposing the `/metrics` web endpoint. There is a use case for perhaps exposing the `tcp` and/or `udp` ports to enable metric collection from sources outside the kubernetes cluster. For example, see niclic/helm-charts/issues/4. However, such a change would require additional changes to support exposing TCP and UDP services.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)

/cc @acondrat @yaron-idan @f84anton
