### PR TITLE
[kube-prometheus-stack] add endpoint port mertics for kube-state-metrics self monitor

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 16.9.1
+version: 16.10.0
 appVersion: 0.48.1
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/exporters/kube-state-metrics/serviceMonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-state-metrics/serviceMonitor.yaml
@@ -26,6 +26,24 @@ spec:
     relabelings:
 {{ toYaml .Values.kubeStateMetrics.serviceMonitor.relabelings | indent 4 }}
 {{- end }}
+{{- if .Values.kubeStateMetrics.serviceMonitor.selfMonitor.enabled }}
+  - port: metrics
+    {{- if .Values.kubeStateMetrics.serviceMonitor.interval }}
+    interval: {{ .Values.kubeStateMetrics.serviceMonitor.interval }}
+    {{- end }}
+    {{- if .Values.kubeStateMetrics.serviceMonitor.proxyUrl }}
+    proxyUrl: {{ .Values.kubeStateMetrics.serviceMonitor.proxyUrl}}
+    {{- end }}
+    honorLabels: true
+{{- if .Values.kubeStateMetrics.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ tpl (toYaml .Values.kubeStateMetrics.serviceMonitor.metricRelabelings | indent 4) . }}
+{{- end }}
+{{- if .Values.kubeStateMetrics.serviceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.kubeStateMetrics.serviceMonitor.relabelings | indent 4 }}
+{{- end }}
+{{- end }}
 {{- if .Values.kubeStateMetrics.serviceMonitor.namespaceOverride }}
   namespaceSelector:
     matchNames:

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1258,6 +1258,10 @@ kubeStateMetrics:
     #   replacement: $1
     #   action: replace
 
+    # Enable self metrics configuration for Service Monitor
+    selfMonitor:
+      enabled: false
+
 ## Configuration for kube-state-metrics subchart
 ##
 kube-state-metrics:


### PR DESCRIPTION

Signed-off-by: Kirchen99 <latias_latios@126.com>

#### What this PR does / why we need it:

This PR provides a possibility to add endpoint `metrics` (port 8081 for self monitor) in ServiceMonitor for kube-state-metrics.
It fixeds #424. If the user wants to have self monitor metrics of kube-state-metrics, the user could set
```
kubeStateMetrics:
  serviceMonitor:
    selfMonitor:
      enabled: true
kube-state-metrics:
  selfMonitor:
    enabled: true
```

#### Which issue this PR fixes
  - fixes #424

#### Special notes for your reviewer:

It looks duplicated with [this](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-state-metrics/templates/servicemonitor.yaml#L1). But since we also have a [file](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/templates/exporters/kube-state-metrics/serviceMonitor.yaml) for kube-state-metrics ServiceMonitor, we should provide a possibility in this file to enable self monitor.

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
