### PR TITLE
[prometheus-postgres-exporter] Don't apply Secret when using one externally-managed

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.9.0"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 2.3.1
+version: 2.3.3
 home: https://github.com/prometheus-community/postgres_exporter
 sources:
 - https://github.com/prometheus-community/postgres_exporter

--- a/charts/prometheus-postgres-exporter/templates/secrets.yaml
+++ b/charts/prometheus-postgres-exporter/templates/secrets.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.config.datasource.passwordSecret -}}
+{{- if not (or .Values.config.datasource.passwordSecret .Values.config.datasourceSecret) -}}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
Adds a validation on `.Values.config.datasourceSecret` to avoid laying down a secret that isn't used. 

When the operator of this chart specifies `.Values.config.datasourceSecret` (commented as being mutually exclusive to `.Values.config.datasource`), the `Secret` is applied regardless. The `Deployment` uses the `datasourceSecret` exclusively when it's defined, so the `Secret` is never mounted and serves no purpose. 
 
I skipped a patch on the chart bump in light of #991.

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
