### PR TITLE
[prometheus-mysql-exporter] make existing secret config more flexible

### DIFF
--- a/charts/prometheus-mysql-exporter/Chart.yaml
+++ b/charts/prometheus-mysql-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for prometheus mysql exporter with cloudsqlproxy
 name: prometheus-mysql-exporter
-version: 1.1.0
+version: 1.2.0
 home: https://github.com/prometheus/mysqld_exporter
 appVersion: v0.12.1
 sources:

--- a/charts/prometheus-mysql-exporter/templates/deployment.yaml
+++ b/charts/prometheus-mysql-exporter/templates/deployment.yaml
@@ -47,9 +47,27 @@ spec:
 {{- end }}
           ]
 {{- end }}
+          {{- if not .Values.mysql.existingSecret }}
+          env:
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+          {{- if .Values.mysql.existingPasswordSecret.name }}
+                  name: {{ .Values.mysql.existingPasswordSecret.name }}
+                  key: {{ .Values.mysql.existingPasswordSecret.key }}
+          {{- else }}
+                  name: {{ template "prometheus-mysql-exporter.fullname" . }}
+                  key: password
+          {{- end }}
+          {{- end }}
+          {{- if .Values.mysql.existingSecret }}
           envFrom:
             - secretRef:
                 name: {{ template "prometheus-mysql-exporter.secret" . }}
+          {{- else }}
+            - name: DATA_SOURCE_NAME
+              value: "{{ .Values.mysql.user }}:$(DB_PASSWORD)@{{ if .Values.mysql.protocol }}{{ .Values.mysql.protocol }}{{ end }}({{ .Values.mysql.host }}:{{ .Values.mysql.port }})/{{ if .Values.mysql.db }}{{ .Values.mysql.db }}{{ end }}{{ if .Values.mysql.param }}?{{ .Values.mysql.param }}{{ end }}"
+          {{- end }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/charts/prometheus-mysql-exporter/templates/secret-env.yaml
+++ b/charts/prometheus-mysql-exporter/templates/secret-env.yaml
@@ -1,11 +1,11 @@
-{{- if or (not .Values.mysql.existingSecret) }}
+{{- if and (not .Values.mysql.existingSecret) (not .Values.mysql.existingPasswordSecret.name) }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "prometheus-mysql-exporter.fullname" . }}
   labels:
-    {{- include "prometheus-mysql-exporter.labels" . | nindent 4 }}  
+    {{- include "prometheus-mysql-exporter.labels" . | nindent 4 }}
 type: Opaque
-stringData:
-  DATA_SOURCE_NAME: "{{ .Values.mysql.user }}:{{ .Values.mysql.pass }}@{{ if .Values.mysql.protocol }}{{ .Values.mysql.protocol }}{{ end }}({{ .Values.mysql.host }}:{{ .Values.mysql.port }})/{{ if .Values.mysql.db }}{{ .Values.mysql.db }}{{ end }}{{ if .Values.mysql.param }}?{{ .Values.mysql.param }}{{ end }}"
+data:
+  password: "{{ .Values.mysql.pass | b64enc }}"
 {{- end }}

--- a/charts/prometheus-mysql-exporter/values.yaml
+++ b/charts/prometheus-mysql-exporter/values.yaml
@@ -114,7 +114,12 @@ mysql:
   port: 3306
   protocol: ""
   user: "exporter"
-  existingSecret: false
+  # secret with full DATA_SOURCE_NAME env var as stringdata
+  existingSecret: ""
+  # secret only containing the password
+  existingPasswordSecret:
+    name: ""
+    key: ""
 
 # cloudsqlproxy https://cloud.google.com/sql/docs/mysql/sql-proxy
 cloudsqlproxy:


### PR DESCRIPTION
Signed-off-by: André Bauer <monotek23@gmail.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
* creates the possibility to use existingPasswordSecret, containing only the mysql password, where name and key can be configured
* keeps old exisitingSecret to not break functionality for existing users

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
