### PR TITLE
[kube-prometheus-stack] Add grpc thanos port to prometheus service

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 12.8.0
+version: 12.8.1
 appVersion: 0.44.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/service.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/service.yaml
@@ -39,6 +39,14 @@ spec:
     {{- end }}
     port: {{ .Values.prometheus.service.port }}
     targetPort: {{ .Values.prometheus.service.targetPort }}
+  {{- if .Values.prometheus.thanosIngress.enabled }}
+  - name: grpc
+    {{- if eq .Values.prometheus.service.type "NodePort" }}
+    nodePort: {{ .Values.prometheus.thanosIngress.servicePort }}
+    {{- end }}
+    port: {{ .Values.prometheus.thanosIngress.servicePort }}
+    targetPort: {{ .Values.prometheus.thanosIngress.servicePort }}
+  {{- end }}
 {{- if .Values.prometheus.service.additionalPorts }}
 {{ toYaml .Values.prometheus.service.additionalPorts | indent 2 }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds grpc thanos port to prometheus service. The thanos ingress was pointing to a non-existent port.

#### Which issue this PR fixes
  - fixes #426 

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
