### PR TITLE
Add a value for namespace selector in kube-api-server's service monitor template

### DIFF
--- a/charts/kube-prometheus-stack/templates/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-api-server/servicemonitor.yaml
@@ -32,8 +32,7 @@ spec:
       insecureSkipVerify: {{ .Values.kubeApiServer.tlsConfig.insecureSkipVerify }}
   jobLabel: {{ .Values.kubeApiServer.serviceMonitor.jobLabel }}
   namespaceSelector:
-    matchNames:
-    - default
+{{ toYaml .Values.kubeApiServer.serviceMonitor.namespaceSelector | indent 4 }}
   selector:
 {{ toYaml .Values.kubeApiServer.serviceMonitor.selector | indent 4 }}
 {{- end}}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -760,6 +760,9 @@ kubeApiServer:
     proxyUrl: ""
 
     jobLabel: component
+    namespaceSelector:
+      matchNames:
+      - default
     selector:
       matchLabels:
         component: apiserver


### PR DESCRIPTION
This is a small change that would be handy for my cluster where we depend on kubernetes-apiserver endpoints in not default namespace. 