### PR TITLE
[kube-prometheus-stack] Exclude default rules from namespace enforcement

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 14.2.0
+version: 14.3.0
 appVersion: 0.46.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/hack/sync_prometheus_rules.py
+++ b/charts/kube-prometheus-stack/hack/sync_prometheus_rules.py
@@ -285,6 +285,17 @@ def write_group_to_file(group, url, destination, min_kubernetes, max_kubernetes)
 
     print("Generated %s" % new_filename)
 
+def write_rules_names_template():
+    with open('../templates/prometheus/_rules.tpl', 'w') as f:
+        f.write('''{{- /*
+Generated file. Do not change in-place! In order to change this file first read following link:
+https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
+*/ -}}\n''')
+        f.write('{{- define "rules.names" }}\n')
+        f.write('rules:\n')
+        for rule in condition_map:
+            f.write('  - "%s"\n' % rule)
+        f.write('{{- end }}')
 
 def main():
     init_yaml_styles()
@@ -305,6 +316,10 @@ def main():
         groups = yaml_text['spec']['groups'] if yaml_text.get('spec') else yaml_text['groups']
         for group in groups:
             write_group_to_file(group, chart['source'], chart['destination'], chart['min_kubernetes'], chart['max_kubernetes'])
+
+    # write rules.names named template
+    write_rules_names_template()
+
     print("Finished")
 
 

--- a/charts/kube-prometheus-stack/templates/prometheus/_rules.tpl
+++ b/charts/kube-prometheus-stack/templates/prometheus/_rules.tpl
@@ -1,0 +1,38 @@
+{{- /*
+Generated file. Do not change in-place! In order to change this file first read following link:
+https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
+*/ -}}
+{{- define "rules.names" }}
+rules:
+  - "alertmanager.rules"
+  - "general.rules"
+  - "k8s.rules"
+  - "kube-apiserver.rules"
+  - "kube-apiserver-availability.rules"
+  - "kube-apiserver-error"
+  - "kube-apiserver-slos"
+  - "kube-prometheus-general.rules"
+  - "kube-prometheus-node-alerting.rules"
+  - "kube-prometheus-node-recording.rules"
+  - "kube-scheduler.rules"
+  - "kube-state-metrics"
+  - "kubelet.rules"
+  - "kubernetes-absent"
+  - "kubernetes-resources"
+  - "kubernetes-storage"
+  - "kubernetes-system"
+  - "kubernetes-system-apiserver"
+  - "kubernetes-system-kubelet"
+  - "kubernetes-system-controller-manager"
+  - "kubernetes-system-scheduler"
+  - "node-exporter.rules"
+  - "node-exporter"
+  - "node.rules"
+  - "node-network"
+  - "node-time"
+  - "prometheus-operator"
+  - "prometheus.rules"
+  - "prometheus"
+  - "kubernetes-apps"
+  - "etcd"
+{{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -268,9 +268,6 @@ spec:
 {{- end }}
   portName: {{ .Values.prometheus.prometheusSpec.portName }}
 {{- end }}
-{{- if .Values.prometheus.prometheusSpec.enforcedNamespaceLabel }}
-  enforcedNamespaceLabel: {{ .Values.prometheus.prometheusSpec.enforcedNamespaceLabel }}
-{{- end }}
 {{- if .Values.prometheus.prometheusSpec.volumes }}
   volumes:
 {{ toYaml .Values.prometheus.prometheusSpec.volumes | indent 4 }}
@@ -292,9 +289,17 @@ spec:
 {{- if .Values.prometheus.prometheusSpec.ignoreNamespaceSelectors }}
   ignoreNamespaceSelectors: {{ .Values.prometheus.prometheusSpec.ignoreNamespaceSelectors }}
 {{- end }}
-{{- if .Values.prometheus.prometheusSpec.prometheusRulesExcludedFromEnforce }}
+{{- if .Values.prometheus.prometheusSpec.enforcedNamespaceLabel }}
+  enforcedNamespaceLabel: {{ .Values.prometheus.prometheusSpec.enforcedNamespaceLabel }}
+{{- $prometheusDefaultRulesExcludedFromEnforce := (include "rules.names" .) | fromYaml }}
   prometheusRulesExcludedFromEnforce:
+{{- range $prometheusDefaultRulesExcludedFromEnforce.rules }}
+    - ruleNamespace: "{{ template "kube-prometheus-stack.namespace" $ }}"
+      ruleName: "{{ printf "%s-%s" (include "kube-prometheus-stack.fullname" $) . | trunc 63 | trimSuffix "-" }}"
+{{- end }}
+{{- if .Values.prometheus.prometheusSpec.prometheusRulesExcludedFromEnforce }}
 {{ toYaml .Values.prometheus.prometheusSpec.prometheusRulesExcludedFromEnforce | indent 4 }}
+{{- end }}
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.queryLogFile }}
   queryLogFile: {{ .Values.prometheus.prometheusSpec.queryLogFile }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -2242,9 +2242,14 @@ prometheus:
     ## configs, and they will only discover endpoints within their current namespace. Defaults to false.
     ignoreNamespaceSelectors: false
 
+    ## EnforcedNamespaceLabel enforces adding a namespace label of origin for each alert and metric that is user created.
+    ## The label value will always be the namespace of the object that is being created.
+    ## Disabled by default
+    enforcedNamespaceLabel: ""
+
     ## PrometheusRulesExcludedFromEnforce - list of prometheus rules to be excluded from enforcing of adding namespace labels.
     ## Works only if enforcedNamespaceLabel set to true. Make sure both ruleNamespace and ruleName are set for each pair
-    prometheusRulesExcludedFromEnforce: false
+    prometheusRulesExcludedFromEnforce: []
 
     ## QueryLogFile specifies the file to which PromQL queries are logged. Note that this location must be writable,
     ## and can be persisted using an attached volume. Alternatively, the location can be set to a stdout location such


### PR DESCRIPTION

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

When enforcedNamespaceLabel is enabled the default rules installed by the
helm chart also also changed dynamically by the operator at runtime.
This breaks cluster wide recorded rules and alert rules.

This patch ensures that default prometheus rules are automatically
added to `prometheusRulesExcludedFromEnforce`


#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)