### PR TITLE
[prometheus] Update Helm dependency to use new kube-state-metrics chart versions

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -29,3 +29,4 @@ dependencies:
     version: "2.9.*"
     repository: https://kubernetes.github.io/kube-state-metrics
     condition: kubeStateMetrics.enabled
+

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -29,4 +29,3 @@ dependencies:
     version: "2.9.*"
     repository: https://kubernetes.github.io/kube-state-metrics
     condition: kubeStateMetrics.enabled
-

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -27,5 +27,5 @@ type: application
 dependencies:
   - name: kube-state-metrics
     version: "2.9.*"
-    repository: https://kubernetes.github.io/kube-state-metrics
+    repository: https://charts.helm.sh/stable
     condition: kubeStateMetrics.enabled

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: prometheus
-version: 13.0.0
+version: 13.0.1
 appVersion: 2.22.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
@@ -26,6 +26,6 @@ engine: gotpl
 type: application
 dependencies:
   - name: kube-state-metrics
-    version: "2.8.*"
-    repository: https://charts.helm.sh/stable/
+    version: "2.9.*"
+    repository: https://kubernetes.github.io/kube-state-metrics
     condition: kubeStateMetrics.enabled

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -27,5 +27,5 @@ type: application
 dependencies:
   - name: kube-state-metrics
     version: "2.9.*"
-    repository: https://charts.helm.sh/stable/
+    repository: https://kubernetes.github.io/kube-state-metrics
     condition: kubeStateMetrics.enabled

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -27,5 +27,5 @@ type: application
 dependencies:
   - name: kube-state-metrics
     version: "2.9.*"
-    repository: https://charts.helm.sh/stable
+    repository: https://charts.helm.sh/stable/
     condition: kubeStateMetrics.enabled

--- a/charts/prometheus/README.md
+++ b/charts/prometheus/README.md
@@ -13,7 +13,7 @@ This chart bootstraps a [Prometheus](https://prometheus.io/) deployment on a [Ku
 
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo add stable https://charts.helm.sh/stable
+helm repo add kube-state-metrics https://kubernetes.github.io/kube-state-metrics
 helm repo update
 ```
 

--- a/charts/prometheus/README.md
+++ b/charts/prometheus/README.md
@@ -13,7 +13,7 @@ This chart bootstraps a [Prometheus](https://prometheus.io/) deployment on a [Ku
 
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo add kube-state-metrics https://kubernetes.github.io/kube-state-metrics
+helm repo add stable https://charts.helm.sh/stable
 helm repo update
 ```
 

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -413,7 +413,7 @@ kubeStateMetrics:
   enabled: true
 
 ## kube-state-metrics sub-chart configurable values
-## Please see https://github.com/helm/charts/tree/master/stable/kube-state-metrics
+## Please see https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics
 ##
 # kube-state-metrics:
 

--- a/ct.yaml
+++ b/ct.yaml
@@ -7,6 +7,7 @@ chart-repos:
   - stable=https://charts.helm.sh/stable
   - prometheus-community=https://prometheus-community.github.io/helm-charts
   - grafana=https://grafana.github.io/helm-charts
+  - kube-state-metrics=https://kubernetes.github.io/kube-state-metrics
 helm-extra-args: --timeout 600s
 excluded-charts:
   # If not running on GCE, will error: "Failed to get GCE config"

--- a/ct.yaml
+++ b/ct.yaml
@@ -13,4 +13,3 @@ helm-extra-args: --timeout 600s
 excluded-charts:
   # If not running on GCE, will error: "Failed to get GCE config"
   - prometheus-to-sd
-

--- a/ct.yaml
+++ b/ct.yaml
@@ -8,8 +8,9 @@ chart-repos:
   - grafana=https://grafana.github.io/helm-charts
   - prometheus-community=https://prometheus-community.github.io/helm-charts
   - stable=https://charts.helm.sh/stable
-  - kube-state-metrics=https://kubernetes.github.io/kube-state-metrics 
+  - kube-state-metrics=https://kubernetes.github.io/kube-state-metrics
 helm-extra-args: --timeout 600s
 excluded-charts:
   # If not running on GCE, will error: "Failed to get GCE config"
   - prometheus-to-sd
+


### PR DESCRIPTION
#### What this PR does / why we need it:

1) Updates the version of the `kube-state-metrics` dependency to `"2.9.*"` - this will allow for support of using the latest features of the chart

#### Which issue this PR fixes
None.

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
