### PR TITLE
[kube-prometheus-stack] add more controls to kubescheduler,kubeproxy,controllermanager,etcd exporters

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 14.3.0
+version: 14.4.0
 appVersion: 0.46.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/service.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kubeControllerManager.enabled }}
+{{- if and .Values.kubeControllerManager.enabled .Values.kubeControllerManager.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kubeControllerManager.enabled }}
+{{- if and .Values.kubeControllerManager.enabled .Values.kubeControllerManager.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/kube-prometheus-stack/templates/exporters/kube-etcd/service.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-etcd/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kubeEtcd.enabled }}
+{{- if and .Values.kubeEtcd.enabled .Values.kubeEtcd.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/kube-prometheus-stack/templates/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-etcd/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kubeEtcd.enabled }}
+{{- if and .Values.kubeEtcd.enabled .Values.kubeEtcd.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/kube-prometheus-stack/templates/exporters/kube-proxy/service.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-proxy/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kubeProxy.enabled }}
+{{- if and .Values.kubeProxy.enabled .Values.kubeProxy.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/kube-prometheus-stack/templates/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-proxy/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kubeProxy.enabled }}
+{{- if and .Values.kubeProxy.enabled .Values.kubeProxy.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/service.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kubeScheduler.enabled }}
+{{- if and .Values.kubeScheduler.enabled .Values.kubeScheduler.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kubeScheduler.enabled }}
+{{- if and .Values.kubeScheduler.enabled .Values.kubeScheduler.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -891,12 +891,14 @@ kubeControllerManager:
   ## If using kubeControllerManager.endpoints only the port and targetPort are used
   ##
   service:
+    enabled: true
     port: 10252
     targetPort: 10252
     # selector:
     #   component: kube-controller-manager
 
   serviceMonitor:
+    enabled: true
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
@@ -1024,6 +1026,7 @@ kubeEtcd:
   ## Etcd service. If using kubeEtcd.endpoints only the port and targetPort are used
   ##
   service:
+    enabled: true
     port: 2379
     targetPort: 2379
     # selector:
@@ -1041,6 +1044,7 @@ kubeEtcd:
   ##   keyFile: /etc/prometheus/secrets/etcd-client-cert/etcd-client-key
   ##
   serviceMonitor:
+    enabled: true
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
@@ -1084,12 +1088,14 @@ kubeScheduler:
   ## If using kubeScheduler.endpoints only the port and targetPort are used
   ##
   service:
+    enabled: true
     port: 10251
     targetPort: 10251
     # selector:
     #   component: kube-scheduler
 
   serviceMonitor:
+    enabled: true
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
@@ -1135,12 +1141,14 @@ kubeProxy:
   # - 10.141.4.24
 
   service:
+    enabled: true
     port: 10249
     targetPort: 10249
     # selector:
     #   k8s-app: kube-proxy
 
   serviceMonitor:
+    enabled: true
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""


### PR DESCRIPTION
Signed-off-by: Vlad Paciu <vlad.paciu@adgear.com>

#### What this PR does / why we need it:
This PR is intended to give more control over what will be deployed 
if kubescheduler, kubeproxy, controllermanager, etcd exporters are enabled. 
Currently they are coupled with  grafana dashboard and prometheus rules altogether.

#### Special notes for your reviewer
In my case I'm using this chart to monitor rancher cluster.
This system components are listening only on localhost in rancher cluster. 
To get metrics I'm using pushProx which already creates ServiceMonitor and service. 

#### Checklist
- [ x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ x] Chart Version bumped
- [x ] Title of the PR starts with chart name
