### PR TITLE
[prometheus] make path.rootfs conditional

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: prometheus
-version: 13.5.0
+version: 13.6.0
 appVersion: 2.24.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: prometheus
-version: 13.4.1
+version: 13.5.0
 appVersion: 2.24.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: prometheus
-version: 13.4.0
+version: 13.4.1
 appVersion: 2.24.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/templates/node-exporter/daemonset.yaml
+++ b/charts/prometheus/templates/node-exporter/daemonset.yaml
@@ -45,7 +45,9 @@ spec:
           args:
             - --path.procfs=/host/proc
             - --path.sysfs=/host/sys
+          {{- if .Values.nodeExporter.hostRootfs }}
             - --path.rootfs=/host/root
+          {{- end }}
           {{- if .Values.nodeExporter.hostNetwork }}
             - --web.listen-address=:{{ .Values.nodeExporter.service.hostPort }}
           {{- end }}
@@ -73,10 +75,12 @@ spec:
             - name: sys
               mountPath: /host/sys
               readOnly: true
+          {{- if .Values.nodeExporter.hostRootfs }}
             - name: root
               mountPath: /host/root
               mountPropagation: HostToContainer
               readOnly: true
+          {{- end }}
           {{- range .Values.nodeExporter.extraHostPathMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
@@ -123,9 +127,11 @@ spec:
         - name: sys
           hostPath:
             path: /sys
+      {{- if .Values.nodeExporter.hostRootfs }}
         - name: root
           hostPath:
             path: /
+      {{- end }}
       {{- range .Values.nodeExporter.extraHostPathMounts }}
         - name: {{ .name }}
           hostPath:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -442,6 +442,10 @@ nodeExporter:
   ##
   hostPID: true
 
+  ## If true, node-exporter pods mounts host / at /host/root
+  ##
+  hostRootfs: true
+
   ## node-exporter container name
   ##
   name: node-exporter


### PR DESCRIPTION
#### What this PR does / why we need it:

Makes it configurable if node-exporter daemonset should mount `/` from host or not. Default to `true` to keep existing default behavior.

As seen in issue #467, it is not always possible to mount / from host in all environments.

#### Which issue this PR fixes

  - fixes #467 (but perhaps needs similar change to the node-exporter chart as well?)

#### Special notes for your reviewer:

> For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.
@gianrubio , @zanhsieh , @Xtigyro , @monotek , @naseemkullah 

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
