### PR TITLE
[kube-state-metrics] Add: Kubernetes recommanded labels

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 3.0.0
+version: 3.0.1
 appVersion: 2.0.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/_helpers.tpl
+++ b/charts/kube-state-metrics/templates/_helpers.tpl
@@ -45,3 +45,16 @@ Allow the release namespace to be overridden for multi-namespace deployments in 
     {{- .Release.Namespace -}}
   {{- end -}}
 {{- end -}}
+
+{{/* Generate basic labels */}}
+{{- define "kube-state-metrics.labels" }}
+app.kubernetes.io/name: {{ template "kube-state-metrics.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/version: "{{ .Chart.Version }}"
+app.kubernetes.io/part-of: {{ template "kube-state-metrics.name" . }} 
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }} 
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels | indent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/kube-state-metrics/templates/clusterrolebinding.yaml
+++ b/charts/kube-state-metrics/templates/clusterrolebinding.yaml
@@ -3,10 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: {{ template "kube-state-metrics.name" . }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- include "kube-state-metrics.labels" . | indent 4 }}
   name: {{ template "kube-state-metrics.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/kube-state-metrics/templates/deployment.yaml
@@ -8,14 +8,7 @@ metadata:
   name: {{ template "kube-state-metrics.fullname" . }}
   namespace: {{ template "kube-state-metrics.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ template "kube-state-metrics.name" . }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    app.kubernetes.io/instance: "{{ .Release.Name }}"
-    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-    app.kubernetes.io/version: "{{ .Chart.AppVersion }}"
-{{- if .Values.customLabels }}
-{{ toYaml .Values.customLabels | indent 4 }}
-{{- end }}
+{{- include "kube-state-metrics.labels" . | indent 4 }}
 spec:
   selector:
     matchLabels:
@@ -28,11 +21,7 @@ spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ template "kube-state-metrics.name" . }}
-        app.kubernetes.io/instance: "{{ .Release.Name }}"
-{{- if .Values.customLabels }}
-{{ toYaml .Values.customLabels | indent 8 }}
-{{- end }}
+        {{- include "kube-state-metrics.labels" . | indent 8 }}
 {{- if .Values.podAnnotations }}
       annotations:
 {{ toYaml .Values.podAnnotations | indent 8 }}

--- a/charts/kube-state-metrics/templates/kubeconfig-secret.yaml
+++ b/charts/kube-state-metrics/templates/kubeconfig-secret.yaml
@@ -5,10 +5,7 @@ metadata:
   name: {{ template "kube-state-metrics.fullname" . }}-kubeconfig
   namespace: {{ template "kube-state-metrics.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ template "kube-state-metrics.name" . }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    app.kubernetes.io/instance: "{{ .Release.Name }}"
-    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+{{- include "kube-state-metrics.labels" . | indent 4 }}
 type: Opaque
 data:
   config: '{{ .Values.kubeconfig.secret }}'

--- a/charts/kube-state-metrics/templates/pdb.yaml
+++ b/charts/kube-state-metrics/templates/pdb.yaml
@@ -5,13 +5,7 @@ metadata:
   name: {{ template "kube-state-metrics.fullname" . }}
   namespace: {{ template "kube-state-metrics.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ template "kube-state-metrics.name" . }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    app.kubernetes.io/instance: "{{ .Release.Name }}"
-    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-{{- if .Values.customLabels }}
-{{ toYaml .Values.customLabels | indent 4 }}
-{{- end }}
+{{- include "kube-state-metrics.labels" . | indent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/kube-state-metrics/templates/podsecuritypolicy.yaml
+++ b/charts/kube-state-metrics/templates/podsecuritypolicy.yaml
@@ -4,10 +4,7 @@ kind: PodSecurityPolicy
 metadata:
   name: {{ template "kube-state-metrics.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ template "kube-state-metrics.name" . }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- include "kube-state-metrics.labels" . | indent 4 }}
 {{- if .Values.podSecurityPolicy.annotations }}
   annotations:
 {{ toYaml .Values.podSecurityPolicy.annotations | indent 4 }}

--- a/charts/kube-state-metrics/templates/psp-clusterrole.yaml
+++ b/charts/kube-state-metrics/templates/psp-clusterrole.yaml
@@ -3,10 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: {{ template "kube-state-metrics.name" . }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- include "kube-state-metrics.labels" . | indent 4 }}
   name: psp-{{ template "kube-state-metrics.fullname" . }}
 rules:
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}

--- a/charts/kube-state-metrics/templates/psp-clusterrolebinding.yaml
+++ b/charts/kube-state-metrics/templates/psp-clusterrolebinding.yaml
@@ -3,10 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: {{ template "kube-state-metrics.name" . }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- include "kube-state-metrics.labels" . | indent 4 }}
   name: psp-{{ template "kube-state-metrics.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/kube-state-metrics/templates/role.yaml
+++ b/charts/kube-state-metrics/templates/role.yaml
@@ -12,10 +12,7 @@ kind: ClusterRole
 {{- end }}
 metadata:
   labels:
-    app.kubernetes.io/name: {{ template "kube-state-metrics.name" $ }}
-    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
-    app.kubernetes.io/managed-by: {{ $.Release.Service }}
-    app.kubernetes.io/instance: {{ $.Release.Name }}
+{{- include "kube-state-metrics.labels" . | indent 4 }}
   name: {{ template "kube-state-metrics.fullname" $ }}
 {{- if eq .Values.rbac.useClusterRole false }}
   namespace: {{ . }}

--- a/charts/kube-state-metrics/templates/rolebinding.yaml
+++ b/charts/kube-state-metrics/templates/rolebinding.yaml
@@ -5,10 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: {{ template "kube-state-metrics.name" $ }}
-    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
-    app.kubernetes.io/managed-by: {{ $.Release.Service }}
-    app.kubernetes.io/instance: {{ $.Release.Name }}
+{{- include "kube-state-metrics.labels" . | indent 4 }}
   name: {{ template "kube-state-metrics.fullname" $ }}
   namespace: {{ . }}
 roleRef:

--- a/charts/kube-state-metrics/templates/service.yaml
+++ b/charts/kube-state-metrics/templates/service.yaml
@@ -4,13 +4,7 @@ metadata:
   name: {{ template "kube-state-metrics.fullname" . }}
   namespace: {{ template "kube-state-metrics.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ template "kube-state-metrics.name" . }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    app.kubernetes.io/instance: "{{ .Release.Name }}"
-    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-{{- if .Values.customLabels }}
-{{ toYaml .Values.customLabels | indent 4 }}
-{{- end }}
+{{- include "kube-state-metrics.labels" . | indent 4 }}
   annotations:
     {{- if .Values.prometheusScrape }}
     prometheus.io/scrape: '{{ .Values.prometheusScrape }}'

--- a/charts/kube-state-metrics/templates/serviceaccount.yaml
+++ b/charts/kube-state-metrics/templates/serviceaccount.yaml
@@ -3,10 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/name: {{ template "kube-state-metrics.name" . }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- include "kube-state-metrics.labels" . | indent 4 }}
   name: {{ template "kube-state-metrics.fullname" . }}
   namespace: {{ template "kube-state-metrics.namespace" . }}
 {{- if .Values.serviceAccount.annotations }}

--- a/charts/kube-state-metrics/templates/servicemonitor.yaml
+++ b/charts/kube-state-metrics/templates/servicemonitor.yaml
@@ -5,10 +5,7 @@ metadata:
   name: {{ template "kube-state-metrics.fullname" . }}
   namespace: {{ template "kube-state-metrics.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ template "kube-state-metrics.name" . }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    app.kubernetes.io/instance: "{{ .Release.Name }}"
-    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+{{- include "kube-state-metrics.labels" . | indent 4 }}
     {{- if .Values.prometheus.monitor.additionalLabels }}
 {{ toYaml .Values.prometheus.monitor.additionalLabels | indent 4 }}
     {{- end }}

--- a/charts/kube-state-metrics/templates/stsdiscovery-role.yaml
+++ b/charts/kube-state-metrics/templates/stsdiscovery-role.yaml
@@ -5,10 +5,7 @@ metadata:
   name: stsdiscovery-{{ template "kube-state-metrics.fullname" . }}
   namespace: {{ template "kube-state-metrics.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ template "kube-state-metrics.name" . }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- include "kube-state-metrics.labels" . | indent 4 }}
 rules:
 - apiGroups:
   - ""

--- a/charts/kube-state-metrics/templates/stsdiscovery-rolebinding.yaml
+++ b/charts/kube-state-metrics/templates/stsdiscovery-rolebinding.yaml
@@ -5,10 +5,7 @@ metadata:
   name: stsdiscovery-{{ template "kube-state-metrics.fullname" . }}
   namespace: {{ template "kube-state-metrics.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ template "kube-state-metrics.name" . }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- include "kube-state-metrics.labels" . | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
Next of : https://github.com/kubernetes/kube-state-metrics/pull/1387

Add Kubernetes recommanded labels https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/

```yaml
---
# Source: kube-state-metrics/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  labels:    
    app.kubernetes.io/name: kube-state-metrics
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/version: "3.0.1"
    app.kubernetes.io/part-of: kube-state-metrics 
    helm.sh/chart: kube-state-metrics-3.0.1
  name: RELEASE-NAME-kube-state-metrics
  namespace: default
imagePullSecrets:
  []
---
# Source: kube-state-metrics/templates/role.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  labels:    
    app.kubernetes.io/name: kube-state-metrics
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/version: "3.0.1"
    app.kubernetes.io/part-of: kube-state-metrics 
    helm.sh/chart: kube-state-metrics-3.0.1
  name: RELEASE-NAME-kube-state-metrics
rules:

- apiGroups: ["certificates.k8s.io"]
  resources:
  - certificatesigningrequests
  verbs: ["list", "watch"]

- apiGroups: [""]
  resources:
  - configmaps
  verbs: ["list", "watch"]

- apiGroups: ["batch"]
  resources:
  - cronjobs
  verbs: ["list", "watch"]

- apiGroups: ["extensions", "apps"]
  resources:
  - daemonsets
  verbs: ["list", "watch"]

- apiGroups: ["extensions", "apps"]
  resources:
  - deployments
  verbs: ["list", "watch"]

- apiGroups: [""]
  resources:
  - endpoints
  verbs: ["list", "watch"]

- apiGroups: ["autoscaling"]
  resources:
  - horizontalpodautoscalers
  verbs: ["list", "watch"]

- apiGroups: ["extensions", "networking.k8s.io"]
  resources:
  - ingresses
  verbs: ["list", "watch"]

- apiGroups: ["batch"]
  resources:
  - jobs
  verbs: ["list", "watch"]

- apiGroups: [""]
  resources:
  - limitranges
  verbs: ["list", "watch"]

- apiGroups: ["admissionregistration.k8s.io"]
  resources:
    - mutatingwebhookconfigurations
  verbs: ["list", "watch"]

- apiGroups: [""]
  resources:
  - namespaces
  verbs: ["list", "watch"]

- apiGroups: ["networking.k8s.io"]
  resources:
  - networkpolicies
  verbs: ["list", "watch"]

- apiGroups: [""]
  resources:
  - nodes
  verbs: ["list", "watch"]

- apiGroups: [""]
  resources:
  - persistentvolumeclaims
  verbs: ["list", "watch"]

- apiGroups: [""]
  resources:
  - persistentvolumes
  verbs: ["list", "watch"]

- apiGroups: ["policy"]
  resources:
    - poddisruptionbudgets
  verbs: ["list", "watch"]

- apiGroups: [""]
  resources:
  - pods
  verbs: ["list", "watch"]

- apiGroups: ["extensions", "apps"]
  resources:
  - replicasets
  verbs: ["list", "watch"]

- apiGroups: [""]
  resources:
  - replicationcontrollers
  verbs: ["list", "watch"]

- apiGroups: [""]
  resources:
  - resourcequotas
  verbs: ["list", "watch"]

- apiGroups: [""]
  resources:
  - secrets
  verbs: ["list", "watch"]

- apiGroups: [""]
  resources:
  - services
  verbs: ["list", "watch"]

- apiGroups: ["apps"]
  resources:
  - statefulsets
  verbs: ["list", "watch"]

- apiGroups: ["storage.k8s.io"]
  resources:
    - storageclasses
  verbs: ["list", "watch"]

- apiGroups: ["admissionregistration.k8s.io"]
  resources:
    - validatingwebhookconfigurations
  verbs: ["list", "watch"]

- apiGroups: ["storage.k8s.io"]
  resources:
    - volumeattachments
  verbs: ["list", "watch"]
---
# Source: kube-state-metrics/templates/clusterrolebinding.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  labels:    
    app.kubernetes.io/name: kube-state-metrics
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/version: "3.0.1"
    app.kubernetes.io/part-of: kube-state-metrics 
    helm.sh/chart: kube-state-metrics-3.0.1
  name: RELEASE-NAME-kube-state-metrics
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: RELEASE-NAME-kube-state-metrics
subjects:
- kind: ServiceAccount
  name: RELEASE-NAME-kube-state-metrics
  namespace: default
---
# Source: kube-state-metrics/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: RELEASE-NAME-kube-state-metrics
  namespace: default
  labels:    
    app.kubernetes.io/name: kube-state-metrics
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/version: "3.0.1"
    app.kubernetes.io/part-of: kube-state-metrics 
    helm.sh/chart: kube-state-metrics-3.0.1
  annotations:
    prometheus.io/scrape: 'true'
spec:
  type: "ClusterIP"
  ports:
  - name: "http"
    protocol: TCP
    port: 8080
    targetPort: 8080
  
  selector:
    app.kubernetes.io/name: kube-state-metrics
    app.kubernetes.io/instance: RELEASE-NAME
---
# Source: kube-state-metrics/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: RELEASE-NAME-kube-state-metrics
  namespace: default
  labels:    
    app.kubernetes.io/name: kube-state-metrics
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/version: "3.0.1"
    app.kubernetes.io/part-of: kube-state-metrics 
    helm.sh/chart: kube-state-metrics-3.0.1
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: kube-state-metrics
  replicas: 1
  template:
    metadata:
      labels:        
        app.kubernetes.io/name: kube-state-metrics
        app.kubernetes.io/instance: RELEASE-NAME
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/version: "3.0.1"
        app.kubernetes.io/part-of: kube-state-metrics 
        helm.sh/chart: kube-state-metrics-3.0.1
    spec:
      hostNetwork: false
      serviceAccountName: RELEASE-NAME-kube-state-metrics
      securityContext:
        fsGroup: 65534
        runAsGroup: 65534
        runAsUser: 65534
      containers:
      - name: kube-state-metrics
        args:


        - --resources=certificatesigningrequests


        - --resources=configmaps


        - --resources=cronjobs


        - --resources=daemonsets


        - --resources=deployments


        - --resources=endpoints


        - --resources=horizontalpodautoscalers


        - --resources=ingresses


        - --resources=jobs


        - --resources=limitranges


        - --resources=mutatingwebhookconfigurations


        - --resources=namespaces


        - --resources=networkpolicies


        - --resources=nodes


        - --resources=persistentvolumeclaims


        - --resources=persistentvolumes


        - --resources=poddisruptionbudgets


        - --resources=pods


        - --resources=replicasets


        - --resources=replicationcontrollers


        - --resources=resourcequotas


        - --resources=secrets


        - --resources=services


        - --resources=statefulsets


        - --resources=storageclasses


        - --resources=validatingwebhookconfigurations



        - --resources=volumeattachments





        - --telemetry-port=8081
        imagePullPolicy: IfNotPresent
        image: "k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0"
        ports:
        - containerPort: 8080
        livenessProbe:
          httpGet:
            path: /healthz
            port: 8080
          initialDelaySeconds: 5
          timeoutSeconds: 5
        readinessProbe:
          httpGet:
            path: /
            port: 8080
          initialDelaySeconds: 5
          timeoutSeconds: 5
```





<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
