### PR TITLE
[prometheus] Add option to set --storage.tsdb.path

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.26.0
-version: 14.0.1
+version: 14.1.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/templates/server/deploy.yaml
+++ b/charts/prometheus/templates/server/deploy.yaml
@@ -84,7 +84,11 @@ spec:
             - --storage.tsdb.retention.time={{ .Values.server.retention }}
           {{- end }}
             - --config.file={{ .Values.server.configPath }}
+            {{- if .Values.server.storagePath }}
+            - --storage.tsdb.path={{ .Values.server.storagePath }}
+            {{- else }}
             - --storage.tsdb.path={{ .Values.server.persistentVolume.mountPath }}
+            {{- end }}
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
           {{- range .Values.server.extraFlags }}

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -671,6 +671,10 @@ server:
   ## Path to a configuration file on prometheus server container FS
   configPath: /etc/config/prometheus.yml
 
+  ### The data directory used by prometheus to set --storage.tsdb.path
+  ### When empty server.persistentVolume.mountPath is used instead
+  storagePath: ""
+
   global:
     ## How frequently to scrape targets by default
     ##


### PR DESCRIPTION
Previously the value of '--storage.tsdb.path' was set via '.Values.server.persistentVolume.mountPath'.
This commit adds the option to specify a 'server.hostPath' value. When
the 'server.hostPath' value is not empty, the 'server.hostPath' value is
used for '--storage.tsdb.path' instead.

Signed-off-by: Vincent Van Ouytsel <vvanouytsel@gmail.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
Make it possible to configure '--storage.tsdb.path' directly via the values file. 
Previously it was 'hardcoded' to use .Values.server.persistentVolume.mountPath as the value of '--storage.tsdb.path'.
With this PR you can now overrule this functionality and set the '--storage.tsdb.path' directly using the 'storagePath' variable.

#### Which issue this PR fixes
n/a

#### Special notes for your reviewer:
n/a

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
