### PR TITLE
[prometheus-postgres-exporter] add initContainers

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.8.0"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 1.4.0
+version: 1.4.1
 home: https://github.com/wrouesnel/postgres_exporter
 sources:
 - https://github.com/wrouesnel/postgres_exporter

--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.8.0"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 1.4.1
+version: 1.5.0
 home: https://github.com/wrouesnel/postgres_exporter
 sources:
 - https://github.com/wrouesnel/postgres_exporter

--- a/charts/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/charts/prometheus-postgres-exporter/templates/deployment.yaml
@@ -31,6 +31,10 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ template "prometheus-postgres-exporter.serviceAccountName" . }}
+{{- if .Values.initContainers }}
+      initContainers:
+{{ toYaml .Values.initContainers | indent 8 }}
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}
           args:

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -320,6 +320,14 @@ annotations: {}
 
 podLabels: {}
 
+# Init containers, e. g. for secrets creation before the exporter
+initContainers: []
+  # - name:
+  #   image:
+  #   volumeMounts:
+  #     - name: creds
+  #       mountPath: /creds
+
 # Additional sidecar containers, e. g. for a database proxy, such as Google's cloudsql-proxy
 extraContainers: |
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Currently the exporter does not propose init containers parameter, it can be useful for example to have an init job to create credentials




#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
