### PR TITLE
[kube-prometheus-stack] Bump Grafana-chart to 6.13.1

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 1.18.1
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.13.0
-digest: sha256:3ca182deee748d72f0ad4d2a984c45eb1d2685018dc29d06a784e93cb281f776
-generated: "2021-06-17T14:10:55.043306+02:00"
+  version: 6.13.1
+digest: sha256:10166e3383b9d69d03c37bf90b652d30cddf18c118e2fbcbee4396b2ef3eec3f
+generated: "2021-06-18T06:45:25.153026161-04:00"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 16.9.1
+version: 16.9.2
 appVersion: 0.48.1
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus


### PR DESCRIPTION
Signed-off-by: Jaskaranbir Dhillon <jaskaranbir.dhillon@gmail.com>

#### What this PR does / why we need it:

Updates Grafana chart to 6.13.1.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
