### PR TITLE
[kube-prometheus-stack] fix lint in additional-prometheus-rules

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 15.4.2
+version: 15.4.3
 appVersion: 0.47.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/additionalPrometheusRules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/additionalPrometheusRules.yaml
@@ -1,6 +1,9 @@
 {{- if or .Values.additionalPrometheusRules .Values.additionalPrometheusRulesMap}}
 apiVersion: v1
 kind: List
+metadata:
+  name: {{ include "kube-prometheus-stack.fullname" $ }}-additional-prometheus-rules
+  namespace: {{ template "kube-prometheus-stack.namespace" . }}
 items:
 {{- if .Values.additionalPrometheusRulesMap }}
 {{- range $prometheusRuleName, $prometheusRule := .Values.additionalPrometheusRulesMap }}


### PR DESCRIPTION
#### What this PR does / why we need it:
`helm lint` want metadata.name for every resource:
```
[WARNING] templates/prometheus/additionalPrometheusRules.yaml: object
name does not conform to Kubernetes naming requirements: "":
metadata.name: Invalid value: "": a lowercase RFC 1123 subdomain must
consist of lower case alphanumeric characters, '-' or '.', and must
start and end with an alphanumeric character (e.g. 'example.com', regex
used for validation is
'[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')

1 chart(s) linted, 0 chart(s) failed
```

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
