### PR TITLE
[kube-prometheus-stack] Version bump prometheus-operator to 0.45.0

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,8 +18,8 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 12.12.1
-appVersion: 0.44.0
+version: 12.13.0
+appVersion: 0.45.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus
 keywords:

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 12.13.0
+version: 13.0.0
 appVersion: 0.45.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/crds/crd-alertmanagerconfigs.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-alertmanagerconfigs.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.44.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.45.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
 
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -50,6 +50,7 @@ spec:
                         properties:
                           name:
                             description: Label to match.
+                            minLength: 1
                             type: string
                           regex:
                             description: Whether to match on equality (false) or regular-expression (true).
@@ -59,7 +60,6 @@ spec:
                             type: string
                         required:
                         - name
-                        - value
                         type: object
                       type: array
                     targetMatch:
@@ -69,6 +69,7 @@ spec:
                         properties:
                           name:
                             description: Label to match.
+                            minLength: 1
                             type: string
                           regex:
                             description: Whether to match on equality (false) or regular-expression (true).
@@ -78,7 +79,6 @@ spec:
                             type: string
                         required:
                         - name
-                        - value
                         type: object
                       type: array
                   type: object
@@ -94,9 +94,10 @@ spec:
                         description: EmailConfig configures notifications via Email.
                         properties:
                           authIdentity:
+                            description: The identity to use for authentication.
                             type: string
                           authPassword:
-                            description: SecretKeySelector selects a key of a Secret.
+                            description: The secret's key that contains the password to use for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
                             properties:
                               key:
                                 description: The key of the secret to select from.  Must be a valid secret key.
@@ -111,7 +112,7 @@ spec:
                             - key
                             type: object
                           authSecret:
-                            description: SecretKeySelector selects a key of a Secret.
+                            description: The secret's key that contains the CRAM-MD5 secret. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
                             properties:
                               key:
                                 description: The key of the secret to select from.  Must be a valid secret key.
@@ -126,7 +127,7 @@ spec:
                             - key
                             type: object
                           authUsername:
-                            description: SMTP authentication information.
+                            description: The username to use for authentication.
                             type: string
                           from:
                             description: The sender address.
@@ -138,6 +139,7 @@ spec:
                               properties:
                                 key:
                                   description: Key of the tuple.
+                                  minLength: 1
                                   type: string
                                 value:
                                   description: Value of the tuple.
@@ -265,6 +267,7 @@ spec:
                       type: array
                     name:
                       description: Name of the receiver. Must be unique across all items from the list.
+                      minLength: 1
                       type: string
                     opsgenieConfigs:
                       description: List of OpsGenie configurations.
@@ -299,6 +302,7 @@ spec:
                               properties:
                                 key:
                                   description: Key of the tuple.
+                                  minLength: 1
                                   type: string
                                 value:
                                   description: Value of the tuple.
@@ -469,7 +473,7 @@ spec:
                           responders:
                             description: List of responders responsible for notifications.
                             items:
-                              description: OpsGenieConfigResponder defines a responder to an incident. One of id, name or username has to be defined.
+                              description: OpsGenieConfigResponder defines a responder to an incident. One of `id`, `name` or `username` has to be defined.
                               properties:
                                 id:
                                   description: ID of the responder.
@@ -479,10 +483,13 @@ spec:
                                   type: string
                                 type:
                                   description: Type of responder.
+                                  minLength: 1
                                   type: string
                                 username:
                                   description: Username of the responder.
                                   type: string
+                              required:
+                              - type
                               type: object
                             type: array
                           sendResolved:
@@ -523,6 +530,7 @@ spec:
                               properties:
                                 key:
                                   description: Key of the tuple.
+                                  minLength: 1
                                   type: string
                                 value:
                                   description: Value of the tuple.
@@ -904,7 +912,7 @@ spec:
                             description: Notification title.
                             type: string
                           token:
-                            description: Your registered application’s API token, see https://pushover.net/apps
+                            description: The secret's key that contains the registered application’s API token, see https://pushover.net/apps. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
                             properties:
                               key:
                                 description: The key of the secret to select from.  Must be a valid secret key.
@@ -925,7 +933,7 @@ spec:
                             description: A title for supplementary URL, otherwise just the URL is shown
                             type: string
                           userKey:
-                            description: The recipient user’s user key.
+                            description: The secret's key that contains the recipient user’s user key. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
                             properties:
                               key:
                                 description: The key of the secret to select from.  Must be a valid secret key.
@@ -959,6 +967,7 @@ spec:
                                     okText:
                                       type: string
                                     text:
+                                      minLength: 1
                                       type: string
                                     title:
                                       type: string
@@ -970,8 +979,10 @@ spec:
                                 style:
                                   type: string
                                 text:
+                                  minLength: 1
                                   type: string
                                 type:
+                                  minLength: 1
                                   type: string
                                 url:
                                   type: string
@@ -1014,8 +1025,10 @@ spec:
                                 short:
                                   type: boolean
                                 title:
+                                  minLength: 1
                                   type: string
                                 value:
+                                  minLength: 1
                                   type: string
                               required:
                               - title
@@ -1210,7 +1223,7 @@ spec:
                         description: VictorOpsConfig configures notifications via VictorOps. See https://prometheus.io/docs/alerting/latest/configuration/#victorops_config
                         properties:
                           apiKey:
-                            description: The API key to use when talking to the VictorOps API.
+                            description: The secret's key that contains the API key to use when talking to the VictorOps API. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
                             properties:
                               key:
                                 description: The key of the secret to select from.  Must be a valid secret key.
@@ -1234,6 +1247,7 @@ spec:
                               properties:
                                 key:
                                   description: Key of the tuple.
+                                  minLength: 1
                                   type: string
                                 value:
                                   description: Value of the tuple.
@@ -1410,8 +1424,6 @@ spec:
                           stateMessage:
                             description: Contains long explanation of the alerted problem.
                             type: string
-                        required:
-                        - routingKey
                         type: object
                       type: array
                     webhookConfigs:
@@ -1569,8 +1581,9 @@ spec:
                                 type: object
                             type: object
                           maxAlerts:
-                            description: Maximum number of alerts to be sent per webhook message.
+                            description: Maximum number of alerts to be sent per webhook message. When 0, all alerts are included.
                             format: int32
+                            minimum: 0
                             type: integer
                           sendResolved:
                             description: Whether or not to notify about resolved alerts.
@@ -1793,7 +1806,7 @@ spec:
                   type: object
                 type: array
               route:
-                description: The Alertmanager route definition for alerts matching the resource’s namespace. It will be added to the generated Alertmanager configuration as a first-level route.
+                description: The Alertmanager route definition for alerts matching the resource’s namespace. If present, it will be added to the generated Alertmanager configuration as a first-level route.
                 properties:
                   continue:
                     description: Boolean indicating whether an alert should continue matching subsequent sibling nodes. It will always be overridden to true for the first-level route by the Prometheus operator.
@@ -1816,6 +1829,7 @@ spec:
                       properties:
                         name:
                           description: Label to match.
+                          minLength: 1
                           type: string
                         regex:
                           description: Whether to match on equality (false) or regular-expression (true).
@@ -1825,11 +1839,10 @@ spec:
                           type: string
                       required:
                       - name
-                      - value
                       type: object
                     type: array
                   receiver:
-                    description: Name of the receiver for this route. If present, it should be listed in the `receivers` field. The field can be omitted only for nested routes otherwise it is mandatory.
+                    description: Name of the receiver for this route. If not empty, it should be listed in the `receivers` field.
                     type: string
                   repeatInterval:
                     description: How long to wait before repeating the last notification. Must match the regular expression `[0-9]+(ms|s|m|h)` (milliseconds seconds minutes hours).

--- a/charts/kube-prometheus-stack/crds/crd-alertmanagers.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-alertmanagers.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.44.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.45.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
 
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/charts/kube-prometheus-stack/crds/crd-podmonitors.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-podmonitors.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.44.0/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.45.0/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
 
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/charts/kube-prometheus-stack/crds/crd-probes.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-probes.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.44.0/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.45.0/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
 
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/charts/kube-prometheus-stack/crds/crd-prometheuses.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-prometheuses.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.44.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.45.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
 
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -2258,7 +2258,7 @@ spec:
                     type: string
                 type: object
               podMonitorNamespaceSelector:
-                description: Namespaces to be selected for PodMonitor discovery. If nil, only check own namespace.
+                description: Namespace's labels to match for PodMonitor discovery. If nil, only check own namespace.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -2849,7 +2849,7 @@ spec:
                 description: Time duration Prometheus shall retain data for. Default is '24h', and must match the regular expression `[0-9]+(ms|s|m|h|d|w|y)` (milliseconds seconds minutes hours days weeks years).
                 type: string
               retentionSize:
-                description: Maximum amount of disk space used by blocks.
+                description: 'Maximum amount of disk space used by blocks. Supported units: B, KB, MB, GB, TB, PB, EB. Ex: `512MB`.'
                 type: string
               routePrefix:
                 description: The route prefix Prometheus registers HTTP handlers for. This is useful, if using ExternalURL and a proxy is rewriting HTTP routes of a request, and the actual ExternalURL is still true, but the server serves requests under a different route prefix. For example for use with `kubectl proxy`.
@@ -3019,7 +3019,7 @@ spec:
                 description: ServiceAccountName is the name of the ServiceAccount to use to run the Prometheus Pods.
                 type: string
               serviceMonitorNamespaceSelector:
-                description: Namespaces to be selected for ServiceMonitor discovery. If nil, only check own namespace.
+                description: Namespace's labels to match for ServiceMonitor discovery. If nil, only check own namespace.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -3456,6 +3456,9 @@ spec:
                     required:
                     - key
                     type: object
+                  tracingConfigFile:
+                    description: TracingConfig specifies the path of the tracing configuration file. When used alongside with TracingConfig, TracingConfigFile takes precedence.
+                    type: string
                   version:
                     description: Version describes the version of Thanos to use.
                     type: string

--- a/charts/kube-prometheus-stack/crds/crd-prometheusrules.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-prometheusrules.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.44.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.45.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
 
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/charts/kube-prometheus-stack/crds/crd-servicemonitors.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-servicemonitors.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.44.0/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.45.0/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
 
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/charts/kube-prometheus-stack/crds/crd-thanosrulers.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-thanosrulers.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.44.0/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.45.0/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
 
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/charts/kube-prometheus-stack/hack/update_crds.sh
+++ b/charts/kube-prometheus-stack/hack/update_crds.sh
@@ -2,7 +2,7 @@
 
 VERSION=$1
 
-[ -z ${VERSION} ] && echo "Pass prometheus-operator version as first comandline argument" && exit 1
+[ -z "${VERSION}" ] && echo "Pass prometheus-operator version as first comandline argument" && exit 1
 
 FILES=(
   "crd-alertmanagerconfigs.yaml :  monitoring.coreos.com_alertmanagerconfigs.yaml"
@@ -20,7 +20,7 @@ for line in "${FILES[@]}" ; do
     SOURCE=$(echo "${line##*:}" | xargs)
 
     URL="https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/$VERSION/example/prometheus-operator-crd/$SOURCE"
-    echo "# $URL" > ../crds/$DESTINATION
-    curl -L $URL >> ../crds/$DESTINATION
+    echo "# ${URL}" > ../crds/"${DESTINATION}"
+    curl -L "${URL}" >> ../crds/"${DESTINATION}"
 
 done

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -58,23 +58,11 @@ spec:
             {{- end }}
             - --namespaces={{ $ns | join "," }}
             {{- end }}
-            {{- if (semverCompare "< v0.44.0" .Values.prometheusOperator.image.tag) }}
-            - --logtostderr=true
-            {{- end }}
             - --localhost=127.0.0.1
             {{- if .Values.prometheusOperator.prometheusConfigReloaderImage.sha }}
             - --prometheus-config-reloader={{ .Values.prometheusOperator.prometheusConfigReloaderImage.repository }}:{{ .Values.prometheusOperator.prometheusConfigReloaderImage.tag }}@sha256:{{ .Values.prometheusOperator.prometheusConfigReloaderImage.sha }}
             {{- else }}
             - --prometheus-config-reloader={{ .Values.prometheusOperator.prometheusConfigReloaderImage.repository }}:{{ .Values.prometheusOperator.prometheusConfigReloaderImage.tag }}
-            {{- end }}
-            # Empty if statement to catch non-semver master tags that do not need the --config-reloader-image flag
-            {{- if regexMatch "master.*" .Values.prometheusOperator.image.tag -}}
-            {{- else if (semverCompare "< v0.43.0" .Values.prometheusOperator.image.tag) -}}
-            {{- if .Values.prometheusOperator.configmapReloadImage.sha }}
-            - --config-reloader-image={{ .Values.prometheusOperator.configmapReloadImage.repository }}:{{ .Values.prometheusOperator.configmapReloadImage.tag }}@sha256:{{ .Values.prometheusOperator.configmapReloadImage.sha }}
-            {{- else }}
-            - --config-reloader-image={{ .Values.prometheusOperator.configmapReloadImage.repository }}:{{ .Values.prometheusOperator.configmapReloadImage.tag }}
-            {{- end }}
             {{- end }}
             - --config-reloader-cpu={{ .Values.prometheusOperator.configReloaderCpu }}
             - --config-reloader-memory={{ .Values.prometheusOperator.configReloaderMemory }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1431,22 +1431,15 @@ prometheusOperator:
   ##
   image:
     repository: quay.io/prometheus-operator/prometheus-operator
-    tag: v0.44.0
+    tag: v0.45.0
     sha: ""
     pullPolicy: IfNotPresent
-
-  ## Configmap-reload image to use for reloading configmaps
-  ##
-  configmapReloadImage:
-    repository: docker.io/jimmidyson/configmap-reload
-    tag: v0.4.0
-    sha: ""
 
   ## Prometheus-config-reloader image to use for config and rule reloading
   ##
   prometheusConfigReloaderImage:
     repository: quay.io/prometheus-operator/prometheus-config-reloader
-    tag: v0.44.0
+    tag: v0.45.0
     sha: ""
 
   ## Set the prometheus config reloader side-car CPU limit

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1729,7 +1729,7 @@ prometheus:
     ##
     image:
       repository: quay.io/prometheus/prometheus
-      tag: v2.22.1
+      tag: v2.24.0
       sha: ""
 
     ## Tolerations for use with node taints


### PR DESCRIPTION
#### What this PR does / why we need it:
Updates prometheus-operator to 0.45.0 
https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.45.0

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
