### PR TITLE
[prometheus] kube-state-metrics subchart updated 3.0.* to 3.1.*

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.26.0
-version: 14.0.0
+version: 14.0.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
@@ -26,6 +26,6 @@ engine: gotpl
 type: application
 dependencies:
   - name: kube-state-metrics
-    version: "3.0.*"
+    version: "3.1.*"
     repository: https://prometheus-community.github.io/helm-charts
     condition: kubeStateMetrics.enabled


### PR DESCRIPTION
#### What this PR does / why we need it:

To keep Prometheus chart updated with the latest kube-state-metrics chart.

#### Which issue this PR fixes

None

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
