### PR TITLE
[prometheus-stackdriver-exporter] Moving scrapeTimeout to the correct location.

### DIFF
--- a/charts/prometheus-stackdriver-exporter/Chart.yaml
+++ b/charts/prometheus-stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: prometheus-stackdriver-exporter
-version: 1.8.1
+version: 1.8.2
 appVersion: 0.11.0
 home: https://www.stackdriver.com/
 sources:

--- a/charts/prometheus-stackdriver-exporter/values.yaml
+++ b/charts/prometheus-stackdriver-exporter/values.yaml
@@ -48,8 +48,6 @@ stackdriver:
     typePrefixes: 'compute.googleapis.com/instance/cpu'
     # The frequency to request
     interval: '5m'
-    # How long until a scrape request times out.
-    scrapeTimeout: '10s'
     # How far into the past to offset
     offset: '0s'
 
@@ -97,6 +95,8 @@ serviceMonitor:
   namespace: monitoring
   # additionalLabels is the set of additional labels to add to the ServiceMonitor
   additionalLabels: {}
+  # How long until a scrape request times out.
+  scrapeTimeout: '10s'
   # fallback to the prometheus default unless specified
   # interval: 10s
   ## Defaults to what's used if you follow CoreOS [Prometheus Install Instructions](https://github.com/helm/charts/tree/master/stable/prometheus-operator#tldr)


### PR DESCRIPTION
Signed-off-by: Whyeasy <Whyeasy@users.noreply.github.com>

#### What this PR does / why we need it:

scrapeTimeout was on the wrong location and when applied gave an error at the creation of the ServiceMonitor.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
