### PR TITLE
[kube-prometheus-stack] Add matchLabel to prevent duplicate kubelet targets

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 14.9.0
+version: 14.9.1
 appVersion: 0.46.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/exporters/kubelet/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kubelet/servicemonitor.yaml
@@ -150,5 +150,6 @@ spec:
     - {{ .Values.kubelet.namespace }}
   selector:
     matchLabels:
+      app.kubernetes.io/managed-by:  prometheus-operator
       k8s-app: kubelet
 {{- end}}


### PR DESCRIPTION
#### What this PR does / why we need it:
When there is another service in kube-system that matches for the ServiceMonitor "kube-prometheus-stack-kubelet"
```
kube-prometheus-stack-kubelet                   ClusterIP   None          <none>        10250/TCP,10255/TCP,4194/TCP   39d
kubelet                                         ClusterIP   None          <none>        10250/TCP,10255/TCP,4194/TCP   31d
```
an error occurs like described in #614. This PR adds an additional filter that ignores the other service.

#### Which issue this PR fixes
* fixes #614

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)