### PR TITLE
[prometheus-adapter] Add missing dnsPolicy for hostNetwork

### DIFF
--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 2.7.2
+version: 2.8.0
 appVersion: v0.7.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/charts/prometheus-adapter/templates/deployment.yaml
+++ b/charts/prometheus-adapter/templates/deployment.yaml
@@ -34,6 +34,7 @@ spec:
       serviceAccountName: {{ template "k8s-prometheus-adapter.serviceAccountName" . }}
       {{- if .Values.hostNetwork.enabled }}
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}

--- a/charts/prometheus-adapter/templates/deployment.yaml
+++ b/charts/prometheus-adapter/templates/deployment.yaml
@@ -34,8 +34,8 @@ spec:
       serviceAccountName: {{ template "k8s-prometheus-adapter.serviceAccountName" . }}
       {{- if .Values.hostNetwork.enabled }}
       hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet
       {{- end }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/prometheus-adapter/values.yaml
+++ b/charts/prometheus-adapter/values.yaml
@@ -142,8 +142,11 @@ hostNetwork:
   #
   # You would require this enabled if you use alternate overlay networking for pods and
   # API server unable to communicate with metrics-server. As an example, this is required
-  # if you use Weave network on EKS
+  # if you use Weave network on EKS. See also dnsPolicy
   enabled: false
+
+# When hostNetwork is enabled, you probably want to set this to ClusterFirstWithHostNet
+dnsPolicy: Default
 
 podDisruptionBudget:
   # Specifies if PodDisruptionBudget should be enabled


### PR DESCRIPTION
#### What this PR does / why we need it:

In order to install prometheus adapter on EKS that is using custom CNI (e.g. Calico), it needs to use hostNetwork. This setting is available but we also need to set the correct dnsPolicy, same way [it is done here for example](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml#L127).

#### Which issue this PR fixes
  - fixes https://github.com/DirectXMan12/k8s-prometheus-adapter/issues/268

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
