### PR TITLE
[prometheus] Potentially change default liveness and readiness to abide by GKE limitations

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: prometheus
-version: 12.0.0
+version: 12.0.1
 appVersion: 2.21.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -897,7 +897,7 @@ server:
   readinessProbeSuccessThreshold: 1
   livenessProbeInitialDelay: 30
   livenessProbePeriodSeconds: 15
-  livenessProbeTimeout: 4
+  livenessProbeTimeout: 10
   livenessProbeFailureThreshold: 3
   livenessProbeSuccessThreshold: 1
 

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -892,12 +892,12 @@ server:
   ##
   readinessProbeInitialDelay: 30
   readinessProbePeriodSeconds: 5
-  readinessProbeTimeout: 30
+  readinessProbeTimeout: 4
   readinessProbeFailureThreshold: 3
   readinessProbeSuccessThreshold: 1
   livenessProbeInitialDelay: 30
   livenessProbePeriodSeconds: 15
-  livenessProbeTimeout: 30
+  livenessProbeTimeout: 4
   livenessProbeFailureThreshold: 3
   livenessProbeSuccessThreshold: 1
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Changes the default configuration so that the liveness and readiness probes have timeouts shorter than the period. This addresses issue #410 which means that the chart does not currently play nicely with GKE HTTP Ingresses when configured in NodePort mode.

It does continue to make sense to me that the timeout for these things should be less than the period (Indeed, this is how Prometheus itself treats scraping). I am not sure that 4 seconds is the correct timeout for us to be using here, but 30 seconds does seem absurd when both the health and liveness endpoints have been designed to respond relatively quickly. I thought opening this PR would at least give us a chance to discuss this, or decide to just improve the documentation around deploying onto GKE rather than changing these default values. 

#### Which issue this PR fixes
Fixes #410 

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
