### PR TITLE
[prometheus-adapter] Increase timeout seconds

### DIFF
--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 2.13.0
+version: 2.13.1
 appVersion: v0.8.4
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/charts/prometheus-adapter/templates/deployment.yaml
+++ b/charts/prometheus-adapter/templates/deployment.yaml
@@ -67,12 +67,14 @@ spec:
             port: https
             scheme: HTTPS
           initialDelaySeconds: 30
+          timeoutSeconds: 5
         readinessProbe:
           httpGet:
             path: /healthz
             port: https
             scheme: HTTPS
           initialDelaySeconds: 30
+          timeoutSeconds: 5
         {{- if .Values.resources }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Increase prometheus-adapter realiness+liveness probes timeout

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

I am using HPAs with prometheus-adapter, sometimes they are reporting unhealthy statuses and spamming notifications

I tried to find a root cause and found that prometheus-adapter /healthz endpoint sometimes are responding very slow.. (seconds vs microseconds). I think it is happening then it is querying prometheus, but not sure

HPA events
```
Warning  FailedGetResourceMetric       28m (x72 over 39h)      horizontal-pod-autoscaler  failed to get cpu utilization: unable to get metrics for resource cpu: unable to fetch metrics from resource metrics API: the server is currently unable to handle the request (get pods.metrics.k8s.io)
Warning  FailedComputeMetricsReplicas  28m (x72 over 39h)      horizontal-pod-autoscaler  invalid metrics (1 invalid out of 1), first error is: failed to get cpu utilization: unable to get metrics for resource cpu: unable to fetch metrics from resource metrics API: the server is currently unable to handle the request (get pods.metrics.k8s.io)
Warning  FailedGetResourceMetric       6m54s (x100 over 2d6h)  horizontal-pod-autoscaler  failed to get cpu utilization: unable to get metrics for resource cpu: no metrics returned from resource metrics API
Warning  FailedComputeMetricsReplicas  6m54s (x100 over 2d6h)  horizontal-pod-autoscaler  invalid metrics (1 invalid out of 1), first error is: failed to get cpu utilization: unable to get metrics for resource cpu: no metrics returned from resource metrics API
```

Some logs latency exemplars (mostly latency has 200us-100ms distribution)

```
I0604 16:12:18.728453 1 httplog.go:89] "HTTP" verb="GET" URI="/healthz" latency="1.190132209s" userAgent="kube-probe/1.21" srcIP="10.42.3.1:54624" resp=200
I0604 16:15:48.665361 1 httplog.go:89] "HTTP" verb="GET" URI="/healthz" latency="1.033431709s" userAgent="kube-probe/1.21" srcIP="10.42.3.1:33816" resp=200
I0604 16:15:48.858312 1 httplog.go:89] "HTTP" verb="GET" URI="/healthz" latency="1.124100243s" userAgent="kube-probe/1.21" srcIP="10.42.3.1:33814" resp=200
I0604 16:17:19.767087 1 httplog.go:89] "HTTP" verb="GET" URI="/healthz" latency="2.231707176s" userAgent="kube-probe/1.21" srcIP="10.42.3.1:36724" resp=200
I0604 16:17:19.771822 1 httplog.go:89] "HTTP" verb="GET" URI="/healthz" latency="2.032905608s" userAgent="kube-probe/1.21" srcIP="10.42.3.1:36722" resp=200
I0604 16:17:38.823259 1 httplog.go:89] "HTTP" verb="GET" URI="/healthz" latency="1.286850232s" userAgent="kube-probe/1.21" srcIP="10.42.3.1:37994" resp=200
I0604 16:17:39.010527 1 httplog.go:89] "HTTP" verb="GET" URI="/healthz" latency="1.274735651s" userAgent="kube-probe/1.21" srcIP="10.42.3.1:37992" resp=200
```

Greping k8s events:

```
28m         Warning   Unhealthy           pod/prometheus-adapter-7bb7576b58-zx9bn    Liveness probe failed: Get "https://10.42.3.180:6443/healthz": context deadline exceeded
28m         Warning   Unhealthy           pod/prometheus-adapter-7bb7576b58-zx9bn    Readiness probe failed: Get "https://10.42.3.180:6443/healthz": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
28m         Normal    Killing             pod/prometheus-adapter-7bb7576b58-zx9bn    Container prometheus-adapter failed liveness probe, will be restarted
```

I am using resource limits, but they are enough:

```yaml
resources:
  limits:
    cpu: 100m
    memory: 128Mi
```

This is prometheus-adapter probes from deployment. Timeout seconds = 1 by default and sometimes it is not enough:

```yaml
livenessProbe:
  failureThreshold: 3
  httpGet:
    path: /healthz
    port: https
    scheme: HTTPS
  initialDelaySeconds: 30
  periodSeconds: 10
  successThreshold: 1
  timeoutSeconds: 1
readinessProbe:
  failureThreshold: 3
  httpGet:
    path: /healthz
    port: https
    scheme: HTTPS
  initialDelaySeconds: 30
  periodSeconds: 10
  successThreshold: 1
  timeoutSeconds: 1
```

A better solution is to add custom readiness and liveness probes, but i have no time to discuss, pick a design, implement and do changes after review =( It can be a good todo)

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
