### PR TITLE
[kube-prometheus-stack] Correct path to `ServiceMonitor` ca cert when running with tls enabled

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 12.9.1
+version: 12.9.2
 appVersion: 0.44.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/servicemonitor.yaml
@@ -17,7 +17,7 @@ spec:
       ca:
         secret:
           name: {{ template "kube-prometheus-stack.fullname" . }}-admission
-          key: {{ if .Values.prometheusOperator.tls.enabled }}ca.crt{{ else }}ca{{ end }}
+          key: {{ if .Values.prometheusOperator.admissionWebhooks.certManager.enabled }}ca.crt{{ else }}ca{{ end }}
           optional: false
   {{- else }}
   - port: http


### PR DESCRIPTION
#### What this PR does / why we need it:

PR #481 in `12.9.0` added support for using cert manager for operator webhooks. Unfortunately this seems to have broken the `ServiceMonitor` for prometheus-operator itself due to what looks like a typo on the correct `{{ if }}` to decide whether the CA certs are at key `ca.crt` or `ca` within the `Secret`.

The chart will work if `admissionWebhooks.certManager.enabled`, but not otherwise; as in both cases it is looking for the CA cert in the `ca.crt` key.

#### Special notes for your reviewer:
@velothump @bismarck 

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
