### PR TITLE
[kube-prometheus-stack] Adding support for multi ingress for thanos

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 16.10.0
+version: 16.11.0
 appVersion: 0.48.1
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/ingressperreplicaThanosSidecar.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/ingressperreplicaThanosSidecar.yaml
@@ -1,0 +1,62 @@
+{{- if and .Values.prometheus.enabled .Values.prometheus.thanosServicePerReplica.enabled .Values.prometheus.thanosIngressPerReplica.enabled }}
+{{- $pathType := .Values.prometheus.thanosIngressPerReplica.pathType | default "" }}
+{{- $count := .Values.prometheus.prometheusSpec.replicas | int -}}
+{{- $thanosPort := .Values.prometheus.thanosServicePerReplica.port -}}
+{{- $ingressValues := .Values.prometheus.thanosIngressPerReplica -}}
+apiVersion: v1
+kind: List
+metadata:
+  name: {{ include "kube-prometheus-stack.fullname" $ }}-thanos-ingressperreplica
+  namespace: {{ template "kube-prometheus-stack.namespace" $ }}
+items:
+{{ range $i, $e := until $count }}
+  - kind: Ingress
+    {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+    apiVersion: networking.k8s.io/v1beta1
+    {{ else }}
+    apiVersion: extensions/v1beta1
+    {{ end -}}
+    metadata:
+      name: {{ include "kube-prometheus-stack.fullname" $ }}-thanos-gateway-{{ $i }}
+      namespace: {{ template "kube-prometheus-stack.namespace" $ }}
+      labels:
+        app: {{ include "kube-prometheus-stack.name" $ }}-prometheus
+{{ include "kube-prometheus-stack.labels" $ | indent 8 }}
+      {{- if $ingressValues.labels }}
+{{ toYaml $ingressValues.labels | indent 8 }}
+      {{- end }}
+      {{- if $ingressValues.annotations }}
+      annotations:
+{{ toYaml $ingressValues.annotations | indent 8 }}
+      {{- end }}
+    spec:
+      {{- if or ($.Capabilities.APIVersions.Has "networking.k8s.io/v1") ($.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1") }}
+      {{- if $ingressValues.ingressClassName }}
+      ingressClassName: {{ $ingressValues.ingressClassName }}
+      {{- end }}
+      {{- end }}
+      rules:
+        - host: {{ $ingressValues.hostPrefix }}-{{ $i }}.{{ $ingressValues.hostDomain }}
+          http:
+            paths:
+      {{- range $p := $ingressValues.paths }}
+              - path: {{ tpl $p $ }}
+                {{- if $pathType }}
+                pathType: {{ $pathType }}
+                {{- end }}
+                backend:
+                  serviceName: {{ include "kube-prometheus-stack.fullname" $ }}-thanos-gateway-{{ $i }}
+                  servicePort: {{ $thanosPort }}
+      {{- end -}}
+      {{- if or $ingressValues.tlsSecretName $ingressValues.tlsSecretPerReplica.enabled }}
+      tls:
+        - hosts:
+            - {{ $ingressValues.hostPrefix }}-{{ $i }}.{{ $ingressValues.hostDomain }}
+          {{- if $ingressValues.tlsSecretPerReplica.enabled }}
+          secretName: {{ $ingressValues.tlsSecretPerReplica.prefix }}-{{ $i }}
+          {{- else }}
+          secretName: {{ $ingressValues.tlsSecretName }}
+          {{- end }}
+      {{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/kube-prometheus-stack/templates/prometheus/serviceperreplicaThanosSidecar.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/serviceperreplicaThanosSidecar.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.prometheus.enabled .Values.prometheus.thanosServicePerReplica.enabled }}
+{{- $count := .Values.prometheus.prometheusSpec.replicas | int -}}
+{{- $serviceValues := .Values.prometheus.thanosServicePerReplica -}}
+apiVersion: v1
+kind: List
+metadata:
+  name: {{ include "kube-prometheus-stack.fullname" $ }}-thanos-serviceperreplica
+  namespace: {{ template "kube-prometheus-stack.namespace" . }}
+items:
+{{- range $i, $e := until $count }}
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: {{ include "kube-prometheus-stack.fullname" $ }}-thanos-{{ $i }}
+      namespace: {{ template "kube-prometheus-stack.namespace" $ }}
+      labels:
+        app: {{ include "kube-prometheus-stack.name" $ }}-thanos
+{{ include "kube-prometheus-stack.labels" $ | indent 8 }}
+      {{- if $serviceValues.annotations }}
+      annotations:
+{{ toYaml $serviceValues.annotations | indent 8 }}
+      {{- end }}
+    spec:
+      type: ClusterIP
+      clusterIP: None
+      ports:
+        - name: {{ $serviceValues.portName }}
+          port: {{ $serviceValues.port }}
+          targetPort: {{ $serviceValues.targetPort }}
+      selector:
+        app: prometheus
+        prometheus: {{ include "kube-prometheus-stack.fullname" $ }}-prometheus
+        statefulset.kubernetes.io/pod-name: prometheus-{{ include "kube-prometheus-stack.fullname" $ }}-prometheus-{{ $i }}
+{{- end }}
+{{- end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1651,6 +1651,13 @@ prometheus:
     ##
     nodePort: 30901
 
+  thanosServicePerReplica:
+    enabled: false
+    annotations: {}
+    portName: grpc
+    port: 10901
+    targetPort: "grpc"
+
   ## Configuration for Prometheus service
   ##
   service:
@@ -1758,6 +1765,47 @@ prometheus:
     # - secretName: thanos-gateway-tls
     #   hosts:
     #   - thanos-gateway.domain.com
+  thanosIngressPerReplica:
+    enabled: false
+
+    # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+    # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
+    # ingressClassName: nginx
+
+    annotations: {}
+    labels: {}
+    servicePort: 10901
+
+    ## Port to expose on each node
+    ## Only used if service.type is 'NodePort'
+    ##
+    nodePort: 30901
+
+    hostPrefix: ""
+    ## Domain that will be used for the per replica ingress
+    hostDomain: ""
+
+    ## Paths to use for ingress rules
+    ##
+    paths: []
+    # - /
+
+    ## For Kubernetes >= 1.18 you should specify the pathType (determines how Ingress paths should be matched)
+    ## See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#better-path-matching-with-path-types
+    # pathType: ImplementationSpecific
+    ## Secret name containing the TLS certificate for Prometheus per replica ingress
+    ## Secret must be manually created in the namespace
+    tlsSecretName: ""
+
+    ## Separated secret for each per replica Ingress. Can be used together with cert-manager
+    ##
+    tlsSecretPerReplica:
+      enabled: false
+      ## Final form of the secret for each per replica ingress is
+      ## {{ tlsSecretPerReplica.prefix }}-{{ $replicaNumber }}
+      ##
+      prefix: "thanos"
+
 
   ingress:
     enabled: false


### PR DESCRIPTION
sidecar

Signed-off-by: Aaron Russell <aaron@therussells.me>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
This adds support for multi ingress for the Thanos sidecar similar to multi ingress for Prometheus.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #845 

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
