### PR TITLE
[prometheus-adapter] Fix overzealous whitespace trimming.

### DIFF
--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 2.12.0
+version: 2.12.1
 appVersion: v0.8.3
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/charts/prometheus-adapter/templates/custom-metrics-apiservice.yaml
+++ b/charts/prometheus-adapter/templates/custom-metrics-apiservice.yaml
@@ -21,7 +21,7 @@ spec:
   service:
     name: {{ template "k8s-prometheus-adapter.fullname" . }}
     namespace: {{ .Release.Namespace | quote }}
-  {{- if .Values.tls.enable -}}
+  {{- if .Values.tls.enable }}
   caBundle: {{ b64enc .Values.tls.ca }}
   {{- end }}
   group: custom.metrics.k8s.io

--- a/charts/prometheus-adapter/templates/external-metrics-apiservice.yaml
+++ b/charts/prometheus-adapter/templates/external-metrics-apiservice.yaml
@@ -21,7 +21,7 @@ spec:
   service:
     name: {{ template "k8s-prometheus-adapter.fullname" . }}
     namespace: {{ .Release.Namespace | quote }}
-  {{- if .Values.tls.enable -}}
+  {{- if .Values.tls.enable }}
   caBundle: {{ b64enc .Values.tls.ca }}
   {{- end }}
   group: external.metrics.k8s.io

--- a/charts/prometheus-adapter/templates/resource-metrics-apiservice.yaml
+++ b/charts/prometheus-adapter/templates/resource-metrics-apiservice.yaml
@@ -21,7 +21,7 @@ spec:
   service:
     name: {{ template "k8s-prometheus-adapter.fullname" . }}
     namespace: {{ .Release.Namespace | quote }}
-  {{- if .Values.tls.enable -}}
+  {{- if .Values.tls.enable }}
   caBundle: {{ b64enc .Values.tls.ca }}
   {{- end }}
   group: metrics.k8s.io


### PR DESCRIPTION
The APIService templates will error in their current state due to fields being unintentionally merged into one line.

Signed-off-by: Joe Hohertz <joe@viafoura.com>

#### What this PR does / why we need it:

Corrects whitespace errors in the template rendering.

#### Which issue this PR fixes

Didn't see existing issue on this.

#### Special notes for your reviewer:

Needs to have the API service records enabled to see the error.

#### Checklist

- [*] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [*] Chart Version bumped
- [*] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
