### PR TITLE
[prometheus-kafka-exporter] Add kafka broker version

### DIFF
--- a/charts/prometheus-kafka-exporter/Chart.yaml
+++ b/charts/prometheus-kafka-exporter/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v1.2.0"
 description: A Helm chart to export the metrics from Kafka in Prometheus format using the kafka-exporter from https://github.com/danielqsj/kafka_exporter
 name: prometheus-kafka-exporter
 home: https://github.com/danielqsj/kafka_exporter
-version: 1.0.0
+version: 1.1.0
 sources:
   - https://gkarthiks.github.io/helm-charts/charts/prometheus-kafka-exporter
 keywords:

--- a/charts/prometheus-kafka-exporter/templates/deployment.yaml
+++ b/charts/prometheus-kafka-exporter/templates/deployment.yaml
@@ -27,6 +27,9 @@ spec:
           {{- range $server := .Values.kafkaServer }}
             - '--kafka.server={{ $server }}'
           {{- end }}
+          {{- if .Values.kafkaBrokerVersion }}
+            - '--kafka.version={{ .Values.kafkaBrokerVersion }}'
+          {{- end }}
           {{- if .Values.tls.enabled }}
             - '--tls.enabled'
             - '--tls.ca-file={{ .Values.tls.mountPath }}/ca.crt'

--- a/charts/prometheus-kafka-exporter/values.yaml
+++ b/charts/prometheus-kafka-exporter/values.yaml
@@ -8,6 +8,9 @@ replicaCount: 1
 kafkaServer:
   - kafka-server:9092
 
+# Specifies broker version to use, leave empty for default
+kafkaBrokerVersion: 
+
 rbac:
   # Specifies whether RBAC resources should be created
   create: true

--- a/charts/prometheus-kafka-exporter/values.yaml
+++ b/charts/prometheus-kafka-exporter/values.yaml
@@ -9,7 +9,7 @@ kafkaServer:
   - kafka-server:9092
 
 # Specifies broker version to use, leave empty for default
-kafkaBrokerVersion: 
+kafkaBrokerVersion:
 
 rbac:
   # Specifies whether RBAC resources should be created


### PR DESCRIPTION
Signed-off-by: Evyatar Cohen <coevyatar@gmail.com>

#### What this PR does / why we need it:

This PR adds the option to specify Kafka broker version to `kafka_exporter`. While trying to install `kafka_exporter` via the chart, an error of connection failure is returned and looking under Kafka's logs an error regarding api key is returned.
Changing the broker version manually worked and this change will help those who encounter similar issue.

#### Which issue this PR fixes

No issue in issues.

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
