### PR TITLE
[kube-prometheus-stack] Sync kube-state-metrics

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://kubernetes.github.io/kube-state-metrics
-  version: 2.9.7
+  version: 2.12.0
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 1.12.0
 - name: grafana
   repository: https://grafana.github.io/helm-charts
   version: 6.1.17
-digest: sha256:618d35aba8290330ef4c39438e6be271e17c68aed8806acd626ce8b844056415
-generated: "2021-01-14T16:55:53.236240429+01:00"
+digest: sha256:dc971b13feac4b52ffcd2394acaa3bcb9a12542f40a9158a9af1ce88c7aa3e33
+generated: "2021-02-08T17:39:09.689233013+01:00"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 13.5.0
+version: 13.5.1
 appVersion: 0.45.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus
@@ -36,7 +36,7 @@ annotations:
 
 dependencies:
 - name: kube-state-metrics
-  version: "2.9.*"
+  version: "2.12.*"
   repository: https://kubernetes.github.io/kube-state-metrics
   condition: kubeStateMetrics.enabled
 - name: prometheus-node-exporter


### PR DESCRIPTION
#### What this PR does / why we need it:
Syncs with latest kube-state-metrics chart

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
