### PR TITLE
[prometheus] Ability for custom dnsConfig

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: prometheus
-version: 13.2.1
+version: 13.3.0
 appVersion: 2.24.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/templates/alertmanager/deploy.yaml
+++ b/charts/prometheus/templates/alertmanager/deploy.yaml
@@ -113,6 +113,10 @@ spec:
       nodeSelector:
 {{ toYaml .Values.alertmanager.nodeSelector | indent 8 }}
     {{- end }}
+    {{- with .Values.alertmanager.dnsConfig }}
+      dnsConfig:
+{{ toYaml . | indent 8 }}
+    {{- end }}
     {{- if .Values.alertmanager.securityContext }}
       securityContext:
 {{ toYaml .Values.alertmanager.securityContext | indent 8 }}

--- a/charts/prometheus/templates/node-exporter/daemonset.yaml
+++ b/charts/prometheus/templates/node-exporter/daemonset.yaml
@@ -108,6 +108,10 @@ spec:
       nodeSelector:
 {{ toYaml .Values.nodeExporter.nodeSelector | indent 8 }}
     {{- end }}
+    {{- with .Values.nodeExporter.dnsConfig }}
+      dnsConfig:
+{{ toYaml . | indent 8 }}
+    {{- end }}
     {{- if .Values.nodeExporter.securityContext }}
       securityContext:
 {{ toYaml .Values.nodeExporter.securityContext | indent 8 }}

--- a/charts/prometheus/templates/pushgateway/deploy.yaml
+++ b/charts/prometheus/templates/pushgateway/deploy.yaml
@@ -89,6 +89,10 @@ spec:
       nodeSelector:
 {{ toYaml .Values.pushgateway.nodeSelector | indent 8 }}
     {{- end }}
+    {{- with .Values.pushgateway.dnsConfig }}
+      dnsConfig:
+{{ toYaml . | indent 8 }}
+    {{- end }}
     {{- if .Values.pushgateway.securityContext }}
       securityContext:
 {{ toYaml .Values.pushgateway.securityContext | indent 8 }}

--- a/charts/prometheus/templates/server/deploy.yaml
+++ b/charts/prometheus/templates/server/deploy.yaml
@@ -164,6 +164,10 @@ spec:
       hostAliases:
 {{ toYaml .Values.server.hostAliases | indent 8 }}
     {{- end }}
+    {{- if .Values.server.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.server.dnsConfig | indent 8 }}
+    {{- end }}
     {{- if .Values.server.securityContext }}
       securityContext:
 {{ toYaml .Values.server.securityContext | indent 8 }}

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -297,6 +297,18 @@ alertmanager:
     #   cpu: 10m
     #   memory: 32Mi
 
+  # Custom DNS configuration to be added to alertmanager pods
+  dnsConfig: {}
+    # nameservers:
+    #   - 1.2.3.4
+    # searches:
+    #   - ns1.svc.cluster-domain.example
+    #   - my.dns.search.suffix
+    # options:
+    #   - name: ndots
+    #     value: "2"
+  #   - name: edns0
+
   ## Security context to be added to alertmanager pods
   ##
   securityContext:
@@ -527,6 +539,18 @@ nodeExporter:
     # requests:
     #   cpu: 100m
     #   memory: 30Mi
+
+  # Custom DNS configuration to be added to node-exporter pods
+  dnsConfig: {}
+    # nameservers:
+    #   - 1.2.3.4
+    # searches:
+    #   - ns1.svc.cluster-domain.example
+    #   - my.dns.search.suffix
+    # options:
+    #   - name: ndots
+    #     value: "2"
+  #   - name: edns0
 
   ## Security context to be added to node-exporter pods
   ##
@@ -931,6 +955,17 @@ server:
     # containerPolicies:
     # - containerName: 'prometheus-server'
 
+  # Custom DNS configuration to be added to prometheus server pods
+  dnsConfig: {}
+    # nameservers:
+    #   - 1.2.3.4
+    # searches:
+    #   - ns1.svc.cluster-domain.example
+    #   - my.dns.search.suffix
+    # options:
+    #   - name: ndots
+    #     value: "2"
+  #   - name: edns0
   ## Security context to be added to server pods
   ##
   securityContext:
@@ -1102,6 +1137,18 @@ pushgateway:
     # requests:
     #   cpu: 10m
     #   memory: 32Mi
+
+  # Custom DNS configuration to be added to push-gateway pods
+  dnsConfig: {}
+    # nameservers:
+    #   - 1.2.3.4
+    # searches:
+    #   - ns1.svc.cluster-domain.example
+    #   - my.dns.search.suffix
+    # options:
+    #   - name: ndots
+    #     value: "2"
+  #   - name: edns0
 
   ## Security context to be added to push-gateway pods
   ##


### PR DESCRIPTION
Signed-off-by: Stavros Foteinopoulos <stafot@gmail.com>

#### What this PR does / why we need it:
Split of #554

#### Which issue this PR fixes
Part of #634
Adding possibility to set a custom dnsConfig for the pods. Pod's DNS Config field enable users more control on the DNS settings for the pods.



#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
