### PR TITLE
#899 - correct test for networking.k8s.io/v1

### DIFF
--- a/charts/kube-prometheus-stack/templates/alertmanager/ingress.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/ingress.yaml
@@ -4,9 +4,9 @@
 {{- $servicePort := .Values.alertmanager.service.port -}}
 {{- $routePrefix := list .Values.alertmanager.alertmanagerSpec.routePrefix }}
 {{- $paths := .Values.alertmanager.ingress.paths | default $routePrefix -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}
 apiVersion: networking.k8s.io/v1
-  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
 apiVersion: networking.k8s.io/v1beta1
   {{- else -}}
 apiVersion: extensions/v1beta1
@@ -26,7 +26,7 @@ metadata:
 {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
-  {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1") }}
+  {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress") }}
   {{- if .Values.alertmanager.ingress.ingressClassName }}
   ingressClassName: {{ .Values.alertmanager.ingress.ingressClassName }}
   {{- end }}
@@ -43,7 +43,7 @@ spec:
             pathType: {{ $pathType }}
             {{- end }}
             backend:
-              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: {{ $serviceName }}
                 port:
@@ -63,7 +63,7 @@ spec:
             pathType: {{ $pathType }}
             {{- end }}
             backend:
-              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: {{ $serviceName }}
                 port:

--- a/charts/kube-prometheus-stack/templates/alertmanager/ingressperreplica.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/ingressperreplica.yaml
@@ -11,9 +11,9 @@ metadata:
 items:
 {{ range $i, $e := until $count }}
   - kind: Ingress
-    {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+    {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
     apiVersion: networking.k8s.io/v1
-    {{- else if $.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+    {{- else if $.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
     apiVersion: networking.k8s.io/v1beta1
     {{- else }}
     apiVersion: extensions/v1beta1
@@ -32,7 +32,7 @@ items:
 {{ toYaml $ingressValues.annotations | indent 8 }}
       {{- end }}
     spec:
-      {{- if or ($.Capabilities.APIVersions.Has "networking.k8s.io/v1") ($.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1") }}
+      {{- if or ($.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") ($.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress") }}
       {{- if $ingressValues.ingressClassName }}
       ingressClassName: {{ $ingressValues.ingressClassName }}
       {{- end }}
@@ -47,7 +47,7 @@ items:
                 pathType: {{ $pathType }}
                 {{- end }}
                 backend:
-                  {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+                  {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
                   service:
                     name: {{ include "kube-prometheus-stack.fullname" $ }}-alertmanager-{{ $i }}
                     port:

--- a/charts/kube-prometheus-stack/templates/prometheus/ingress.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/ingress.yaml
@@ -4,9 +4,9 @@
   {{- $servicePort := .Values.prometheus.service.port -}}
   {{- $routePrefix := list .Values.prometheus.prometheusSpec.routePrefix -}}
   {{- $paths := .Values.prometheus.ingress.paths | default $routePrefix -}}
-  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}
 apiVersion: networking.k8s.io/v1
-  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
 apiVersion: networking.k8s.io/v1beta1
   {{- else -}}
 apiVersion: extensions/v1beta1
@@ -26,7 +26,7 @@ metadata:
 {{ toYaml .Values.prometheus.ingress.labels | indent 4 }}
 {{- end }}
 spec:
-  {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1") }}
+  {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress") }}
   {{- if .Values.prometheus.ingress.ingressClassName }}
   ingressClassName: {{ .Values.prometheus.ingress.ingressClassName }}
   {{- end }}
@@ -43,7 +43,7 @@ spec:
             pathType: {{ $pathType }}
             {{- end }}
             backend:
-              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: {{ $serviceName }}
                 port:
@@ -63,7 +63,7 @@ spec:
             pathType: {{ $pathType }}
             {{- end }}
             backend:
-              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: {{ $serviceName }}
                 port:

--- a/charts/kube-prometheus-stack/templates/prometheus/ingressThanosSidecar.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/ingressThanosSidecar.yaml
@@ -4,9 +4,9 @@
 {{- $thanosPort := .Values.prometheus.thanosIngress.servicePort -}}
 {{- $routePrefix := list .Values.prometheus.prometheusSpec.routePrefix }}
 {{- $paths := .Values.prometheus.thanosIngress.paths | default $routePrefix -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}
 apiVersion: networking.k8s.io/v1
-  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
 apiVersion: networking.k8s.io/v1beta1
   {{- else -}}
 apiVersion: extensions/v1beta1
@@ -25,7 +25,7 @@ metadata:
 {{ toYaml .Values.prometheus.thanosIngress.labels | indent 4 }}
 {{- end }}
 spec:
-  {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1") }}
+  {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress") }}
   {{- if .Values.prometheus.thanosIngress.ingressClassName }}
   ingressClassName: {{ .Values.prometheus.thanosIngress.ingressClassName }}
   {{- end }}
@@ -42,7 +42,7 @@ spec:
             pathType: {{ $pathType }}
             {{- end }}
             backend:
-              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: {{ $serviceName }}
                 port:
@@ -62,7 +62,7 @@ spec:
             pathType: {{ $pathType }}
             {{- end }}
             backend:
-              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: {{ $serviceName }}
                 port:

--- a/charts/kube-prometheus-stack/templates/prometheus/ingressperreplica.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/ingressperreplica.yaml
@@ -11,9 +11,9 @@ metadata:
 items:
 {{ range $i, $e := until $count }}
   - kind: Ingress
-    {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+    {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
     apiVersion: networking.k8s.io/v1
-    {{- else if $.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+    {{- else if $.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
     apiVersion: networking.k8s.io/v1beta1
     {{- else }}
     apiVersion: extensions/v1beta1
@@ -32,7 +32,7 @@ items:
 {{ toYaml $ingressValues.annotations | indent 8 }}
       {{- end }}
     spec:
-      {{- if or ($.Capabilities.APIVersions.Has "networking.k8s.io/v1") ($.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1") }}
+      {{- if or ($.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") ($.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress") }}
       {{- if $ingressValues.ingressClassName }}
       ingressClassName: {{ $ingressValues.ingressClassName }}
       {{- end }}
@@ -47,7 +47,7 @@ items:
                 pathType: {{ $pathType }}
                 {{- end }}
                 backend:
-                  {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+                  {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
                   service:
                     name: {{ include "kube-prometheus-stack.fullname" $ }}-prometheus-{{ $i }}
                     port:


### PR DESCRIPTION
#### What this PR does / why we need it:
Change test 
`{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}`
to
`{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}`

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #899

