### PR TITLE
[stackdriver-exporter] feat: Adding relabeling config to serviceMonitor

### DIFF
--- a/charts/prometheus-stackdriver-exporter/Chart.yaml
+++ b/charts/prometheus-stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: prometheus-stackdriver-exporter
-version: 1.6.1
+version: 1.7.0
 appVersion: 0.6.0
 home: https://www.stackdriver.com/
 sources:

--- a/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
@@ -23,15 +23,15 @@ spec:
       labels:
         app: {{ template "stackdriver-exporter.name" . }}
         release: "{{ .Release.Name }}"
-{{- if .Values.annotations }}
+      {{- if .Values.annotations }}
       annotations:
-{{ toYaml .Values.annotations | indent 8 }}
-{{- end }}
+        {{- toYaml .Values.annotations | nindent 8 }}
+      {{- end }}
     spec:
-{{- if .Values.affinity }}
+      {{- if .Values.affinity }}
       affinity:
-{{ toYaml .Values.affinity | indent 8 }}
-{{- end }}
+        {{- toYaml .Values.affinity | nindent 8 }}
+      {{- end }}
       serviceAccount: {{ template "stackdriver-exporter.serviceAccountName" . }}
       restartPolicy: {{ .Values.restartPolicy }}
       volumes:
@@ -84,7 +84,7 @@ spec:
             - name: STACKDRIVER_EXPORTER_DROP_DELEGATED_PROJECTS
               value: {{ .Values.stackdriver.dropDelegatedProjects | quote}}
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+            {{- toYaml .Values.resources | nindent 12 }}
           ports:
             - containerPort: {{ .Values.service.httpPort }}
               name: http
@@ -100,12 +100,12 @@ spec:
               port: http
             initialDelaySeconds: 10
             timeoutSeconds: 10
-{{- if .Values.nodeSelector }}
+      {{- if .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-    {{- end }}
-{{- if .Values.tolerations }}
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
       tolerations:
-{{ toYaml .Values.tolerations | indent 8 }}
-    {{- end }}
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
 

--- a/charts/prometheus-stackdriver-exporter/templates/service.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/service.yaml
@@ -7,10 +7,10 @@ metadata:
     app: {{ template "stackdriver-exporter.name" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-{{- if .Values.service.annotations }}
+  {{- if .Values.service.annotations }}
   annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
-{{- end }}
+    {{- toYaml .Values.service.annotations | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/prometheus-stackdriver-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/serviceaccount.yaml
@@ -10,6 +10,6 @@ metadata:
   name: {{ template "stackdriver-exporter.serviceAccountName" . }}
   {{- if .Values.serviceAccount.annotations }}
   annotations:
-{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
   {{- end }}
 {{- end -}}

--- a/charts/prometheus-stackdriver-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/servicemonitor.yaml
@@ -22,6 +22,14 @@ spec:
     scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
     {{- end }}
     honorLabels: {{ .Values.serviceMonitor.honorLabels }}
+    {{- if .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ toYaml .Values.serviceMonitor.metricRelabelings | indent 4 }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.serviceMonitor.relabelings | indent 4 }}
+    {{- end }}
   selector:
     matchLabels:
       chart: {{ template "stackdriver-exporter.chart" . }}

--- a/charts/prometheus-stackdriver-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/servicemonitor.yaml
@@ -12,7 +12,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     {{- if .Values.serviceMonitor.additionalLabels }}
-{{ toYaml .Values.serviceMonitor.additionalLabels | indent 4 }}
+    {{- toYaml .Values.serviceMonitor.additionalLabels | nindent 4 }}
     {{- end }}
 spec:
   endpoints:
@@ -24,11 +24,11 @@ spec:
     honorLabels: {{ .Values.serviceMonitor.honorLabels }}
     {{- if .Values.serviceMonitor.metricRelabelings }}
     metricRelabelings:
-{{ toYaml .Values.serviceMonitor.metricRelabelings | indent 4 }}
+    {{- toYaml .Values.serviceMonitor.metricRelabelings | nindent 4 }}
     {{- end }}
     {{- if .Values.serviceMonitor.relabelings }}
     relabelings:
-{{ toYaml .Values.serviceMonitor.relabelings | indent 4 }}
+    {{- toYaml .Values.serviceMonitor.relabelings | nindent 4 }}
     {{- end }}
   selector:
     matchLabels:

--- a/charts/prometheus-stackdriver-exporter/values.yaml
+++ b/charts/prometheus-stackdriver-exporter/values.yaml
@@ -99,3 +99,7 @@ serviceMonitor:
   # interval: 10s
   ## Defaults to what's used if you follow CoreOS [Prometheus Install Instructions](https://github.com/helm/charts/tree/master/stable/prometheus-operator#tldr)
   honorLabels: true
+  # MetricRelabelConfigs to apply to samples before ingestion https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+  metricRelabelings: []
+  # RelabelConfigs to apply to samples before scraping. https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+  relabelings: []


### PR DESCRIPTION
Adding relabeling configs to its serviceMonitor. Will be useful to improve Prometheus cardinality.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
