### PR TITLE
[prometheus-pingdom-exporter] Add secret override for pingdom exporter

### DIFF
--- a/charts/prometheus-pingdom-exporter/Chart.yaml
+++ b/charts/prometheus-pingdom-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-pingdom-exporter
-version: 2.3.2
+version: 2.4.2
 appVersion: 20190610-1
 home: https://github.com/giantswarm/prometheus-pingdom-exporter
 description: A Helm chart for Prometheus Pingdom Exporter

--- a/charts/prometheus-pingdom-exporter/Chart.yaml
+++ b/charts/prometheus-pingdom-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-pingdom-exporter
-version: 2.4.2
+version: 2.4.0
 appVersion: 20190610-1
 home: https://github.com/giantswarm/prometheus-pingdom-exporter
 description: A Helm chart for Prometheus Pingdom Exporter

--- a/charts/prometheus-pingdom-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-pingdom-exporter/templates/_helpers.tpl
@@ -60,3 +60,14 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Determine secret name, can either be the self-created of an existing one
+*/}}
+{{- define "prometheus-pingdom-exporter.secretName" -}}
+{{- if .Values.existingSecret.name -}}
+    {{- .Values.existingSecret.name -}}
+{{- else -}}
+    {{ include "prometheus-pingdom-exporter.fullname" . }}
+{{- end -}}
+{{- end -}}

--- a/charts/prometheus-pingdom-exporter/templates/deployment.yaml
+++ b/charts/prometheus-pingdom-exporter/templates/deployment.yaml
@@ -34,22 +34,22 @@ spec:
             - name: PINGDOM_USER
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "prometheus-pingdom-exporter.name" . }}
+                  name: {{ include "prometheus-pingdom-exporter.secretName" . }}
                   key: user
             - name: PINGDOM_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "prometheus-pingdom-exporter.name" . }}
+                  name: {{ include "prometheus-pingdom-exporter.secretName" . }}
                   key: password
             - name: PINGDOM_APPID
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "prometheus-pingdom-exporter.name" . }}
+                  name: {{ include "prometheus-pingdom-exporter.secretName" . }}
                   key: appId
             - name: PINGDOM_ACCOUNT
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "prometheus-pingdom-exporter.name" . }}
+                  name: {{ include "prometheus-pingdom-exporter.secretName" . }}
                   key: accountEmail
           ports:
             - name: http

--- a/charts/prometheus-pingdom-exporter/templates/secret.yaml
+++ b/charts/prometheus-pingdom-exporter/templates/secret.yaml
@@ -1,7 +1,8 @@
+{{- if not .Values.existingSecret.name -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "prometheus-pingdom-exporter.name" . }}
+  name: {{ include "prometheus-pingdom-exporter.secretName" . }}
   {{- if .Values.secret.annotations }}
   annotations:
     {{- toYaml .Values.secret.annotations | nindent 4 }}
@@ -14,3 +15,4 @@ data:
   password: {{ .Values.pingdom.password | b64enc }}
   appId: {{ .Values.pingdom.appId | b64enc }}
   accountEmail: {{ .Values.pingdom.accountEmail | b64enc }}
+{{- end }}

--- a/charts/prometheus-pingdom-exporter/values.yaml
+++ b/charts/prometheus-pingdom-exporter/values.yaml
@@ -57,7 +57,7 @@ pod:
     # example: "false"
 
 existingSecret:
-  name: "blah"
+  name: ""
 
 secret:
   annotations: {}

--- a/charts/prometheus-pingdom-exporter/values.yaml
+++ b/charts/prometheus-pingdom-exporter/values.yaml
@@ -56,6 +56,9 @@ pod:
     # key: "true"
     # example: "false"
 
+existingSecret:
+  name: ""
+
 secret:
   annotations: {}
     # key: "true"

--- a/charts/prometheus-pingdom-exporter/values.yaml
+++ b/charts/prometheus-pingdom-exporter/values.yaml
@@ -57,7 +57,7 @@ pod:
     # example: "false"
 
 existingSecret:
-  name: ""
+  name: "blah"
 
 secret:
   annotations: {}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

This PR adds the ability to specify an existing `Secret` in place of the generated secret when the chart is installed. This is useful in our case because we manage our secrets externally so already have a secure mechanism in place to generate this.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
