### PR TITLE
[kube-prometheus-stack] Allow setting caBundle value for admission webhook configuration

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 12.10.5
+version: 12.10.6
 appVersion: 0.44.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/mutatingWebhookConfiguration.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/mutatingWebhookConfiguration.yaml
@@ -33,6 +33,9 @@ webhooks:
         namespace: {{ template "kube-prometheus-stack.namespace" . }}
         name: {{ template "kube-prometheus-stack.operator.fullname" $ }}
         path: /admission-prometheusrules/mutate
+      {{- if .Values.prometheusOperator.admissionWebhooks.caBundle }}
+      caBundle: {{ .Values.prometheusOperator.admissionWebhooks.caBundle }}
+      {{- end }}
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/mutatingWebhookConfiguration.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/mutatingWebhookConfiguration.yaml
@@ -33,7 +33,7 @@ webhooks:
         namespace: {{ template "kube-prometheus-stack.namespace" . }}
         name: {{ template "kube-prometheus-stack.operator.fullname" $ }}
         path: /admission-prometheusrules/mutate
-      {{- if .Values.prometheusOperator.admissionWebhooks.caBundle }}
+      {{- if and .Values.prometheusOperator.admissionWebhooks.caBundle (not .Values.prometheusOperator.admissionWebhooks.patch.enabled) (not .Values.prometheusOperator.admissionWebhooks.certManager.enabled) }}
       caBundle: {{ .Values.prometheusOperator.admissionWebhooks.caBundle }}
       {{- end }}
     admissionReviewVersions: ["v1", "v1beta1"]

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/validatingWebhookConfiguration.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/validatingWebhookConfiguration.yaml
@@ -33,7 +33,7 @@ webhooks:
         namespace: {{ template "kube-prometheus-stack.namespace" . }}
         name: {{ template "kube-prometheus-stack.operator.fullname" $ }}
         path: /admission-prometheusrules/validate
-      {{- if .Values.prometheusOperator.admissionWebhooks.caBundle }}
+      {{- if and .Values.prometheusOperator.admissionWebhooks.caBundle (not .Values.prometheusOperator.admissionWebhooks.patch.enabled) (not .Values.prometheusOperator.admissionWebhooks.certManager.enabled) }}
       caBundle: {{ .Values.prometheusOperator.admissionWebhooks.caBundle }}
       {{- end }}
     admissionReviewVersions: ["v1", "v1beta1"]

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/validatingWebhookConfiguration.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/validatingWebhookConfiguration.yaml
@@ -33,6 +33,9 @@ webhooks:
         namespace: {{ template "kube-prometheus-stack.namespace" . }}
         name: {{ template "kube-prometheus-stack.operator.fullname" $ }}
         path: /admission-prometheusrules/validate
+      {{- if .Values.prometheusOperator.admissionWebhooks.caBundle }}
+      caBundle: {{ .Values.prometheusOperator.admissionWebhooks.caBundle }}
+      {{- end }}
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None
 {{- end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1237,6 +1237,9 @@ prometheusOperator:
   admissionWebhooks:
     failurePolicy: Fail
     enabled: true
+    ## A PEM encoded CA bundle which will be used to validate the webhook's server certificate.
+    ## If unspecified, system trust roots on the apiserver are used.
+    caBundle: ""
     ## If enabled, generate a self-signed certificate, then patch the webhook configurations with the generated data.
     ## On chart upgrades (or if the secret exists) the cert will not be re-generated. You can use this to provide your own
     ## certs ahead of time if you wish.


### PR DESCRIPTION
#### What this PR does / why we need it:
Allows setting a value for 'caBundle' for the admission webhook configurations. The feature enables providing a pre-existing certificate without using cert-manager, or the patch mechanism.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
