### PR TITLE
[prometheus-rabbitmq-exporter] Polish up Prometheus rules

### DIFF
--- a/charts/prometheus-rabbitmq-exporter/Chart.yaml
+++ b/charts/prometheus-rabbitmq-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Rabbitmq metrics exporter for prometheus
 name: prometheus-rabbitmq-exporter
-version: 0.7.0
+version: 1.0.0
 appVersion: v0.29.0
 home: https://github.com/kbudde/rabbitmq_exporter
 sources:

--- a/charts/prometheus-rabbitmq-exporter/templates/prometheusrule.yaml
+++ b/charts/prometheus-rabbitmq-exporter/templates/prometheusrule.yaml
@@ -12,36 +12,58 @@ metadata:
   {{- end }}
 spec:
   groups:
-  - name: rabbitmq
-    rules:
-    - alert: RabbitmqDown
-      expr: |
-        absent(rabbitmq_up == 1)
-      for: 1m
-      labels:
-        severity: critical
-    - alert: RabbitmqNotRunning
-      expr: |
-        rabbitmq_running{self="1"} != 1
-      for: 1m
-      labels:
-        severity: critical
-    - alert: RabbitmqMessages
-      expr: |
-        rabbitmq_queue_messages > 250
-      for: 10m
-      labels:
-        severity: warning
-    - alert: RabbitmqMessages
-      expr: |
-        rabbitmq_queue_messages > 500
-      for: 10m
-      labels:
-        severity: critical
-    - alert: RabbitmqPartition
-      expr: |
-        rabbitmq_partitions{self="1"} != 0
-      for: 1m
-      labels:
-        severity: critical
+    - name: {{ template "prometheus-rabbitmq-exporter.fullname" . }}
+      rules:
+        - alert: RabbitmqNodeDown
+          expr: rabbitmq_running{service="{{ template "prometheus-rabbitmq-exporter.fullname" . }}"} == 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: A Rabbitmq node is down
+            description: |
+              The Rabbitmq node {{ "{{ $labels.node }}" }} of
+               the cluster tracked by {{ "{{ $labels.service }}" }} was not running during the last 5m.
+        - alert: RabbitmqClusterDown
+          expr: |
+            rabbitmq_up{service="{{ template "prometheus-rabbitmq-exporter.fullname" . }}"} == 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: The Rabbitmq cluster {{ "{{ $labels.service }}" }} is maybe down.
+            description: |
+                The Rabbitmq exporter couldn't scrape any Rabbitmq node of the
+                cluster tracked by {{ "{{ $labels.service }}" }} during the last 5m, the cluster is maybe down.
+        - alert: RabbitMQClusterPartition
+          expr: rabbitmq_partitions{service="{{ template "prometheus-rabbitmq-exporter.fullname" . }}"} > 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: A cluster partition was detected
+            description: |
+                Cluster partition in Rabbitmq cluster tracked by {{ "{{ $labels.service }}" }} was detected
+                by the node {{ "{{ $labels.node }}" }}
+        - alert: RabbitmqOutOfMemory
+          expr: |
+            rabbitmq_node_mem_used{service="{{ template "prometheus-rabbitmq-exporter.fullname" . }}"}
+            / rabbitmq_node_mem_limit{service="{{ template "prometheus-rabbitmq-exporter.fullname" . }}"}
+            * 100 > 90
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: The Rabbitmq node {{ "{{ $labels.node }}" }} is Out of memory
+            description: |
+                Memory available for Rabbmitmq node {{ "{{ $labels.node }}" }} is lower than 10%
+        - alert: RabbitmqTooManyConnections
+          expr: rabbitmq_connectionsTotal{service="{{ template "prometheus-rabbitmq-exporter.fullname" . }}"} > 1000
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: Too many connections to the Rabbitmq cluster
+            description: |
+                The Rabbitmq cluster tracked by {{ "{{ $labels.service }}" }} has too many connections {{ "{{ $value }}" }} (> 1000)
 {{- end }}


### PR DESCRIPTION
I don't know if we should keep the old rules, if we should only bump the patch version...


#### What this PR does / why we need it:

The existing rules are vague.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
