### PR TITLE
[prometheus-blackbox-exporter] Allow specifying volumeMounts for container

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 4.13.0
+version: 4.14.0
 appVersion: 0.19.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/charts/prometheus-blackbox-exporter/templates/deployment.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/deployment.yaml
@@ -124,6 +124,9 @@ spec:
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
           {{- end }}
+          {{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 12 }}
+          {{- end }}
 {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy | toString }}
 {{- end }}

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -22,6 +22,11 @@ extraVolumes: []
   #   persistentVolumeClaim:
   #     claimName: example
 
+## Additional volumes that will be attached to the blackbox-exporter container
+extraVolumeMounts:
+  # - name: ca-certs
+  #   mountPath: /etc/ssl/certs/ca-certificates.crt
+
 extraContainers: []
   # - name: oAuth2-proxy
   #   args:


### PR DESCRIPTION
#### What this PR does / why we need it:
In a previous PR (https://github.com/prometheus-community/helm-charts/pull/194)
support for specifying "extraVolumes" was introduced.
However, these extra volumes cannot be mounted in the main blackbox-exporter
container (only in sidecar containers).

This patch adds a new value "extraVolumeMounts" which lets the user mount
arbitrary volumes on the main container.

#### Which issue this PR fixes
(none)

Signed-off-by: Jack Henschel <jackdev@mailbox.org>

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
