### PR TITLE
[kube-prometheus-stack] unify timezone in grafana dashboards

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 14.1.2
+version: 14.1.3
 appVersion: 0.46.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/apiserver.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/apiserver.yaml
@@ -1739,7 +1739,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "browser",
         "title": "Kubernetes / API server",
         "uid": "09ec8aa1e996d6ffcd6817bbaff4db1b",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/cluster-total.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/cluster-total.yaml
@@ -1874,7 +1874,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "browser",
         "title": "Kubernetes / Networking / Cluster",
         "uid": "ff635a025bcfea7bc3dd4f508990a3e9",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/controller-manager.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/controller-manager.yaml
@@ -1143,7 +1143,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "browser",
         "title": "Kubernetes / Controller Manager",
         "uid": "72e0e05bef5099e5f049b05fdc429ed4",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-coredns.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-coredns.yaml
@@ -1523,7 +1523,7 @@ data:
           "1d"
         ]
       },
-      "timezone": "utc",
+      "timezone": "browser",
       "title": "CoreDNS",
       "uid": "vkQ0UHxik",
       "version": 2

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-cluster.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-cluster.yaml
@@ -2574,7 +2574,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "browser",
         "title": "Kubernetes / Compute Resources / Cluster",
         "uid": "efa86fd1d0c121a26444b636a3f509a8",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-namespace.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-namespace.yaml
@@ -2278,7 +2278,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "browser",
         "title": "Kubernetes / Compute Resources / Namespace (Pods)",
         "uid": "85a562078cdf77779eaa1add43ccec1e",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-node.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-node.yaml
@@ -970,7 +970,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "browser",
         "title": "Kubernetes / Compute Resources / Node (Pods)",
         "uid": "200ac8fdbfbb74b39aff88118e4d1c2c",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-pod.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-pod.yaml
@@ -1764,7 +1764,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "browser",
         "title": "Kubernetes / Compute Resources / Pod",
         "uid": "6581e46e4e5c7ba40a07646395ef7b23",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-workload.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-workload.yaml
@@ -2026,7 +2026,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "browser",
         "title": "Kubernetes / Compute Resources / Workload",
         "uid": "a164a7f0339f99e89cea5cb47e9be617",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-workloads-namespace.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-workloads-namespace.yaml
@@ -2187,7 +2187,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "browser",
         "title": "Kubernetes / Compute Resources / Namespace (Workloads)",
         "uid": "a87fb0d919ec0ea5f6543124e16c42a5",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/kubelet.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/kubelet.yaml
@@ -2525,7 +2525,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "browser",
         "title": "Kubernetes / Kubelet",
         "uid": "3138fa155d5915769fbded898ac09fd9",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/namespace-by-pod.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/namespace-by-pod.yaml
@@ -1456,7 +1456,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "browser",
         "title": "Kubernetes / Networking / Namespace (Pods)",
         "uid": "8b7a8b326d7a6f1f04244066368c67af",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/namespace-by-workload.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/namespace-by-workload.yaml
@@ -1728,7 +1728,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "browser",
         "title": "Kubernetes / Networking / Namespace (Workload)",
         "uid": "bbb2a765a623ae38130206c7d94a160f",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/node-cluster-rsrc-use.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/node-cluster-rsrc-use.yaml
@@ -956,7 +956,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "utc",
+        "timezone": "browser",
         "title": "USE Method / Cluster",
         "uid": "",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/node-rsrc-use.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/node-rsrc-use.yaml
@@ -983,7 +983,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "utc",
+        "timezone": "browser",
         "title": "USE Method / Node",
         "uid": "",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/persistentvolumesusage.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/persistentvolumesusage.yaml
@@ -569,7 +569,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "browser",
         "title": "Kubernetes / Persistent Volumes",
         "uid": "919b92a8e8041bd567af9edab12c840c",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/pod-total.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/pod-total.yaml
@@ -1220,7 +1220,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "browser",
         "title": "Kubernetes / Networking / Pod",
         "uid": "7a18067ce943a40ae25454675c19ff5c",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/prometheus.yaml
@@ -1219,7 +1219,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "utc",
+        "timezone": "browser",
         "title": "Prometheus / Overview",
         "uid": "",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/proxy.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/proxy.yaml
@@ -1223,7 +1223,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "browser",
         "title": "Kubernetes / Proxy",
         "uid": "632e265de029684c40b21cb76bca4f94",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/scheduler.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/scheduler.yaml
@@ -1066,7 +1066,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "browser",
         "title": "Kubernetes / Scheduler",
         "uid": "2e6b6a3b4bddf1427b3a55aa1311c656",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/statefulset.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/statefulset.yaml
@@ -920,7 +920,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "browser",
         "title": "Kubernetes / StatefulSets",
         "uid": "a31c1f46e6f727cb37c0d731a7245005",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/workload-total.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/workload-total.yaml
@@ -1430,7 +1430,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "browser",
         "title": "Kubernetes / Networking / Workload",
         "uid": "728bf77cc1166d2f3133bf25846876cc",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards/k8s-cluster-rsrc-use.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards/k8s-cluster-rsrc-use.yaml
@@ -951,7 +951,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "",
+        "timezone": "browser",
         "title": "Kubernetes / USE Method / Cluster",
         "uid": "a6e7d1362e1ddbb79db21d5bb40d7137",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards/k8s-node-rsrc-use.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards/k8s-node-rsrc-use.yaml
@@ -978,7 +978,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "",
+        "timezone": "browser",
         "title": "Kubernetes / USE Method / Node",
         "uid": "4ac4f123aae0ff6dbaf4f4f66120033b",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards/k8s-resources-cluster.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards/k8s-resources-cluster.yaml
@@ -1471,7 +1471,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "",
+        "timezone": "browser",
         "title": "Kubernetes / Compute Resources / Cluster",
         "uid": "efa86fd1d0c121a26444b636a3f509a8",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards/k8s-resources-namespace.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards/k8s-resources-namespace.yaml
@@ -955,7 +955,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "",
+        "timezone": "browser",
         "title": "Kubernetes / Compute Resources / Namespace (Pods)",
         "uid": "85a562078cdf77779eaa1add43ccec1e",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards/k8s-resources-pod.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards/k8s-resources-pod.yaml
@@ -998,7 +998,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "",
+        "timezone": "browser",
         "title": "Kubernetes / Compute Resources / Pod",
         "uid": "6581e46e4e5c7ba40a07646395ef7b23",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards/k8s-resources-workload.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards/k8s-resources-workload.yaml
@@ -928,7 +928,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "",
+        "timezone": "browser",
         "title": "Kubernetes / Compute Resources / Workload",
         "uid": "a164a7f0339f99e89cea5cb47e9be617",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards/k8s-resources-workloads-namespace.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards/k8s-resources-workloads-namespace.yaml
@@ -964,7 +964,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "",
+        "timezone": "browser",
         "title": "Kubernetes / Compute Resources / Namespace (Workloads)",
         "uid": "a87fb0d919ec0ea5f6543124e16c42a5",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards/nodes.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards/nodes.yaml
@@ -1375,7 +1375,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "",
+        "timezone": "browser",
         "title": "Kubernetes / Nodes",
         "uid": "fa49a4706d07a042595b664c87fb33ea",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards/persistentvolumesusage.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards/persistentvolumesusage.yaml
@@ -565,7 +565,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "",
+        "timezone": "browser",
         "title": "Kubernetes / Persistent Volumes",
         "uid": "919b92a8e8041bd567af9edab12c840c",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards/pods.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards/pods.yaml
@@ -672,7 +672,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "",
+        "timezone": "browser",
         "title": "Kubernetes / Pods",
         "uid": "ab4f13a9892a76a4d21ce8c2445bf4ea",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards/statefulset.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards/statefulset.yaml
@@ -918,7 +918,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "",
+        "timezone": "browser",
         "title": "Kubernetes / StatefulSets",
         "uid": "a31c1f46e6f727cb37c0d731a7245005",
         "version": 0


### PR DESCRIPTION
Signed-off-by: Richard Steinbrück <richard.steinbrueck@googlemail.com>

#### What this PR does / why we need it:
- unify timezone in grafana dashboards

#### Which issue this PR fixes
- fixes #779

#### Special notes for your reviewer:
I found the following commit and PR from the old helm stable repo where many resource changes inc. the timezone and in the PR nobody has mentioned this changed and in my eyes, that's pretty wired.

- c9542ad
- https://github.com/helm/charts/pull/22900/files#diff-2a7f38bd4b1ecfa7d2043fc1ffaa362a4d1b0226737fa08dd409c1e6081bd942

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
