### PR TITLE
[kube-prometheus-stack] #876 Update kube-prometheus-stack grafana dependency to 6.8.0

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 1.17.0
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.7.4
-digest: sha256:3ad6db588084a1f225ee1a3bb8e5d47b30f1fab9dbba701e039d0919aaf86aef
-generated: "2021-04-14T12:41:24.546213-04:00"
+  version: 6.8.0
+digest: sha256:54bd36030ef0f5cac21d8c06b2a98b108cbfccdbba112770f8b8158fe479a00e
+generated: "2021-04-22T14:35:03.234101561+02:00"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 15.1.3
+version: 15.2.0
 appVersion: 0.47.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus
@@ -44,6 +44,6 @@ dependencies:
   repository: https://prometheus-community.github.io/helm-charts
   condition: nodeExporter.enabled
 - name: grafana
-  version: "6.7.*"
+  version: "6.8.*"
   repository: https://grafana.github.io/helm-charts
   condition: grafana.enabled


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR will fix https://github.com/prometheus-community/helm-charts/issues/876 which leads to issues if long lines used in grafana.ini block.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
