### PR TITLE
[kube-prometheus-stack]      [URGENT]        fix: versioning kps chart

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 15.1.2
+version: 15.1.3
 appVersion: 0.47.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus


### PR DESCRIPTION
Signed-off-by: gkarthiks <github.gkarthiks@gmail.com>


#### What this PR does / why we need it:
This PR is to fix the versioning mistake that happened in the #692. For some reason, the diff didn't complain about the chart.yaml conflicts.


#### Special notes for your reviewer:
For some reason, the file diff in the PR #692 [here](https://github.com/prometheus-community/helm-charts/pull/692/files) didn't complain about the chart version during the time of the merge, but later it failed to release on 15.1.2. So I am bumping the version. Please approve.

@scottrigby
@Xtigyro
@bismarck 

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
