### PR TITLE
[prometheus] Allow templating sidecar containers for prometheus server

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.26.0
-version: 14.2.0
+version: 14.2.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/templates/server/deploy.yaml
+++ b/charts/prometheus/templates/server/deploy.yaml
@@ -153,7 +153,11 @@ spec:
       {{- if .Values.server.sidecarContainers }}
         {{- range $name, $spec :=  .Values.server.sidecarContainers }}
         - name: {{ $name }}
-          {{- toYaml $spec | nindent 10 }}
+          {{- if kindIs "string" $spec }}
+            {{- tpl $spec $ | nindent 10 }}
+          {{- else }}
+            {{- toYaml $spec | nindent 10 }}
+          {{- end }}
         {{- end }}
       {{- end }}
       hostNetwork: {{ .Values.server.hostNetwork }}

--- a/charts/prometheus/templates/server/sts.yaml
+++ b/charts/prometheus/templates/server/sts.yaml
@@ -158,7 +158,11 @@ spec:
     {{- if .Values.server.sidecarContainers }}
       {{- range $name, $spec :=  .Values.server.sidecarContainers }}
         - name: {{ $name }}
-          {{- toYaml $spec | nindent 10 }}
+          {{- if kindIs "string" $spec }}
+            {{- tpl $spec $ | nindent 10 }}
+          {{- else }}
+            {{- toYaml $spec | nindent 10 }}
+          {{- end }}
       {{- end }}
     {{- end }}
     {{- if .Values.imagePullSecrets }}

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -617,6 +617,18 @@ server:
   #        image: nginx
   sidecarContainers: {}
 
+  # sidecarTemplateValues - context to be used in template for sidecarContainers
+  # Example:
+  #   sidecarTemplateValues: *your-custom-globals
+  #   sidecarContainers:
+  #     webserver: |-
+  #       {{ include "webserver-container-template" . }}
+  # Template for `webserver-container-template` might looks like this:
+  #   image: "{{ .Values.server.sidecarTemplateValues.repository }}:{{ .Values.server.sidecarTemplateValues.tag }}"
+  #   ...
+  #
+  sidecarTemplateValues: {}
+
   ## Prometheus server container image
   ##
   image:


### PR DESCRIPTION
#### What this PR does / why we need it:

I have been looking for a way to use some values from values.yaml in sidecarContainers to use a specific image tag and end up with the following feature.

In my case it looks like this:
```
# values.yaml:
myproject:
  image: &myproject-image-globals
    ...

prometheus:
  server:
    sidecarTemplateValues: *databand-image-globals
    sidecarContainers:
      my-sidecar-container: |-
        {{ include "my-sidecar-container" . }}
...
````

```
# templates/_helpers.tpl:
{{- define "my-sidecar-container" -}}
image: "{{ .Values.server.sidecarTemplateValues.repository }}:{{ .Values.server.sidecarTemplateValues.tag }}"
...
{{- end -}}
```

Hope it's valuable 🙂
Is there a better workaround for this?
Let me know if further work is required.

#### Which issue this PR fixes
--

#### Special notes for your reviewer:
@zanhsieh recreated https://github.com/prometheus-community/helm-charts/pull/1079

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
