### PR TITLE
[prometheus] fix chart version

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: prometheus
-version: 13.0.1
+version: 13.0.2
 appVersion: 2.22.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/


### PR DESCRIPTION
#### What this PR does / why we need it:

PR #508 and #470 used same chart version 13.0.1

```
$ git log --oneline charts/prometheus
034bbda1 (origin/main, origin/HEAD) Added absent allowedHostPath to psp for node-exporter (#470)
e4d7a0c7 (tag: prometheus-13.0.1) [prometheus] add .Capabilities.APIVersions for IngressClass fixes #507 (#508)
```

Therefor chart releasing failed for the second time as a chart with that version was already released.
This PR just bumps the version to create a new release with that change.


#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
