### PR TITLE
[prometheus-nats-exporter] support service annotations

### DIFF
--- a/charts/prometheus-nats-exporter/Chart.yaml
+++ b/charts/prometheus-nats-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.7.0
 description: A Helm chart for prometheus-nats-exporter
 name: prometheus-nats-exporter
-version: 2.6.0
+version: 2.7.0
 home: https://github.com/nats-io/prometheus-nats-exporter
 sources:
   - https://github.com/nats-io/prometheus-nats-exporter

--- a/charts/prometheus-nats-exporter/templates/service.yaml
+++ b/charts/prometheus-nats-exporter/templates/service.yaml
@@ -1,6 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
   name: {{ include "prometheus-nats-exporter.fullname" . }}
   labels:
     app.kubernetes.io/name: {{ include "prometheus-nats-exporter.name" . }}

--- a/charts/prometheus-nats-exporter/templates/service.yaml
+++ b/charts/prometheus-nats-exporter/templates/service.yaml
@@ -2,8 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
-{{- end }}
+{{ Values.service.annotations | indent 4 }}
   name: {{ include "prometheus-nats-exporter.fullname" . }}
   labels:
     app.kubernetes.io/name: {{ include "prometheus-nats-exporter.name" . }}

--- a/charts/prometheus-nats-exporter/templates/service.yaml
+++ b/charts/prometheus-nats-exporter/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-{{ Values.service.annotations | indent 4 }}
+{{ .Values.service.annotations | indent 4 }}
   name: {{ include "prometheus-nats-exporter.fullname" . }}
   labels:
     app.kubernetes.io/name: {{ include "prometheus-nats-exporter.name" . }}

--- a/charts/prometheus-nats-exporter/templates/service.yaml
+++ b/charts/prometheus-nats-exporter/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-{{ .Values.service.annotations | indent 4 }}
+{{ toYaml .Values.service.annotations | indent 4 }}
   name: {{ include "prometheus-nats-exporter.fullname" . }}
   labels:
     app.kubernetes.io/name: {{ include "prometheus-nats-exporter.name" . }}

--- a/charts/prometheus-nats-exporter/values.yaml
+++ b/charts/prometheus-nats-exporter/values.yaml
@@ -10,6 +10,7 @@ image:
   pullPolicy: IfNotPresent
 
 service:
+  annotations: {}
   type: ClusterIP
   port: 80
   targetPort: 7777


### PR DESCRIPTION
Signed-off-by: brunopadz <bpadz@protonmail.com>

#### What this PR does / why we need it:

This PR adds the option to specify annotations in the service that exposes `nats-exporter`. This is necessary specially when creating a service type `LoadBalancer` on major cloud providers to specify what type of Load Balancer will be used and whether it's internal or external. 

#### Which issue this PR fixes

No issue.

#### Special notes for your reviewer:

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
