### PR TITLE
[kube-prometheus-stack]: Parse Prometehus remote config using tpl 

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 15.2.3
+version: 15.2.4
 appVersion: 0.47.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -159,7 +159,7 @@ spec:
 {{- if (or .Values.prometheus.prometheusSpec.remoteRead .Values.prometheus.prometheusSpec.additionalRemoteRead) }}
   remoteRead:
 {{- if .Values.prometheus.prometheusSpec.remoteRead }}
-{{ toYaml .Values.prometheus.prometheusSpec.remoteRead | indent 4 }}
+{{ tpl (toYaml .Values.prometheus.prometheusSpec.remoteRead | indent 4) . }}
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.additionalRemoteRead }}
 {{ toYaml .Values.prometheus.prometheusSpec.additionalRemoteRead | indent 4 }}
@@ -168,7 +168,7 @@ spec:
 {{- if (or .Values.prometheus.prometheusSpec.remoteWrite .Values.prometheus.prometheusSpec.additionalRemoteWrite) }}
   remoteWrite:
 {{- if .Values.prometheus.prometheusSpec.remoteWrite }}
-{{ toYaml .Values.prometheus.prometheusSpec.remoteWrite | indent 4 }}
+{{ tpl (toYaml .Values.prometheus.prometheusSpec.remoteWrite | indent 4) . }}
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.additionalRemoteWrite }}
 {{ toYaml .Values.prometheus.prometheusSpec.additionalRemoteWrite | indent 4 }}


### PR DESCRIPTION
Add templating helm function to kube-prometheus remote config. On using kube-prometheus as a dependent helm chart passing {{ .Release.Name}} & {{ .Release.Namespace }} the respective values aren't parsed as tpl function isn't used.

Signed-off-by: Vineeth Pothulapati <vineethpothulapati@outlook.com>

#### What this PR does / why we need it:

Parse `remoteWrite` & `remoteRead` config with template function to parse the `releaseName` & `namespace` when kube-prometheus is used as an dependent helm chart. 

#### Which issue this PR fixes
#874 

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
