### PR TITLE
[alertmanager] Ability for custom dnsConfig 

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 0.5.0
+version: 0.6.0
 appVersion: v0.21.0
 maintainers:
   - name: monotek

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -24,6 +24,10 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       serviceAccountName: {{ include "alertmanager.serviceAccountName" . }}
+    {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -27,7 +27,16 @@ serviceAccount:
 
 podSecurityContext:
   fsGroup: 65534
-
+dnsConfig: {}
+  # nameservers:
+  #   - 1.2.3.4
+  # searches:
+  #   - ns1.svc.cluster-domain.example
+  #   - my.dns.search.suffix
+  # options:
+  #   - name: ndots
+  #     value: "2"
+  #   - name: edns0
 securityContext:
   # capabilities:
   #   drop:


### PR DESCRIPTION
Signed-off-by: Stavros Foteinopoulos <stafot@gmail.com>

What this PR does / why we need it:
Split of #554

Which issue this PR fixes
Part of #634
Adding possibility to set a custom dnsConfig for the pods. Pod's DNS Config field enable users more control on the DNS settings for the pods.

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
