### PR TITLE
[kube-prometheus-stack] Fix issue #1038

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,9 +23,9 @@ appVersion: 0.48.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus
 keywords:
-  - operator
-  - prometheus
-  - kube-prometheus
+- operator
+- prometheus
+- kube-prometheus
 annotations:
   "artifacthub.io/operator": "true"
   "artifacthub.io/links": |
@@ -35,15 +35,15 @@ annotations:
       url: https://github.com/prometheus-operator/kube-prometheus
 
 dependencies:
-  - name: kube-state-metrics
-    version: "3.1.*"
-    repository: https://prometheus-community.github.io/helm-charts
-    condition: kubeStateMetrics.enabled
-  - name: prometheus-node-exporter
-    version: "1.18.*"
-    repository: https://prometheus-community.github.io/helm-charts
-    condition: nodeExporter.enabled
-  - name: grafana
-    version: "6.9.*"
-    repository: https://grafana.github.io/helm-charts
-    condition: grafana.enabled
+- name: kube-state-metrics
+  version: "3.1.*"
+  repository: https://prometheus-community.github.io/helm-charts
+  condition: kubeStateMetrics.enabled
+- name: prometheus-node-exporter
+  version: "1.18.*"
+  repository: https://prometheus-community.github.io/helm-charts
+  condition: nodeExporter.enabled
+- name: grafana
+  version: "6.9.*"
+  repository: https://grafana.github.io/helm-charts
+  condition: grafana.enabled

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,14 +18,14 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 16.2.0
+version: 16.3.0
 appVersion: 0.48.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus
 keywords:
-- operator
-- prometheus
-- kube-prometheus
+  - operator
+  - prometheus
+  - kube-prometheus
 annotations:
   "artifacthub.io/operator": "true"
   "artifacthub.io/links": |
@@ -35,15 +35,15 @@ annotations:
       url: https://github.com/prometheus-operator/kube-prometheus
 
 dependencies:
-- name: kube-state-metrics
-  version: "3.1.*"
-  repository: https://prometheus-community.github.io/helm-charts
-  condition: kubeStateMetrics.enabled
-- name: prometheus-node-exporter
-  version: "1.18.*"
-  repository: https://prometheus-community.github.io/helm-charts
-  condition: nodeExporter.enabled
-- name: grafana
-  version: "6.9.*"
-  repository: https://grafana.github.io/helm-charts
-  condition: grafana.enabled
+  - name: kube-state-metrics
+    version: "3.1.*"
+    repository: https://prometheus-community.github.io/helm-charts
+    condition: kubeStateMetrics.enabled
+  - name: prometheus-node-exporter
+    version: "1.18.*"
+    repository: https://prometheus-community.github.io/helm-charts
+    condition: nodeExporter.enabled
+  - name: grafana
+    version: "6.9.*"
+    repository: https://grafana.github.io/helm-charts
+    condition: grafana.enabled

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-createSecret.yaml
@@ -58,8 +58,8 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
       {{- end }}
+{{- if .Values.prometheusOperator.admissionWebhooks.patch.securityContext }}
       securityContext:
-        runAsGroup: 2000
-        runAsNonRoot: true
-        runAsUser: 2000
+{{ toYaml .Values.prometheusOperator.admissionWebhooks.patch.securityContext | indent 8 }}
+{{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -59,8 +59,8 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
       {{- end }}
+{{- if .Values.prometheusOperator.admissionWebhooks.patch.securityContext }}
       securityContext:
-        runAsGroup: 2000
-        runAsNonRoot: true
-        runAsUser: 2000
+{{ toYaml .Values.prometheusOperator.admissionWebhooks.patch.securityContext | indent 8 }}
+{{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1365,6 +1365,16 @@ prometheusOperator:
       nodeSelector: {}
       affinity: {}
       tolerations: []
+
+      ## SecurityContext holds pod-level security attributes and common container settings.
+      ## This defaults to non root user with uid 2000 and gid 2000.	*v1.PodSecurityContext	false
+      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+      ##
+      securityContext:
+        runAsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 2000
+
     # Use certmanager to generate webhook certs
     certManager:
       enabled: false


### PR DESCRIPTION
Make admission Web Hook Jobs securityContext configurable

Signed-off-by: Dmitrii Ermakov <demonihin@gmail.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
This PR makes Kube Prometheus Stack Jobs Security Context configurable. It allows a user to set required UID, GID for installation in restricted environments such as Openshift (please, take a look at #1038).

#### Which issue this PR fixes
  - fixes #1038 

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
