### PR TITLE
[kube-prometheus-stack] add extra support for Amazon EKS and Google GKE KubeVersion on ingress

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 16.8.0
+version: 16.9.0
 appVersion: 0.48.1
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/_helpers.tpl
+++ b/charts/kube-prometheus-stack/templates/_helpers.tpl
@@ -98,7 +98,12 @@ Allow the release namespace to be overridden for multi-namespace deployments in 
 
 {{/* Allow KubeVersion to be overridden. */}}
 {{- define "kube-prometheus-stack.ingress.kubeVersion" -}}
-  {{- default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride -}}
+  {{- $kubeVersion := default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride -}}
+  {{/* Special use case for Amazon EKS, Google GKE */}}
+  {{- if and (regexMatch "\\d+\\.\\d+\\.\\d+-(?:eks|gke).+" $kubeVersion) (not .Values.kubeVersionOverride) -}}
+    {{- $kubeVersion = regexFind "\\d+\\.\\d+\\.\\d+" $kubeVersion -}}
+  {{- end -}}
+  {{- $kubeVersion -}}
 {{- end -}}
 
 {{/* Get Ingress API Version */}}


### PR DESCRIPTION

Signed-off-by: Kirchen99 <latias_latios@126.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

This one https://github.com/prometheus-community/helm-charts/pull/1060 is closed since I have tried to resolve the conflicts by `git rebase`. But it brings more problems to solve. So I open a new pull request.

This PR adds support when this Chart is deployed on an Amazon EKS Cluster or a Google GKE Cluster. 

The Kube-Version of an EKS Cluster is like a pre-release version e.g. `v1.20.4-eks-6b7464` and of a GKE Cluster is like `v1.11.5-gke.3`, which makes helm confused thus rendered wrong apiVersion for resources like ingress of Alertmanager and Prometheus.

This PR, for example, replaces `v1.20.4-eks-6b7464` with `1.20.4`, if there is an `eks` in it or replaces `v1.11.5-gke.3` with `1.11.5` if there is a `gke` in it.

#### Which issue this PR fixes
  - fixes #1057
  - fixes #1071

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
