### PR TITLE
[prometheus-cloudwatch-exporter] - Added option to enable sts regional endpoints

### DIFF
--- a/charts/prometheus-cloudwatch-exporter/CHANGELOG.md
+++ b/charts/prometheus-cloudwatch-exporter/CHANGELOG.md
@@ -6,6 +6,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 0.4.10 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 12.0.2
+
+Added option to enable STS regional endpoints via ENV variable mounted to pods
+
 ## 0.8.4
 
 Chart moved from stable to prometheus-community helm repo

--- a/charts/prometheus-cloudwatch-exporter/CHANGELOG.md
+++ b/charts/prometheus-cloudwatch-exporter/CHANGELOG.md
@@ -6,7 +6,7 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 0.4.10 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
-## 12.0.2
+## 0.13.0
 
 Added option to enable STS regional endpoints via ENV variable mounted to pods
 

--- a/charts/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/charts/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.8.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.12.1
+version: 0.12.2
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/charts/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/charts/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.8.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.12.2
+version: 0.13.0
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/charts/prometheus-cloudwatch-exporter/templates/deployment.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/deployment.yaml
@@ -35,6 +35,11 @@ spec:
     {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+        {{- if .Values.aws.stsRegional.enabled }}
+          env:
+            - name: AWS_STS_REGIONAL_ENDPOINTS
+              value: regional
+        {{- end }}
         {{- if not .Values.aws.role }}
         {{- if .Values.aws.secret.name }}
           env:

--- a/charts/prometheus-cloudwatch-exporter/templates/deployment.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/deployment.yaml
@@ -35,11 +35,6 @@ spec:
     {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-        {{- if .Values.aws.stsRegional.enabled }}
-          env:
-            - name: AWS_STS_REGIONAL_ENDPOINTS
-              value: regional
-        {{- end }}
         {{- if not .Values.aws.role }}
         {{- if .Values.aws.secret.name }}
           env:
@@ -72,8 +67,12 @@ spec:
                 secretKeyRef:
                   key: aws_secret_access_key
                   name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
-          {{- end }}
-          {{- end }}
+        {{- end }}
+        {{- else if .Values.aws.stsRegional.enabled }}
+          env:
+            - name: AWS_STS_REGIONAL_ENDPOINTS
+              value: regional
+        {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.command }}

--- a/charts/prometheus-cloudwatch-exporter/values.yaml
+++ b/charts/prometheus-cloudwatch-exporter/values.yaml
@@ -51,6 +51,9 @@ resources: {}
 
 aws:
   role:
+  # Enables usage of regional STS endpoints rather than global which is default
+  stsRegional:
+    enabled: false
 
   # The name of a pre-created secret in which AWS credentials are stored. When
   # set, aws_access_key_id is assumed to be in a field called access_key,


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

This PR fixes the issue that when using STS to assume a role the global endpoint is used by default. If this is not accessible and a regional endpoint is configured the launched pods/containers will get in a crash loop. By setting the ENV variable `AWS_STS_REGIONAL_ENDPOINTS=regional` this tells the SDK to use the regional endpoint instead of the global endpoint.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
