### PR TITLE
[Alertmanager] update: Enable annotations for service tpl

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 0.6.0
+version: 0.7.0
 appVersion: v0.21.0
 maintainers:
   - name: monotek

--- a/charts/alertmanager/templates/services.yaml
+++ b/charts/alertmanager/templates/services.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "alertmanager.fullname" . }}
   labels:
     {{- include "alertmanager.labels" . | nindent 4 }}
+{{- if .Values.service.annotations }}
+  annotations:
+    {{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -49,6 +49,7 @@ securityContext:
 additionalPeers: []
 
 service:
+  annotations: {}
   type: ClusterIP
   port: 9093
 


### PR DESCRIPTION
Signed-off-by: ffafi <firas.fafi@polarsquad.com>
@monotek @naseemkullah 

#### What this PR does / why we need it:
I'm providing here minors changes for Service Annotations. I have noticed that it's not configurable via the Alertmanager Helm chart. 
The annotations might be useful for some custom clusters, in kube-stack-prometheus chart it's already enabled but here it's missing.

There are also cases when the alertmanager is linked to different Prometheus instances via external endpoint and this might involve exposure of service via LoadBalancer mode and custom annotations.

Example of usage for being able to expose service privately via LB mode or define domain using external-dns ... 

```
service:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: mydomain.com
    service.beta.kubernetes.io/azure-load-balancer-internal: true
  type: LoadBalancer
```
