### PR TITLE
[prometheus-postgres-exporter]add optional constantLabels

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.8.0"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 1.7.0
+version: 1.8.0
 home: https://github.com/wrouesnel/postgres_exporter
 sources:
 - https://github.com/wrouesnel/postgres_exporter

--- a/charts/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/charts/prometheus-postgres-exporter/templates/deployment.yaml
@@ -58,6 +58,10 @@ spec:
           - {{ .Values.config.excludeDatabases | join "," }}
           {{- end }}
           {{- end }}
+          {{- if .Values.config.constantLabels }}
+          {{ $firstLabel := true -}}
+          - "--constantLabels={{- range $k, $v := .Values.config.constantLabels }}{{- if not $firstLabel -}},{{ end -}}{{ $firstLabel = false -}}{{ $k }}={{ $v }}{{- end }}"
+          {{- end }}
           env:
           {{- if .Values.config.datasourceSecret }}
           - name: DATA_SOURCE_NAME

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -113,6 +113,7 @@ config:
   disableSettingsMetrics: false
   autoDiscoverDatabases: false
   excludeDatabases: []
+  constantLabels: {}
   # this are the defaults queries that the exporter will run, extracted from: https://github.com/wrouesnel/postgres_exporter/blob/master/queries.yaml
   queries: |-
     pg_replication:


### PR DESCRIPTION
Signed-off-by: Petr Kohut <me@petrkohut.cz>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
The Helm Chart doesn't support configuration for the `--constantLabels` flag which is available in https://github.com/wrouesnel/postgres_exporter .
The flag allow adding additional custom labels to all metrics provided by postgres-exporter.

I found the missing feature as a blocker for what I need to do on my project hence I made the PR :-)
#### Which issue this PR fixes
*none

#### Special notes for your reviewer:
I decided to make the configuration of `constantLabels` a bit nicer by allowing a user to set it up as object (dictionary).
So instead having this in values.yaml:
```yaml
constantLabels: "customLabel1=x,customLabel2=y"
```
there can be:
```yaml
constantLabels: 
   customLabel1: x
   customLabel2: y
```
#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)

CC: @gianrubio @zanhsieh