### PR TITLE
[prometheus] Bump up chart version to v2.26 

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
-appVersion: 2.24.0
-version: 13.6.0
+appVersion: 2.26.0
+version: 13.7.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -617,7 +617,7 @@ server:
   ##
   image:
     repository: quay.io/prometheus/prometheus
-    tag: v2.24.0
+    tag: v2.26.0
     pullPolicy: IfNotPresent
 
   ## prometheus server priorityClassName


### PR DESCRIPTION

Signed-off-by: Imaya Kumar Jagannathan <ijaganna@amazon.com>


#### What this PR does / why we need it:
This PR bumps up the Prometheus chart version to v2.26 to include changes in [PR 8509](https://github.com/prometheus/prometheus/pull/8509)


#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)

@monotek 