### PR TITLE
[prometheus-couchdb-exporter]: add configurable apiVersion

### DIFF
--- a/charts/prometheus-couchdb-exporter/Chart.yaml
+++ b/charts/prometheus-couchdb-exporter/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart to export the metrics from couchdb in Prometheus format.
 name: prometheus-couchdb-exporter
 home: https://github.com/gesellix/couchdb-prometheus-exporter
-version: 0.1.3
+version: 0.2.0
 keywords:
 - couchdb-exporter
 sources:

--- a/charts/prometheus-couchdb-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-couchdb-exporter/templates/_helpers.tpl
@@ -41,3 +41,14 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for rbac.
+*/}}
+{{- define "rbac.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
+{{- print "rbac.authorization.k8s.io/v1" -}}
+{{- else -}}
+{{- print "rbac.authorization.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}} 

--- a/charts/prometheus-couchdb-exporter/templates/role.yaml
+++ b/charts/prometheus-couchdb-exporter/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: {{ template "rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ template "prometheus-couchdb-exporter.fullname" . }}

--- a/charts/prometheus-couchdb-exporter/templates/rolebinding.yaml
+++ b/charts/prometheus-couchdb-exporter/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: {{ template "rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   name: {{ template "prometheus-couchdb-exporter.fullname" . }}


### PR DESCRIPTION
Signed-off-by: Gabriel Melillo <gabriel@melillo.me>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

To successfully lint the helm chart with the latest version of Helm the RBAC apiVersion needs to be returned as `rbac.authorization.k8s.io/v1` since `rbac.authorization.k8s.io/v1beta1` is marked for deprecation.

#### Which issue this PR fixes

  - fixes #380 

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
