### PR TITLE
[prometheus-postgres-exporter] Use arrays instead of strings for extraContainers, extraVolumes and extraVolumeMounts

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.9.0"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 2.2.0
+version: 2.3.0
 home: https://github.com/prometheus-community/postgres_exporter
 sources:
 - https://github.com/prometheus-community/postgres_exporter

--- a/charts/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/charts/prometheus-postgres-exporter/templates/deployment.yaml
@@ -111,10 +111,10 @@ spec:
               mountPath: /etc/config.yaml
               subPath: config.yaml
 {{- with .Values.extraVolumeMounts }}
-{{ tpl . $ | indent 12 }}
+{{ toYaml . | indent 12 }}
 {{- end }}
 {{- with .Values.extraContainers }}
-{{ tpl . $ | indent 8 }}
+{{ toYaml . | indent 8 }}
 {{- end }}
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}
@@ -136,5 +136,5 @@ spec:
           name: {{ template "prometheus-postgres-exporter.fullname" . }}
         name: queries
 {{- with .Values.extraVolumes }}
-{{ tpl . $ | indent 6 }}
+{{ toYaml . | indent 6 }}
 {{- end }}

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -421,10 +421,10 @@ initContainers: []
   #       mountPath: /creds
 
 # Additional sidecar containers, e. g. for a database proxy, such as Google's cloudsql-proxy
-extraContainers: |
+extraContainers: []
 
 # Additional volumes, e. g. for secrets used in an extraContainer
-extraVolumes: |
+extraVolumes: []
 
 # Uncomment for mounting custom ca-certificates
 #  - name: ssl-certs
@@ -436,7 +436,7 @@ extraVolumes: |
 #      secretName: ssl-certs
 
 # Additional volume mounts
-extraVolumeMounts: |
+extraVolumeMounts: []
 
 # Uncomment for mounting custom ca-certificates file into container
 #  - name: ssl-certs


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

The current version of this chart uses the `tpl` function for `extraContainers`, `extraVolumes` and `extraVolumeMounts` which enforces the user to provide them as strings like:

```yaml
---
apiVersion: helm.toolkit.fluxcd.io/v2beta1
kind: HelmRelease
metadata:
  name: prometheus-postgres-exporter
  namespace: monitoring
spec:
  chart:
    spec:
      chart: prometheus-postgres-exporter
      version: ">=2.2.0 <2.3.0"
      sourceRef:
        kind: HelmRepository
        name: prometheus-community
        namespace: flux-system
  interval: 5m0s
  values:
    serviceMonitor:
      enabled: true
    extraContainers: |
      - name: cloud-sql-proxy
        image: gcr.io/cloudsql-docker/gce-proxy:1.17
        command:
          - "/cloud_sql_proxy"
          - "-instances=INSTANCE_CONNECTION_NAME=tcp:5432"
        securityContext:
          runAsNonRoot: true
```

To make it more intuitive and to align more with other charts like the [*prometheus-blackbox-exporter*](https://github.com/prometheus-community/helm-charts/blob/acb625d5051ff73032cbb0e2a3275735f6113afb/charts/prometheus-blackbox-exporter/templates/deployment.yaml#L123-L125), this PR changes the behavior to accept arrays instead of strings like:

```yaml
---
apiVersion: helm.toolkit.fluxcd.io/v2beta1
kind: HelmRelease
metadata:
  name: prometheus-postgres-exporter
  namespace: monitoring
spec:
  chart:
    spec:
      chart: prometheus-postgres-exporter
      version: ">=2.2.0 <2.3.0"
      sourceRef:
        kind: HelmRepository
        name: prometheus-community
        namespace: flux-system
  interval: 5m0s
  values:
    serviceMonitor:
      enabled: true
    extraContainers:
      - name: cloud-sql-proxy
        image: gcr.io/cloudsql-docker/gce-proxy:1.17
        command:
          - "/cloud_sql_proxy"
          - "-instances=INSTANCE_CONNECTION_NAME=tcp:5432"
        securityContext:
          runAsNonRoot: true
```

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped (**minor** bumped, but as the interface of this chart changes maybe a major would be better?)
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
