### PR TITLE
[kube-state-metrics] Fix rbac.useClusterRole=false behavior

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 3.1.2
+version: 3.1.0
 appVersion: 2.0.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 3.0.2
+version: 3.1.2
 appVersion: 2.0.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/role.yaml
+++ b/charts/kube-state-metrics/templates/role.yaml
@@ -1,11 +1,8 @@
-{{- if and (eq $.Values.rbac.create true) (not .Values.rbac.useExistingRole) -}}
-{{- if eq .Values.rbac.useClusterRole false }}
-{{- range (split "," $.Values.namespace) }}
-{{- end }}
-{{- end -}}
+{{- if and (eq .Values.rbac.create true) (not .Values.rbac.useExistingRole) -}}
+{{- range (split "," .Values.namespaces) }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-{{- if eq .Values.rbac.useClusterRole false }}
+{{- if eq $.Values.rbac.useClusterRole false }}
 kind: Role
 {{- else }}
 kind: ClusterRole
@@ -17,7 +14,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
     app.kubernetes.io/instance: {{ $.Release.Name }}
   name: {{ template "kube-state-metrics.fullname" $ }}
-{{- if eq .Values.rbac.useClusterRole false }}
+{{- if eq $.Values.rbac.useClusterRole false }}
   namespace: {{ . }}
 {{- end }}
 rules:
@@ -189,4 +186,5 @@ rules:
     - verticalpodautoscalers
   verbs: ["list", "watch"]
 {{ end -}}
+{{- end -}}
 {{- end -}}

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -147,8 +147,8 @@ kubeconfig:
   # base64 encoded kube-config file
   secret:
 
-# Namespaces to be enabled for collecting resources. By default all namespaces are collected.
-# namespaces: ""
+# Comma-separated list of namespaces to be enabled for collecting resources. By default all namespaces are collected.
+namespaces: ""
 
 ## Override the deployment namespace
 ##


### PR DESCRIPTION
#### What this PR does / why we need it:

Looks like there is a bug affecting kube-state-metrics if a user sets `useClusterRole=false` and `namespace=<namespace1>,<namespace2>`. When a user sets those two values, they expect multiple `Role`s to be created (one per namespace), but instead it errors:

```
$ cd charts/kube-state-metrics/
$ helm template --debug --set namespaces="ns1\,ns2" --set namespace="ns1\,ns2" --set rbac.useClusterRole=false .
install.go:172: [debug] Original chart version: ""
install.go:189: [debug] CHART PATH: /Users/machaffe/personal/mac-prom-helm/charts/kube-state-metrics

---
# Source: kube-state-metrics/templates/role.yaml
---
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  labels:
    app.kubernetes.io/name: kube-state-metrics
    helm.sh/chart: kube-state-metrics-3.0.2
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/instance: RELEASE-NAME
  name: RELEASE-NAME-kube-state-metrics
  namespace: map[Capabilities:0x35345c0 Chart:0xc000347e60 Files:map[.helmignore:[35 32 80 97 116
  ...
...
Error: YAML parse error on kube-state-metrics/templates/role.yaml: error converting YAML to JSON: yaml: line 10: mapping values are not allowed in this context
helm.go:81: [debug] error converting YAML to JSON: yaml: line 10: mapping values are not allowed in this context
```
This PR fixes that bug by just copying the existing logic from [rolebinding.yaml:2](https://github.com/prometheus-community/helm-charts/blob/d6ae19c6bb7089bd0080952ca6f98b68177e3dcb/charts/kube-state-metrics/templates/rolebinding.yaml#L2)

#### Which issue this PR fixes
  - 

#### Special notes for your reviewer:
Note I renamed `namespace` to `namespaces` to match rolebinding.yaml.

Also note that I set a default value of `""`  for `namespaces`. This is needed because `namespaces` must be a string in order to apply `split` to it, even when the user doesn't override it.

I bumped the minor version instead of the patch version since this may break for users who set `useClusterRole=false` but set `namespace=some-single-namespace`. This was never documented behavior, but they will have to migrate to using `namespaces` instead of `namespace`.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
