### PR TITLE
[prometheus] Updated kube-state-metrics sub-chart to version 3.0.*

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.26.0
-version: 13.8.0
+version: 14.0.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
@@ -26,6 +26,6 @@ engine: gotpl
 type: application
 dependencies:
   - name: kube-state-metrics
-    version: "2.13.*"
-    repository: https://kubernetes.github.io/kube-state-metrics
+    version: "3.0.*"
+    repository: https://prometheus-community.github.io/helm-charts
     condition: kubeStateMetrics.enabled


### PR DESCRIPTION
#### What this PR does / why we need it:

Update kube-state-metrics sub-chart to v3.0.*

#### Which issue this PR fixes

None

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
