### PR TITLE
[prometheus] allow boolean pushgateway extraArgs

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.26.0
-version: 14.1.2
+version: 14.2.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/templates/pushgateway/deploy.yaml
+++ b/charts/prometheus/templates/pushgateway/deploy.yaml
@@ -31,9 +31,9 @@ spec:
     {{- end }}
       labels:
         {{- include "prometheus.pushgateway.labels" . | nindent 8 }}
-        {{- if .Values.pushgateway.podLabels}}
+        {{- if .Values.pushgateway.podLabels }}
         {{ toYaml .Values.pushgateway.podLabels | nindent 8 }}
-        {{- end}}
+        {{- end }}
     spec:
       serviceAccountName: {{ template "prometheus.serviceAccountName.pushgateway" . }}
       {{- if .Values.pushgateway.extraInitContainers }}
@@ -49,7 +49,11 @@ spec:
           imagePullPolicy: "{{ .Values.pushgateway.image.pullPolicy }}"
           args:
           {{- range $key, $value := .Values.pushgateway.extraArgs }}
+          {{- if $value }}
+            - --{{ $key }}
+          {{- else }}
             - --{{ $key }}={{ $value }}
+          {{- end }}
           {{- end }}
           ports:
             - containerPort: 9091

--- a/charts/prometheus/templates/pushgateway/deploy.yaml
+++ b/charts/prometheus/templates/pushgateway/deploy.yaml
@@ -49,7 +49,8 @@ spec:
           imagePullPolicy: "{{ .Values.pushgateway.image.pullPolicy }}"
           args:
           {{- range $key, $value := .Values.pushgateway.extraArgs }}
-          {{- if $value }}
+          {{- $stringvalue := toString $value }}
+          {{- if eq $stringvalue "true" }}
             - --{{ $key }}
           {{- else }}
             - --{{ $key }}={{ $value }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Its actually not possible to set boolean pushgateway extraArgs.
For example a boolean [argument](https://github.com/prometheus/pushgateway/blob/master/main.go#L61-L75) like `push.disable-consistency-check` doesnt expect a value.
Set the variable with value "true" or true leads to the following error:
`pushgateway: error: unexpected true, try --help`

With this change the extraArg value will be converted to string and checked for the value "true". In that case the value will be ignored when adding the argument.

#### Which issue this PR fixes
none

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
