### PR TITLE
[prometheus-blackbox-exporter] add detail comment to the option allowMonitoringNamespace in values.yaml

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 4.10.0
+version: 4.10.1
 appVersion: 0.18.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -211,6 +211,8 @@ networkPolicy:
   # Enable network policy and allow access from anywhere
   enabled: false
   # Limit access only from monitoring namespace
+  # Before setting this value to true, you must add the name=monitoring label to the monitoring namespace
+  # Network Policy uses label filtering
   allowMonitoringNamespace: false
 
 ## dnsPolicy and dnsConfig for Deployments and Daemonsets if you want non-default settings.


### PR DESCRIPTION
#### What this PR does / why we need it:
The namespaceSelector applies to labels on a Namespace, not fields on a Namespace.
There is a discussion about this in the kubernetes repository - kubernetes/kubernetes#88253

I described this in more detail in the comment on the option `allowMonitoringNamespace` in `values.yaml`

#### Which issue this PR fixes
  - fixes #221 
