### PR TITLE
[prometheus] Respect storagePath value when deployed as StatefulSet

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.26.0
-version: 14.1.0
+version: 14.1.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/templates/server/sts.yaml
+++ b/charts/prometheus/templates/server/sts.yaml
@@ -90,7 +90,11 @@ spec:
             - --storage.tsdb.retention.time={{ .Values.server.retention }}
           {{- end }}
             - --config.file={{ .Values.server.configPath }}
+          {{- if .Values.server.storagePath }}
+            - --storage.tsdb.path={{ .Values.server.storagePath }}
+          {{- else }}
             - --storage.tsdb.path={{ .Values.server.persistentVolume.mountPath }}
+          {{- end }}
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
           {{- range .Values.server.extraFlags }}


### PR DESCRIPTION
#### What this PR does / why we need it:

As discussed in the StatefulSet deploy option of Prometheus server previously ignored the `server.storagePath` Helm value.

This patch fixes that behavior.

Signed-off-by: Jack Henschel <jackdev@mailbox.org>

#### Which issue this PR fixes
fixes https://github.com/prometheus-community/helm-charts/issues/1002

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
