### PR TITLE
[prometheus] add liveness and readiness probes configuration to alertmanager deplo…

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: prometheus
-version: 13.0.2
+version: 13.0.3
 appVersion: 2.22.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/templates/alertmanager/deploy.yaml
+++ b/charts/prometheus/templates/alertmanager/deploy.yaml
@@ -73,9 +73,21 @@ spec:
           readinessProbe:
             httpGet:
               path: {{ .Values.alertmanager.prefixURL }}/-/ready
-              port: 9093
-            initialDelaySeconds: 30
-            timeoutSeconds: 30
+              port: 9090
+            initialDelaySeconds: {{ .Values.alertmanager.readinessProbeInitialDelay }}
+            periodSeconds: {{ .Values.alertmanager.readinessProbePeriodSeconds }}
+            timeoutSeconds: {{ .Values.alertmanager.readinessProbeTimeout }}
+            failureThreshold: {{ .Values.alertmanager.readinessProbeFailureThreshold }}
+            successThreshold: {{ .Values.alertmanager.readinessProbeSuccessThreshold }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.alertmanager.prefixURL }}/-/healthy
+              port: 9090
+            initialDelaySeconds: {{ .Values.alertmanager.livenessProbeInitialDelay }}
+            periodSeconds: {{ .Values.alertmanager.livenessProbePeriodSeconds }}
+            timeoutSeconds: {{ .Values.alertmanager.livenessProbeTimeout }}
+            failureThreshold: {{ .Values.alertmanager.livenessProbeFailureThreshold }}
+            successThreshold: {{ .Values.alertmanager.livenessProbeSuccessThreshold }}
           resources:
 {{ toYaml .Values.alertmanager.resources | indent 12 }}
           volumeMounts:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -286,6 +286,20 @@ alertmanager:
 
       servicePort: 80
 
+  ## alertmanager readiness and liveness probe initial delay and timeout
+  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+  ##
+  readinessProbeInitialDelay: 30
+  readinessProbePeriodSeconds: 5
+  readinessProbeTimeout: 4
+  readinessProbeFailureThreshold: 3
+  readinessProbeSuccessThreshold: 1
+  livenessProbeInitialDelay: 30
+  livenessProbePeriodSeconds: 15
+  livenessProbeTimeout: 10
+  livenessProbeFailureThreshold: 3
+  livenessProbeSuccessThreshold: 1
+
   ## alertmanager resource requests and limits
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##


### PR DESCRIPTION
#### What this PR does / why we need it

Fixes the issue of alertmanager deployment failing on GKE with the following error:
Error during sync: error running backend syncing routine: error ensuring health check: Error creating health check &{beta 10 Kubernetes L7 health check generated with readiness probe settings. 1 <nil> 0xc000b93900 <nil> 0 <nil> k8s1-502cf455-test2-prom-prometheus-alertmanager-80-91d8a53a europe-west1 <nil> <nil> 30 HTTP <nil> 2 {0 map[]} [] []}: googleapi: Error 400: Invalid value for field 'resource.timeoutSec': '30'. TimeoutSec should be less than checkIntervalSec., invalid

The issue is caused by the readiness probe having timeoutSeconds value hardcoded to 30[1:78]. The default checkInterval value on GKE is 10, hence it is lower than the hardcoded timeout and the deployment fails.

I've added explicit configuration of readiness and liveness probes as it is currently implemented in the server deployment.

[1] https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/templates/alertmanager/deploy.yaml

@gianrubio  @zanhsieh @Xtigyro @monotek @naseemkullah 

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
