### PR TITLE
[prometheus-postgres-exporter] add initialDelaySeconds configuration

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.8.0"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 1.8.0
+version: 1.9.0
 home: https://github.com/wrouesnel/postgres_exporter
 sources:
 - https://github.com/wrouesnel/postgres_exporter

--- a/charts/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/charts/prometheus-postgres-exporter/templates/deployment.yaml
@@ -92,10 +92,12 @@ spec:
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
           livenessProbe:
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             httpGet:
               path: /
               port: http
           readinessProbe:
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             httpGet:
               path: /
               port: http

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -332,6 +332,13 @@ annotations: {}
 
 podLabels: {}
 
+# Configurable health checks
+livenessProbe:
+  initialDelaySeconds: 0
+
+readinessProbe:
+  initialDelaySeconds: 0
+
 # Init containers, e. g. for secrets creation before the exporter
 initContainers: []
   # - name:


### PR DESCRIPTION
@gianrubio @zanhsieh 

#### What this PR does / why we need it:

In some casses initial query to the database, for some complex queries, takse more time than the succeding. This time might be so long it exceeds the time for liveness and readiness probe. This fails and restarts the container even before the initialisation can be succesfully done.

This MR adds initialDelaySeconds configuration option to allow setting it when needed.

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
