### PR TITLE
[prometheus] - Bump up to v2.26 to include PR 8509

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.26.0
-version: 13.6.0
+version: 13.7.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: prometheus
-appVersion: 2.24.0
+appVersion: 2.26.0
 version: 13.6.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -617,7 +617,7 @@ server:
   ##
   image:
     repository: quay.io/prometheus/prometheus
-    tag: v2.24.0
+    tag: v2.26.0
     pullPolicy: IfNotPresent
 
   ## prometheus server priorityClassName


### PR DESCRIPTION

#### What this PR does / why we need it:
This PR bumps up the chart version to v2.26 that includes changes from [PR - 8509](https://github.com/prometheus/prometheus/pull/8509)

@gianrubio 
@monotek 

#### Checklist
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
