### PR TITLE
[prometheus-adapter] Add hostPorts in psp

### DIFF
--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 2.12.3
+version: 2.12.4
 appVersion: v0.8.4
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 2.12.4
+version: 2.13.0
 appVersion: v0.8.4
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/charts/prometheus-adapter/templates/psp.yaml
+++ b/charts/prometheus-adapter/templates/psp.yaml
@@ -12,8 +12,6 @@ metadata:
 spec:
   {{- if .Values.hostNetwork.enabled }}
   hostNetwork: true
-  {{- end }}
-  {{- if .Values.hostNetwork.hostPortsEnabled }}
   hostPorts:
     - min: {{ .Values.listenPort }}
       max: {{ .Values.listenPort }}

--- a/charts/prometheus-adapter/templates/psp.yaml
+++ b/charts/prometheus-adapter/templates/psp.yaml
@@ -13,6 +13,11 @@ spec:
   {{- if .Values.hostNetwork.enabled }}
   hostNetwork: true
   {{- end }}
+  {{- if .Values.hostNetwork.hostPortsEnabled }}
+  hostPorts:
+    - min: {{ .Values.listenPort }}
+      max: {{ .Values.listenPort }}
+  {{- end }}
   fsGroup:
     rule: RunAsAny
   runAsGroup:

--- a/charts/prometheus-adapter/values.yaml
+++ b/charts/prometheus-adapter/values.yaml
@@ -160,11 +160,6 @@ hostNetwork:
   # if you use Weave network on EKS. See also dnsPolicy
   enabled: false
 
-  # If enabled, updates the PodSecurityPolicy to set the hostPorts range to include the value
-  # from listenPort. This may be necessary if you need hostNetwork enabled and pods are
-  # not allowed to use hostPorts by default in your k8s installation
-  hostPortsEnabled: false
-
 # When hostNetwork is enabled, you probably want to set this to ClusterFirstWithHostNet
 # dnsPolicy: ClusterFirstWithHostNet
 

--- a/charts/prometheus-adapter/values.yaml
+++ b/charts/prometheus-adapter/values.yaml
@@ -160,6 +160,11 @@ hostNetwork:
   # if you use Weave network on EKS. See also dnsPolicy
   enabled: false
 
+  # If enabled, updates the PodSecurityPolicy to set the hostPorts range to include the value
+  # from listenPort. This may be necessary if you need hostNetwork enabled and pods are 
+  # not allowed to use hostPorts by default in your k8s installation
+  hostPortsEnabled: false
+
 # When hostNetwork is enabled, you probably want to set this to ClusterFirstWithHostNet
 # dnsPolicy: ClusterFirstWithHostNet
 

--- a/charts/prometheus-adapter/values.yaml
+++ b/charts/prometheus-adapter/values.yaml
@@ -161,7 +161,7 @@ hostNetwork:
   enabled: false
 
   # If enabled, updates the PodSecurityPolicy to set the hostPorts range to include the value
-  # from listenPort. This may be necessary if you need hostNetwork enabled and pods are 
+  # from listenPort. This may be necessary if you need hostNetwork enabled and pods are
   # not allowed to use hostPorts by default in your k8s installation
   hostPortsEnabled: false
 


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

When trying to install prometheus-adapter into our EKS cluster with Calico CNI and rbac, psp, and serviceaccount enabled, we hit an issue that the ReplicaSet was unable to spin up a pod due to the following error:

```
 Warning  FailedCreate  106s (x15 over 3m8s)  replicaset-controller  Error creating: pods "prometheus-adapter-85684bb67d-" is forbidden: unable to validate against any pod security policy: [spec.containers[0].hostPort: Invalid value: 6443: Host port 6443 is not allowed to be used. Allowed ports: []]
```

We did set `hostNetwork: true` and `dnsPolicy: ClusterFirstWithHostNet` based on some notes in https://github.com/prometheus-community/helm-charts/pull/375, but our cluster does not allow the use of hostPorts by default. 

This PR adds the optional ability to include the `hostPorts` section in the psp to set it to only allow `.Values.listenPort`. 


#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
