### PR TITLE
[kube-prometheus-stack] Avoid relying on working directory when specifying path to prometheus-operator TLS cert/key

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 12.9.2
+version: 12.9.3
 appVersion: 0.44.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -92,8 +92,8 @@ spec:
             {{- end }}
             {{- if .Values.prometheusOperator.tls.enabled }}
             - --web.enable-tls=true
-            - --web.cert-file=cert/{{ if .Values.prometheusOperator.admissionWebhooks.certManager.enabled }}tls.crt{{ else }}cert{{ end }}
-            - --web.key-file=cert/{{ if .Values.prometheusOperator.admissionWebhooks.certManager.enabled }}tls.key{{ else }}key{{ end }}
+            - --web.cert-file=/cert/{{ if .Values.prometheusOperator.admissionWebhooks.certManager.enabled }}tls.crt{{ else }}cert{{ end }}
+            - --web.key-file=/cert/{{ if .Values.prometheusOperator.admissionWebhooks.certManager.enabled }}tls.key{{ else }}key{{ end }}
             - --web.listen-address=:8443
             - --web.tls-min-version={{ .Values.prometheusOperator.tls.tlsMinVersion }}
           ports:


### PR DESCRIPTION
#### What this PR does / why we need it:

The current `Deployment` specifies path to the TLS cert/key via relative paths that depend on the image default `WORKDIR`. Since the certs are always mounted from root by the chart; it would be clearer to specify this in the path rather than incidentally relying on `WORKDIR=/`.

This also improves interoperability for those re-using the chart with custom-built images which might change the working dir for various reasons; avoiding coupling with the way the image is built.

For example, we combine use of this chart with [the bitnami images](https://github.com/bitnami/bitnami-docker-prometheus-operator), which are regularly rebuilt for security/patching purposes; but which use an [alternate working dir](https://github.com/bitnami/bitnami-docker-prometheus-operator/blob/master/0/debian-10/Dockerfile)) which causes this chart to not work with them out-of-the-box.

#### Special notes for your reviewer:
Thanks for your work maintaining this chart!
@vsliouniaev @bismarck @gianrubio @gkarthiks @scottrigby @Xtigyro 

#### Checklist
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
