### PR TITLE
[kube-prometheus-stack] Update prometheus service selector for 0.48.0

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 16.1.1
+version: 16.1.2
 appVersion: 0.48.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/README.md
+++ b/charts/kube-prometheus-stack/README.md
@@ -395,7 +395,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   labels:
-    app: prometheus
+    app.kubernetes.io/name: prometheus
     prometheus: prometheus-migration-prometheus
   name: prometheus-prometheus-migration-prometheus-db-prometheus-prometheus-migration-prometheus-0
   namespace: monitoring

--- a/charts/kube-prometheus-stack/templates/prometheus/podDisruptionBudget.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/podDisruptionBudget.yaml
@@ -16,6 +16,6 @@ spec:
   {{- end  }}
   selector:
     matchLabels:
-      app: prometheus
+      app.kubernetes.io/name: prometheus
       prometheus: {{ template "kube-prometheus-stack.fullname" . }}-prometheus
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -218,7 +218,7 @@ spec:
       - topologyKey: {{ .Values.prometheus.prometheusSpec.podAntiAffinityTopologyKey }}
         labelSelector:
           matchExpressions:
-            - {key: app, operator: In, values: [prometheus]}
+            - {key: app.kubernetes.io/name, operator: In, values: [prometheus]}
             - {key: prometheus, operator: In, values: [{{ template "kube-prometheus-stack.fullname" . }}-prometheus]}
 {{- else if eq .Values.prometheus.prometheusSpec.podAntiAffinity "soft" }}
     podAntiAffinity:
@@ -228,7 +228,7 @@ spec:
           topologyKey: {{ .Values.prometheus.prometheusSpec.podAntiAffinityTopologyKey }}
           labelSelector:
             matchExpressions:
-              - {key: app, operator: In, values: [prometheus]}
+              - {key: app.kubernetes.io/name, operator: In, values: [prometheus]}
               - {key: prometheus, operator: In, values: [{{ template "kube-prometheus-stack.fullname" . }}-prometheus]}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/service.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/service.yaml
@@ -51,7 +51,7 @@ spec:
 {{ toYaml .Values.prometheus.service.additionalPorts | indent 2 }}
 {{- end }}
   selector:
-    app: prometheus
+    app.kubernetes.io/name: prometheus
     prometheus: {{ template "kube-prometheus-stack.fullname" . }}-prometheus
 {{- if .Values.prometheus.service.sessionAffinity }}
   sessionAffinity: {{ .Values.prometheus.service.sessionAffinity }}

--- a/charts/kube-prometheus-stack/templates/prometheus/serviceThanosSidecar.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/serviceThanosSidecar.yaml
@@ -25,6 +25,6 @@ spec:
     nodePort: {{ .Values.prometheus.thanosService.nodePort }}
     {{- end }}
   selector:
-    app: prometheus
+    app.kubernetes.io/name: prometheus
     prometheus: {{ template "kube-prometheus-stack.fullname" . }}-prometheus
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/serviceThanosSidecarExternal.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/serviceThanosSidecarExternal.yaml
@@ -23,6 +23,6 @@ spec:
     nodePort: {{ .Values.prometheus.thanosServiceExternal.nodePort }}
     {{- end }}
   selector:
-    app: prometheus
+    app.kubernetes.io/name: prometheus
     prometheus: {{ template "kube-prometheus-stack.fullname" . }}-prometheus
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/serviceperreplica.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/serviceperreplica.yaml
@@ -38,7 +38,7 @@ items:
           port: {{ $serviceValues.port }}
           targetPort: {{ $serviceValues.targetPort }}
       selector:
-        app: prometheus
+        app.kubernetes.io/name: prometheus
         prometheus: {{ include "kube-prometheus-stack.fullname" $ }}-prometheus
         statefulset.kubernetes.io/pod-name: prometheus-{{ include "kube-prometheus-stack.fullname" $ }}-prometheus-{{ $i }}
       type: "{{ $serviceValues.type }}"


### PR DESCRIPTION
#### What this PR does / why we need it: 

The upstream prometheus-operator changed the `app` labels to `app.kubernetes.io/name`, and that broke the prometheus service selector.

#### Which issue this PR fixes
  - fixes #1009

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
