### PR TITLE
Allow alertmanager to be deployed in IPv6 only environments 

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: prometheus
-version: 13.0.2
+version: 13.0.3
 appVersion: 2.22.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/templates/alertmanager/deploy.yaml
+++ b/charts/prometheus/templates/alertmanager/deploy.yaml
@@ -60,7 +60,7 @@ spec:
           args:
             - --config.file=/etc/config/{{ .Values.alertmanager.configFileName }}
             - --storage.path={{ .Values.alertmanager.persistentVolume.mountPath }}
-            - --cluster.advertise-address=$(POD_IP):6783
+            - --cluster.advertise-address=[$(POD_IP)]:6783
           {{- range $key, $value := .Values.alertmanager.extraArgs }}
             - --{{ $key }}={{ $value }}
           {{- end }}

--- a/charts/prometheus/templates/alertmanager/sts.yaml
+++ b/charts/prometheus/templates/alertmanager/sts.yaml
@@ -61,7 +61,7 @@ spec:
             - --config.file=/etc/config/alertmanager.yml
             - --storage.path={{ .Values.alertmanager.persistentVolume.mountPath }}
           {{- if .Values.alertmanager.statefulSet.headless.enableMeshPeer }}
-            - --cluster.advertise-address=$(POD_IP):6783
+            - --cluster.advertise-address=[$(POD_IP)]:6783
             - --cluster.listen-address=0.0.0.0:6783
           {{- range $n := until (.Values.alertmanager.replicaCount | int) }}
             - --cluster.peer={{ template "prometheus.alertmanager.fullname" $ }}-{{ $n }}.{{ template "prometheus.alertmanager.fullname" $ }}-headless:6783


### PR DESCRIPTION
This PR is to address #241. In this stage, it only aims to allow the deployment to proceed properly.

It may be needed to also modify the `cluster.listen-address` parameter (it's now set to 0.0.0.0).

I've simply added brackets to the $(POD_IP) parameter; the alertmanager code seems to properly handle this, so using brackets around the IP address is supported by alertmanager for the "cluster.advertise-address" command line option for both ipv4 and ipv6 so this should not affect existing IPv4 functionality.
See: https://github.com/prometheus/alertmanager/blob/ce108378d4c8d580804452dcc3a31222067793b2/cluster/cluster.go#L135 - this uses net.SplitHostPort() which handles, as said above, brackets around the host.


