### PR TITLE
[kube-prometheus-stack] Update dependency version

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 2.13.0
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
-  version: 1.14.2
+  version: 1.16.2
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.4.4
-digest: sha256:5e586e0b76974dd04f00096c4a7063dc0a01620b8ae1edc3069282966b38b9e7
-generated: "2021-02-23T11:31:31.313137303Z"
+  version: 6.4.8
+digest: sha256:991fe26c7d83e23501a8e280606ada2613da5eaf25063bb6a48b2afd7e0295ab
+generated: "2021-03-19T10:37:08.7061295+01:00"

--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 1.16.2
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.4.8
-digest: sha256:991fe26c7d83e23501a8e280606ada2613da5eaf25063bb6a48b2afd7e0295ab
-generated: "2021-03-19T10:37:08.7061295+01:00"
+  version: 6.6.3
+digest: sha256:52acbef377da70248ae3fa926dc7f6601df9022b1b1e17224a8fe99e6995d3af
+generated: "2021-03-19T17:50:36.8566658+01:00"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -40,7 +40,7 @@ dependencies:
   repository: https://kubernetes.github.io/kube-state-metrics
   condition: kubeStateMetrics.enabled
 - name: prometheus-node-exporter
-  version: "1.14.*"
+  version: "1.16.*"
   repository: https://prometheus-community.github.io/helm-charts
   condition: nodeExporter.enabled
 - name: grafana

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -44,6 +44,6 @@ dependencies:
   repository: https://prometheus-community.github.io/helm-charts
   condition: nodeExporter.enabled
 - name: grafana
-  version: "6.4.*"
+  version: "6.6.*"
   repository: https://grafana.github.io/helm-charts
   condition: grafana.enabled

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 14.1.2
+version: 14.2.0
 appVersion: 0.46.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus


### PR DESCRIPTION
#### What this PR does / why we need it:

Updates `kube-prometheus-stack` chart to use the latest `prometheus-node-exporter`. This is necessary to be able to use the new features added with PR #757 from the parent chart.

#### Which issue this PR fixes

This completely solves the issue: #467

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name
