### PR TITLE
[prometheus-kafka-exporter] Servicemonitor is not able to find endpoints for kafka-exporter target (shows 0/0 up) #343

### DIFF
--- a/charts/prometheus-kafka-exporter/Chart.yaml
+++ b/charts/prometheus-kafka-exporter/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v1.2.0"
 description: A Helm chart to export the metrics from Kafka in Prometheus format using the kafka-exporter from https://github.com/danielqsj/kafka_exporter
 name: prometheus-kafka-exporter
 home: https://github.com/danielqsj/kafka_exporter
-version: 0.1.4
+version: 0.1.5
 sources:
   - https://gkarthiks.github.io/helm-charts/charts/prometheus-kafka-exporter
 keywords:

--- a/charts/prometheus-kafka-exporter/templates/service.yaml
+++ b/charts/prometheus-kafka-exporter/templates/service.yaml
@@ -15,7 +15,7 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: exporter-port
       protocol: TCP
-      name: http
+      name: exporter-port
   selector:
     app: {{ template "prometheus-kafka-exporter.name" . }}
     release: {{ .Release.Name }}

--- a/charts/prometheus-kafka-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-kafka-exporter/templates/servicemonitor.yaml
@@ -18,8 +18,8 @@ spec:
   jobLabel: jobLabel
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "prometheus-kafka-exporter.name" . }}
-      helm.sh/chart: {{ include "prometheus-kafka-exporter.chart" . }}
+      app: {{ template "prometheus-kafka-exporter.name" . }}
+      release: {{ .Release.Name }}
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}

--- a/charts/prometheus-kafka-exporter/values.yaml
+++ b/charts/prometheus-kafka-exporter/values.yaml
@@ -42,6 +42,12 @@ prometheus:
     enabled: false
     namespace: monitoring
     interval: "30s"
+    # If serviceMonitor is enabled and you want prometheus to automatically register
+    # target using serviceMonitor, add additionalLabels with prometheus release name
+    # e.g. If you have deployed kube-prometheus-stack with release name kube-prometheus
+    # then additionalLabels will be
+    # additionalLabels:
+    #   release: kube-prometheus
     additionalLabels: {}
 
 resources: {}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
This PR fix the issue of kafka-exporter endpoints not being displayed in prometheus targets.
After merging this PR serviceMonitor will be able to find the endpoints and endpoints will be shown in prometheus targets.
Kafka-exporter metrics then will be scraped by prometheus.

#### Which issue this PR fixes
  - fixes #343

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-kafka-exporter]`)

@gkarthiks Please review the PR.