### PR TITLE
[kube-state-metrics] Fix: Use serviceAccountName template helper where it should

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 3.2.0
+version: 3.2.1
 appVersion: 2.0.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/clusterrolebinding.yaml
+++ b/charts/kube-state-metrics/templates/clusterrolebinding.yaml
@@ -18,6 +18,6 @@ roleRef:
 {{- end }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "kube-state-metrics.fullname" . }}
+  name: {{ template "kube-state-metrics.serviceAccountName" . }}
   namespace: {{ template "kube-state-metrics.namespace" . }}
 {{- end -}}

--- a/charts/kube-state-metrics/templates/psp-clusterrolebinding.yaml
+++ b/charts/kube-state-metrics/templates/psp-clusterrolebinding.yaml
@@ -14,6 +14,6 @@ roleRef:
   name: psp-{{ template "kube-state-metrics.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "kube-state-metrics.fullname" . }}
+    name: {{ template "kube-state-metrics.serviceAccountName" . }}
     namespace: {{ template "kube-state-metrics.namespace" . }}
 {{- end }}

--- a/charts/kube-state-metrics/templates/rolebinding.yaml
+++ b/charts/kube-state-metrics/templates/rolebinding.yaml
@@ -21,7 +21,7 @@ roleRef:
 {{- end }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "kube-state-metrics.fullname" $ }}
+  name: {{ template "kube-state-metrics.serviceAccountName" $ }}
   namespace: {{ template "kube-state-metrics.namespace" $ }}
 {{- end -}}
 {{- end -}}

--- a/charts/kube-state-metrics/templates/serviceaccount.yaml
+++ b/charts/kube-state-metrics/templates/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-  name: {{ template "kube-state-metrics.fullname" . }}
+  name: {{ template "kube-state-metrics.serviceAccountName" . }}
   namespace: {{ template "kube-state-metrics.namespace" . }}
 {{- if .Values.serviceAccount.annotations }}
   annotations:

--- a/charts/kube-state-metrics/templates/stsdiscovery-rolebinding.yaml
+++ b/charts/kube-state-metrics/templates/stsdiscovery-rolebinding.yaml
@@ -15,6 +15,6 @@ roleRef:
   name: stsdiscovery-{{ template "kube-state-metrics.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "kube-state-metrics.fullname" . }}
+    name: {{ template "kube-state-metrics.serviceAccountName" . }}
     namespace: {{ template "kube-state-metrics.namespace" . }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:
It makes all serviceAccount related resources be created which the right template helper **`kube-state-metrics.serviceAccountName`** instead of `kube-state-metrics.fullname`

#### Which issue this PR fixes
None that I know of/have found

#### Special notes for your reviewer:
Before this PR, when installing with serviceAccount.name set
```
helm install --generate-name --set-string serviceAccount.name=somename prometheus-community/kube-state-metrics
```
All resources except deployment are created using the fullname template helper...
Ex:
```
kubectl get sa
NAME                            SECRETS   AGE
default                         1         4m45s
kube-state-metrics-1623393733   1         2m4s
```
which results in the following error in deployment:
```
kubectl get deployments.apps kube-state-metrics-1623393733 -o yaml
...
  - lastTransitionTime: "2021-06-11T06:42:14Z"
    lastUpdateTime: "2021-06-11T06:42:14Z"
    message: 'pods "kube-state-metrics-1623393733-5cdfc67d8f-" is forbidden: error
      looking up service account default/somename: serviceaccount "somename" not found'
    reason: FailedCreate
    status: "True"
    type: ReplicaFailure
...
```

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
