### PR TITLE
Update github actions and remove unused helm repositories

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           python-version: 3.7
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.0.1
+        uses: helm/chart-testing-action@v2.1.0
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,12 +20,10 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      # See https://github.com/helm/chart-releaser-action/issues/6
-      - name: Install Helm
-        run: |
-          curl -fsSLo get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
-          chmod 700 get_helm.sh
-          ./get_helm.sh
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.5.0
 
       - name: Add dependency chart repos
         run: |
@@ -33,6 +31,6 @@ jobs:
           helm repo add grafana https://grafana.github.io/helm-charts
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.0.0
+        uses: helm/chart-releaser-action@v1.2.1
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,6 @@ jobs:
 
       - name: Add dependency chart repos
         run: |
-          helm repo add stable https://charts.helm.sh/stable
           helm repo add grafana https://grafana.github.io/helm-charts
 
       - name: Run chart-releaser

--- a/ct.yaml
+++ b/ct.yaml
@@ -7,8 +7,6 @@ chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
   - grafana=https://grafana.github.io/helm-charts
   - prometheus-community=https://prometheus-community.github.io/helm-charts
-  - stable=https://charts.helm.sh/stable
-  - kube-state-metrics=https://kubernetes.github.io/kube-state-metrics
 helm-extra-args: --timeout 600s
 excluded-charts:
   # If not running on GCE, will error: "Failed to get GCE config"


### PR DESCRIPTION
#### What this PR does / why we need it:

* Update github actions to latest version
* Unify how we pull helm binary
* Remove stable and kube-state-metrics repositories as they are not used anymore


#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)

None of the above applies except DCO.