### PR TITLE
[kube-prometheus-stack] Updated deprecated metrics with new versions

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 13.10.0
+version: 13.10.1
 appVersion: 0.45.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/k8s.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/k8s.rules.yaml
@@ -59,7 +59,7 @@ spec:
         sum by (namespace) (
             sum by (namespace, pod) (
                 max by (namespace, pod, container) (
-                    kube_pod_container_resource_requests_memory_bytes{job="kube-state-metrics"}
+                    kube_pod_container_resource_requests{resource="memory", unit="byte", job="kube-state-metrics"}
                 ) * on(namespace, pod) group_left() max by (namespace, pod) (
                     kube_pod_status_phase{phase=~"Pending|Running"} == 1
                 )
@@ -70,7 +70,7 @@ spec:
         sum by (namespace) (
             sum by (namespace, pod) (
                 max by (namespace, pod, container) (
-                    kube_pod_container_resource_requests_cpu_cores{job="kube-state-metrics"}
+                    kube_pod_container_resource_requests{resource="cpu", unit="core", job="kube-state-metrics"}
                 ) * on(namespace, pod) group_left() max by (namespace, pod) (
                   kube_pod_status_phase{phase=~"Pending|Running"} == 1
                 )


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

Refer this changelog: https://github.com/kubernetes/kube-state-metrics/blob/33db2356bf1f0a1f51ddaaeb165bce04ab5aa0df/CHANGELOG.md#v200-alpha--2020-09-16

`kube_pod_container_resource_requests_cpu_cores` and `kube_pod_container_resource_requests_memory_bytes` are deprecated.


#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
