### PR TITLE
[kube-prometheus-stack] wrong comparisons fixed, sum vs count

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 12.7.0
+version: 12.7.1
 appVersion: 0.44.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-resources.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-resources.yaml
@@ -34,7 +34,7 @@ spec:
           /
         sum(kube_node_status_allocatable_cpu_cores)
           >
-        (count(kube_node_status_allocatable_cpu_cores)-1) / count(kube_node_status_allocatable_cpu_cores)
+        (sum(kube_node_status_allocatable_cpu_cores)-1) / sum(kube_node_status_allocatable_cpu_cores)
       for: 5m
       labels:
         severity: warning
@@ -51,9 +51,9 @@ spec:
           /
         sum(kube_node_status_allocatable_memory_bytes)
           >
-        (count(kube_node_status_allocatable_memory_bytes)-1)
+        (sum(kube_node_status_allocatable_memory_bytes)-1)
           /
-        count(kube_node_status_allocatable_memory_bytes)
+        sum(kube_node_status_allocatable_memory_bytes)
       for: 5m
       labels:
         severity: warning


### PR DESCRIPTION
CPU and Memory Overcommit rules are broken, being the comparisons to be fixed:

https://prometheus.io/docs/prometheus/latest/querying/operators/#aggregation-operators
Differently from sum, count doesn't take into account the actual value, leading to a comparison bug and to a firing even if the resource are not in an overcommit status

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
Bug fix

#### Which issue this PR fixes
  - fixes #471

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
