### PR TITLE
[alertmanager] allow possibility to use alertmanager in HA

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: v0.21.0
 maintainers:
   - name: monotek

--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 0.3.1
+version: 0.4.0
 appVersion: v0.21.0
 maintainers:
   - name: monotek

--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 0.4.0
+version: 0.5.0
 appVersion: v0.21.0
 maintainers:
   - name: monotek

--- a/charts/alertmanager/templates/services.yaml
+++ b/charts/alertmanager/templates/services.yaml
@@ -31,29 +31,11 @@ spec:
     - port: 9094
       targetPort: 9094
       protocol: TCP
-      name: mesh-tcp
-    {{- end }}
-  selector:
-    {{- include "alertmanager.selectorLabels" . | nindent 4 }}
----
-{{ if or (gt .Values.replicaCount 1.0) (.Values.additionalPeers) }}
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ include "alertmanager.fullname" . }}-mesh
-  labels:
-    {{- include "alertmanager.labels" . | nindent 4 }}
-spec:
-  clusterIP: None
-  ports:
-    - port: 9094
-      targetPort: 9094
-      protocol: TCP
-      name: mesh-tcp
+      name: cluster-tcp
     - port: 9094
       targetPort: 9094
       protocol: UDP
-      name: mesh-udp
+      name: cluster-udp
+    {{- end }}
   selector:
     {{- include "alertmanager.selectorLabels" . | nindent 4 }}
-{{ end}}

--- a/charts/alertmanager/templates/services.yaml
+++ b/charts/alertmanager/templates/services.yaml
@@ -27,5 +27,33 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if or (gt .Values.replicaCount 1.0) (.Values.additionalPeers) }}
+    - port: 9094
+      targetPort: 9094
+      protocol: TCP
+      name: mesh-tcp
+    {{- end }}
   selector:
     {{- include "alertmanager.selectorLabels" . | nindent 4 }}
+---
+{{ if or (gt .Values.replicaCount 1.0) (.Values.additionalPeers) }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "alertmanager.fullname" . }}-mesh
+  labels:
+    {{- include "alertmanager.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  ports:
+    - port: 9094
+      targetPort: 9094
+      protocol: TCP
+      name: mesh-tcp
+    - port: 9094
+      targetPort: 9094
+      protocol: UDP
+      name: mesh-udp
+  selector:
+    {{- include "alertmanager.selectorLabels" . | nindent 4 }}
+{{ end}}

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -32,9 +32,29 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
           args:
             - --storage.path=/alertmanager
             - --config.file=/etc/alertmanager/alertmanager.yml
+            {{- if or (gt .Values.replicaCount 1.0) (.Values.additionalPeers) }}
+            - --cluster.advertise-address=$(POD_IP):9094
+            - --cluster.listen-address=0.0.0.0:9094
+            {{- end }}
+            {{- if gt .Values.replicaCount 1.0}}
+            {{- range $i := until (int .Values.replicaCount) }}
+            - --cluster.peer={{ tpl $.Release.Name $ }}-{{ tpl $.Chart.Name $ }}-{{ $i }}.{{ tpl $.Release.Name $ }}-{{ tpl $.Chart.Name $ }}-headless:9094
+            {{- end }}
+            {{- end }}
+            {{- if .Values.additionalPeers }}
+            {{- range $item := .Values.additionalPeers }}
+            - --cluster.peer={{ $item }}
+            {{- end }}
+            {{- end }}
             {{- range $key, $value := .Values.extraArgs }}
             - --{{ $key }}={{ $value }}
             {{- end }}

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -37,6 +37,8 @@ securityContext:
   runAsNonRoot: true
   runAsGroup: 65534
 
+additionalPeers: []
+
 service:
   type: ClusterIP
   port: 9093


### PR DESCRIPTION
Signed-off-by: Pavol Stanka <stanka@ehs.sk>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
This allows alertmanager to be used in HA mode, either in one cluster or between clusters.

#### Which issue this PR fixes
fixes #598 

#### Special notes for your reviewer:
@monotek , @naseemkullah 

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
