### PR TITLE
[kube-prometheus-stack] Allow custom TLS min version for operator

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 12.2.1
+version: 12.2.2
 appVersion: 0.43.2
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -93,6 +93,7 @@ spec:
             - --web.cert-file=cert/cert
             - --web.key-file=cert/key
             - --web.listen-address=:8443
+            - --web.tls-min-version={{ .Values.prometheusOperator.tls.tlsMinVersion }}
           ports:
             - containerPort: 8443
               name: https

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1214,6 +1214,8 @@ prometheusOperator:
   # Prometheus-Operator v0.39.0 and later support TLS natively.
   tls:
     enabled: true
+    # Value must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants
+    tlsMinVersion: VersionTLS13
 
   ## Admission webhook support for PrometheusRules resources added in Prometheus Operator 0.30 can be enabled to prevent incorrectly formatted
   ## rules from making their way into prometheus and potentially preventing the container from starting


### PR DESCRIPTION
#### What this PR does / why we need it:

With TLS enabled, by default kubectl (at least versions v1.14.x v1.15.x and v1.16.x) cannot create PrometheusRules because the min TLS version is too high. This allows a deployer to set a lower TLS version.

#### Which issue this PR fixes
Error from client: 
```
$ kubectl -n infra create -f rules.yaml 
Error from server (InternalError): error when creating "rules.yaml": Internal error occurred: failed calling webhook "prometheusrulemutate.monitoring.coreos.com": Post https://prometheus-operator-kube-p-operator.infra.svc:443/admission-prometheusrules/mutate?timeout=10s: remote error: tls: protocol version not supported

```
Error from prometheus-operator:
```
http: TLS handshake error from 10.244.67.0:42380: tls: client offered only unsupported versions: [303 302 301]
```
#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
