### PR TITLE
[kube-prometheus-stack] Default to auto-generate Grafana admin password

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 16.11.0
+version: 16.12.0
 appVersion: 0.48.1
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -625,7 +625,8 @@ grafana:
   ##
   defaultDashboardsEnabled: true
 
-  adminPassword: prom-operator
+  ## Admin user password. Leave empty to auto-generate on first install and lookup from the secret on upgrades
+  adminPassword: ""
 
   ingress:
     ## If true, Grafana Ingress will be created


### PR DESCRIPTION
#### What this PR does / why we need it:
 The kube-prometheus-stack chart still hardcodes a Grafana admin password of `prom-operator`. The Grafana chart added [support](https://github.com/grafana/helm-charts/pull/62) for auto generating the admin password on install and using [lookup](https://github.com/grafana/helm-charts/blob/2d6bfcc7d2e29cb428f26fb6e05b9361bd885873/charts/grafana/templates/_helpers.tpl#L112) so it doesn't change on upgrades. We should utilize this feature to provide a more secure default for new installs of the chart.

This change does not impact users who manually set a `grafana.adminPassword` or users who left the previous chart default and do an upgrade. In the latter case it will simply lookup `prom-operator` from the existing secret.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
