### PR TITLE
[prometheus] chore: improve ingress support for k8s v1.18

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.26.0
-version: 14.2.1
+version: 14.3.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/templates/alertmanager/ingress.yaml
+++ b/charts/prometheus/templates/alertmanager/ingress.yaml
@@ -1,7 +1,12 @@
 {{- if and .Values.alertmanager.enabled .Values.alertmanager.ingress.enabled -}}
+{{- $ingressApiIsStable := eq (include "ingress.isStable" .) "true" -}}
+{{- $ingressSupportsIngressClassName := eq (include "ingress.supportsIngressClassName" .) "true" -}}
+{{- $ingressSupportsPathType := eq (include "ingress.supportsPathType" .) "true" -}}
 {{- $releaseName := .Release.Name -}}
 {{- $serviceName := include "prometheus.alertmanager.fullname" . }}
 {{- $servicePort := .Values.alertmanager.service.servicePort -}}
+{{- $ingressPath := .Values.alertmanager.ingress.path -}}
+{{- $ingressPathType := .Values.alertmanager.ingress.pathType -}}
 {{- $extraPaths := .Values.alertmanager.ingress.extraPaths -}}
 apiVersion: {{ template "ingress.apiVersion" . }}
 kind: Ingress
@@ -18,10 +23,8 @@ metadata:
   name: {{ template "prometheus.alertmanager.fullname" . }}
 {{ include "prometheus.namespace" . | indent 2 }}
 spec:
-  {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass") (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/IngressClass") }}
-  {{- if .Values.alertmanager.ingress.ingressClassName }}
+  {{- if and $ingressSupportsIngressClassName .Values.alertmanager.ingress.ingressClassName }}
   ingressClassName: {{ .Values.alertmanager.ingress.ingressClassName }}
-  {{- end }}
   {{- end }}
   rules:
   {{- range .Values.alertmanager.ingress.hosts }}
@@ -32,10 +35,20 @@ spec:
 {{ if $extraPaths }}
 {{ toYaml $extraPaths | indent 10 }}
 {{- end }}
-          - path: /{{ rest $url | join "/" }}
+          - path: {{ $ingressPath }}
+            {{- if $ingressSupportsPathType }}
+            pathType: {{ $ingressPathType }}
+            {{- end }}
             backend:
+              {{- if $ingressApiIsStable }}
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
+              {{- else }}
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
+              {{- end }}
   {{- end -}}
 {{- if .Values.alertmanager.ingress.tls }}
   tls:

--- a/charts/prometheus/templates/pushgateway/ingress.yaml
+++ b/charts/prometheus/templates/pushgateway/ingress.yaml
@@ -1,7 +1,12 @@
 {{- if and .Values.pushgateway.enabled .Values.pushgateway.ingress.enabled -}}
+{{- $ingressApiIsStable := eq (include "ingress.isStable" .) "true" -}}
+{{- $ingressSupportsIngressClassName := eq (include "ingress.supportsIngressClassName" .) "true" -}}
+{{- $ingressSupportsPathType := eq (include "ingress.supportsPathType" .) "true" -}}
 {{- $releaseName := .Release.Name -}}
 {{- $serviceName := include "prometheus.pushgateway.fullname" . }}
 {{- $servicePort := .Values.pushgateway.service.servicePort -}}
+{{- $ingressPath := .Values.pushgateway.ingress.path -}}
+{{- $ingressPathType := .Values.pushgateway.ingress.pathType -}}
 {{- $extraPaths := .Values.pushgateway.ingress.extraPaths -}}
 apiVersion: {{ template "ingress.apiVersion" . }}
 kind: Ingress
@@ -15,10 +20,8 @@ metadata:
   name: {{ template "prometheus.pushgateway.fullname" . }}
 {{ include "prometheus.namespace" . | indent 2 }}
 spec:
-  {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass") (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/IngressClass") }}
-  {{- if .Values.pushgateway.ingress.ingressClassName }}
+  {{- if and $ingressSupportsIngressClassName .Values.pushgateway.ingress.ingressClassName }}
   ingressClassName: {{ .Values.pushgateway.ingress.ingressClassName }}
-  {{- end }}
   {{- end }}
   rules:
   {{- range .Values.pushgateway.ingress.hosts }}
@@ -29,10 +32,20 @@ spec:
 {{ if $extraPaths }}
 {{ toYaml $extraPaths | indent 10 }}
 {{- end }}
-          - path: /{{ rest $url | join "/" }}
+          - path: {{ $ingressPath }}
+            {{- if $ingressSupportsPathType }}
+            pathType: {{ $ingressPathType }}
+            {{- end }}
             backend:
+              {{- if $ingressApiIsStable }}
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
+              {{- else }}
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
+              {{- end }}
   {{- end -}}
 {{- if .Values.pushgateway.ingress.tls }}
   tls:

--- a/charts/prometheus/templates/server/ingress.yaml
+++ b/charts/prometheus/templates/server/ingress.yaml
@@ -1,8 +1,13 @@
 {{- if .Values.server.enabled -}}
 {{- if .Values.server.ingress.enabled -}}
+{{- $ingressApiIsStable := eq (include "ingress.isStable" .) "true" -}}
+{{- $ingressSupportsIngressClassName := eq (include "ingress.supportsIngressClassName" .) "true" -}}
+{{- $ingressSupportsPathType := eq (include "ingress.supportsPathType" .) "true" -}}
 {{- $releaseName := .Release.Name -}}
 {{- $serviceName := include "prometheus.server.fullname" . }}
 {{- $servicePort := .Values.server.service.servicePort -}}
+{{- $ingressPath := .Values.server.ingress.path -}}
+{{- $ingressPathType := .Values.server.ingress.pathType -}}
 {{- $extraPaths := .Values.server.ingress.extraPaths -}}
 apiVersion: {{ template "ingress.apiVersion" . }}
 kind: Ingress
@@ -19,10 +24,8 @@ metadata:
   name: {{ template "prometheus.server.fullname" . }}
 {{ include "prometheus.namespace" . | indent 2 }}
 spec:
-  {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass") (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/IngressClass") }}
-  {{- if .Values.server.ingress.ingressClassName }}
+  {{- if and $ingressSupportsIngressClassName .Values.server.ingress.ingressClassName }}
   ingressClassName: {{ .Values.server.ingress.ingressClassName }}
-  {{- end }}
   {{- end }}
   rules:
   {{- range .Values.server.ingress.hosts }}
@@ -33,10 +36,20 @@ spec:
 {{ if $extraPaths }}
 {{ toYaml $extraPaths | indent 10 }}
 {{- end }}
-          - path: /{{ rest $url | join "/" }}
+          - path: {{ $ingressPath }}
+            {{- if $ingressSupportsPathType }}
+            pathType: {{ $ingressPathType }}
+            {{- end }}
             backend:
+              {{- if $ingressApiIsStable }}
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
+              {{- else }}
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
+              {{- end }}
   {{- end -}}
 {{- if .Values.server.ingress.tls }}
   tls:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -128,6 +128,11 @@ alertmanager:
     #   - alertmanager.domain.com
     #   - domain.com/alertmanager
 
+    path: /
+
+    # pathType is only for k8s >= 1.18
+    pathType: Prefix
+
     ## Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
     extraPaths: []
     # - path: /*
@@ -781,6 +786,11 @@ server:
     #   - prometheus.domain.com
     #   - domain.com/prometheus
 
+    path: /
+
+    # pathType is only for k8s >= 1.18
+    pathType: Prefix
+
     ## Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
     extraPaths: []
     # - path: /*
@@ -1102,6 +1112,11 @@ pushgateway:
     hosts: []
     #   - pushgateway.domain.com
     #   - domain.com/pushgateway
+
+    path: /
+
+    # pathType is only for k8s >= 1.18
+    pathType: Prefix
 
     ## Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
     extraPaths: []


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

#### Which issue this PR fixes

Hi, I recently implemented version 14.2.1 of the prometheus chart and it sets the default "**pathType**" to "**ImplementationSpecific**" when apiVersion is networking.k8s.io/*

example:

`spec:
  ingressClassName: alb-controller
  rules:
  - host: alertmanager.example.com
    http:
      paths:
      - backend:
          serviceName: prometheus-alertmanager
          servicePort: 9093
        path: /*
        pathType: ImplementationSpecific
  tls:
  - hosts:
    - alertmanager.example.com
 `

Making these changes in the chart we can choose the "pathType" from the values.yaml file in case it is compatible with the apiVersion. 

Also simplify the support function for ingressClassName. [https://github.com/prometheus-community/helm-charts/pull/1061](https://github.com/prometheus-community/helm-charts/pull/1061)


I take as a reference these PR:

PR: [https://github.com/grafana/helm-charts/pull/505](https://github.com/grafana/helm-charts/pull/505)

PR: [https://github.com/prometheus-community/helm-charts/pull/960](https://github.com/prometheus-community/helm-charts/pull/960)

PR: [https://github.com/prometheus-community/helm-charts/pull/1061](https://github.com/prometheus-community/helm-charts/pull/1061)

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
