### PR TITLE
[kube-prometheus-stack] 333 - need to template the alertmanager tls settings as well

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 12.9.2
+version: 12.9.3
 appVersion: 0.44.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/alertmanager/ingress.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/ingress.yaml
@@ -53,6 +53,6 @@ spec:
   {{- end -}}
   {{- if .Values.alertmanager.ingress.tls }}
   tls:
-{{ toYaml .Values.alertmanager.ingress.tls | indent 4 }}
+{{ tpl (toYaml .Values.alertmanager.ingress.tls | indent 4) . }}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:
Missing templating for the alertmanager tls field.  The alertmanager hosts field has it as well as prometheus hosts and tls fields.

#### Which issue this PR fixes
#333 

#### Special notes for your reviewer:

#### Checklist
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
