### PR TITLE
[prometheus-snmp-exporter] Fixes #398 and adds some features

### DIFF
--- a/charts/prometheus-snmp-exporter/Chart.yaml
+++ b/charts/prometheus-snmp-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Prometheus SNMP Exporter
 name: prometheus-snmp-exporter
-version: 0.0.6
-appVersion: 0.14.0
+version: 0.0.7
+appVersion: 0.19.0
 home: https://github.com/prometheus/snmp_exporter
 sources:
   - https://github.com/prometheus/snmp_exporter

--- a/charts/prometheus-snmp-exporter/Chart.yaml
+++ b/charts/prometheus-snmp-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus SNMP Exporter
 name: prometheus-snmp-exporter
-version: 0.0.7
+version: 0.1.0
 appVersion: 0.19.0
 home: https://github.com/prometheus/snmp_exporter
 sources:

--- a/charts/prometheus-snmp-exporter/Chart.yaml
+++ b/charts/prometheus-snmp-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus SNMP Exporter
 name: prometheus-snmp-exporter
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.19.0
 home: https://github.com/prometheus/snmp_exporter
 sources:

--- a/charts/prometheus-snmp-exporter/README.md
+++ b/charts/prometheus-snmp-exporter/README.md
@@ -91,3 +91,19 @@ scrape_configs:
       - target_label: __address__
         replacement: my-service-name:9116  # The SNMP exporter's Service name and port.
 ```
+
+Eaxample configuration via a ServiceMonitor
+```yaml
+serviceMonitor:
+  enabled: true
+  relabelings:
+    - sourceLabels: [__param_target]
+      targetLabel: instance
+  params:
+    enabled: true
+    conf:
+      module:
+        - fortigate_snmp
+      target:
+        - 192.168.1.2 # SNMP device
+```

--- a/charts/prometheus-snmp-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-snmp-exporter/templates/servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ template "prometheus-snmp-exporter.name" .  }}
+  name: {{ template "prometheus-snmp-exporter.fullname" .  }}
   {{- if .Values.serviceMonitor.namespace }}
   namespace: {{ .Values.serviceMonitor.namespace }}
   {{- end }}
@@ -18,6 +18,9 @@ spec:
     {{- end }}
     honorLabels: {{ .Values.serviceMonitor.honorLabels }}
     path: {{ .Values.serviceMonitor.path }}
+    {{- if .Values.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
+    {{- end }}
     {{- if .Values.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
     {{- end }}
@@ -25,7 +28,14 @@ spec:
     params:
 {{ toYaml .Values.serviceMonitor.params.conf | indent 6 }}
     {{- end }}
+    {{- if .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings: {{ toYaml .Values.serviceMonitor.metricRelabelings | nindent 8 }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.relabelings }}
+    relabelings: {{ toYaml .Values.serviceMonitor.relabelings | nindent 8 }}
+    {{- end }}
   selector:
     matchLabels:
-      app: {{ template "prometheus-snmp-exporter.name" . }}
+      app.kubernetes.io/name: {{ template "prometheus-snmp-exporter.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}

--- a/charts/prometheus-snmp-exporter/values.yaml
+++ b/charts/prometheus-snmp-exporter/values.yaml
@@ -2,7 +2,7 @@ restartPolicy: Always
 
 image:
   repository: prom/snmp-exporter
-  tag: v0.14.0
+  tag: v0.19.0
   pullPolicy: IfNotPresent
 
 nodeSelector: {}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
- Fixes ServiceMonitor to crawl the correct pods
- Fixes ServiceMonitor to properly work when multiple instances
  of the chart are installed
- Allows specifying relabelings and metricRelabelings configuration
  in ServiceMonitor

#### Which issue this PR fixes
  - fixes #398

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
