### PR TITLE
[kube-prometheus-stack] Update grafana dependency to 6.7.*

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://kubernetes.github.io/kube-state-metrics
-  version: 2.13.0
+  version: 2.13.1
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 1.16.2
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.6.3
-digest: sha256:52acbef377da70248ae3fa926dc7f6601df9022b1b1e17224a8fe99e6995d3af
-generated: "2021-03-19T17:50:36.8566658+01:00"
+  version: 6.7.2
+digest: sha256:d726ffd86c69fda2ebe65ebc92ae61689607263979968b50c4eaa65dda5cdc00
+generated: "2021-04-07T10:20:27.853917+02:00"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 14.5.0
+version: 14.6.0
 appVersion: 0.46.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus
@@ -44,6 +44,6 @@ dependencies:
   repository: https://prometheus-community.github.io/helm-charts
   condition: nodeExporter.enabled
 - name: grafana
-  version: "6.6.*"
+  version: "6.7.*"
   repository: https://grafana.github.io/helm-charts
   condition: grafana.enabled


### PR DESCRIPTION
#### What this PR does / why we need it:

* Update Grafana dependency to 6.7.*
* Update kube-state-metrics in Chart.lock to 2.13.1

#### Discussion
Would it be useful to use something like Renovate ( https://github.com/renovatebot/renovate ) to automatically create dependency Bump PRs? I believe Depenendabot does not support this (yet)

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
