### PR TITLE
[prometheus-postgres-exporter]Update default password or passwordSecr…

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.9.0"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 2.3.0
+version: 2.3.1
 home: https://github.com/prometheus-community/postgres_exporter
 sources:
 - https://github.com/prometheus-community/postgres_exporter

--- a/charts/prometheus-postgres-exporter/templates/secrets.yaml
+++ b/charts/prometheus-postgres-exporter/templates/secrets.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.config.datasource.password -}}
+{{- if not .Values.config.datasource.passwordSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,5 +10,5 @@ metadata:
     release: {{ .Release.Name }}
 type: Opaque
 data:
-  data_source_password: {{ .Values.config.datasource.password | b64enc }}
+  data_source_password: {{ .Values.config.datasource.password | default "somepaswword" | b64enc }}
 {{- end -}}

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -94,7 +94,7 @@ config:
     host:
     user: postgres
     # Only one of password and passwordSecret can be specified
-    password: somepassword
+    password:
     # Specify passwordSecret if DB password is stored in secret.
     passwordSecret: {}
     # Secret name


### PR DESCRIPTION
…et in values.yaml

Signed-off-by: Raghunandana S K <skraghunandan11@gmail.com>

Co-authored-by: Gabriel Machado <gabriel.ms1@hotmail.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

When using passwordSecret with the current default values.yaml the users have to mention both ***password*** and passwordSecret  in custom values.yaml they pass during deployment , because the default values.yaml contains ```password : somepassword. ``` . 
Which means we have to override this using the custom values file and requires an unnecessary mentioning of ***password*** as an empty value. Only then the deployment works because of the condition [here](https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus-postgres-exporter/templates/deployment.yaml#L2) 


This PR addresses this by removing the default value for ***password*** and leaving it empty and making the changes in secrets.yaml to contain the default password.

This allows the users to either have password or passwordSecret mentioned in the custom values.yaml they pass.

#### Special notes for your reviewer:


#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
