### PR TITLE
Add ability for custom dnsConfig to multiple charts

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 0.5.0
+version: 0.5.1
 appVersion: v0.21.0
 maintainers:
   - name: monotek

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -26,6 +26,10 @@ spec:
       serviceAccountName: {{ include "alertmanager.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+    {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       containers:
         {{- if and (.Values.configmapReload.enabled) (.Values.config) }}
         - name: {{ .Chart.Name }}-{{ .Values.configmapReload.name }}

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -27,7 +27,16 @@ serviceAccount:
 
 podSecurityContext:
   fsGroup: 65534
-
+dnsConfig: {}
+  # nameservers:
+  #   - 1.2.3.4
+  # searches:
+  #   - ns1.svc.cluster-domain.example
+  #   - my.dns.search.suffix
+  # options:
+#   - name: ndots
+#     value: "2"
+#   - name: edns0
 securityContext:
   # capabilities:
   #   drop:

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 13.5.0
+version: 13.5.1
 appVersion: 0.45.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -114,6 +114,10 @@ spec:
             defaultMode: 420
             secretName: {{ template "kube-prometheus-stack.fullname" . }}-admission
 {{- end }}
+    {{- with .Values.prometheusOperator.dnsConfig }}
+      dnsConfig:
+{{ toYaml . | indent 8 }}
+    {{- end }}
 {{- if .Values.prometheusOperator.securityContext }}
       securityContext:
 {{ toYaml .Values.prometheusOperator.securityContext | indent 8 }}

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -158,6 +158,10 @@ spec:
   remoteWrite:
 {{ toYaml .Values.prometheus.prometheusSpec.remoteWrite | indent 4 }}
 {{- end }}
+{{- if .Values.prometheus.prometheusSpec.dnsConfig }}
+  dnsConfig:
+{{ toYaml .Values.prometheus.prometheusSpec.dnsConfig | indent 4 }}
+{{- end }}
 {{- if .Values.prometheus.prometheusSpec.securityContext }}
   securityContext:
 {{ toYaml .Values.prometheus.prometheusSpec.securityContext | indent 4 }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1429,7 +1429,16 @@ prometheusOperator:
     #         values:
     #         - e2e-az1
     #         - e2e-az2
-
+  dnsConfig: {}
+    # nameservers:
+    #   - 1.2.3.4
+    # searches:
+    #   - ns1.svc.cluster-domain.example
+    #   - my.dns.search.suffix
+    # options:
+    #   - name: ndots
+    #     value: "2"
+    #   - name: edns0
   securityContext:
     fsGroup: 65534
     runAsGroup: 65534
@@ -2133,6 +2142,17 @@ prometheus:
       runAsUser: 1000
       fsGroup: 2000
 
+    # Custom DNS configuration to be added to prometheus pods
+    dnsConfig: {}
+      # nameservers:
+      #   - 1.2.3.4
+      # searches:
+      #   - ns1.svc.cluster-domain.example
+      #   - my.dns.search.suffix
+      # options:
+      #   - name: ndots
+      #     value: "2"
+      #   - name: edns0
     ## 	Priority class assigned to the Pods
     ##
     priorityClassName: ""

--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 2.11.1
+version: 2.11.2
 appVersion: v0.8.3
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/charts/prometheus-adapter/templates/deployment.yaml
+++ b/charts/prometheus-adapter/templates/deployment.yaml
@@ -77,6 +77,10 @@ spec:
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         {{- end }}
+        {{- with .Values.dnsConfig }}
+        dnsConfig:
+        {{ toYaml . | indent 8 }}
+        {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/charts/prometheus-adapter/values.yaml
+++ b/charts/prometheus-adapter/values.yaml
@@ -39,7 +39,17 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
-
+# Custom DNS configuration to be added to prometheus pods
+dnsConfig: {}
+# nameservers:
+#   - 1.2.3.4
+# searches:
+#   - ns1.svc.cluster-domain.example
+#   - my.dns.search.suffix
+# options:
+#   - name: ndots
+#     value: "2"
+#   - name: edns0
 resources: {}
   # requests:
   #   cpu: 100m

--- a/charts/prometheus-elasticsearch-exporter/Chart.yaml
+++ b/charts/prometheus-elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: prometheus-elasticsearch-exporter
-version: 4.1.0
+version: 4.1.1
 kubeVersion: ">=1.10.0-0"
 appVersion: 1.1.0
 home: https://github.com/justwatchcom/elasticsearch_exporter

--- a/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
+++ b/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
@@ -49,6 +49,10 @@ spec:
         runAsNonRoot: true
         runAsUser: {{ .Values.securityContext.runAsUser }}
       {{- end }}
+{{- with .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml . | indent 8 }}
+{{- end }}
       containers:
         - name: exporter
           env:

--- a/charts/prometheus-elasticsearch-exporter/values.yaml
+++ b/charts/prometheus-elasticsearch-exporter/values.yaml
@@ -20,6 +20,18 @@ securityContext:
   enabled: true  # Should be set to false when running on OpenShift
   runAsUser: 1000
 
+# Custom DNS configuration to be added to prometheus pods
+dnsConfig: {}
+# nameservers:
+#   - 1.2.3.4
+# searches:
+#   - ns1.svc.cluster-domain.example
+#   - my.dns.search.suffix
+# options:
+#   - name: ndots
+#     value: "2"
+#   - name: edns0
+
 log:
   format: logfmt
   level: info

--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.1
 description: A Helm chart for prometheus node-exporter
 name: prometheus-node-exporter
-version: 1.14.2
+version: 1.14.3
 home: https://github.com/prometheus/node_exporter/
 sources:
 - https://github.com/prometheus/node_exporter/

--- a/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -127,6 +127,10 @@ spec:
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}
 {{- end }}
+{{- with .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml . | indent 8 }}
+{{- end }}
 {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -100,6 +100,18 @@ podAnnotations:
 # Extra labels to be added to node exporter pods
 podLabels: {}
 
+# Custom DNS configuration to be added to prometheus pods
+dnsConfig: {}
+# nameservers:
+#   - 1.2.3.4
+# searches:
+#   - ns1.svc.cluster-domain.example
+#   - my.dns.search.suffix
+# options:
+#   - name: ndots
+#     value: "2"
+#   - name: edns0
+
 ## Assign a nodeSelector if operating a hybrid cluster
 ##
 nodeSelector: {}

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: prometheus
-version: 13.2.1
+version: 13.2.2
 appVersion: 2.24.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/templates/alertmanager/deploy.yaml
+++ b/charts/prometheus/templates/alertmanager/deploy.yaml
@@ -113,6 +113,10 @@ spec:
       nodeSelector:
 {{ toYaml .Values.alertmanager.nodeSelector | indent 8 }}
     {{- end }}
+    {{- with .Values.alertmanager.dnsConfig }}
+      dnsConfig:
+{{ toYaml . | indent 8 }}
+    {{- end }}
     {{- if .Values.alertmanager.securityContext }}
       securityContext:
 {{ toYaml .Values.alertmanager.securityContext | indent 8 }}

--- a/charts/prometheus/templates/node-exporter/daemonset.yaml
+++ b/charts/prometheus/templates/node-exporter/daemonset.yaml
@@ -108,6 +108,10 @@ spec:
       nodeSelector:
 {{ toYaml .Values.nodeExporter.nodeSelector | indent 8 }}
     {{- end }}
+    {{- with .Values.nodeExporter.dnsConfig }}
+      dnsConfig:
+{{ toYaml . | indent 8 }}
+    {{- end }}
     {{- if .Values.nodeExporter.securityContext }}
       securityContext:
 {{ toYaml .Values.nodeExporter.securityContext | indent 8 }}

--- a/charts/prometheus/templates/pushgateway/deploy.yaml
+++ b/charts/prometheus/templates/pushgateway/deploy.yaml
@@ -89,6 +89,10 @@ spec:
       nodeSelector:
 {{ toYaml .Values.pushgateway.nodeSelector | indent 8 }}
     {{- end }}
+  {{- with .Values.pushgateway.dnsConfig }}
+      dnsConfig:
+{{ toYaml . | indent 8 }}
+  {{- end }}
     {{- if .Values.pushgateway.securityContext }}
       securityContext:
 {{ toYaml .Values.pushgateway.securityContext | indent 8 }}

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -528,6 +528,17 @@ nodeExporter:
     #   cpu: 100m
     #   memory: 30Mi
 
+  # Custom DNS configuration to be added to node-exporter pods
+  dnsConfig: {}
+    # nameservers:
+    #   - 1.2.3.4
+    # searches:
+    #   - ns1.svc.cluster-domain.example
+    #   - my.dns.search.suffix
+    # options:
+    #   - name: ndots
+    #     value: "2"
+    #   - name: edns0
   ## Security context to be added to node-exporter pods
   ##
   securityContext:


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
Adding possibility to set a custom dnsConfig for the pods. Pod's DNS Config field enable users more control on the DNS settings for the pods.
#### Which issue this PR fixes
Adds custom dnsConfig value to the following charts:

- alertmanager
- kube-prometheus-stack
- prometheus
- prometheus-adapter
- prometheus-elasticsearch-exporter
- prometheus-node-exporter

#### Special notes for your reviewer:
https://github.com/prometheus-community/helm-charts/issues/634
#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
