### PR TITLE
[prometheus-pushgateway] add extraVolumes and extraVolumeMounts to chart

### DIFF
--- a/charts/prometheus-pushgateway/Chart.yaml
+++ b/charts/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.3.0"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 1.10.1
+version: 1.11.0
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/charts/prometheus-pushgateway/templates/deployment.yaml
+++ b/charts/prometheus-pushgateway/templates/deployment.yaml
@@ -60,11 +60,12 @@ spec:
             timeoutSeconds: 10
           resources:
 {{ toYaml .Values.resources | indent 12 }}
-          {{- if .Values.persistentVolume.enabled }}
           volumeMounts:
             - name: storage-volume
               mountPath: "{{ .Values.persistentVolume.mountPath }}"
               subPath: "{{ .Values.persistentVolume.subPath }}"
+          {{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 12 }}
           {{- end }}
     {{- if .Values.nodeSelector }}
       nodeSelector:
@@ -78,13 +79,18 @@ spec:
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}
     {{- end }}
-      {{- if .Values.persistentVolume.enabled }}
     {{- if .Values.securityContext }}
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}
     {{- end }}
       volumes:
         - name: storage-volume
+      {{- if .Values.persistentVolume.enabled }}
           persistentVolumeClaim:
             claimName: {{ if .Values.persistentVolume.existingClaim }}{{ .Values.persistentVolume.existingClaim }}{{- else }}{{ template "prometheus-pushgateway.fullname" . }}{{- end }}
+      {{- else}}
+          emptyDir: {}
       {{- end -}}
+      {{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 8 }}
+      {{- end }}

--- a/charts/prometheus-pushgateway/values.yaml
+++ b/charts/prometheus-pushgateway/values.yaml
@@ -218,6 +218,14 @@ persistentVolume:
   ##
   subPath: ""
 
+extraVolumes: {}
+  # - name: extra
+  #   emptyDir: {}
+extraVolumeMounts: {}
+  # - name: extra
+  #   mountPath: /usr/share/extras
+  #   readOnly: true
+
 # Configuration for clusters with restrictive network policies in place:
 # - allowAll allows access to the PushGateway from any namespace
 # - customSelector is a list of pod/namespaceSelectors to allow access from


### PR DESCRIPTION
Signed-off-by: DilasserT <dilassert@gmail.com>

#### What this PR does / why we need it:
Allow additionnal volumes to be added, can be used to add shared volumes

Also added emptyDir in case `persistentVolume.enabled: false`, as it is specified in `values.yaml`

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
