### PR TITLE
[prometheus-node-exporter] Add the ability to define a proxyUrl via values

### DIFF
--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.1.2
 description: A Helm chart for prometheus node-exporter
 name: prometheus-node-exporter
-version: 1.18.1
+version: 1.18.2
 home: https://github.com/prometheus/node_exporter/
 sources:
 - https://github.com/prometheus/node_exporter/

--- a/charts/prometheus-node-exporter/templates/monitor.yaml
+++ b/charts/prometheus-node-exporter/templates/monitor.yaml
@@ -22,6 +22,9 @@ spec:
       {{- if $.Values.prometheus.monitor.tlsConfig }}
       tlsConfig: {{ toYaml $.Values.prometheus.monitor.tlsConfig | nindent 8 }}
       {{- end }}
+      {{- if .Values.prometheus.monitor.proxyUrl }}
+      proxyUrl: {{ .Values.prometheus.monitor.proxyUrl}}
+      {{- end }}
       {{- if .Values.prometheus.monitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.prometheus.monitor.scrapeTimeout }}
       {{- end }}

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -23,6 +23,7 @@ prometheus:
     scheme: http
     bearerTokenFile:
     tlsConfig: {}
+    proxyUrl: ""
 
     relabelings: []
     scrapeTimeout: 10s

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -23,6 +23,9 @@ prometheus:
     scheme: http
     bearerTokenFile:
     tlsConfig: {}
+
+    ## proxyUrl: URL of a proxy that should be used for scraping.
+    ##
     proxyUrl: ""
 
     relabelings: []


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds the ability to define a proxyUrl in the ServiceMonitor. This is similar to  #789

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
