### PR TITLE
[kube-prometheus-stack] Fix an errant dash in prometheus-operator's args

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 12.9.2
+version: 12.9.3
 appVersion: 0.44.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -58,7 +58,7 @@ spec:
             {{- end }}
             - --namespaces={{ $ns | join "," }}
             {{- end }}
-            {{- if (semverCompare "< v0.44.0" .Values.prometheusOperator.image.tag) -}}
+            {{- if (semverCompare "< v0.44.0" .Values.prometheusOperator.image.tag) }}
             - --logtostderr=true
             {{- end }}
             - --localhost=127.0.0.1


### PR DESCRIPTION
#### What this PR does / why we need it:

When templating with

`version.BuildInfo{Version:"v3.4.1", GitCommit:"c4e74854886b2efe3321e185578e6db9be0a6e29", GitTreeState:"dirty", GoVersion:"go1.15.4"}`

a stray dash is inserted which causes the following error: 

```
Service \"prom-kubelet- --logtostderr=true\" is invalid: metadata.name: Invalid value: \"prom-kubelet- --logtostderr=true\": a DNS-1035 label must consist of lower case alphanumeric characters or '-', start w │
│ ith an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')"
```

This is because `-}}` [removes all trailing whitespace](https://golang.org/pkg/text/template/#hdr-Text_and_spaces), so the args get lumped together.

This PR resolves the error. Tested and verified locally.

Before:
```
args:
  - --kubelet-service=kube-system/prom-kubelet- --logtostderr=true
```

After:
```
args:
  - --kubelet-service=kube-system/prom-kubelet
  - --logtostderr=true
```

cc @bismarck @scottrigby

#### Special notes for your reviewer:

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
