### PR TITLE
bugfix: Urgent - Fix context change in range for ingress apiversions

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 15.1.2
+version: 15.1.3
 appVersion: 0.47.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/alertmanager/ingress.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/ingress.yaml
@@ -43,7 +43,7 @@ spec:
             pathType: {{ $pathType }}
             {{- end }}
             backend:
-              {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
               service:
                 name: {{ $serviceName }}
                 port:
@@ -63,7 +63,7 @@ spec:
             pathType: {{ $pathType }}
             {{- end }}
             backend:
-              {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
               service:
                 name: {{ $serviceName }}
                 port:

--- a/charts/kube-prometheus-stack/templates/alertmanager/ingressperreplica.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/ingressperreplica.yaml
@@ -11,9 +11,9 @@ metadata:
 items:
 {{ range $i, $e := until $count }}
   - kind: Ingress
-    {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+    {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
     apiVersion: networking.k8s.io/v1
-    {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+    {{- else if $.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
     apiVersion: networking.k8s.io/v1beta1
     {{- else }}
     apiVersion: extensions/v1beta1
@@ -47,7 +47,7 @@ items:
                 pathType: {{ $pathType }}
                 {{- end }}
                 backend:
-                  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+                  {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
                   service:
                     name: {{ include "kube-prometheus-stack.fullname" $ }}-alertmanager-{{ $i }}
                     port:

--- a/charts/kube-prometheus-stack/templates/prometheus/ingress.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/ingress.yaml
@@ -43,7 +43,7 @@ spec:
             pathType: {{ $pathType }}
             {{- end }}
             backend:
-              {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
               service:
                 name: {{ $serviceName }}
                 port:
@@ -63,7 +63,7 @@ spec:
             pathType: {{ $pathType }}
             {{- end }}
             backend:
-              {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
               service:
                 name: {{ $serviceName }}
                 port:

--- a/charts/kube-prometheus-stack/templates/prometheus/ingressThanosSidecar.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/ingressThanosSidecar.yaml
@@ -42,7 +42,7 @@ spec:
             pathType: {{ $pathType }}
             {{- end }}
             backend:
-              {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
               service:
                 name: {{ $serviceName }}
                 port:
@@ -62,7 +62,7 @@ spec:
             pathType: {{ $pathType }}
             {{- end }}
             backend:
-              {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
               service:
                 name: {{ $serviceName }}
                 port:

--- a/charts/kube-prometheus-stack/templates/prometheus/ingressperreplica.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/ingressperreplica.yaml
@@ -11,9 +11,9 @@ metadata:
 items:
 {{ range $i, $e := until $count }}
   - kind: Ingress
-    {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+    {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
     apiVersion: networking.k8s.io/v1
-    {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+    {{- else if $.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
     apiVersion: networking.k8s.io/v1beta1
     {{- else }}
     apiVersion: extensions/v1beta1
@@ -47,7 +47,7 @@ items:
                 pathType: {{ $pathType }}
                 {{- end }}
                 backend:
-                  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+                  {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
                   service:
                     name: {{ include "kube-prometheus-stack.fullname" $ }}-prometheus-{{ $i }}
                     port:


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

Fixes the context change in the range loop of the paths causing root .Values to not be addressable.

Had to deal with DCO in #870 
#### Which issue this PR fixes
  - fixes oversight in https://github.com/prometheus-community/helm-charts/pull/850

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
