### PR TITLE
CI: Check if CODEOWNERS reflect chart maintainers

### DIFF
--- a/.github/workflows/check-codeowners.yaml
+++ b/.github/workflows/check-codeowners.yaml
@@ -1,0 +1,17 @@
+name: Check CODEOWNERS
+
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: install yq
+        run: |
+          sudo snap install yq
+      - name: generate CODEOWNERS
+        run: |
+          ./scripts/check-codeowners.sh > .github/CODEOWNERS
+      - name: check CODEOWNERS for modifications
+        run: |
+          git diff --exit-code

--- a/.github/workflows/check-codeowners.yaml
+++ b/.github/workflows/check-codeowners.yaml
@@ -6,10 +6,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: install yq
-        run: |
-          sudo snap install yq
       - name: generate CODEOWNERS
+        uses: mikefarah/yq@3.4.1
         run: |
           ./scripts/check-codeowners.sh > .github/CODEOWNERS
       - name: check CODEOWNERS for modifications

--- a/scripts/check-codeowners.sh
+++ b/scripts/check-codeowners.sh
@@ -15,6 +15,6 @@ for DIR in $(ls -1 -d ./charts/*)
 do
   FILE="$DIR/Chart.yaml"
   DIR=$(echo $DIR | sed 's/^\.//')
-  MAINTAINERS=$(yq r $FILE 'maintainers.[*].name'| sed 's/^/@/' | sort)
+  MAINTAINERS=$(yq r $FILE 'maintainers.[*].name'| sed 's/^/@/' | sort --ignore-case)
   echo $DIR/ $MAINTAINERS
 done


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

Script generates CODEOWNERS based on chart maintainers and checks if generated file shows a diff.


#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
