### PR TITLE
[prometheus-postgres-exporter] Update to postgres_exporter 0.9.0

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "0.8.0"
+appVersion: "0.9.0"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 2.0.0
+version: 2.1.0
 home: https://github.com/wrouesnel/postgres_exporter
 sources:
 - https://github.com/wrouesnel/postgres_exporter

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -5,8 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: wrouesnel/postgres_exporter
-  tag: v0.8.0
+  repository: quay.io/prometheuscommunity/postgres-exporter
+  tag: v0.9.0
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
#### What this PR does / why we need it:

Bumps the postgres_exporter version to the 0.9.0 that was recently released:
https://github.com/prometheus-community/postgres_exporter/releases/tag/v0.9.0

Also changing the image repo to point to the current one mentioned in the readme:
https://github.com/prometheus-community/postgres_exporter/tree/v0.9.0#quick-start

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
