### PR TITLE
 [prometheus-rabbitmq-exporter] update default rabbitmq secret key

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 0.7.0
+version: 0.7.1
 appVersion: v0.21.0
 maintainers:
   - name: monotek

--- a/charts/alertmanager/templates/services.yaml
+++ b/charts/alertmanager/templates/services.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "alertmanager.labels" . | nindent 4 }}
 {{- if .Values.service.annotations }}
   annotations:
-    {{ toYaml .Values.service.annotations | indent 4 }}
+    {{- toYaml .Values.service.annotations | nindent 4 }}
 {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/charts/prometheus-rabbitmq-exporter/Chart.yaml
+++ b/charts/prometheus-rabbitmq-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Rabbitmq metrics exporter for prometheus
 name: prometheus-rabbitmq-exporter
-version: 0.6.0
+version: 0.6.1
 appVersion: v0.29.0
 home: https://github.com/kbudde/rabbitmq_exporter
 sources:

--- a/charts/prometheus-rabbitmq-exporter/Chart.yaml
+++ b/charts/prometheus-rabbitmq-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Rabbitmq metrics exporter for prometheus
 name: prometheus-rabbitmq-exporter
-version: 0.6.1
+version: 0.7.0
 appVersion: v0.29.0
 home: https://github.com/kbudde/rabbitmq_exporter
 sources:

--- a/charts/prometheus-rabbitmq-exporter/Chart.yaml
+++ b/charts/prometheus-rabbitmq-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Rabbitmq metrics exporter for prometheus
 name: prometheus-rabbitmq-exporter
-version: 0.7.0
+version: 0.6.1
 appVersion: v0.29.0
 home: https://github.com/kbudde/rabbitmq_exporter
 sources:

--- a/charts/prometheus-rabbitmq-exporter/templates/deployment.yaml
+++ b/charts/prometheus-rabbitmq-exporter/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name:  "{{ .Values.rabbitmq.existingPasswordSecret }}"
-                  key: rabbitmq-password
+                  key: {{ .Values.rabbitmq.existingPasswordSecretKey | default "password" }}
             {{- else }}
             - name: RABBIT_PASSWORD
               value: "{{ .Values.rabbitmq.password }}"

--- a/charts/prometheus-rabbitmq-exporter/templates/deployment.yaml
+++ b/charts/prometheus-rabbitmq-exporter/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name:  "{{ .Values.rabbitmq.existingPasswordSecret }}"
-                  key: {{ .Values.rabbitmq.existingPasswordSecretKey | default "password" }}
+                  key: {{ .Values.rabbitmq.existingPasswordSecretKey }}
             {{- else }}
             - name: RABBIT_PASSWORD
               value: "{{ .Values.rabbitmq.password }}"

--- a/charts/prometheus-rabbitmq-exporter/templates/deployment.yaml
+++ b/charts/prometheus-rabbitmq-exporter/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name:  "{{ .Values.rabbitmq.existingPasswordSecret }}"
-                  key: password
+                  key: rabbitmq-password
             {{- else }}
             - name: RABBIT_PASSWORD
               value: "{{ .Values.rabbitmq.password }}"

--- a/charts/prometheus-rabbitmq-exporter/values.yaml
+++ b/charts/prometheus-rabbitmq-exporter/values.yaml
@@ -37,6 +37,7 @@ rabbitmq:
   password: guest
   # If existingPasswordSecret is set then password is ignored
   existingPasswordSecret: ~
+  #existingPasswordSecretKey:
   capabilities: bert,no_sort
   include_queues: ".*"
   include_vhost: ".*"

--- a/charts/prometheus-rabbitmq-exporter/values.yaml
+++ b/charts/prometheus-rabbitmq-exporter/values.yaml
@@ -37,7 +37,7 @@ rabbitmq:
   password: guest
   # If existingPasswordSecret is set then password is ignored
   existingPasswordSecret: ~
-  # existingPasswordSecretKey:
+  existingPasswordSecretKey: password
   capabilities: bert,no_sort
   include_queues: ".*"
   include_vhost: ".*"

--- a/charts/prometheus-rabbitmq-exporter/values.yaml
+++ b/charts/prometheus-rabbitmq-exporter/values.yaml
@@ -37,7 +37,7 @@ rabbitmq:
   password: guest
   # If existingPasswordSecret is set then password is ignored
   existingPasswordSecret: ~
-  #existingPasswordSecretKey:
+  # existingPasswordSecretKey:
   capabilities: bert,no_sort
   include_queues: ".*"
   include_vhost: ".*"


### PR DESCRIPTION

#### What this PR does / why we need it:
I think that bitnami rmq helm chart most popular. 
And they changed secret key for storing rabbitmq password from 'password' to 'rabbimq-password'

https://github.com/bitnami/charts/blob/master/bitnami/rabbitmq/templates/secrets.yaml#L12

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
