### PR TITLE
[prometheus-stackdriver-exporter] Add feature for custom key.

### DIFF
--- a/charts/prometheus-stackdriver-exporter/Chart.yaml
+++ b/charts/prometheus-stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: prometheus-stackdriver-exporter
-version: 1.8.0
+version: 1.8.1
 appVersion: 0.11.0
 home: https://www.stackdriver.com/
 sources:

--- a/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
@@ -39,6 +39,11 @@ spec:
         - name: stackdriver-service-account
           secret:
             secretName: {{ .Values.stackdriver.serviceAccountSecret | quote }}
+            {{- if and (.Values.stackdriver.serviceAccountSecret) (.Values.stackdriver.serviceAccountSecretKey) }}
+            items:
+              - key: {{ .Values.stackdriver.serviceAccountSecretKey | quote }}
+                path: credentials.json
+            {{- end }}
       {{- else if .Values.stackdriver.serviceAccountKey }}
         - name: stackdriver-service-account
           secret:
@@ -108,4 +113,3 @@ spec:
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
-

--- a/charts/prometheus-stackdriver-exporter/values.yaml
+++ b/charts/prometheus-stackdriver-exporter/values.yaml
@@ -27,6 +27,8 @@ stackdriver:
   projectId: "FALSE"
   # An existing secret which contains credentials.json
   serviceAccountSecret: ""
+  # Provide custom key for the existing secret to load credentials.json from
+  serviceAccountSecretKey: ""
   # A service account key JSON file. Must be provided when no existing secret is used, in this case a new secret will be created holding this service account
   serviceAccountKey: ""
   # Max number of retries that should be attempted on 503 errors from Stackdriver


### PR DESCRIPTION
Signed-off-by: Whyeasy <Whyeasy@users.noreply.github.com>

#### What this PR does / why we need it:

Add the capability to provide a custom key to load the credentials from in a secret.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
