### PR TITLE
[kube-prometheus-stack] Add prometheus.thanosService.omitClusterIP

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 15.2.0
+version: 15.2.1
 appVersion: 0.47.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/serviceThanosSidecar.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/serviceThanosSidecar.yaml
@@ -16,7 +16,9 @@ metadata:
 {{- end }}
 spec:
   type: {{ .Values.prometheus.thanosService.type }}
+  {{- if not .Values.prometheus.thanosService.omitClusterIP }}
   clusterIP: {{ .Values.prometheus.thanosService.clusterIP }}
+  {{- end }}
   ports:
   - name: {{ .Values.prometheus.thanosService.portName }}
     port: {{ .Values.prometheus.thanosService.port }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1597,6 +1597,7 @@ prometheus:
     portName: grpc
     port: 10901
     targetPort: "grpc"
+    omitClusterIP: false
     clusterIP: "None"
 
     ## Service type


### PR DESCRIPTION
#### What this PR does / why we need it:

Support omission of the Thanos service `clusterIP`.

#### Which issue this PR fixes
  - fixes #863

#### Special notes for your reviewer:

Similar to https://github.com/helm/charts/pull/13646

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
