### PR TITLE
[prometheus] - Fix/node exporter host bug

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: prometheus
-version: 12.0.1
+version: 12.0.2
 appVersion: 2.21.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/templates/node-exporter/daemonset.yaml
+++ b/charts/prometheus/templates/node-exporter/daemonset.yaml
@@ -45,6 +45,7 @@ spec:
           args:
             - --path.procfs=/host/proc
             - --path.sysfs=/host/sys
+            - --path.rootfs=/host/root
           {{- if .Values.nodeExporter.hostNetwork }}
             - --web.listen-address=:{{ .Values.nodeExporter.service.hostPort }}
           {{- end }}
@@ -71,6 +72,10 @@ spec:
               readOnly:  true
             - name: sys
               mountPath: /host/sys
+              readOnly: true
+            - name: root
+              mountPath: /host/root
+              mountPropagation: HostToContainer
               readOnly: true
           {{- range .Values.nodeExporter.extraHostPathMounts }}
             - name: {{ .name }}
@@ -114,6 +119,9 @@ spec:
         - name: sys
           hostPath:
             path: /sys
+        - name: root
+          hostPath:
+            path: /
       {{- range .Values.nodeExporter.extraHostPathMounts }}
         - name: {{ .name }}
           hostPath:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -530,8 +530,11 @@ nodeExporter:
 
   ## Security context to be added to node-exporter pods
   ##
-  securityContext: {}
-    # runAsUser: 0
+  securityContext:
+    fsGroup: 65534
+    runAsGroup: 65534
+    runAsNonRoot: true
+    runAsUser: 65534
 
   service:
     annotations:


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds in default enabling of flag `path.rootfs` with required mounts and volumes.
As per [docs](https://github.com/prometheus/node_exporter#using-docker) 
```
If you start container for host monitoring, specify path.rootfs argument. This argument must match path in bind-mount of host root. The node_exporter will use path.rootfs as prefix to access host filesystem.
```

Also enables default securityContexts for the pods (to match [prometheus-node-exporter] chart
@naseemkullah @monotek @Xtigyro @zanhsieh @gianrubio 

#### Which issue this PR fixes
fixes https://github.com/prometheus-community/helm-charts/issues/447

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ x] Chart Version bumped
- [ x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
