### PR TITLE
[alertmanager]fix cluster-peer name follow statefullSet name 

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 0.9.0
+version: 0.9.1
 appVersion: v0.21.0
 maintainers:
   - name: monotek

--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 0.9.1
+version: 0.9.2
 appVersion: v0.21.0
 maintainers:
   - name: monotek

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -71,8 +71,9 @@ spec:
             - --cluster.listen-address=0.0.0.0:9094
             {{- end }}
             {{- if gt .Values.replicaCount 1.0}}
+            {{- $fullName := include "alertmanager.fullname" . }}
             {{- range $i := until (int .Values.replicaCount) }}
-            - --cluster.peer={{ tpl $.Release.Name $ }}-{{ tpl $.Chart.Name $ }}-{{ $i }}:9094
+            - --cluster.peer={{ $fullName }}-{{ $i }}:9094
             {{- end }}
             {{- end }}
             {{- if .Values.additionalPeers }}

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -72,7 +72,7 @@ spec:
             {{- end }}
             {{- if gt .Values.replicaCount 1.0}}
             {{- range $i := until (int .Values.replicaCount) }}
-            - --cluster.peer={{ tpl $.Release.Name $ }}-{{ tpl $.Chart.Name $ }}-{{ $i }}.{{ tpl $.Release.Name $ }}-{{ tpl $.Chart.Name $ }}-headless:9094
+            - --cluster.peer={{ tpl $.Release.Name $ }}-{{ tpl $.Chart.Name $ }}-{{ $i }}:9094
             {{- end }}
             {{- end }}
             {{- if .Values.additionalPeers }}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
cluster-peer name, was not exactly following statefullSet name. Now it should work also if nameOveride/fullNameOveride is used.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
