### PR TITLE
[kube-prometheus-stack] add optional kube-state-metrics ServiceMonitor namespace selector

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 14.6.2
+version: 14.7.0
 appVersion: 0.46.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/exporters/kube-state-metrics/serviceMonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-state-metrics/serviceMonitor.yaml
@@ -23,6 +23,11 @@ spec:
     relabelings:
 {{ toYaml .Values.kubeStateMetrics.serviceMonitor.relabelings | indent 4 }}
 {{- end }}
+{{- if .Values.kubeStateMetrics.serviceMonitor.namespaceOverride }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Values.kubeStateMetrics.serviceMonitor.namespaceOverride }}
+{{- end }}
   selector:
     matchLabels:
 {{- if .Values.kubeStateMetrics.serviceMonitor.selectorOverride }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1184,6 +1184,9 @@ kubeStateMetrics:
     ## Override serviceMonitor selector
     ##
     selectorOverride: {}
+    ## Override namespace selector
+    ##
+    namespaceOverride: ""
 
     ## 	metric relabel configs to apply to samples before ingestion.
     ##


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it: 

This PR adds an optional namespaceSelector to the `kube-state-metrics` ServiceMonitor. This is useful because if you override `kube-state-metrics.namespaceOverride` to deploy kube-state-metrics elsewhere, the ServiceMonitor that is deployed does not work. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #820 

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
