### PR TITLE
[stackdriver-exporter] add scrapeTimeout parameter

### DIFF
--- a/charts/prometheus-stackdriver-exporter/Chart.yaml
+++ b/charts/prometheus-stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: prometheus-stackdriver-exporter
-version: 1.5.0
+version: 1.6.0
 appVersion: 0.6.0
 home: https://www.stackdriver.com/
 sources:

--- a/charts/prometheus-stackdriver-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/servicemonitor.yaml
@@ -19,6 +19,7 @@ spec:
   - port: http
     {{- if .Values.serviceMonitor.interval }}
     interval: {{ .Values.serviceMonitor.interval }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
     {{- end }}
     honorLabels: {{ .Values.serviceMonitor.honorLabels }}
   selector:

--- a/charts/prometheus-stackdriver-exporter/values.yaml
+++ b/charts/prometheus-stackdriver-exporter/values.yaml
@@ -46,6 +46,8 @@ stackdriver:
     typePrefixes: 'compute.googleapis.com/instance/cpu'
     # The frequency to request
     interval: '5m'
+    # How long until a scrape request times out.
+    scrapeTimeout: 10s
     # How far into the past to offset
     offset: '0s'
 


### PR DESCRIPTION
Will be useful to be able to increase scrape timeout like we are doing in other charts that use serviceMonitor.


#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
