### PR TITLE
[alertmanager] forse restart if configmapReload disable

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 0.12.0
+version: 0.12.1
 appVersion: v0.22.1
 maintainers:
   - name: monotek

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -18,8 +18,11 @@ spec:
     metadata:
       labels:
         {{- include "alertmanager.selectorLabels" . | nindent 8 }}
-{{- if .Values.podAnnotations }}
       annotations:
+      {{- if not .Values.configmapReload.enabled }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- end }}
+{{- if .Values.podAnnotations }}
         {{- toYaml .Values.podAnnotations | nindent 8 }}
 {{- end }}
     spec:


### PR DESCRIPTION


#### What this PR does / why we need it:
 recreate the pod if the config has changed and auto rereading is disabled.

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
