### PR TITLE
[kube-prometheus-stack] Invalid value "None" for clusterIP

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,8 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 14.4.0
+<<<<<<< HEAD
+version: 14.5.0
 appVersion: 0.46.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/serviceThanosSidecar.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/serviceThanosSidecar.yaml
@@ -16,7 +16,9 @@ metadata:
 {{- end }}
 spec:
   type: {{ .Values.prometheus.thanosService.type }}
-  clusterIP: None
+{{- if .Values.prometheus.thanosService.clusterIP }}
+  clusterIP: {{ .Values.prometheus.thanosService.clusterIP }}
+{{- end }}
   ports:
   - name: {{ .Values.prometheus.thanosService.portName }}
     port: {{ .Values.prometheus.thanosService.port }}

--- a/charts/kube-prometheus-stack/templates/prometheus/serviceThanosSidecar.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/serviceThanosSidecar.yaml
@@ -16,9 +16,7 @@ metadata:
 {{- end }}
 spec:
   type: {{ .Values.prometheus.thanosService.type }}
-{{- if .Values.prometheus.thanosService.clusterIP }}
   clusterIP: {{ .Values.prometheus.thanosService.clusterIP }}
-{{- end }}
   ports:
   - name: {{ .Values.prometheus.thanosService.portName }}
     port: {{ .Values.prometheus.thanosService.port }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1548,6 +1548,7 @@ prometheus:
     portName: grpc
     port: 10901
     targetPort: "grpc"
+    clusterIP: ""
 
     ## Service type
     ##

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1548,7 +1548,7 @@ prometheus:
     portName: grpc
     port: 10901
     targetPort: "grpc"
-    clusterIP: ""
+    clusterIP: "None"
 
     ## Service type
     ##


### PR DESCRIPTION
Signed-off-by: Esther Kim <jabbukka@naver.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
  - ClusterIP should not be set "None" when service type is `NodePort`.  
  - Also, renamed wrong filename from `serviceThanosSIdecar.yaml` to `serviceThanosSidecar.yaml`
  - Bump up to 14.3.1

#### Which issue this PR fixes
  - fixes #783 

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
