### PR TITLE
[prometheus-redis-exporter] Migrate to chart v2

### DIFF
--- a/charts/prometheus-redis-exporter/Chart.yaml
+++ b/charts/prometheus-redis-exporter/Chart.yaml
@@ -14,3 +14,4 @@ maintainers:
     email: arcadie.condrat@gmail.com
   - name: zanhsieh
     email: zanhsieh@gmail.com
+type: application

--- a/charts/prometheus-redis-exporter/Chart.yaml
+++ b/charts/prometheus-redis-exporter/Chart.yaml
@@ -1,8 +1,8 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: 1.11.1
 description: Prometheus exporter for Redis metrics
 name: prometheus-redis-exporter
-version: 3.7.0
+version: 4.0.0
 home: https://github.com/oliver006/redis_exporter
 sources:
   - https://github.com/oliver006/redis_exporter

--- a/charts/prometheus-redis-exporter/README.md
+++ b/charts/prometheus-redis-exporter/README.md
@@ -7,11 +7,13 @@ This chart bootstraps a [Redis exporter](https://github.com/oliver006/redis_expo
 ## Prerequisites
 
 - Kubernetes 1.10+ with Beta APIs enabled
+- Helm 3+
 
 ## Get Repo Info
 
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo add stable https://charts.helm.sh/stable
 helm repo update
 ```
 
@@ -20,11 +22,8 @@ _See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation
 ## Install Chart
 
 ```console
-# Helm 3
+# Helm
 $ helm install [RELEASE_NAME] prometheus-community/prometheus-redis-exporter
-
-# Helm 2
-$ helm install --name [RELEASE_NAME] prometheus-community/prometheus-redis-exporter
 ```
 
 _See [configuration](#configuration) below._
@@ -34,11 +33,8 @@ _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documen
 ## Uninstall Chart
 
 ```console
-# Helm 3
+# Helm
 $ helm uninstall [RELEASE_NAME]
-
-# Helm 2
-# helm delete --purge [RELEASE_NAME]
 ```
 
 This removes all the Kubernetes components associated with the chart and deletes the release.
@@ -48,7 +44,7 @@ _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command doc
 ## Upgrading Chart
 
 ```console
-# Helm 3 or 2
+# Helm
 $ helm upgrade [RELEASE_NAME] [CHART] --install
 ```
 
@@ -63,10 +59,7 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
 
 ```console
-# Helm 2
-$ helm inspect values prometheus-community/prometheus-redis-exporter
-
-# Helm 3
+# Helm
 $ helm show values prometheus-community/prometheus-redis-exporter
 ```
 


### PR DESCRIPTION
Signed-off-by: zanhsieh <zanhsieh@gmail.com>

#### What this PR does / why we need it:
Initial attempt to move to chart v2, since helm v2 has been out of support from Nov. 15th, 2020.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-redis-exporter]`)
