### PR TITLE
[kube-prometheus-stack] New location for kube-state-metrics

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kube-state-metrics
-  repository: https://kubernetes.github.io/kube-state-metrics
+  repository: https://prometheus-community.github.io/helm-charts
   version: 2.13.2
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 1.17.0
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.8.0
-digest: sha256:54bd36030ef0f5cac21d8c06b2a98b108cbfccdbba112770f8b8158fe479a00e
-generated: "2021-04-22T14:35:03.234101561+02:00"
+  version: 6.8.1
+digest: sha256:03740677070731b95281dd2f7baab61968df1b0f34edf92ce816e7ce5882d5e4
+generated: "2021-04-26T12:45:12.225507767+02:00"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 15.2.2
+version: 15.2.3
 appVersion: 0.47.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus
@@ -37,7 +37,7 @@ annotations:
 dependencies:
 - name: kube-state-metrics
   version: "2.13.*"
-  repository: https://kubernetes.github.io/kube-state-metrics
+  repository: https://prometheus-community.github.io/helm-charts
   condition: kubeStateMetrics.enabled
 - name: prometheus-node-exporter
   version: "1.17.*"


### PR DESCRIPTION
#### What this PR does / why we need it:
Switches kube-state-metrics over to the new location inside of this repository
Synchronizes Chart.lock

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
