### PR TITLE
[kube-prometheus-stack] Clarify log format options in kube-prometheus-stack

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 12.0.3
+version: 12.0.4
 appVersion: 0.43.2
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -426,7 +426,7 @@ alertmanager:
     #     alertmanagerconfig: enabled
 
     ## Define Log Format
-    # Use logfmt (default) or json-formatted logging
+    # Use logfmt (default) or json logging
     logFormat: logfmt
 
     ## Log level for Alertmanager to be configured with.
@@ -1308,7 +1308,7 @@ prometheusOperator:
   # priorityClassName: ""
 
   ## Define Log Format
-  # Use logfmt (default) or json-formatted logging
+  # Use logfmt (default) or json logging
   # logFormat: logfmt
 
   ## Decrease log verbosity to errors only


### PR DESCRIPTION

#### What this PR does / why we need it:
- There are 2 logFormat options for Operator and Alertmanager, which are
`logfmt` and `json`, but the comments now make it look like that the
options are `logfmt` and `json-formatted`

#### Special notes for your reviewer:


#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped (No need, since this PR only updates the comments?)
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
