### PR TITLE
[prometheus-pushgateway] Adds imagePullSecrets value for deployment

### DIFF
--- a/charts/prometheus-pushgateway/Chart.yaml
+++ b/charts/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.3.0"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 1.5.1
+version: 1.5.2
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/charts/prometheus-pushgateway/Chart.yaml
+++ b/charts/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.3.0"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 1.5.2
+version: 1.6.0
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/charts/prometheus-pushgateway/templates/deployment.yaml
+++ b/charts/prometheus-pushgateway/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
     spec:
       serviceAccountName: {{ template "prometheus-pushgateway.serviceAccountName" . }}
+    {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+    {{- end }}
       containers:
         - name: pushgateway
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/prometheus-pushgateway/values.yaml
+++ b/charts/prometheus-pushgateway/values.yaml
@@ -13,6 +13,9 @@ image:
   tag: v1.3.0
   pullPolicy: IfNotPresent
 
+# Optional pod imagePullSecrets
+imagePullSecrets: []
+
 service:
   type: ClusterIP
   port: 9091


### PR DESCRIPTION
Signed-off-by: Nick Abt <nicholas-abt@pluralsight.com>

#### What this PR does / why we need it:
It adds `imagePullSecrets` handling for the deployment of the `prometheus-pushgateway` chart to allow injection of `imagePullSecrets` for custom image registries.  This brings the chart in line with other prometheus charts and common practices.  Such registries are commonly in use in airgapped Kubernetes instances.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
