### PR TITLE
[Alertmanager] command podannotations

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 0.7.1
+version: 0.8.0
 appVersion: v0.21.0
 maintainers:
   - name: monotek

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -20,7 +20,7 @@ spec:
         {{- include "alertmanager.selectorLabels" . | nindent 8 }}
 {{- if .Values.podAnnotations }}
       annotations:
-        {{ toYaml .Values.podAnnotations | nindent 8 }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
 {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
@@ -61,7 +61,7 @@ spec:
                   fieldPath: status.podIP
 {{- if .Values.command }}
           command:
-            {{ toYaml .Values.command | nindent 12 }}
+            {{- toYaml .Values.command | nindent 12 }}
 {{- end }}
           args:
             - --storage.path=/alertmanager

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -18,9 +18,9 @@ spec:
     metadata:
       labels:
         {{- include "alertmanager.selectorLabels" . | nindent 8 }}
-{{- if .Values.statefulSet.podAnnotations }}
+{{- if .Values.podAnnotations }}
       annotations:
-        {{ toYaml .Values.statefulSet.podAnnotations | nindent 8 }}
+        {{ toYaml .Values.podAnnotations | nindent 8 }}
 {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
@@ -59,9 +59,9 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-{{- if .Values.statefulSet.command }}
+{{- if .Values.command }}
           command:
-            {{ toYaml .Values.statefulSet.command | nindent 12 }}
+            {{ toYaml .Values.command | nindent 12 }}
 {{- end }}
           args:
             - --storage.path=/alertmanager

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -18,6 +18,10 @@ spec:
     metadata:
       labels:
         {{- include "alertmanager.selectorLabels" . | nindent 8 }}
+{{- if .Values.statefulSet.podAnnotations }}
+      annotations:
+        {{ toYaml .Values.statefulSet.podAnnotations | nindent 8 }}
+{{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -55,6 +55,10 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+{{- if .Values.statefulSet.command }}
+          command:
+            {{ toYaml .Values.statefulSet.command | nindent 12 }}
+{{- end }}
           args:
             - --storage.path=/alertmanager
             - --config.file=/etc/alertmanager/alertmanager.yml

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -84,6 +84,7 @@ affinity: {}
 
 statefulSet:
   annotations: {}
+  command: []
 
 persistence:
   enabled: true

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -84,6 +84,7 @@ affinity: {}
 
 statefulSet:
   annotations: {}
+  podAnnotations: {}
   command: []
 
 persistence:

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -84,8 +84,10 @@ affinity: {}
 
 statefulSet:
   annotations: {}
-  podAnnotations: {}
-  command: []
+
+podAnnotations: {}
+
+command: []
 
 persistence:
   enabled: true


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds 2 new abilities to Alertmanager chart :
* add the possibility to specify our own command
* add the possibility add annotations to the statefulset Pod (e.g. podAnnotations)

#### Which issue this PR fixes

When you want to use Vault Sidecar Injector (https://www.vaultproject.io/docs/platform/k8s/injector) you first need to be able to specify annotations to your pod.

This will create a file `/vault/secrets/whatever`.

Then, in order to take that file into account, the easier way is to use it on the command line, usually like this : `['source /vault/secrets/whatever; /bin/alertmanager']`

This is why this patch allows adding podAnnotations and command.

#### Special notes for your reviewer:

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)

Note : I did not update Chart Version because it depends on when the PR is merged.
Edit : I finally updated it.