### PR TITLE
[prometheus-postgres-exporter] add opportunity to specify log.level in container args

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.8.0"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 1.9.0
+version: 1.9.1
 home: https://github.com/wrouesnel/postgres_exporter
 sources:
 - https://github.com/wrouesnel/postgres_exporter

--- a/charts/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/charts/prometheus-postgres-exporter/templates/deployment.yaml
@@ -62,6 +62,9 @@ spec:
           {{ $firstLabel := true -}}
           - "--constantLabels={{- range $k, $v := .Values.config.constantLabels }}{{- if not $firstLabel -}},{{ end -}}{{ $firstLabel = false -}}{{ $k }}={{ $v }}{{- end }}"
           {{- end }}
+          {{- if .Values.config.logLevel }}
+          - "--log.level={{ .Values.config.logLevel }}"
+          {{- end}}
           env:
           {{- if .Values.config.datasourceSecret }}
           - name: DATA_SOURCE_NAME

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -114,6 +114,8 @@ config:
   autoDiscoverDatabases: false
   excludeDatabases: []
   constantLabels: {}
+  # possible values debug, info, warn, error, fatal
+  logLevel: ""
   # this are the defaults queries that the exporter will run, extracted from: https://github.com/wrouesnel/postgres_exporter/blob/master/queries.yaml
   queries: |-
     pg_replication:


### PR DESCRIPTION
Signed-off-by: Jasstkn <jasssstkn@yahoo.com>

#### What this PR does / why we need it:
- Add opportunity to specify log.level argument for exporter container in deployment manifest 

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
