### PR TITLE
[kube-prometheus-stack] Allow override of job names for k3s compatibility

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 13.4.1
+version: 13.5.0
 appVersion: 0.45.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kubeControllerManager.enabled }}
+{{- if and .Values.kubeControllerManager.enabled .Values.kubeControllerManager.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kubeScheduler.enabled }}
+{{- if and .Values.kubeScheduler.enabled .Values.kubeScheduler.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/controller-manager.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/controller-manager.yaml
@@ -107,7 +107,7 @@ data:
                         "tableColumn": "",
                         "targets": [
                             {
-                                "expr": "sum(up{job=\"kube-controller-manager\"})",
+                                "expr": "sum(up{job=\"{{ .Values.kubeControllerManager.jobName }}\"})",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "",
@@ -176,7 +176,7 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(workqueue_adds_total{job=\"kube-controller-manager\", instance=~\"$instance\"}[5m])) by (instance, name)",
+                                "expr": "sum(rate(workqueue_adds_total{job=\"{{ .Values.kubeControllerManager.jobName }}\", instance=~\"$instance\"}[5m])) by (instance, name)",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}instance{{`}}`}} {{`{{`}}name{{`}}`}}",
@@ -282,7 +282,7 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(workqueue_depth{job=\"kube-controller-manager\", instance=~\"$instance\"}[5m])) by (instance, name)",
+                                "expr": "sum(rate(workqueue_depth{job=\"{{ .Values.kubeControllerManager.jobName }}\", instance=~\"$instance\"}[5m])) by (instance, name)",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}instance{{`}}`}} {{`{{`}}name{{`}}`}}",
@@ -388,7 +388,7 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{job=\"kube-controller-manager\", instance=~\"$instance\"}[5m])) by (instance, name, le))",
+                                "expr": "histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{job=\"{{ .Values.kubeControllerManager.jobName }}\", instance=~\"$instance\"}[5m])) by (instance, name, le))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}instance{{`}}`}} {{`{{`}}name{{`}}`}}",
@@ -494,28 +494,28 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"$instance\",code=~\"2..\"}[5m]))",
+                                "expr": "sum(rate(rest_client_requests_total{job=\"{{ .Values.kubeControllerManager.jobName }}\", instance=~\"$instance\",code=~\"2..\"}[5m]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "2xx",
                                 "refId": "A"
                             },
                             {
-                                "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"$instance\",code=~\"3..\"}[5m]))",
+                                "expr": "sum(rate(rest_client_requests_total{job=\"{{ .Values.kubeControllerManager.jobName }}\", instance=~\"$instance\",code=~\"3..\"}[5m]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "3xx",
                                 "refId": "B"
                             },
                             {
-                                "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"$instance\",code=~\"4..\"}[5m]))",
+                                "expr": "sum(rate(rest_client_requests_total{job=\"{{ .Values.kubeControllerManager.jobName }}\", instance=~\"$instance\",code=~\"4..\"}[5m]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "4xx",
                                 "refId": "C"
                             },
                             {
-                                "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"$instance\",code=~\"5..\"}[5m]))",
+                                "expr": "sum(rate(rest_client_requests_total{job=\"{{ .Values.kubeControllerManager.jobName }}\", instance=~\"$instance\",code=~\"5..\"}[5m]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "5xx",
@@ -608,7 +608,7 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{job=\"kube-controller-manager\", instance=~\"$instance\", verb=\"POST\"}[5m])) by (verb, url, le))",
+                                "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{job=\"{{ .Values.kubeControllerManager.jobName }}\", instance=~\"$instance\", verb=\"POST\"}[5m])) by (verb, url, le))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}verb{{`}}`}} {{`{{`}}url{{`}}`}}",
@@ -714,7 +714,7 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{job=\"kube-controller-manager\", instance=~\"$instance\", verb=\"GET\"}[5m])) by (verb, url, le))",
+                                "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{job=\"{{ .Values.kubeControllerManager.jobName }}\", instance=~\"$instance\", verb=\"GET\"}[5m])) by (verb, url, le))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}verb{{`}}`}} {{`{{`}}url{{`}}`}}",
@@ -820,7 +820,7 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "process_resident_memory_bytes{job=\"kube-controller-manager\",instance=~\"$instance\"}",
+                                "expr": "process_resident_memory_bytes{job=\"{{ .Values.kubeControllerManager.jobName }}\",instance=~\"$instance\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}instance{{`}}`}}",
@@ -913,7 +913,7 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "rate(process_cpu_seconds_total{job=\"kube-controller-manager\",instance=~\"$instance\"}[5m])",
+                                "expr": "rate(process_cpu_seconds_total{job=\"{{ .Values.kubeControllerManager.jobName }}\",instance=~\"$instance\"}[5m])",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}instance{{`}}`}}",
@@ -1006,7 +1006,7 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "go_goroutines{job=\"kube-controller-manager\",instance=~\"$instance\"}",
+                                "expr": "go_goroutines{job=\"{{ .Values.kubeControllerManager.jobName }}\",instance=~\"$instance\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}instance{{`}}`}}",
@@ -1100,7 +1100,7 @@ data:
                     "options": [
 
                     ],
-                    "query": "label_values(process_cpu_seconds_total{job=\"kube-controller-manager\"}, instance)",
+                    "query": "label_values(process_cpu_seconds_total{job=\"{{ .Values.kubeControllerManager.jobName }}\"}, instance)",
                     "refresh": 2,
                     "regex": "",
                     "sort": 1,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/scheduler.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/scheduler.yaml
@@ -107,7 +107,7 @@ data:
                         "tableColumn": "",
                         "targets": [
                             {
-                                "expr": "sum(up{job=\"kube-scheduler\"})",
+                                "expr": "sum(up{job=\"{{ .Values.kubeScheduler.jobName }}\"})",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "",
@@ -176,28 +176,28 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(scheduler_e2e_scheduling_duration_seconds_count{job=\"kube-scheduler\", instance=~\"$instance\"}[5m])) by (instance)",
+                                "expr": "sum(rate(scheduler_e2e_scheduling_duration_seconds_count{job=\"{{ .Values.kubeScheduler.jobName }}\", instance=~\"$instance\"}[5m])) by (instance)",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}instance{{`}}`}} e2e",
                                 "refId": "A"
                             },
                             {
-                                "expr": "sum(rate(scheduler_binding_duration_seconds_count{job=\"kube-scheduler\", instance=~\"$instance\"}[5m])) by (instance)",
+                                "expr": "sum(rate(scheduler_binding_duration_seconds_count{job=\"{{ .Values.kubeScheduler.jobName }}\", instance=~\"$instance\"}[5m])) by (instance)",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}instance{{`}}`}} binding",
                                 "refId": "B"
                             },
                             {
-                                "expr": "sum(rate(scheduler_scheduling_algorithm_duration_seconds_count{job=\"kube-scheduler\", instance=~\"$instance\"}[5m])) by (instance)",
+                                "expr": "sum(rate(scheduler_scheduling_algorithm_duration_seconds_count{job=\"{{ .Values.kubeScheduler.jobName }}\", instance=~\"$instance\"}[5m])) by (instance)",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}instance{{`}}`}} scheduling algorithm",
                                 "refId": "C"
                             },
                             {
-                                "expr": "sum(rate(scheduler_volume_scheduling_duration_seconds_count{job=\"kube-scheduler\", instance=~\"$instance\"}[5m])) by (instance)",
+                                "expr": "sum(rate(scheduler_volume_scheduling_duration_seconds_count{job=\"{{ .Values.kubeScheduler.jobName }}\", instance=~\"$instance\"}[5m])) by (instance)",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}instance{{`}}`}} volume",
@@ -290,28 +290,28 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job=\"kube-scheduler\",instance=~\"$instance\"}[5m])) by (instance, le))",
+                                "expr": "histogram_quantile(0.99, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job=\"{{ .Values.kubeScheduler.jobName }}\",instance=~\"$instance\"}[5m])) by (instance, le))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}instance{{`}}`}} e2e",
                                 "refId": "A"
                             },
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(scheduler_binding_duration_seconds_bucket{job=\"kube-scheduler\",instance=~\"$instance\"}[5m])) by (instance, le))",
+                                "expr": "histogram_quantile(0.99, sum(rate(scheduler_binding_duration_seconds_bucket{job=\"{{ .Values.kubeScheduler.jobName }}\",instance=~\"$instance\"}[5m])) by (instance, le))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}instance{{`}}`}} binding",
                                 "refId": "B"
                             },
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job=\"kube-scheduler\",instance=~\"$instance\"}[5m])) by (instance, le))",
+                                "expr": "histogram_quantile(0.99, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job=\"{{ .Values.kubeScheduler.jobName }}\",instance=~\"$instance\"}[5m])) by (instance, le))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}instance{{`}}`}} scheduling algorithm",
                                 "refId": "C"
                             },
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(scheduler_volume_scheduling_duration_seconds_bucket{job=\"kube-scheduler\",instance=~\"$instance\"}[5m])) by (instance, le))",
+                                "expr": "histogram_quantile(0.99, sum(rate(scheduler_volume_scheduling_duration_seconds_bucket{job=\"{{ .Values.kubeScheduler.jobName }}\",instance=~\"$instance\"}[5m])) by (instance, le))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}instance{{`}}`}} volume",
@@ -417,28 +417,28 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(rest_client_requests_total{job=\"kube-scheduler\", instance=~\"$instance\",code=~\"2..\"}[5m]))",
+                                "expr": "sum(rate(rest_client_requests_total{job=\"{{ .Values.kubeScheduler.jobName }}\", instance=~\"$instance\",code=~\"2..\"}[5m]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "2xx",
                                 "refId": "A"
                             },
                             {
-                                "expr": "sum(rate(rest_client_requests_total{job=\"kube-scheduler\", instance=~\"$instance\",code=~\"3..\"}[5m]))",
+                                "expr": "sum(rate(rest_client_requests_total{job=\"{{ .Values.kubeScheduler.jobName }}\", instance=~\"$instance\",code=~\"3..\"}[5m]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "3xx",
                                 "refId": "B"
                             },
                             {
-                                "expr": "sum(rate(rest_client_requests_total{job=\"kube-scheduler\", instance=~\"$instance\",code=~\"4..\"}[5m]))",
+                                "expr": "sum(rate(rest_client_requests_total{job=\"{{ .Values.kubeScheduler.jobName }}\", instance=~\"$instance\",code=~\"4..\"}[5m]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "4xx",
                                 "refId": "C"
                             },
                             {
-                                "expr": "sum(rate(rest_client_requests_total{job=\"kube-scheduler\", instance=~\"$instance\",code=~\"5..\"}[5m]))",
+                                "expr": "sum(rate(rest_client_requests_total{job=\"{{ .Values.kubeScheduler.jobName }}\", instance=~\"$instance\",code=~\"5..\"}[5m]))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "5xx",
@@ -531,7 +531,7 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{job=\"kube-scheduler\", instance=~\"$instance\", verb=\"POST\"}[5m])) by (verb, url, le))",
+                                "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{job=\"{{ .Values.kubeScheduler.jobName }}\", instance=~\"$instance\", verb=\"POST\"}[5m])) by (verb, url, le))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}verb{{`}}`}} {{`{{`}}url{{`}}`}}",
@@ -637,7 +637,7 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{job=\"kube-scheduler\", instance=~\"$instance\", verb=\"GET\"}[5m])) by (verb, url, le))",
+                                "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{job=\"{{ .Values.kubeScheduler.jobName }}\", instance=~\"$instance\", verb=\"GET\"}[5m])) by (verb, url, le))",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}verb{{`}}`}} {{`{{`}}url{{`}}`}}",
@@ -743,7 +743,7 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "process_resident_memory_bytes{job=\"kube-scheduler\", instance=~\"$instance\"}",
+                                "expr": "process_resident_memory_bytes{job=\"{{ .Values.kubeScheduler.jobName }}\", instance=~\"$instance\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}instance{{`}}`}}",
@@ -836,7 +836,7 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "rate(process_cpu_seconds_total{job=\"kube-scheduler\", instance=~\"$instance\"}[5m])",
+                                "expr": "rate(process_cpu_seconds_total{job=\"{{ .Values.kubeScheduler.jobName }}\", instance=~\"$instance\"}[5m])",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}instance{{`}}`}}",
@@ -929,7 +929,7 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "go_goroutines{job=\"kube-scheduler\",instance=~\"$instance\"}",
+                                "expr": "go_goroutines{job=\"{{ .Values.kubeScheduler.jobName }}\",instance=~\"$instance\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}instance{{`}}`}}",
@@ -1023,7 +1023,7 @@ data:
                     "options": [
 
                     ],
-                    "query": "label_values(process_cpu_seconds_total{job=\"kube-scheduler\"}, instance)",
+                    "query": "label_values(process_cpu_seconds_total{job=\"{{ .Values.kubeScheduler.jobName }}\"}, instance)",
                     "refresh": 2,
                     "regex": "",
                     "sort": 1,

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-scheduler.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-scheduler.rules.yaml
@@ -24,39 +24,39 @@ spec:
   groups:
   - name: kube-scheduler.rules
     rules:
-    - expr: histogram_quantile(0.99, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+    - expr: histogram_quantile(0.99, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="{{ .Values.kubeScheduler.jobName }}"}[5m])) without(instance, pod))
       labels:
         quantile: '0.99'
       record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
-    - expr: histogram_quantile(0.99, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+    - expr: histogram_quantile(0.99, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="{{ .Values.kubeScheduler.jobName }}"}[5m])) without(instance, pod))
       labels:
         quantile: '0.99'
       record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
-    - expr: histogram_quantile(0.99, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+    - expr: histogram_quantile(0.99, sum(rate(scheduler_binding_duration_seconds_bucket{job="{{ .Values.kubeScheduler.jobName }}"}[5m])) without(instance, pod))
       labels:
         quantile: '0.99'
       record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
-    - expr: histogram_quantile(0.9, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+    - expr: histogram_quantile(0.9, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="{{ .Values.kubeScheduler.jobName }}"}[5m])) without(instance, pod))
       labels:
         quantile: '0.9'
       record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
-    - expr: histogram_quantile(0.9, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+    - expr: histogram_quantile(0.9, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="{{ .Values.kubeScheduler.jobName }}"}[5m])) without(instance, pod))
       labels:
         quantile: '0.9'
       record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
-    - expr: histogram_quantile(0.9, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+    - expr: histogram_quantile(0.9, sum(rate(scheduler_binding_duration_seconds_bucket{job="{{ .Values.kubeScheduler.jobName }}"}[5m])) without(instance, pod))
       labels:
         quantile: '0.9'
       record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
-    - expr: histogram_quantile(0.5, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+    - expr: histogram_quantile(0.5, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="{{ .Values.kubeScheduler.jobName }}"}[5m])) without(instance, pod))
       labels:
         quantile: '0.5'
       record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
-    - expr: histogram_quantile(0.5, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+    - expr: histogram_quantile(0.5, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="{{ .Values.kubeScheduler.jobName }}"}[5m])) without(instance, pod))
       labels:
         quantile: '0.5'
       record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
-    - expr: histogram_quantile(0.5, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+    - expr: histogram_quantile(0.5, sum(rate(scheduler_binding_duration_seconds_bucket{job="{{ .Values.kubeScheduler.jobName }}"}[5m])) without(instance, pod))
       labels:
         quantile: '0.5'
       record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-controller-manager.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-controller-manager.yaml
@@ -4,7 +4,7 @@ Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
-{{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.kubeControllerManager.enabled }}
+{{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.kubeControllerManager.enabled .Values.kubeControllerManager.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -24,7 +24,6 @@ spec:
   groups:
   - name: kubernetes-system-controller-manager
     rules:
-{{- if .Values.kubeControllerManager.enabled }}
     - alert: KubeControllerManagerDown
       annotations:
         description: KubeControllerManager has disappeared from Prometheus target discovery.
@@ -36,6 +35,5 @@ spec:
         severity: critical
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-scheduler.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-scheduler.yaml
@@ -4,7 +4,7 @@ Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
-{{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.kubeScheduler.enabled .Values.defaultRules.rules.kubeScheduler }}
+{{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.kubeScheduler.enabled .Values.defaultRules.rules.kubeScheduler .Values.kubeScheduler.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -24,7 +24,6 @@ spec:
   groups:
   - name: kubernetes-system-scheduler
     rules:
-{{- if .Values.kubeScheduler.enabled }}
     - alert: KubeSchedulerDown
       annotations:
         description: KubeScheduler has disappeared from Prometheus target discovery.
@@ -36,6 +35,5 @@ spec:
         severity: critical
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules/kube-scheduler.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules/kube-scheduler.rules.yaml
@@ -24,39 +24,39 @@ spec:
   groups:
   - name: kube-scheduler.rules
     rules:
-    - expr: histogram_quantile(0.99, sum(rate(scheduler_e2e_scheduling_latency_microseconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod)) / 1e+06
+    - expr: histogram_quantile(0.99, sum(rate(scheduler_e2e_scheduling_latency_microseconds_bucket{job="{{ .Values.kubeScheduler.jobName }}"}[5m])) without(instance, pod)) / 1e+06
       labels:
         quantile: '0.99'
       record: cluster_quantile:scheduler_e2e_scheduling_latency:histogram_quantile
-    - expr: histogram_quantile(0.99, sum(rate(scheduler_scheduling_algorithm_latency_microseconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod)) / 1e+06
+    - expr: histogram_quantile(0.99, sum(rate(scheduler_scheduling_algorithm_latency_microseconds_bucket{job="{{ .Values.kubeScheduler.jobName }}"}[5m])) without(instance, pod)) / 1e+06
       labels:
         quantile: '0.99'
       record: cluster_quantile:scheduler_scheduling_algorithm_latency:histogram_quantile
-    - expr: histogram_quantile(0.99, sum(rate(scheduler_binding_latency_microseconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod)) / 1e+06
+    - expr: histogram_quantile(0.99, sum(rate(scheduler_binding_latency_microseconds_bucket{job="{{ .Values.kubeScheduler.jobName }}"}[5m])) without(instance, pod)) / 1e+06
       labels:
         quantile: '0.99'
       record: cluster_quantile:scheduler_binding_latency:histogram_quantile
-    - expr: histogram_quantile(0.9, sum(rate(scheduler_e2e_scheduling_latency_microseconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod)) / 1e+06
+    - expr: histogram_quantile(0.9, sum(rate(scheduler_e2e_scheduling_latency_microseconds_bucket{job="{{ .Values.kubeScheduler.jobName }}"}[5m])) without(instance, pod)) / 1e+06
       labels:
         quantile: '0.9'
       record: cluster_quantile:scheduler_e2e_scheduling_latency:histogram_quantile
-    - expr: histogram_quantile(0.9, sum(rate(scheduler_scheduling_algorithm_latency_microseconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod)) / 1e+06
+    - expr: histogram_quantile(0.9, sum(rate(scheduler_scheduling_algorithm_latency_microseconds_bucket{job="{{ .Values.kubeScheduler.jobName }}"}[5m])) without(instance, pod)) / 1e+06
       labels:
         quantile: '0.9'
       record: cluster_quantile:scheduler_scheduling_algorithm_latency:histogram_quantile
-    - expr: histogram_quantile(0.9, sum(rate(scheduler_binding_latency_microseconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod)) / 1e+06
+    - expr: histogram_quantile(0.9, sum(rate(scheduler_binding_latency_microseconds_bucket{job="{{ .Values.kubeScheduler.jobName }}"}[5m])) without(instance, pod)) / 1e+06
       labels:
         quantile: '0.9'
       record: cluster_quantile:scheduler_binding_latency:histogram_quantile
-    - expr: histogram_quantile(0.5, sum(rate(scheduler_e2e_scheduling_latency_microseconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod)) / 1e+06
+    - expr: histogram_quantile(0.5, sum(rate(scheduler_e2e_scheduling_latency_microseconds_bucket{job="{{ .Values.kubeScheduler.jobName }}"}[5m])) without(instance, pod)) / 1e+06
       labels:
         quantile: '0.5'
       record: cluster_quantile:scheduler_e2e_scheduling_latency:histogram_quantile
-    - expr: histogram_quantile(0.5, sum(rate(scheduler_scheduling_algorithm_latency_microseconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod)) / 1e+06
+    - expr: histogram_quantile(0.5, sum(rate(scheduler_scheduling_algorithm_latency_microseconds_bucket{job="{{ .Values.kubeScheduler.jobName }}"}[5m])) without(instance, pod)) / 1e+06
       labels:
         quantile: '0.5'
       record: cluster_quantile:scheduler_scheduling_algorithm_latency:histogram_quantile
-    - expr: histogram_quantile(0.5, sum(rate(scheduler_binding_latency_microseconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod)) / 1e+06
+    - expr: histogram_quantile(0.5, sum(rate(scheduler_binding_latency_microseconds_bucket{job="{{ .Values.kubeScheduler.jobName }}"}[5m])) without(instance, pod)) / 1e+06
       labels:
         quantile: '0.5'
       record: cluster_quantile:scheduler_binding_latency:histogram_quantile

--- a/charts/kube-prometheus-stack/templates/prometheus/rules/kubernetes-absent.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules/kubernetes-absent.yaml
@@ -80,7 +80,7 @@ spec:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
 {{- end }}
-{{- if .Values.kubeScheduler.enabled }}
+{{- if and .Values.kubeScheduler.enabled .Values.kubeScheduler.serviceMonitor.enabled }}
     - alert: KubeSchedulerDown
       annotations:
         message: KubeScheduler has disappeared from Prometheus target discovery.

--- a/charts/kube-prometheus-stack/templates/prometheus/rules/kubernetes-absent.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules/kubernetes-absent.yaml
@@ -67,7 +67,7 @@ spec:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
 {{- end }}
-{{- if .Values.kubeControllerManager.enabled }}
+{{- if and .Values.kubeControllerManager.enabled .Values.kubeControllerManager.serviceMonitor.enabled }}
     - alert: KubeControllerManagerDown
       annotations:
         message: KubeControllerManager has disappeared from Prometheus target discovery.

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -875,6 +875,8 @@ kubeControllerManager:
     #   component: kube-controller-manager
 
   serviceMonitor:
+    enabled: true
+
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
@@ -906,6 +908,9 @@ kubeControllerManager:
     #   targetLabel: nodename
     #   replacement: $1
     #   action: replace
+
+  ## Override job name used in rules and dashboards. Useful if ServiceMonitor disabled above, such as in k3s where kube-controller-manager metrics come from the "apiserver" job.
+  jobName: kube-controller-manager
 
 ## Component scraping coreDns. Use either this or kubeDns
 ##
@@ -1101,7 +1106,7 @@ kubeScheduler:
     #   replacement: $1
     #   action: replace
 
-  ## Override job name used in rules and dashboards. Useful if ServiceMonitor disabled above, such as in k3s where scheduler metrics come from the "apiserver" job.
+  ## Override job name used in rules and dashboards. Useful if ServiceMonitor disabled above, such as in k3s where kube-scheduler metrics come from the "apiserver" job.
   jobName: kube-scheduler
 
 ## Component scraping kube proxy

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1068,6 +1068,8 @@ kubeScheduler:
     #   component: kube-scheduler
 
   serviceMonitor:
+    enabled: true
+
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
@@ -1099,6 +1101,8 @@ kubeScheduler:
     #   replacement: $1
     #   action: replace
 
+  ## Override job name used in rules and dashboards. Useful if ServiceMonitor disabled above, such as in k3s where scheduler metrics come from the "apiserver" job.
+  jobName: kube-scheduler
 
 ## Component scraping kube proxy
 ##


### PR DESCRIPTION
#### What this PR does / why we need it:
For kube-scheduler and kube-controller-manager, make it possible to have the dashboards/rules enabled but ServiceMonitor disabled. Then make it possible to override the job name used in rules/dashboards.

This is useful for k3s where the "apiserver" job pulls in metrics for scheduler, controller-manager, as well as the API server. With this change it is possible to add the following values and have working dashboards/rules for these components (rather than just having to disable these features of the chart).

```
kubeScheduler:
  jobName: apiserver
  serviceMonitor:
    enabled: false
kubeControllerManager:
  jobName: apiserver
  serviceMonitor:
    enabled: false
```

Unfortunately it's not yet possible to scrape the new embedded etcd implementation until a k3s release built with this change: https://github.com/k3s-io/k3s/pull/2750

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:
I have verified that under normal (non-k3s) circumstances there are no changes to the templated YAML. I've removed a couple of if statements in `rules-1.14/kubernetes-system-scheduler.yaml` and `rules-1.14/kubernetes-system-controller-manager.yaml` which weren't having any effect due to the big if statement at the top of these files.

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
