### PR TITLE
[alertmanager] Fixing indentation for node selector keys in case persistence is enabled

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 0.10.0
+version: 0.10.1
 appVersion: v0.21.0
 maintainers:
   - name: monotek

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -43,7 +43,7 @@ spec:
             - --volume-dir=/etc/alertmanager
             - --webhook-url=http://127.0.0.1:{{ .Values.service.port }}/-/reload
           resources:
-            {{ toYaml .Values.configmapReload.resources | indent 12 }}
+            {{- toYaml .Values.configmapReload.resources | nindent 12 }}
           volumeMounts:
             - name: config
               mountPath: /etc/alertmanager
@@ -111,6 +111,18 @@ spec:
           configMap:
             name: {{ include "alertmanager.fullname" . }}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
 {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:
@@ -132,15 +144,3 @@ spec:
         - name: storage
           emptyDir: {}
 {{- end -}}
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-    {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}


### PR DESCRIPTION
Also, fixing syntax error related to configMapReload resource declaration

#### What this PR does / why we need it:
1. When alertmanager chart is used with `nodeSelector` `affinity` or `tolerations` along with `persistence.enabled = True`, the chart deployment fails due to indentation issues. These 3 keys are supposed to be a part of `spec.template.spec` whereas `volumeClaimTemplates` should be a child of `spec`. Fixed this by re-ordering.

2. For `configmapReload.resources`, fixed an indentation issue by chomping whitespace using `{{-`. Also used `nindent` to be consistent with the default container. [Check](https://github.com/prometheus-community/helm-charts/blob/079bcdf9d8d28a30aeb42b22027f6c298dcdd903/charts/alertmanager/templates/statefulset.yaml#L100)

#### Which issue this PR fixes
NA

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
