### PR TITLE
[prometheus-redis-exporter] Add custom labels support

### DIFF
--- a/charts/prometheus-redis-exporter/Chart.yaml
+++ b/charts/prometheus-redis-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.11.1
 description: Prometheus exporter for Redis metrics
 name: prometheus-redis-exporter
-version: 4.0.2
+version: 4.1.0
 home: https://github.com/oliver006/redis_exporter
 sources:
   - https://github.com/oliver006/redis_exporter

--- a/charts/prometheus-redis-exporter/templates/deployment.yaml
+++ b/charts/prometheus-redis-exporter/templates/deployment.yaml
@@ -20,6 +20,9 @@ spec:
       labels:
         app: {{ template "prometheus-redis-exporter.name" . }}
         release: {{ .Release.Name }}
+        {{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ template "prometheus-redis-exporter.serviceAccountName" . }}
       {{- if .Values.image.pullSecrets }}

--- a/charts/prometheus-redis-exporter/values.yaml
+++ b/charts/prometheus-redis-exporter/values.yaml
@@ -41,6 +41,7 @@ affinity: {}
 
 redisAddress: redis://myredis:6379
 annotations: {}
+labels: {}
 #  prometheus.io/path: /metrics
 #  prometheus.io/port: "9121"
 #  prometheus.io/scrape: "true"


### PR DESCRIPTION
#### What this PR does / why we need it:
Add the option to add additional labels to pods.
One need that we have is to add the label app.kubernetes.io/part-of: redis-exporter to forward it to the right index pattern for our ELK log stack, but we could have wanted other labels as well for other needs.

Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
