### PR TITLE
[prometheus-blackbox-exporter] - Added option to customize config path by setting it into values file

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 4.11.0
+version: 4.12.0
 appVersion: 0.18.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/charts/prometheus-blackbox-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/daemonset.yaml
@@ -78,7 +78,11 @@ spec:
           {{- end }}
           args:
 {{- if (or .Values.config .Values.configExistingSecretName) }}
+   {{- if .Values.configPath }}
+            - "--config.file={{ .Values.configPath }}"
+   {{- else }}
             - "--config.file=/config/blackbox.yaml"
+   {{- end }}
 {{- else }}
             - "--config.file=/etc/blackbox_exporter/config.yml"
 {{- end }}

--- a/charts/prometheus-blackbox-exporter/templates/deployment.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/deployment.yaml
@@ -89,7 +89,11 @@ spec:
           {{- end }}
           args:
 {{- if .Values.config }}
+   {{- if .Values.configPath }}
+            - "--config.file={{ .Values.configPath }}"
+   {{- else }}
             - "--config.file=/config/blackbox.yaml"
+   {{- end }}
 {{- else }}
             - "--config.file=/etc/blackbox_exporter/config.yml"
 {{- end }}

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -102,6 +102,9 @@ config:
         no_follow_redirects: false
         preferred_ip_protocol: "ip4"
 
+# Set custom config path, other than default /config/blackbox.yaml. If let empty, path will be "/config/blackbox.yaml"
+# configPath: "/foo/bar"
+
 extraConfigmapMounts: []
   # - name: certs-configmap
   #   mountPath: /etc/secrets/ssl/


### PR DESCRIPTION
Signed-off-by: Cristi Vlad <vlad_crst@yahoo.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

Add possibility to customize config file path
Needed for integration with vault and vault-agent-injector

#### Which issue this PR fixes
n/a

#### Special notes for your reviewer:

@desaintmartin: Closed previous PR (980) and open a new one
Maybe you can help me again with this PR. Thank you !

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
