### PR TITLE
[kube-prometheus-stack] Update node-exporter dep to 1.17.0 + kube-state-metrics to 2.13.2 + grafana to 6.7.4

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://kubernetes.github.io/kube-state-metrics
-  version: 2.13.1
+  version: 2.13.2
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
-  version: 1.16.2
+  version: 1.17.0
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.7.2
-digest: sha256:d726ffd86c69fda2ebe65ebc92ae61689607263979968b50c4eaa65dda5cdc00
-generated: "2021-04-07T10:20:27.853917+02:00"
+  version: 6.7.4
+digest: sha256:3ad6db588084a1f225ee1a3bb8e5d47b30f1fab9dbba701e039d0919aaf86aef
+generated: "2021-04-14T12:41:24.546213-04:00"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 14.7.2
+version: 14.8.0
 appVersion: 0.46.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus
@@ -40,7 +40,7 @@ dependencies:
   repository: https://kubernetes.github.io/kube-state-metrics
   condition: kubeStateMetrics.enabled
 - name: prometheus-node-exporter
-  version: "1.16.*"
+  version: "1.17.*"
   repository: https://prometheus-community.github.io/helm-charts
   condition: nodeExporter.enabled
 - name: grafana


### PR DESCRIPTION
Signed-off-by: Vlad Paciu <vlad.paciu@adgear.com>

#### What this PR does / why we need it:
* Update node-exporter to 1.17.0
* Update Grafana dependency to 6.7.4
* Update kube-state-metrics in Chart.lock to 2.13.2

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
