### PR TITLE
[kube-prometheus-stack] Add securityContext for admission_webhook in values.yaml

### DIFF
--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-createSecret.yaml
@@ -59,7 +59,5 @@ spec:
 {{ toYaml . | indent 8 }}
       {{- end }}
       securityContext:
-        runAsGroup: 2000
-        runAsNonRoot: true
-        runAsUser: 2000
+{{ toYaml .Values.prometheusOperator.admissionWebhooks.patch.securityContext | indent 8 }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -60,7 +60,5 @@ spec:
 {{ toYaml . | indent 8 }}
       {{- end }}
       securityContext:
-        runAsGroup: 2000
-        runAsNonRoot: true
-        runAsUser: 2000
+{{ toYaml .Values.prometheusOperator.admissionWebhooks.patch.securityContext | indent 8 }}
 {{- end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1353,6 +1353,11 @@ prometheusOperator:
       nodeSelector: {}
       affinity: {}
       tolerations: []
+      securityContext:
+        runAsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 2000
+
     # Use certmanager to generate webhook certs
     certManager:
       enabled: false


### PR DESCRIPTION
Signed-off-by: Michel Morin <michel.morin@ouest-france.fr>

#### What this PR does / why we need it:
Add securityContext for admission_webhook in values.yaml

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #786

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
