### PR TITLE
Changing default container port in prometheus-blackbox-exporter

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 4.10.1
+version: 4.10.2
 appVersion: 0.18.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/charts/prometheus-blackbox-exporter/templates/deployment.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/deployment.yaml
@@ -90,7 +90,7 @@ spec:
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           ports:
-            - containerPort: {{ .Values.service.targetPort }}
+            - containerPort: {{ .Values.containerPort }}
               name: http
           livenessProbe:
             {{- toYaml .Values.livenessProbe | trim | nindent 12 }}

--- a/charts/prometheus-blackbox-exporter/templates/deployment.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/deployment.yaml
@@ -90,7 +90,7 @@ spec:
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           ports:
-            - containerPort: {{ .Values.service.port }}
+            - containerPort: {{ .Values.service.targetPort }}
               name: http
           livenessProbe:
             {{- toYaml .Values.livenessProbe | trim | nindent 12 }}

--- a/charts/prometheus-blackbox-exporter/templates/service.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/service.yaml
@@ -19,7 +19,7 @@ spec:
   ports:
     - name: http
       port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.targetPort }}
+      targetPort: http
       protocol: TCP
 {{- if .Values.service.externalIPs }}
   externalIPs:

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -132,7 +132,11 @@ service:
   labels: {}
   type: ClusterIP
   port: 9115
-  targetPort: 9115
+
+# Only changes container port. Application port can be changed with extraArgs (--web.listen-address=:9115)
+# https://github.com/prometheus/blackbox_exporter/blob/998037b5b40c1de5fee348ffdea8820509d85171/main.go#L55
+containerPort: 9115
+
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
Imagine we want to change the service port from 9115 to another value.
Because the `containerPort` in `deployment.yaml` is referring to service port, if we want to change the service port in `Values.yaml`, app will still listen in 9115 and container in the newly specified port and the probes will fail. That's why I think container port meant to listen to the `targetPort` in the `Values.yaml`.

#### Comment to the maintainers
Though I cannot see the reason why someone would like to do that, but the same issue will arise if someone changes the targetPort in `Values.yaml`. We should either change app listening port to be set to the targetPort [(here)](https://github.com/prometheus/blackbox_exporter/blob/57b2925620b3ea2d3bb20899e16a415c2d5dd95b/main.go#L55) or just remove the the line from `Values.yaml`. I didn't change that because it is rare scenario and also it also depends on how maintainers wanted to proceed.


#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
