### PR TITLE
[prometheus-mysql-exporter] Use alpine cloudsql-proxy image

### DIFF
--- a/charts/prometheus-mysql-exporter/Chart.yaml
+++ b/charts/prometheus-mysql-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for prometheus mysql exporter with cloudsqlproxy
 name: prometheus-mysql-exporter
-version: 1.0.0
+version: 1.0.1
 home: https://github.com/prometheus/mysqld_exporter
 appVersion: v0.12.1
 sources:

--- a/charts/prometheus-mysql-exporter/values.yaml
+++ b/charts/prometheus-mysql-exporter/values.yaml
@@ -109,7 +109,7 @@ cloudsqlproxy:
   enabled: false
   image:
     repo: "gcr.io/cloudsql-docker/gce-proxy"
-    tag: "1.16"
+    tag: "1.19.1-alpine"
     pullPolicy: "IfNotPresent"
   instanceConnectionName: "project:us-central1:dbname"
   port: "3306"


### PR DESCRIPTION
From the 1.16 version, they move the cloudsql-proxy image from alpine to distroless.

https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/317#issuecomment-540869722

Its make the lives probe starting to fail for us as well: https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus-mysql-exporter/templates/deployment.yaml#L68

But they include other tags for folks that need a shell in the container: https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/371

I did a test, seems good:
```
docker run -ti --rm gcr.io/cloudsql-docker/gce-proxy:1.19.1-alpine /bin/sh
/ $ nc
BusyBox v1.31.1 () multi-call binary.

Usage: nc [OPTIONS] HOST PORT  - connect
nc [OPTIONS] -l -p PORT [HOST] [PORT]  - listen

	-e PROG	Run PROG after connect (must be last)
	-l	Listen mode, for inbound connects
	-lk	With -e, provides persistent server
	-p PORT	Local port
	-s ADDR	Local address
	-w SEC	Timeout for connects and final net reads
	-i SEC	Delay interval for lines sent
	-n	Don't do DNS resolution
	-u	UDP mode
	-v	Verbose
	-o FILE	Hex dump traffic
	-z	Zero-I/O mode (scanning)
```