### PR TITLE
[prometheus-cloudwatch-exporter] Set namespace

### DIFF
--- a/charts/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/charts/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.10.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.14.0
+version: 0.14.1
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/charts/prometheus-cloudwatch-exporter/templates/configmap.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-cloudwatch-exporter.name" . }}
     chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}

--- a/charts/prometheus-cloudwatch-exporter/templates/deployment.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-cloudwatch-exporter.name" . }}
     chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}

--- a/charts/prometheus-cloudwatch-exporter/templates/ingress.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/ingress.yaml
@@ -6,6 +6,7 @@ apiVersion: {{ template "ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-cloudwatch-exporter.name" . }}
     chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}

--- a/charts/prometheus-cloudwatch-exporter/templates/secrets.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/secrets.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-cloudwatch-exporter.name" . }}
     chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}

--- a/charts/prometheus-cloudwatch-exporter/templates/service.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}
   labels:

--- a/charts/prometheus-cloudwatch-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "prometheus-cloudwatch-exporter.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "prometheus-cloudwatch-exporter.name" . }}
     chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}    


### PR DESCRIPTION
#### What this PR does / why we need it:

Set namespace on objects where it is not set, to `.Release.namespace`

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
