### PR TITLE
prometheus-cloudwatch-exporter - Add imagePullSecrets

### DIFF
--- a/charts/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/charts/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.8.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.10.1
+version: 0.11.0
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/charts/prometheus-cloudwatch-exporter/templates/deployment.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/deployment.yaml
@@ -26,6 +26,10 @@ spec:
       {{- with .Values.priorityClassName }}
       priorityClassName: "{{ . }}"
       {{- end }}
+    {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.image.pullSecrets | nindent 8 }}
+    {{- end }}
       containers:
         - name: {{ .Chart.Name }}
         {{- if not .Values.aws.role }}

--- a/charts/prometheus-cloudwatch-exporter/values.yaml
+++ b/charts/prometheus-cloudwatch-exporter/values.yaml
@@ -8,6 +8,8 @@ image:
   repository: prom/cloudwatch-exporter
   tag: cloudwatch_exporter-0.8.0
   pullPolicy: IfNotPresent
+  pullSecrets:
+  # - name: "image-pull-secret"
 
 # Example proxy configuration:
 # command:


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds `imagePullSecrets` to prometheus-cloudwatch-exporter.

#### Which issue this PR fixes
  - fixes https://github.com/prometheus-community/helm-charts/issues/129

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
