### PR TITLE
[kube-prometheus-stack] Add proxyUrl variable to exporters

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 14.3.0
+version: 14.4.0
 appVersion: 0.46.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/alertmanager/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/servicemonitor.yaml
@@ -21,6 +21,9 @@ spec:
     {{- if .Values.alertmanager.serviceMonitor.interval }}
     interval: {{ .Values.alertmanager.serviceMonitor.interval }}
     {{- end }}
+    {{- if .Values.alertmanager.serviceMonitor.proxyUrl }}
+    proxyUrl: {{ .Values.alertmanager.serviceMonitor.proxyUrl}}
+    {{- end }}
     {{- if .Values.alertmanager.serviceMonitor.scheme }}
     scheme: {{ .Values.alertmanager.serviceMonitor.scheme }}
     {{- end }}

--- a/charts/kube-prometheus-stack/templates/exporters/core-dns/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/core-dns/servicemonitor.yaml
@@ -21,6 +21,9 @@ spec:
     {{- if .Values.coreDns.serviceMonitor.interval}}
     interval: {{ .Values.coreDns.serviceMonitor.interval }}
     {{- end }}
+    {{- if .Values.coreDns.serviceMonitor.proxyUrl }}
+    proxyUrl: {{ .Values.coreDns.serviceMonitor.proxyUrl}}
+    {{- end }}
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
 {{- if .Values.coreDns.serviceMonitor.metricRelabelings }}
     metricRelabelings:

--- a/charts/kube-prometheus-stack/templates/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-api-server/servicemonitor.yaml
@@ -13,6 +13,9 @@ spec:
     {{- if .Values.kubeApiServer.serviceMonitor.interval }}
     interval: {{ .Values.kubeApiServer.serviceMonitor.interval }}
     {{- end }}
+    {{- if .Values.kubeApiServer.serviceMonitor.proxyUrl }}
+    proxyUrl: {{ .Values.kubeApiServer.serviceMonitor.proxyUrl}}
+    {{- end }}
     port: https
     scheme: https
 {{- if .Values.kubeApiServer.serviceMonitor.metricRelabelings }}

--- a/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/servicemonitor.yaml
@@ -22,6 +22,9 @@ spec:
     interval: {{ .Values.kubeControllerManager.serviceMonitor.interval }}
     {{- end }}
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    {{- if .Values.kubeControllerManager.serviceMonitor.proxyUrl }}
+    proxyUrl: {{ .Values.kubeControllerManager.serviceMonitor.proxyUrl}}
+    {{- end }}
     {{- if .Values.kubeControllerManager.serviceMonitor.https }}
     scheme: https
     tlsConfig:

--- a/charts/kube-prometheus-stack/templates/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-dns/servicemonitor.yaml
@@ -22,6 +22,9 @@ spec:
     interval: {{ .Values.kubeDns.serviceMonitor.interval }}
     {{- end }}
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    {{- if .Values.kubeDns.serviceMonitor.proxyUrl }}
+    proxyUrl: {{ .Values.kubeDns.serviceMonitor.proxyUrl}}
+    {{- end }}
 {{- if .Values.kubeDns.serviceMonitor.dnsmasqMetricRelabelings }}
     metricRelabelings:
 {{ tpl (toYaml .Values.kubeDns.serviceMonitor.dnsmasqMetricRelabelings | indent 4) . }}

--- a/charts/kube-prometheus-stack/templates/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-etcd/servicemonitor.yaml
@@ -22,6 +22,9 @@ spec:
     interval: {{ .Values.kubeEtcd.serviceMonitor.interval }}
     {{- end }}
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    {{- if .Values.kubeEtcd.serviceMonitor.proxyUrl }}
+    proxyUrl: {{ .Values.kubeEtcd.serviceMonitor.proxyUrl}}
+    {{- end }}
     {{- if eq .Values.kubeEtcd.serviceMonitor.scheme "https" }}
     scheme: https
     tlsConfig:

--- a/charts/kube-prometheus-stack/templates/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-proxy/servicemonitor.yaml
@@ -22,6 +22,9 @@ spec:
     interval: {{ .Values.kubeProxy.serviceMonitor.interval }}
     {{- end }}
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    {{- if .Values.kubeProxy.serviceMonitor.proxyUrl }}
+    proxyUrl: {{ .Values.kubeProxy.serviceMonitor.proxyUrl}}
+    {{- end }}
     {{- if .Values.kubeProxy.serviceMonitor.https }}
     scheme: https
     tlsConfig:

--- a/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -22,6 +22,9 @@ spec:
     interval: {{ .Values.kubeScheduler.serviceMonitor.interval }}
     {{- end }}
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    {{- if .Values.kubeScheduler.serviceMonitor.proxyUrl }}
+    proxyUrl: {{ .Values.kubeScheduler.serviceMonitor.proxyUrl}}
+    {{- end }}
     {{- if .Values.kubeScheduler.serviceMonitor.https }}
     scheme: https
     tlsConfig:

--- a/charts/kube-prometheus-stack/templates/exporters/kube-state-metrics/serviceMonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-state-metrics/serviceMonitor.yaml
@@ -14,6 +14,9 @@ spec:
     {{- if .Values.kubeStateMetrics.serviceMonitor.interval }}
     interval: {{ .Values.kubeStateMetrics.serviceMonitor.interval }}
     {{- end }}
+    {{- if .Values.kubeStateMetrics.serviceMonitor.proxyUrl }}
+    proxyUrl: {{ .Values.kubeStateMetrics.serviceMonitor.proxyUrl}}
+    {{- end }}
     honorLabels: true
 {{- if .Values.kubeStateMetrics.serviceMonitor.metricRelabelings }}
     metricRelabelings:

--- a/charts/kube-prometheus-stack/templates/exporters/kubelet/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kubelet/servicemonitor.yaml
@@ -15,6 +15,9 @@ spec:
     {{- if .Values.kubelet.serviceMonitor.interval }}
     interval: {{ .Values.kubelet.serviceMonitor.interval }}
     {{- end }}
+    {{- if .Values.kubelet.serviceMonitor.proxyUrl }}
+    proxyUrl: {{ .Values.kubelet.serviceMonitor.proxyUrl}}
+    {{- end }}
     tlsConfig:
       caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
       insecureSkipVerify: true

--- a/charts/kube-prometheus-stack/templates/exporters/node-exporter/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/node-exporter/servicemonitor.yaml
@@ -18,6 +18,9 @@ spec:
     {{- if .Values.nodeExporter.serviceMonitor.interval }}
     interval: {{ .Values.nodeExporter.serviceMonitor.interval }}
     {{- end }}
+    {{- if .Values.kubeApiServer.serviceMonitor.proxyUrl }}
+    proxyUrl: {{ .Values.kubeApiServer.serviceMonitor.proxyUrl}}
+    {{- end }}
     {{- if .Values.nodeExporter.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.nodeExporter.serviceMonitor.scrapeTimeout }}
     {{- end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1256,7 +1256,7 @@ nodeExporter:
 
     ## proxyUrl: URL of a proxy that should be used for scraping.
     ##
-    proxyUrl: ""    
+    proxyUrl: ""
 
     ## How long until a scrape request times out. If not set, the Prometheus default scape timeout is used.
     ##

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -345,6 +345,10 @@ alertmanager:
     interval: ""
     selfMonitor: true
 
+    ## proxyUrl: URL of a proxy that should be used for scraping.
+    ##
+    proxyUrl: ""
+
     ## scheme: HTTP scheme to use for scraping. Can be used with `tlsConfig` for example if using istio mTLS.
     scheme: ""
 
@@ -747,6 +751,10 @@ kubeApiServer:
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
+    ## proxyUrl: URL of a proxy that should be used for scraping.
+    ##
+    proxyUrl: ""
+
     jobLabel: component
     selector:
       matchLabels:
@@ -770,6 +778,10 @@ kubelet:
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
+
+    ## proxyUrl: URL of a proxy that should be used for scraping.
+    ##
+    proxyUrl: ""
 
     ## Enable scraping the kubelet over https. For requirements to enable this see
     ## https://github.com/prometheus-operator/prometheus-operator/issues/926
@@ -901,6 +913,10 @@ kubeControllerManager:
     ##
     interval: ""
 
+    ## proxyUrl: URL of a proxy that should be used for scraping.
+    ##
+    proxyUrl: ""
+
     ## Enable scraping kube-controller-manager over https.
     ## Requires proper certs (not self-signed) and delegated authentication/authorization checks
     ##
@@ -943,6 +959,10 @@ coreDns:
     ##
     interval: ""
 
+    ## proxyUrl: URL of a proxy that should be used for scraping.
+    ##
+    proxyUrl: ""
+
     ## 	metric relabel configs to apply to samples before ingestion.
     ##
     metricRelabelings: []
@@ -977,6 +997,10 @@ kubeDns:
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
+
+    ## proxyUrl: URL of a proxy that should be used for scraping.
+    ##
+    proxyUrl: ""
 
     ## 	metric relabel configs to apply to samples before ingestion.
     ##
@@ -1044,6 +1068,9 @@ kubeEtcd:
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
+    ## proxyUrl: URL of a proxy that should be used for scraping.
+    ##
+    proxyUrl: ""
     scheme: http
     insecureSkipVerify: false
     serverName: ""
@@ -1093,6 +1120,9 @@ kubeScheduler:
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
+    ## proxyUrl: URL of a proxy that should be used for scraping.
+    ##
+    proxyUrl: ""
     ## Enable scraping kube-scheduler over https.
     ## Requires proper certs (not self-signed) and delegated authentication/authorization checks
     ##
@@ -1145,6 +1175,10 @@ kubeProxy:
     ##
     interval: ""
 
+    ## proxyUrl: URL of a proxy that should be used for scraping.
+    ##
+    proxyUrl: ""
+
     ## Enable scraping kube-proxy over https.
     ## Requires proper certs (not self-signed) and delegated authentication/authorization checks
     ##
@@ -1173,6 +1207,9 @@ kubeStateMetrics:
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
+    ## proxyUrl: URL of a proxy that should be used for scraping.
+    ##
+    proxyUrl: ""
     ## Override serviceMonitor selector
     ##
     selectorOverride: {}
@@ -1216,6 +1253,10 @@ nodeExporter:
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
+
+    ## proxyUrl: URL of a proxy that should be used for scraping.
+    ##
+    proxyUrl: ""    
 
     ## How long until a scrape request times out. If not set, the Prometheus default scape timeout is used.
     ##


### PR DESCRIPTION

Signed-off-by: r.maika <r.maika@samsung.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
This PR enables an argument for `proxyUrl` to any ServiceMonitor objects that are under the `./exporters/` path. 

This supports the pattern that is used by some to expose metrics for cluster components on localhost only, then scrape them through a proxy. For example, when using https://github.com/rancher/PushProx as a vehicle to expose metrics, it is now required to have `proxyUrl` configured on the ServiceMonitor. I would like to be able to do this while still using this chart to create/configure the ServiceMonitor object and other Prometheus objects. 

@vsliouniaev @bismarck @gkarthiks @scottrigby @Xtigyro 

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
