### PR TITLE
[kube-prometheus-stack] Upgrade to latest kube-state-metrics chart

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://kubernetes.github.io/kube-state-metrics
-  version: 2.12.2
+  version: 2.13.0
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 1.14.2
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.4.2
-digest: sha256:85c10f738a38ffa4da9ba6051c6fff662983c9bf728883e55ce37bdbbe3214da
-generated: "2021-02-18T15:13:46.0264967+01:00"
+  version: 6.4.4
+digest: sha256:5e586e0b76974dd04f00096c4a7063dc0a01620b8ae1edc3069282966b38b9e7
+generated: "2021-02-23T11:31:31.313137303Z"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 13.12.0
+version: 13.13.0
 appVersion: 0.45.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus
@@ -36,7 +36,7 @@ annotations:
 
 dependencies:
 - name: kube-state-metrics
-  version: "2.12.*"
+  version: "2.13.*"
   repository: https://kubernetes.github.io/kube-state-metrics
   condition: kubeStateMetrics.enabled
 - name: prometheus-node-exporter


### PR DESCRIPTION
#### What this PR does / why we need it:
Upgrades to latest kube-state-metrics v1.9 version

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #373 

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
