### PR TITLE
[prometheus-postgres-exporter] drop capability on service monitor

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.9.0"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 2.3.1
+version: 2.3.2
 home: https://github.com/prometheus-community/postgres_exporter
 sources:
 - https://github.com/prometheus-community/postgres_exporter

--- a/charts/prometheus-postgres-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-postgres-exporter/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.serviceMonitor.enabled ) }}
+{{- if .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
Removes the API capability check on the ServiceMonitor. Reasoning here is that there's already an opt-in flag on `serviceMonitor.enabled`.

This fixes the use-case where `helm` is responsible only for templating and releasing is performed by another tool. This is the behavior of Spinnaker's manifest render engine that uses Helm to bake the manifests it applies to a cluster separately. The capabilities check fails and we have no way of getting a ServiceMonitor. 

I omitted changes to the `rbac` capability check in `/templates/_helpers.tpl` since that might have broader implications. 

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
