### PR TITLE
[kube-prometheus-stack] fix: match containerPort and listen-address in operator

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 13.4.0
+version: 13.4.1
 appVersion: 0.45.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -88,7 +88,7 @@ spec:
             - --web.enable-tls=true
             - --web.cert-file=/cert/{{ if .Values.prometheusOperator.admissionWebhooks.certManager.enabled }}tls.crt{{ else }}cert{{ end }}
             - --web.key-file=/cert/{{ if .Values.prometheusOperator.admissionWebhooks.certManager.enabled }}tls.key{{ else }}key{{ end }}
-            - --web.listen-address=:8443
+            - --web.listen-address=:{{ .Values.prometheusOperator.tls.internalPort }}
             - --web.tls-min-version={{ .Values.prometheusOperator.tls.tlsMinVersion }}
           ports:
             - containerPort: {{ .Values.prometheusOperator.tls.internalPort }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes port mismatch introduced in 13.4.0 by https://github.com/prometheus-community/helm-charts/pull/400

#### Which issue this PR fixes

- `containerPort` doesn't match the port specified in the container args with `web.listen-address`
- operator target is therefore unreachable using the address provided by the `ServiceMonitor`

#### Special notes for your reviewer:

@gkarthiks as you were the maintainer involved in the previous change

I've confirmed that this fixes the issue by manually editing the `Deployment` on our cluster so that the `arg` matches the `containerPort`.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
