### PR TITLE
[kube-prometheus-stack] Use https for kube-scheduler and kube-controller-manager metrics

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 12.8.0
+version: 12.8.1
 appVersion: 0.44.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -863,8 +863,8 @@ kubeControllerManager:
   ## If using kubeControllerManager.endpoints only the port and targetPort are used
   ##
   service:
-    port: 10252
-    targetPort: 10252
+    port: 10257
+    targetPort: 10257
     # selector:
     #   component: kube-controller-manager
 
@@ -876,10 +876,10 @@ kubeControllerManager:
     ## Enable scraping kube-controller-manager over https.
     ## Requires proper certs (not self-signed) and delegated authentication/authorization checks
     ##
-    https: false
+    https: true
 
     # Skip TLS certificate validation when scraping
-    insecureSkipVerify: null
+    insecureSkipVerify: true
 
     # Name of the server to use when validating TLS certificate
     serverName: null
@@ -1056,8 +1056,8 @@ kubeScheduler:
   ## If using kubeScheduler.endpoints only the port and targetPort are used
   ##
   service:
-    port: 10251
-    targetPort: 10251
+    port: 10259
+    targetPort: 10259
     # selector:
     #   component: kube-scheduler
 
@@ -1068,10 +1068,10 @@ kubeScheduler:
     ## Enable scraping kube-scheduler over https.
     ## Requires proper certs (not self-signed) and delegated authentication/authorization checks
     ##
-    https: false
+    https: true
 
     ## Skip TLS certificate validation when scraping
-    insecureSkipVerify: null
+    insecureSkipVerify: true
 
     ## Name of the server to use when validating TLS certificate
     serverName: null


### PR DESCRIPTION
#### What this PR does / why we need it:
Since k8s 1.18.x uses https ports and disable http port for Kube-scheduler, Kube-controller manager. So we need to update service monitor settings to work with new ports.

prometheus-operator already did that: https://github.com/prometheus-operator/kube-prometheus/pull/621/files

Without these changes alerts KubeControllerManagerDown and kubeSchedulerDown are firing.

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
