### PR TITLE
[prometheus-statsd-exporter] Adding `honorLabels` to `statsd-exporter` `ServiceMonitor`

### DIFF
--- a/charts/prometheus-statsd-exporter/Chart.yaml
+++ b/charts/prometheus-statsd-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus-statsd-exporter
 description: A Helm chart for prometheus stats-exporter
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.18.0
 home: https://github.com/prometheus/statsd_exporter
 sources:

--- a/charts/prometheus-statsd-exporter/Chart.yaml
+++ b/charts/prometheus-statsd-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus-statsd-exporter
 description: A Helm chart for prometheus stats-exporter
-version: 0.1.1
+version: 0.2.0
 appVersion: 0.18.0
 home: https://github.com/prometheus/statsd_exporter
 sources:

--- a/charts/prometheus-statsd-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-statsd-exporter/templates/servicemonitor.yaml
@@ -24,6 +24,9 @@ spec:
       {{- if .Values.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
       {{- end }}
+      {{- with .Values.serviceMonitor.honorLabels }}
+      honorLabels: {{ . }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/prometheus-statsd-exporter/values.yaml
+++ b/charts/prometheus-statsd-exporter/values.yaml
@@ -47,6 +47,7 @@ serviceMonitor:
   interval: 30s
   scrapeTimeout: 10s
   namespace: monitoring
+  honorLabels: false
   additionalLabels: {}
 
 serviceAccount:


### PR DESCRIPTION
Adding the configuration to set the `honorLabels` of the `statsd-exporter` `ServiceMonitor` to `true`