### PR TITLE
[kube-prometheus-stack] Upgrade grafana dependency to 6.1 & update configReloaderMemory default

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -1,0 +1,12 @@
+dependencies:
+- name: kube-state-metrics
+  repository: https://charts.helm.sh/stable
+  version: 2.9.4
+- name: prometheus-node-exporter
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 1.12.0
+- name: grafana
+  repository: https://grafana.github.io/helm-charts
+  version: 6.1.16
+digest: sha256:501848912e007b99631a6cd03347c17f9b661c9645d571da9f633a85c095df31
+generated: "2021-01-04T16:02:02.806098+01:00"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 12.9.2
+version: 12.10.0
 appVersion: 0.44.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus
@@ -44,6 +44,6 @@ dependencies:
   repository: https://prometheus-community.github.io/helm-charts
   condition: nodeExporter.enabled
 - name: grafana
-  version: "5.8.*"
+  version: "6.1.*"
   repository: https://grafana.github.io/helm-charts
   condition: grafana.enabled

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1452,7 +1452,7 @@ prometheusOperator:
 
   ## Set the prometheus config reloader side-car memory limit
   ##
-  configReloaderMemory: 25Mi
+  configReloaderMemory: 50Mi
 
   ## Set a Field Selector to filter watched secrets
   ##


### PR DESCRIPTION
- Upgrade grafana dependency to 6.1
- ~~bump major version to match grafana breaking change~~ -> No, see below
- update prometheusOperator.configReloaderMemory from 25Mi to 50Mi to follow 0.44.0 change in https://github.com/prometheus-operator/prometheus-operator/pull/3660.
- Add Chart.lock in .gitignore

#### Special notes for your reviewer:

~~Should we add Chart.lock in .gitignore or add Chart.lock? ;)~~ -> yes

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
