### PR TITLE
[kube-prometheus-stack] Version bump for grafana, node-exporter and kube-state-metrics

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
-  version: 3.1.0
+  version: 3.1.1
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
-  version: 1.18.0
+  version: 1.18.1
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.9.1
-digest: sha256:288156ef9d1e49c047a24ede1b3b8e852aaa08aa4c03c96f65d7f42977f19251
-generated: "2021-05-18T17:09:28.105172864+02:00"
+  version: 6.11.0
+digest: sha256:006471d0c078b98484e1a5ce2f6c29bbc9945a67b7de0a7da6cdcda935e67cd8
+generated: "2021-06-07T16:03:06.262078+02:00"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 16.3.1
+version: 16.4.0
 appVersion: 0.48.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus
@@ -44,6 +44,6 @@ dependencies:
   repository: https://prometheus-community.github.io/helm-charts
   condition: nodeExporter.enabled
 - name: grafana
-  version: "6.9.*"
+  version: "6.11.*"
   repository: https://grafana.github.io/helm-charts
   condition: grafana.enabled


### PR DESCRIPTION
Signed-off-by: Andres Alvarez <kir4h.gh@gmail.com>

#### What this PR does / why we need it:

This PR updates dependencies for `grafana` chart from `6.9` to `6.11`. It also bumps patch versions for `prometheus-node-exporter` and `kube-state-metrics`.

One of the benefits comes with [this commit](https://github.com/grafana/helm-charts/commit/e26d831611878d5bfa273012d433c319ba65208c#diff-8b8fb109a9ea067b4502be557279dbe8d342582d4850974f62766f3cd4c7b82c) as grafana secret is no longer overriden during upgrades.

Grafana changes seem safe to upgrade without further modification:

6.10 -> 6.11 https://github.com/grafana/helm-charts/commit/e5244943392c8b87d266d66bca8591e96c931923#diff-4ca0ec9c453f5f1f65d24210ec2e8068b2522937374dd462314125a8299ad5ae

6.9 -> 6.10 https://github.com/grafana/helm-charts/commit/880ef0d42892c6b45c9050380ec078be5c326a8c#diff-4ca0ec9c453f5f1f65d24210ec2e8068b2522937374dd462314125a8299ad5ae


#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
