### PR TITLE
[prometheus] add .Capabilities.APIVersions for IngressClass fixes #507

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: prometheus
-version: 13.0.0
+version: 13.0.1
 appVersion: 2.22.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/templates/alertmanager/ingress.yaml
+++ b/charts/prometheus/templates/alertmanager/ingress.yaml
@@ -18,6 +18,11 @@ metadata:
   name: {{ template "prometheus.alertmanager.fullname" . }}
 {{ include "prometheus.namespace" . | indent 2 }}
 spec:
+  {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass") (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/IngressClass") }}
+  {{- if .Values.alertmanager.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.alertmanager.ingress.ingressClassName }}
+  {{- end }}
+  {{- end }}
   rules:
   {{- range .Values.alertmanager.ingress.hosts }}
     {{- $url := splitList "/" . }}

--- a/charts/prometheus/templates/server/ingress.yaml
+++ b/charts/prometheus/templates/server/ingress.yaml
@@ -19,6 +19,11 @@ metadata:
   name: {{ template "prometheus.server.fullname" . }}
 {{ include "prometheus.namespace" . | indent 2 }}
 spec:
+ {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass") (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/IngressClass") }}
+  {{- if .Values.prometheus.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.prometheus.ingress.ingressClassName }}
+  {{- end }}
+  {{- end }}
   rules:
   {{- range .Values.server.ingress.hosts }}
     {{- $url := splitList "/" . }}

--- a/charts/prometheus/templates/server/ingress.yaml
+++ b/charts/prometheus/templates/server/ingress.yaml
@@ -19,9 +19,9 @@ metadata:
   name: {{ template "prometheus.server.fullname" . }}
 {{ include "prometheus.namespace" . | indent 2 }}
 spec:
- {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass") (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/IngressClass") }}
-  {{- if .Values.prometheus.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.prometheus.ingress.ingressClassName }}
+  {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass") (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/IngressClass") }}
+  {{- if .Values.server.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.server.ingress.ingressClassName }}
   {{- end }}
   {{- end }}
   rules:


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds support for ingressClassName for kubernetes >1.18. 
#### Which issue this PR fixes
Fixes #507 

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
