### PR TITLE
[kube-prometheus-stack] Omit imagePullSecrets element if no secrets provided

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 15.4.3
+version: 15.4.4
 appVersion: 0.47.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/alertmanager/serviceaccount.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/serviceaccount.yaml
@@ -13,6 +13,8 @@ metadata:
   annotations:
 {{ toYaml .Values.alertmanager.serviceAccount.annotations | indent 4 }}
 {{- end }}
+{{- if .Values.global.imagePullSecrets }}
 imagePullSecrets:
 {{ toYaml .Values.global.imagePullSecrets | indent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/serviceaccount.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/serviceaccount.yaml
@@ -10,6 +10,8 @@ metadata:
   labels:
     app: {{ template "kube-prometheus-stack.name" $ }}-admission
 {{- include "kube-prometheus-stack.labels" $ | indent 4 }}
+{{- if .Values.global.imagePullSecrets }}
 imagePullSecrets:
 {{ toYaml .Values.global.imagePullSecrets | indent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/serviceaccount.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/serviceaccount.yaml
@@ -9,6 +9,8 @@ metadata:
     app.kubernetes.io/name: {{ template "kube-prometheus-stack.name" . }}-prometheus-operator
     app.kubernetes.io/component: prometheus-operator
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
+{{- if .Values.global.imagePullSecrets }}
 imagePullSecrets:
 {{ toYaml .Values.global.imagePullSecrets | indent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/serviceaccount.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/serviceaccount.yaml
@@ -13,6 +13,8 @@ metadata:
   annotations:
 {{ toYaml .Values.prometheus.serviceAccount.annotations | indent 4 }}
 {{- end }}
+{{- if .Values.global.imagePullSecrets }}
 imagePullSecrets:
 {{ toYaml .Values.global.imagePullSecrets | indent 2 }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Simon Roberts <simon.roberts@anz.com>

#### What this PR does / why we need it:
Don't include elements that we don't need (and can cause problems for config-management systems).
Fresh PR to replace #918 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #917

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
