### PR TITLE
[prometheus-adapter] cert-manager support

### DIFF
--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 2.10.1
+version: 2.11.0
 appVersion: v0.8.2
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/charts/prometheus-adapter/templates/certmanager.yaml
+++ b/charts/prometheus-adapter/templates/certmanager.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.certManager.enabled -}}
+---
+# Create a selfsigned Issuer, in order to create a root CA certificate for
+# signing webhook serving certificates
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ template "k8s-prometheus-adapter.fullname" . }}-self-signed-issuer
+spec:
+  selfSigned: {}
+---
+# Generate a CA Certificate used to sign certificates for the webhook
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ template "k8s-prometheus-adapter.fullname" . }}-root-cert
+spec:
+  secretName: {{ template "k8s-prometheus-adapter.fullname" . }}-root-cert
+  duration: {{ .Values.certManager.caCertDuration }}
+  issuerRef:
+    name: {{ template "k8s-prometheus-adapter.fullname" . }}-self-signed-issuer
+  commonName: "ca.webhook.prometheus-adapter"
+  isCA: true
+---
+# Create an Issuer that uses the above generated CA certificate to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ template "k8s-prometheus-adapter.fullname" . }}-root-issuer
+spec:
+  ca:
+    secretName: {{ template "k8s-prometheus-adapter.fullname" . }}-root-cert
+---
+# Finally, generate a serving certificate for the apiservices to use
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ template "k8s-prometheus-adapter.fullname" . }}-cert
+spec:
+  secretName: {{ template "k8s-prometheus-adapter.fullname" . }}
+  duration: {{ .Values.certManager.certDuration }}
+  issuerRef:
+    name: {{ template "k8s-prometheus-adapter.fullname" . }}-root-issuer
+  dnsNames:
+  - {{ template "k8s-prometheus-adapter.fullname" . }}
+  - {{ template "k8s-prometheus-adapter.fullname" . }}.{{ .Release.Namespace }}
+  - {{ template "k8s-prometheus-adapter.fullname" . }}.{{ .Release.Namespace }}.svc
+{{- end -}}

--- a/charts/prometheus-adapter/templates/custom-metrics-apiservice.yaml
+++ b/charts/prometheus-adapter/templates/custom-metrics-apiservice.yaml
@@ -6,6 +6,11 @@ apiVersion: apiregistration.k8s.io/v1beta1
 {{- end }}
 kind: APIService
 metadata:
+{{- if .Values.certManager.enabled }}
+  annotations:
+    certmanager.k8s.io/inject-ca-from: {{ printf "%s/%s-root-cert" .Release.Namespace (include "k8s-prometheus-adapter.fullname" .) | quote }}
+    cert-manager.io/inject-ca-from: {{ printf "%s/%s-root-cert" .Release.Namespace (include "k8s-prometheus-adapter.fullname" .) | quote }}
+{{- end }}
   labels:
     app: {{ template "k8s-prometheus-adapter.name" . }}
     chart: {{ template "k8s-prometheus-adapter.chart" . }}
@@ -16,12 +21,12 @@ spec:
   service:
     name: {{ template "k8s-prometheus-adapter.fullname" . }}
     namespace: {{ .Release.Namespace | quote }}
-  {{ if .Values.tls.enable -}}
+  {{- if .Values.tls.enable -}}
   caBundle: {{ b64enc .Values.tls.ca }}
   {{- end }}
   group: custom.metrics.k8s.io
   version: v1beta1
-  insecureSkipTLSVerify: {{ if .Values.tls.enable }}false{{ else }}true{{ end }}
+  insecureSkipTLSVerify: {{ if or .Values.tls.enable .Values.certManager.enabled }}false{{ else }}true{{ end }}
   groupPriorityMinimum: 100
   versionPriority: 100
 {{- end }}

--- a/charts/prometheus-adapter/templates/deployment.yaml
+++ b/charts/prometheus-adapter/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
         args:
         - /adapter
         - --secure-port={{ .Values.listenPort }}
-        {{- if .Values.tls.enable }}
+        {{- if or .Values.tls.enable .Values.certManager.enabled }}
         - --tls-cert-file=/var/run/serving-cert/tls.crt
         - --tls-private-key-file=/var/run/serving-cert/tls.key
         {{- end }}
@@ -93,7 +93,7 @@ spec:
           readOnly: true
         - mountPath: /tmp
           name: tmp
-        {{- if .Values.tls.enable }}
+        {{- if or .Values.tls.enable .Values.certManager.enabled }}
         - mountPath: /var/run/serving-cert
           name: volume-serving-cert
           readOnly: true
@@ -120,7 +120,7 @@ spec:
           name: {{ .Values.rules.existing | default (include "k8s-prometheus-adapter.fullname" . ) }}
       - name: tmp
         emptyDir: {}
-      {{- if .Values.tls.enable }}
+      {{- if or .Values.tls.enable .Values.certManager.enabled }}
       - name: volume-serving-cert
         secret:
           secretName: {{ template "k8s-prometheus-adapter.fullname" . }}

--- a/charts/prometheus-adapter/templates/external-metrics-apiservice.yaml
+++ b/charts/prometheus-adapter/templates/external-metrics-apiservice.yaml
@@ -6,6 +6,11 @@ apiVersion: apiregistration.k8s.io/v1beta1
 {{- end }}
 kind: APIService
 metadata:
+{{- if .Values.certManager.enabled }}
+  annotations:
+    certmanager.k8s.io/inject-ca-from: {{ printf "%s/%s-root-cert" .Release.Namespace (include "k8s-prometheus-adapter.fullname" .) | quote }}
+    cert-manager.io/inject-ca-from: {{ printf "%s/%s-root-cert" .Release.Namespace (include "k8s-prometheus-adapter.fullname" .) | quote }}
+{{- end }}
   labels:
     app: {{ template "k8s-prometheus-adapter.name" . }}
     chart: {{ template "k8s-prometheus-adapter.chart" . }}
@@ -16,12 +21,12 @@ spec:
   service:
     name: {{ template "k8s-prometheus-adapter.fullname" . }}
     namespace: {{ .Release.Namespace | quote }}
-  {{ if .Values.tls.enable -}}
+  {{- if .Values.tls.enable -}}
   caBundle: {{ b64enc .Values.tls.ca }}
   {{- end }}
   group: external.metrics.k8s.io
   version: v1beta1
-  insecureSkipTLSVerify: {{ if .Values.tls.enable }}false{{ else }}true{{ end }}
+  insecureSkipTLSVerify: {{ if or .Values.tls.enable .Values.certManager.enabled }}false{{ else }}true{{ end }}
   groupPriorityMinimum: 100
   versionPriority: 100
 {{- end -}}

--- a/charts/prometheus-adapter/templates/resource-metrics-apiservice.yaml
+++ b/charts/prometheus-adapter/templates/resource-metrics-apiservice.yaml
@@ -6,6 +6,11 @@ apiVersion: apiregistration.k8s.io/v1beta1
 {{- end }}
 kind: APIService
 metadata:
+{{- if .Values.certManager.enabled }}
+  annotations:
+    certmanager.k8s.io/inject-ca-from: {{ printf "%s/%s-root-cert" .Release.Namespace (include "k8s-prometheus-adapter.fullname" .) | quote }}
+    cert-manager.io/inject-ca-from: {{ printf "%s/%s-root-cert" .Release.Namespace (include "k8s-prometheus-adapter.fullname" .) | quote }}
+{{- end }}
   labels:
     app: {{ template "k8s-prometheus-adapter.name" . }}
     chart: {{ template "k8s-prometheus-adapter.chart" . }}
@@ -16,12 +21,12 @@ spec:
   service:
     name: {{ template "k8s-prometheus-adapter.fullname" . }}
     namespace: {{ .Release.Namespace | quote }}
-  {{ if .Values.tls.enable -}}
+  {{- if .Values.tls.enable -}}
   caBundle: {{ b64enc .Values.tls.ca }}
   {{- end }}
   group: metrics.k8s.io
   version: v1beta1
-  insecureSkipTLSVerify: {{ if .Values.tls.enable }}false{{ else }}true{{ end }}
+  insecureSkipTLSVerify: {{ if or .Values.tls.enable .Values.certManager.enabled }}false{{ else }}true{{ end }}
   groupPriorityMinimum: 100
   versionPriority: 100
 {{- end -}}

--- a/charts/prometheus-adapter/values.yaml
+++ b/charts/prometheus-adapter/values.yaml
@@ -159,3 +159,8 @@ podDisruptionBudget:
   enabled: false
   minAvailable:
   maxUnavailable: 1
+
+certManager:
+  enabled: false
+  caCertDuration: 43800h
+  certDuration: 8760h


### PR DESCRIPTION
Signed-off-by: Adam Graves <adam.graves85@gmail.com>

#### What this PR does / why we need it:

Adds cert-manager support to the prometheus-adapter apiservice.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
