### PR TITLE
[prometheus-to-sd]add optional monitoredResourceTypes

### DIFF
--- a/charts/prometheus-to-sd/Chart.yaml
+++ b/charts/prometheus-to-sd/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 - name: acondrat
   email: arcadie.condrat@gmail.com
 name: prometheus-to-sd
-version: 0.3.2
+version: 0.4.0

--- a/charts/prometheus-to-sd/Chart.yaml
+++ b/charts/prometheus-to-sd/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 - name: acondrat
   email: arcadie.condrat@gmail.com
 name: prometheus-to-sd
-version: 0.3.1
+version: 0.3.2

--- a/charts/prometheus-to-sd/templates/deployment.yaml
+++ b/charts/prometheus-to-sd/templates/deployment.yaml
@@ -32,6 +32,9 @@ spec:
             {{- range $key, $value := .Values.metricsSources }}
             - --source={{ $key }}:{{ $value }}
             {{- end }}
+            {{- with .Values.monitoredResourceTypes }}
+            - --monitored-resource-types={{ . }}
+            {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- if .Values.nodeSelector }}

--- a/charts/prometheus-to-sd/values.yaml
+++ b/charts/prometheus-to-sd/values.yaml
@@ -7,5 +7,7 @@ resources: {}
 port: 6060
 metricsSources:
   kube-state-metrics: http://kube-state-metrics:8080
+# The monitored resource types to use, either the legacy 'gke_container', or the new 'k8s'
+monitoredResourceTypes: gke_container
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
Hi

`prometheus-to-sd` sends to Cloud Monitoring using [`gke_containers` Monitored resource types](https://cloud.google.com/monitoring/api/resources#tag_gke_container)

But, after March 31, 2021, Legacy Logging and Monitoring is no longer supported, and some resource type changed. https://cloud.google.com/stackdriver/docs/solutions/gke/migration#resource-changes

In prometheus-to-sd v0.5.2, [`monitored-resource-types`](https://github.com/GoogleCloudPlatform/k8s-stackdriver/blob/prom-to-sd-v0.5.2/prometheus-to-sd/main.go#L55) flag exists and when use `monitored-resource-types=k8s`,new type is used.
https://github.com/GoogleCloudPlatform/k8s-stackdriver/pull/211#issuecomment-447974372

So, I added this flag as optional values.
I test this chat at my GKE cluster 1.17.14-gke.400 and it seems to work.
Please review this PR.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
