### PR TITLE
[prometheus-node-exporter] Allow to opt-out node exporter rootfs mount

### DIFF
--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.1
 description: A Helm chart for prometheus node-exporter
 name: prometheus-node-exporter
-version: 1.15.0
+version: 1.15.1
 home: https://github.com/prometheus/node_exporter/
 sources:
 - https://github.com/prometheus/node_exporter/

--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.1
 description: A Helm chart for prometheus node-exporter
 name: prometheus-node-exporter
-version: 1.16.0
+version: 1.16.1
 home: https://github.com/prometheus/node_exporter/
 sources:
 - https://github.com/prometheus/node_exporter/

--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.1
 description: A Helm chart for prometheus node-exporter
 name: prometheus-node-exporter
-version: 1.15.1
+version: 1.16.0
 home: https://github.com/prometheus/node_exporter/
 sources:
 - https://github.com/prometheus/node_exporter/

--- a/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -38,7 +38,9 @@ spec:
           args:
             - --path.procfs=/host/proc
             - --path.sysfs=/host/sys
+            {{- if .Values.hostRootFsMount }}
             - --path.rootfs=/host/root
+            {{- end }}
             - --web.listen-address=$(HOST_IP):{{ .Values.service.port }}
 {{- if .Values.extraArgs }}
 {{ toYaml .Values.extraArgs | indent 12 }}
@@ -77,10 +79,12 @@ spec:
             - name: sys
               mountPath: /host/sys
               readOnly: true
+            {{- if .Values.hostRootFsMount }}
             - name: root
               mountPath: /host/root
               mountPropagation: HostToContainer
               readOnly: true
+            {{- end }}
             {{- if .Values.extraHostVolumeMounts }}
             {{- range $_, $mount := .Values.extraHostVolumeMounts }}
             - name: {{ $mount.name }}
@@ -146,9 +150,11 @@ spec:
         - name: sys
           hostPath:
             path: /sys
+        {{- if .Values.hostRootFsMount }}
         - name: root
           hostPath:
             path: /
+        {{- end }}
         {{- if .Values.extraHostVolumeMounts }}
         {{- range $_, $mount := .Values.extraHostVolumeMounts }}
         - name: {{ $mount.name }}

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -80,6 +80,10 @@ endpoints: []
 # Expose the service to the host network
 hostNetwork: true
 
+## If true, node-exporter pods mounts host / at /host/root
+##
+hostRootFsMount: true
+
 ## Assign a group of affinity scheduling rules
 ##
 affinity: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

Allows to opt-out the node-exporter deamonset mount of / from the host. This is necessary because it's not always possible to do it. To avoid changing the current behaviour of the chart the defaul value is set to true.

#### Which issue this PR fixes

#467

#### Special notes for your reviewer:

Another PR (no. 737) with similar changes has already been merged, but it did not modify all required charts.

Moreover, in order to completely fix the related issue, the `kube-prometheus-stack` chart dependency version with this must be bumped to `1.15.*`. Let me know if I have to create another PR for this change or you can do it directly.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name
