### PR TITLE
[kube-prometheus-stack] move relabelings filed to servicemonitor in kubeApiServer

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 16.1.0
+version: 16.1.1
 appVersion: 0.48.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-api-server/servicemonitor.yaml
@@ -22,9 +22,9 @@ spec:
     metricRelabelings:
 {{ tpl (toYaml .Values.kubeApiServer.serviceMonitor.metricRelabelings | indent 6) . }}
 {{- end }}
-{{- if .Values.kubeApiServer.relabelings }}
+{{- if .Values.kubeApiServer.serviceMonitor.relabelings }}
     relabelings:
-{{ toYaml .Values.kubeApiServer.relabelings | indent 6 }}
+{{ toYaml .Values.kubeApiServer.serviceMonitor.relabelings | indent 6 }}
 {{- end }}
     tlsConfig:
       caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -762,7 +762,7 @@ kubeApiServer:
     # - action: keep
     #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
     #   sourceLabels: [__name__]
-    relabelings: [ ]
+    relabelings: []
     # - sourceLabels:
     #     - __meta_kubernetes_namespace
     #     - __meta_kubernetes_service_name

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -742,19 +742,6 @@ kubeApiServer:
   tlsConfig:
     serverName: kubernetes
     insecureSkipVerify: false
-
-  ## If your API endpoint address is not reachable (as in AKS) you can replace it with the kubernetes service
-  ##
-  relabelings: []
-  # - sourceLabels:
-  #     - __meta_kubernetes_namespace
-  #     - __meta_kubernetes_service_name
-  #     - __meta_kubernetes_endpoint_port_name
-  #   action: keep
-  #   regex: default;kubernetes;https
-  # - targetLabel: __address__
-  #   replacement: kubernetes.default.svc:443
-
   serviceMonitor:
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
@@ -775,6 +762,15 @@ kubeApiServer:
     # - action: keep
     #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
     #   sourceLabels: [__name__]
+    relabelings: [ ]
+    # - sourceLabels:
+    #     - __meta_kubernetes_namespace
+    #     - __meta_kubernetes_service_name
+    #     - __meta_kubernetes_endpoint_port_name
+    #   action: keep
+    #   regex: default;kubernetes;https
+    # - targetLabel: __address__
+    #   replacement: kubernetes.default.svc:443
 
 ## Component scraping the kubelet and kubelet-hosted cAdvisor
 ##


### PR DESCRIPTION
Signed-off-by: devincd <505259926@qq.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
move relabelings filed to servicemonitor in kubeApiServer.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
