### PR TITLE
[prometheus] add IngressClassName support for pushgateway

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.26.0
-version: 14.1.1
+version: 14.1.2
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/templates/pushgateway/ingress.yaml
+++ b/charts/prometheus/templates/pushgateway/ingress.yaml
@@ -15,6 +15,11 @@ metadata:
   name: {{ template "prometheus.pushgateway.fullname" . }}
 {{ include "prometheus.namespace" . | indent 2 }}
 spec:
+  {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass") (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/IngressClass") }}
+  {{- if .Values.pushgateway.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.pushgateway.ingress.ingressClassName }}
+  {{- end }}
+  {{- end }}
   rules:
   {{- range .Values.pushgateway.ingress.hosts }}
     {{- $url := splitList "/" . }}

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -107,6 +107,10 @@ alertmanager:
     ##
     enabled: false
 
+    # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+    # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
+    # ingressClassName: nginx
+
     ## alertmanager Ingress annotations
     ##
     annotations: {}
@@ -744,6 +748,10 @@ server:
     ##
     enabled: false
 
+    # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+    # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
+    # ingressClassName: nginx
+
     ## Prometheus server Ingress annotations
     ##
     annotations: {}
@@ -1065,6 +1073,10 @@ pushgateway:
     ## If true, pushgateway Ingress will be created
     ##
     enabled: false
+
+    # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+    # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
+    # ingressClassName: nginx
 
     ## pushgateway Ingress annotations
     ##


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

#### Which issue this PR fixes

Adds support for ingressClassName for kubernetes >1.18.

  - fixes #507 

#### Special notes for your reviewer:

Hi! i'm deploying pushgateway with ingress enabled and i was not rendering the value "ingressClassName". I see that these lines were not added for the pushgateway ingress in the PR #508

`spec:
  {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass") (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/IngressClass") }}
  {{- if .Values.pushgateway.ingress.ingressClassName }}
  ingressClassName: {{ .Values.pushgateway.ingress.ingressClassName }}
  {{- end }}
  {{- end }}`

Add this would be completing the support for ingressClassName.

I take as a reference these PR: 
 - PR #508 
 - PR #265 

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
