### PR TITLE
[prometheus-kafka-exporter] fixed typo in readme

### DIFF
--- a/charts/prometheus-kafka-exporter/README.md
+++ b/charts/prometheus-kafka-exporter/README.md
@@ -1,6 +1,6 @@
 # prometheus-kafka-exporter
 
-A Prometheus exporter for [Apacher Kafka](https://kafka.apache.org/) metrics.
+A Prometheus exporter for [Apache Kafka](https://kafka.apache.org/) metrics.
 
 This chart bootstraps a [Kafka Exporter](https://github.com/danielqsj/kafka_exporter) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 


### PR DESCRIPTION
Signed-off-by: Rami H rami.hassanein@gmail.com

#### What this PR does / why we need it:
This PR fixes a typo in the [prometheus-kafka-exporter] readme

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
