### PR TITLE
[kube-prometheus-stack] Upgrade grafana dependency to 6.4

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://kubernetes.github.io/kube-state-metrics
-  version: 2.12.2
+  version: 2.12.*
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 1.14.2
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.1.17
-digest: sha256:cad54f9caae0b4893e664307aa5189a01fb9e3cb2f756d48d88aa2875351742f
-generated: "2021-02-16T15:07:35.3511933+01:00"
+  version: 6.4.2
+digest: sha256:32d5c99e7e49c57ac074e25e68d0858685387c461baf83946387999615a116be
+generated: "2021-02-18T14:51:10.1241605+01:00"

--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://kubernetes.github.io/kube-state-metrics
-  version: 2.12.*
+  version: 2.12.2
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 1.14.2
 - name: grafana
   repository: https://grafana.github.io/helm-charts
   version: 6.4.2
-digest: sha256:32d5c99e7e49c57ac074e25e68d0858685387c461baf83946387999615a116be
-generated: "2021-02-18T14:51:10.1241605+01:00"
+digest: sha256:85c10f738a38ffa4da9ba6051c6fff662983c9bf728883e55ce37bdbbe3214da
+generated: "2021-02-18T15:13:46.0264967+01:00"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 13.9.1
+version: 13.10.0
 appVersion: 0.45.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus
@@ -44,6 +44,6 @@ dependencies:
   repository: https://prometheus-community.github.io/helm-charts
   condition: nodeExporter.enabled
 - name: grafana
-  version: "6.1.*"
+  version: "6.4.*"
   repository: https://grafana.github.io/helm-charts
   condition: grafana.enabled


### PR DESCRIPTION
#### What this PR does / why we need it:
* Upgrade grafana dependency to 6.4 (includes Grafana 7.4.1)

#### Special notes for your reviewer:
None

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)