### PR TITLE
[kube-prometheus-stack] set cert-manager generated certificate duration to include minutes and seconds

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 14.0.1
+version: 14.0.2
 appVersion: 0.46.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/certmanager.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/certmanager.yaml
@@ -18,7 +18,7 @@ metadata:
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
 spec:
   secretName: {{ template "kube-prometheus-stack.fullname" . }}-root-cert
-  duration: 43800h # 5y
+  duration: 43800h0m0s # 5y
   issuerRef:
     name: {{ template "kube-prometheus-stack.fullname" . }}-self-signed-issuer
   commonName: "ca.webhook.kube-prometheus-stack"
@@ -43,7 +43,7 @@ metadata:
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
 spec:
   secretName: {{ template "kube-prometheus-stack.fullname" . }}-admission
-  duration: 8760h # 1y
+  duration: 8760h0m0s # 1y
   issuerRef:
     {{- if .Values.prometheusOperator.admissionWebhooks.certManager.issuerRef }}
     {{- toYaml .Values.prometheusOperator.admissionWebhooks.certManager.issuerRef | nindent 4 }}


### PR DESCRIPTION
@vsliouniaev , @bismarck , @gianrubio , @gkarthiks , @scottrigby , @Xtigyro 

#### What this PR does / why we need it:
cert-manager updates the certificate specification and sets the duration including minutes and seconds. this leads to a representation of e.g. `8760h0m0s` instead of `8760h` which is generally fine if you only apply and use the chart.
however, when using tools like argo-cd which synchronise and auto-heal out-of-sync manifests, this is detected as a drift and will get synchronised over and over again.
setting minutes and seconds in the specification resolves this problem.

#### Checklist
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
