### PR TITLE
[prometheus-node-exporter] Adding secret support for oauth psidecar

### DIFF
--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.1
 description: A Helm chart for prometheus node-exporter
 name: prometheus-node-exporter
-version: 1.12.0
+version: 1.13.0
 home: https://github.com/prometheus/node_exporter/
 sources:
 - https://github.com/prometheus/node_exporter/

--- a/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -55,7 +55,7 @@ spec:
             {{- end }}
           ports:
             - name: metrics
-              containerPort: {{ .Values.service.targetPort }}
+              containerPort: {{ .Values.service.port }}
               protocol: TCP
           livenessProbe:
             httpGet:
@@ -99,6 +99,12 @@ spec:
             {{- range $_, $mount := .Values.configmaps }}
             - name: {{ $mount.name }}
               mountPath: {{ $mount.mountPath }}
+            {{- end }}
+            {{- if .Values.secrets }}
+            {{- range $_, $mount := .Values.secrets }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+            {{- end }}
             {{- end }}
             {{- end }}
 {{- if .Values.sidecars }}
@@ -155,5 +161,12 @@ spec:
         - name: {{ $mount.name }}
           configMap:
             name: {{ $mount.name }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.secrets }}
+        {{- range $_, $mount := .Values.secrets }}
+        - name: {{ $mount.name }}
+          secret:
+            secretName: {{ $mount.name }}
         {{- end }}
         {{- end }}

--- a/charts/prometheus-node-exporter/templates/monitor.yaml
+++ b/charts/prometheus-node-exporter/templates/monitor.yaml
@@ -15,6 +15,13 @@ spec:
       release: {{ .Release.Name }}
   endpoints:
     - port: metrics
+      scheme: {{ $.Values.prometheus.monitor.scheme }}
+      {{- if $.Values.prometheus.monitor.bearerTokenFile }}
+      bearerTokenFile: {{ $.Values.prometheus.monitor.bearerTokenFile }}
+      {{- end }}
+      {{- if $.Values.prometheus.monitor.tlsConfig }}
+      tlsConfig: {{ toYaml $.Values.prometheus.monitor.tlsConfig | nindent 8 }}
+      {{- end }}
       {{- if .Values.prometheus.monitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.prometheus.monitor.scrapeTimeout }}
       {{- end }}

--- a/charts/prometheus-node-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-node-exporter/templates/serviceaccount.yaml
@@ -10,6 +10,8 @@ metadata:
     chart: {{ template "prometheus-node-exporter.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
 imagePullSecrets:
 {{ toYaml .Values.serviceAccount.imagePullSecrets | indent 2 }}
 {{- end -}}

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -20,6 +20,9 @@ prometheus:
     enabled: false
     additionalLabels: {}
     namespace: ""
+    scheme: http
+    bearerTokenFile:
+    tlsConfig: {}
 
     relabelings: []
     scrapeTimeout: 10s
@@ -48,6 +51,7 @@ serviceAccount:
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
+  annotations: {}
   imagePullSecrets: []
 
 securityContext:
@@ -122,7 +126,9 @@ extraHostVolumeMounts: []
 configmaps: []
 # - name: <configMapName>
 #   mountPath: <mountPath>
-
+secrets: []
+# - name: <secretName>
+#   mountPath: <mountPatch>
 ## Override the deployment namespace
 ##
 namespaceOverride: ""


### PR DESCRIPTION
Signed-off-by: Philippe Bürgisser <philippe.burgisser@camptocamp.com>

#### What this PR does / why we need it:
- Adding secrets mount used to expose for eg tls certificate used by oauth proxy
- Changed port variable in daemonset so we can keep node-exporter on the same port but targetPort points to the sidecar container

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)