### PR TITLE
[kube-prometheus-stack] Fix broken volumes and volumeMounts fields on alertmanager

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 12.2.2
+version: 12.2.3
 appVersion: 0.43.2
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/alertmanager/alertmanager.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/alertmanager.yaml
@@ -116,10 +116,12 @@ spec:
 {{ toYaml .Values.alertmanager.alertmanagerSpec.additionalPeers | indent 4 }}
 {{- end }}
 {{- if .Values.alertmanager.alertmanagerSpec.volumes }}
-  volumes: {{.Values.alertmanager.alertmanagerSpec.volumes }}
+  volumes:
+{{ toYaml .Values.alertmanager.alertmanagerSpec.volumes | indent 4 }}
 {{- end }}
 {{- if .Values.alertmanager.alertmanagerSpec.volumeMounts }}
-  volumeMounts: {{.Values.alertmanager.alertmanagerSpec.volumeMounts }}
+  volumeMounts:
+{{ toYaml .Values.alertmanager.alertmanagerSpec.volumeMounts | indent 4 }}
 {{- end }}
   portName: {{ .Values.alertmanager.alertmanagerSpec.portName }}
 {{- end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -539,6 +539,12 @@ alertmanager:
     ##
     containers: []
 
+    # Additional volumes on the output StatefulSet definition.
+    volumes: []
+
+    # Additional VolumeMounts on the output StatefulSet definition.
+    volumeMounts: []
+
     ## Priority class assigned to the Pods
     ##
     priorityClassName: ""
@@ -1968,6 +1974,7 @@ prometheus:
 
     # Additional volumes on the output StatefulSet definition.
     volumes: []
+
     # Additional VolumeMounts on the output StatefulSet definition.
     volumeMounts: []
 


### PR DESCRIPTION

#### What this PR does / why we need it:

The `volume` and `volumeMounts` fields are currently treated as strings instead of an array of objects.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
