### PR TITLE
[prometheus-statsd-exporter] corret ingress render in k8s 1.19 above

### DIFF
--- a/charts/prometheus-statsd-exporter/Chart.yaml
+++ b/charts/prometheus-statsd-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus-statsd-exporter
 description: A Helm chart for prometheus stats-exporter
-version: 0.3.1
+version: 0.3.2
 appVersion: 0.20.0
 home: https://github.com/prometheus/statsd_exporter
 sources:

--- a/charts/prometheus-statsd-exporter/templates/ingress.yaml
+++ b/charts/prometheus-statsd-exporter/templates/ingress.yaml
@@ -2,6 +2,7 @@
 {{- $fullName := include "prometheus-statsd-exporter.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
+{{- $pathType := .Values.ingress.pathType -}}
 {{- if semverCompare ">=1.19.0-0" $kubeTargetVersion }}
 apiVersion: networking.k8s.io/v1
 {{- else }}
@@ -35,7 +36,7 @@ spec:
           {{- range .paths }}
           - path: {{ . }}
             {{- if semverCompare ">=1.19.0-0" $kubeTargetVersion }}
-            pathType: {{ .Values.ingress.pathType | default "ImplementationSpecific" }}
+            pathType: {{ $pathType | default "ImplementationSpecific" }}
             {{- end }}
             backend:
               {{- if semverCompare ">=1.19.0-0" $kubeTargetVersion }}

--- a/charts/prometheus-statsd-exporter/templates/ingress.yaml
+++ b/charts/prometheus-statsd-exporter/templates/ingress.yaml
@@ -2,7 +2,6 @@
 {{- $fullName := include "prometheus-statsd-exporter.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
-{{- $pathType := .Values.ingress.pathType -}}
 {{- if semverCompare ">=1.19.0-0" $kubeTargetVersion }}
 apiVersion: networking.k8s.io/v1
 {{- else }}
@@ -34,9 +33,9 @@ spec:
       http:
         paths:
           {{- range .paths }}
-          - path: {{ . }}
+          - path: {{ .path }}
             {{- if semverCompare ">=1.19.0-0" $kubeTargetVersion }}
-            pathType: {{ $pathType | default "ImplementationSpecific" }}
+            pathType: {{ .pathType | default "ImplementationSpecific" }}
             {{- end }}
             backend:
               {{- if semverCompare ">=1.19.0-0" $kubeTargetVersion }}

--- a/charts/prometheus-statsd-exporter/values.yaml
+++ b/charts/prometheus-statsd-exporter/values.yaml
@@ -85,10 +85,11 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  # pathType: ImplementationSpecific # only Kubernetes v1.19+
   hosts:
     - host: chart-example.local
-      paths: []
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/charts/prometheus-statsd-exporter/values.yaml
+++ b/charts/prometheus-statsd-exporter/values.yaml
@@ -85,9 +85,9 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  # pathType: ImplementationSpecific # only Kubernetes v1.19+
   hosts:
     - host: chart-example.local
-      #  pathType: ImplementationSpecific # only Kubernetes v1.19+
       paths: []
   tls: []
   #  - secretName: chart-example-tls


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

when installing chart with `helm install test-statsd prom/prometheus-statsd-exporter --values ingress.enabled=true` in a k8s 1.19 cluster , things will go wrong 

```
Error: UPGRADE FAILED: template: prometheus-statsd-exporter/templates/ingress.yaml:38:32: executing "prometheus-statsd-exporter/templates/ingress.yaml" at <.Values.ingress.pathType>: can't evaluate field Values in type interface {}
``` 
the reason is that the `.Values` varible is not available in a loop. assign it in the header can fix this

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
