### PR TITLE
[prometheus-adapter] Default to not dnsPolicy to keep cluster default

### DIFF
--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 2.8.0
+version: 2.8.1
 appVersion: v0.7.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/charts/prometheus-adapter/templates/deployment.yaml
+++ b/charts/prometheus-adapter/templates/deployment.yaml
@@ -35,7 +35,9 @@ spec:
       {{- if .Values.hostNetwork.enabled }}
       hostNetwork: true
       {{- end }}
+      {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
+      {{- end}}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/prometheus-adapter/values.yaml
+++ b/charts/prometheus-adapter/values.yaml
@@ -146,7 +146,7 @@ hostNetwork:
   enabled: false
 
 # When hostNetwork is enabled, you probably want to set this to ClusterFirstWithHostNet
-dnsPolicy: Default
+# dnsPolicy: ClusterFirstWithHostNet
 
 podDisruptionBudget:
   # Specifies if PodDisruptionBudget should be enabled


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

This fixes a regression from #375. That made the default dnsPolicy Default. This is *not* typically the default dnsPolicy of a cluster. In EKS the default is ClusterFirst.

I got an error message like this after installing the chart:

```
> kubectl top nodes
Error from server: Error while fetching node metrics for selector : unable to fetch node CPU metrics: unable to execute query: Get http://prometheus:9090/api/v1/query?query=...: dial tcp: lookup prometheus on XX.XX.0.2:53: no such host
```

Instead with this fix no dnsPolicy is set by default in the Deployment.
#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
