### PR TITLE
[prometheus-blackbox-exporter] Add support for hostNetwork

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 4.10.3
+version: 4.10.4
 appVersion: 0.18.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/charts/prometheus-blackbox-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/daemonset.yaml
@@ -103,6 +103,7 @@ spec:
 {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy | toString }}
 {{- end }}
+      hostNetwork: {{ .Values.hostNetwork }}
 {{- if .Values.dnsConfig }}
       dnsConfig:
         {{- toYaml .Values.dnsConfig | nindent 8 }}

--- a/charts/prometheus-blackbox-exporter/templates/deployment.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/deployment.yaml
@@ -114,6 +114,7 @@ spec:
 {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy | toString }}
 {{- end }}
+      hostNetwork: {{ .Values.hostNetwork }}
 {{- if .Values.dnsConfig }}
       dnsConfig:
         {{- toYaml .Values.dnsConfig | nindent 8 }}

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -46,6 +46,8 @@ extraContainers: []
 ## Enable pod security policy
 pspEnabled: true
 
+hostNetwork: false
+
 strategy:
   rollingUpdate:
     maxSurge: 1


### PR DESCRIPTION

#### What this PR does / why we need it:
Add support for host network on blackbox

#### Which issue this PR fixes
Probes can require special network setup that is provided only by the host.

