### PR TITLE
[node-exporter] Bugfix with .serviceName

### DIFF
--- a/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -21,9 +21,7 @@ spec:
       {{- toYaml .Values.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
-{{- if and .Values.rbac.create .Values.serviceAccount.create }}
       serviceAccountName: {{ template "prometheus-node-exporter.serviceAccountName" . }}
-{{- end }}
 {{- if .Values.securityContext }}
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR fixes bug in "node-exporter" when existing service account is ignored (.Values.serviceAccount.name is specified and .Values.serviceAccount.create = true)



#### Special notes for your reviewer:

#### Checklist
- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
