### PR TITLE
[prometheus-postgres-exporter]: Add annotations to postgres-exporter ServiceAccount

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.8.0"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 1.9.1
+version: 1.10.0
 home: https://github.com/wrouesnel/postgres_exporter
 sources:
 - https://github.com/wrouesnel/postgres_exporter

--- a/charts/prometheus-postgres-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-postgres-exporter/templates/serviceaccount.yaml
@@ -5,8 +5,11 @@ metadata:
   name: {{ template "prometheus-postgres-exporter.serviceAccountName" . }}
   labels:
     app: {{ template "prometheus-postgres-exporter.name" . }}
-    chart: {{ template "prometheus-postgres-exporter.chart" . }}    
+    chart: {{ template "prometheus-postgres-exporter.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.serviceAccount.annotations }}
+  annotations:
+    {{ toYaml .Values.serviceAccount.annotations }}
+  {{- end }}
 {{- end -}}
-  

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -81,6 +81,8 @@ serviceAccount:
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
+  # Add annotations to the ServiceAccount, useful for EKS IAM Roles for Service Accounts or Google Workload Identity.
+  annotations: {}
 
 securityContext: {}
   # The securityContext this Pod should use. See https://kubernetes.io/docs/concepts/policy/security-context/ for more.


### PR DESCRIPTION
#### What this PR does / why we need it:

Allow setting annotations on the ServiceAccount used by the
postgres-exporter Deployment. If we are running a sidecar container such
as the Google Cloud SQL Proxy we can annotate the service account to
enable Workload Identity. The approach is the same in EKS clusters
also.

I notice in the `values.yaml` there is already a reference to running the
cloud SQL proxy as a sidecar container.

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
