### PR TITLE
[Alertmanager] fix indentation service annotations

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 0.7.0
+version: 0.7.1
 appVersion: v0.21.0
 maintainers:
   - name: monotek

--- a/charts/alertmanager/templates/services.yaml
+++ b/charts/alertmanager/templates/services.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "alertmanager.labels" . | nindent 4 }}
 {{- if .Values.service.annotations }}
   annotations:
-    {{ toYaml .Values.service.annotations | indent 4 }}
+    {{- toYaml .Values.service.annotations | nindent 4 }}
 {{- end }}
 spec:
   type: {{ .Values.service.type }}


### PR DESCRIPTION
@monotek @naseemkullah

**What this PR does / why we need it:**
It's a follow up fix from recently closed PR: https://github.com/prometheus-community/helm-charts/pull/767
The service tpl annotation was merged with wrong indentations.
I'm totally agreeing with @monotek  nit: reads better and much safe :) 
Issue:
```
{{- if .Values.service.annotations }}
  annotations:
    {{ toYaml .Values.service.annotations | indent 4 }}
{{- end }}
```
Fix:
```
{{- if .Values.service.annotations }}
  annotations: {{ toYaml .Values.service.annotations | nindent 4 }}
{{- end }}
```

Thank you!