### PR TITLE
[kube-prometheus-stack] Support multicluster dashboards only for etcd

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 17.1.3
+version: 17.2.0
 appVersion: 0.49.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/apiserver.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/apiserver.yaml
@@ -1662,7 +1662,7 @@ data:
 
                     },
                     "datasource": "$datasource",
-                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster.global.enabled }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": "cluster",
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/cluster-total.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/cluster-total.yaml
@@ -1823,7 +1823,7 @@ data:
 
                     },
                     "datasource": "$datasource",
-                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster.global.enabled }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": null,
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/controller-manager.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/controller-manager.yaml
@@ -1092,7 +1092,7 @@ data:
 
                     },
                     "datasource": "$datasource",
-                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster.global.enabled }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": "cluster",
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/etcd.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/etcd.yaml
@@ -1061,7 +1061,7 @@ data:
                         "value": "prod"
                     },
                     "datasource": "$datasource",
-                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
+                    "hide": {{ if (or .Values.grafana.sidecar.dashboards.multicluster.global.enabled .Values.grafana.sidecar.dashboards.multicluster.etcd.enabled) }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": "cluster",
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-cluster.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-cluster.yaml
@@ -2965,7 +2965,7 @@ data:
                         "value": ""
                     },
                     "datasource": "$datasource",
-                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster.global.enabled }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": null,
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-namespace.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-namespace.yaml
@@ -2658,7 +2658,7 @@ data:
                         "value": ""
                     },
                     "datasource": "$datasource",
-                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster.global.enabled }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": null,
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-node.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-node.yaml
@@ -892,7 +892,7 @@ data:
                         "value": ""
                     },
                     "datasource": "$datasource",
-                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster.global.enabled }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": null,
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-pod.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-pod.yaml
@@ -2314,7 +2314,7 @@ data:
                         "value": ""
                     },
                     "datasource": "$datasource",
-                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster.global.enabled }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": null,
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-workload.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-workload.yaml
@@ -1846,7 +1846,7 @@ data:
                         "value": ""
                     },
                     "datasource": "$datasource",
-                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster.global.enabled }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": null,
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-workloads-namespace.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-workloads-namespace.yaml
@@ -2033,7 +2033,7 @@ data:
                         "value": ""
                     },
                     "datasource": "$datasource",
-                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster.global.enabled }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": null,
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/kubelet.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/kubelet.yaml
@@ -2163,7 +2163,7 @@ data:
 
                     },
                     "datasource": "$datasource",
-                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster.global.enabled }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": "cluster",
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/namespace-by-pod.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/namespace-by-pod.yaml
@@ -1293,7 +1293,7 @@ data:
 
                     },
                     "datasource": "$datasource",
-                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster.global.enabled }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": null,
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/namespace-by-workload.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/namespace-by-workload.yaml
@@ -1533,7 +1533,7 @@ data:
 
                     },
                     "datasource": "$datasource",
-                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster.global.enabled }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": null,
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/node-cluster-rsrc-use.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/node-cluster-rsrc-use.yaml
@@ -21,23 +21,30 @@ metadata:
 data:
   node-cluster-rsrc-use.json: |-
     {
+        "__inputs": [
+
+        ],
+        "__requires": [
+
+        ],
         "annotations": {
             "list": [
 
             ]
         },
-        "editable": true,
+        "editable": false,
         "gnetId": null,
-        "graphTooltip": 0,
+        "graphTooltip": 1,
         "hideControls": false,
+        "id": null,
         "links": [
 
         ],
-        "refresh": "10s",
+        "refresh": "30s",
         "rows": [
             {
                 "collapse": false,
-                "height": "250px",
+                "collapsed": false,
                 "panels": [
                     {
                         "aliasColors": {
@@ -48,26 +55,34 @@ data:
                         "dashes": false,
                         "datasource": "$datasource",
                         "fill": 10,
-                        "id": 1,
+                        "fillGradient": 0,
+                        "gridPos": {
+
+                        },
+                        "id": 2,
                         "legend": {
+                            "alignAsTable": false,
                             "avg": false,
                             "current": false,
                             "max": false,
                             "min": false,
-                            "show": true,
+                            "rightSide": false,
+                            "show": false,
+                            "sideWidth": null,
                             "total": false,
                             "values": false
                         },
                         "lines": true,
-                        "linewidth": 0,
+                        "linewidth": 1,
                         "links": [
 
                         ],
-                        "nullPointMode": "null as zero",
+                        "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
+                        "repeat": null,
                         "seriesOverrides": [
 
                         ],
@@ -77,12 +92,11 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "(\n  instance:node_cpu_utilisation:rate5m{job=\"node-exporter\"}\n*\n  instance:node_num_cpu:sum{job=\"node-exporter\"}\n)\n/ scalar(sum(instance:node_num_cpu:sum{job=\"node-exporter\"}))\n",
+                                "expr": "((\n  instance:node_cpu_utilisation:rate5m{job=\"node-exporter\", cluster=\"$cluster\"}\n  *\n  instance:node_num_cpu:sum{job=\"node-exporter\", cluster=\"$cluster\"}\n) != 0 )\n/ scalar(sum(instance:node_num_cpu:sum{job=\"node-exporter\", cluster=\"$cluster\"}))\n",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "{{`{{`}}instance{{`}}`}}",
-                                "legendLink": "/dashboard/file/node-rsrc-use.json",
-                                "step": 10
+                                "legendFormat": "{{`{{`}} instance {{`}}`}}",
+                                "refId": "A"
                             }
                         ],
                         "thresholds": [
@@ -92,8 +106,8 @@ data:
                         "timeShift": null,
                         "title": "CPU Utilisation",
                         "tooltip": {
-                            "shared": false,
-                            "sort": 0,
+                            "shared": true,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -111,17 +125,17 @@ data:
                                 "format": "percentunit",
                                 "label": null,
                                 "logBase": 1,
-                                "max": 1,
-                                "min": 0,
+                                "max": null,
+                                "min": null,
                                 "show": true
                             },
                             {
-                                "format": "short",
+                                "format": "percentunit",
                                 "label": null,
                                 "logBase": 1,
                                 "max": null,
                                 "min": null,
-                                "show": false
+                                "show": true
                             }
                         ]
                     },
@@ -134,26 +148,34 @@ data:
                         "dashes": false,
                         "datasource": "$datasource",
                         "fill": 10,
-                        "id": 2,
+                        "fillGradient": 0,
+                        "gridPos": {
+
+                        },
+                        "id": 3,
                         "legend": {
+                            "alignAsTable": false,
                             "avg": false,
                             "current": false,
                             "max": false,
                             "min": false,
-                            "show": true,
+                            "rightSide": false,
+                            "show": false,
+                            "sideWidth": null,
                             "total": false,
                             "values": false
                         },
                         "lines": true,
-                        "linewidth": 0,
+                        "linewidth": 1,
                         "links": [
 
                         ],
-                        "nullPointMode": "null as zero",
+                        "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
+                        "repeat": null,
                         "seriesOverrides": [
 
                         ],
@@ -163,12 +185,11 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "instance:node_load1_per_cpu:ratio{job=\"node-exporter\"}\n/ scalar(count(instance:node_load1_per_cpu:ratio{job=\"node-exporter\"}))\n",
+                                "expr": "(\n  instance:node_load1_per_cpu:ratio{job=\"node-exporter\", cluster=\"$cluster\"}\n  / scalar(count(instance:node_load1_per_cpu:ratio{job=\"node-exporter\", cluster=\"$cluster\"}))\n)  != 0\n",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}instance{{`}}`}}",
-                                "legendLink": "/dashboard/file/node-rsrc-use.json",
-                                "step": 10
+                                "refId": "A"
                             }
                         ],
                         "thresholds": [
@@ -176,10 +197,10 @@ data:
                         ],
                         "timeFrom": null,
                         "timeShift": null,
-                        "title": "CPU Saturation (load1 per CPU)",
+                        "title": "CPU Saturation (Load1 per CPU)",
                         "tooltip": {
-                            "shared": false,
-                            "sort": 0,
+                            "shared": true,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -197,17 +218,17 @@ data:
                                 "format": "percentunit",
                                 "label": null,
                                 "logBase": 1,
-                                "max": 1,
-                                "min": 0,
+                                "max": null,
+                                "min": null,
                                 "show": true
                             },
                             {
-                                "format": "short",
+                                "format": "percentunit",
                                 "label": null,
                                 "logBase": 1,
                                 "max": null,
                                 "min": null,
-                                "show": false
+                                "show": true
                             }
                         ]
                     }
@@ -217,11 +238,12 @@ data:
                 "repeatRowId": null,
                 "showTitle": true,
                 "title": "CPU",
-                "titleSize": "h6"
+                "titleSize": "h6",
+                "type": "row"
             },
             {
                 "collapse": false,
-                "height": "250px",
+                "collapsed": false,
                 "panels": [
                     {
                         "aliasColors": {
@@ -232,26 +254,34 @@ data:
                         "dashes": false,
                         "datasource": "$datasource",
                         "fill": 10,
-                        "id": 3,
+                        "fillGradient": 0,
+                        "gridPos": {
+
+                        },
+                        "id": 4,
                         "legend": {
+                            "alignAsTable": false,
                             "avg": false,
                             "current": false,
                             "max": false,
                             "min": false,
-                            "show": true,
+                            "rightSide": false,
+                            "show": false,
+                            "sideWidth": null,
                             "total": false,
                             "values": false
                         },
                         "lines": true,
-                        "linewidth": 0,
+                        "linewidth": 1,
                         "links": [
 
                         ],
-                        "nullPointMode": "null as zero",
+                        "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
+                        "repeat": null,
                         "seriesOverrides": [
 
                         ],
@@ -261,12 +291,11 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "instance:node_memory_utilisation:ratio{job=\"node-exporter\"}\n/ scalar(count(instance:node_memory_utilisation:ratio{job=\"node-exporter\"}))\n",
+                                "expr": "(\n  instance:node_memory_utilisation:ratio{job=\"node-exporter\", cluster=\"$cluster\"}\n  / scalar(count(instance:node_memory_utilisation:ratio{job=\"node-exporter\", cluster=\"$cluster\"}))\n) != 0\n",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}instance{{`}}`}}",
-                                "legendLink": "/dashboard/file/node-rsrc-use.json",
-                                "step": 10
+                                "refId": "A"
                             }
                         ],
                         "thresholds": [
@@ -276,8 +305,8 @@ data:
                         "timeShift": null,
                         "title": "Memory Utilisation",
                         "tooltip": {
-                            "shared": false,
-                            "sort": 0,
+                            "shared": true,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -295,17 +324,17 @@ data:
                                 "format": "percentunit",
                                 "label": null,
                                 "logBase": 1,
-                                "max": 1,
-                                "min": 0,
+                                "max": null,
+                                "min": null,
                                 "show": true
                             },
                             {
-                                "format": "short",
+                                "format": "percentunit",
                                 "label": null,
                                 "logBase": 1,
                                 "max": null,
                                 "min": null,
-                                "show": false
+                                "show": true
                             }
                         ]
                     },
@@ -318,26 +347,34 @@ data:
                         "dashes": false,
                         "datasource": "$datasource",
                         "fill": 10,
-                        "id": 4,
+                        "fillGradient": 0,
+                        "gridPos": {
+
+                        },
+                        "id": 5,
                         "legend": {
+                            "alignAsTable": false,
                             "avg": false,
                             "current": false,
                             "max": false,
                             "min": false,
-                            "show": true,
+                            "rightSide": false,
+                            "show": false,
+                            "sideWidth": null,
                             "total": false,
                             "values": false
                         },
                         "lines": true,
-                        "linewidth": 0,
+                        "linewidth": 1,
                         "links": [
 
                         ],
-                        "nullPointMode": "null as zero",
+                        "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
+                        "repeat": null,
                         "seriesOverrides": [
 
                         ],
@@ -347,12 +384,11 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "instance:node_vmstat_pgmajfault:rate5m{job=\"node-exporter\"}",
+                                "expr": "instance:node_vmstat_pgmajfault:rate5m{job=\"node-exporter\", cluster=\"$cluster\"}",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}instance{{`}}`}}",
-                                "legendLink": "/dashboard/file/node-rsrc-use.json",
-                                "step": 10
+                                "refId": "A"
                             }
                         ],
                         "thresholds": [
@@ -362,8 +398,8 @@ data:
                         "timeShift": null,
                         "title": "Memory Saturation (Major Page Faults)",
                         "tooltip": {
-                            "shared": false,
-                            "sort": 0,
+                            "shared": true,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -378,20 +414,20 @@ data:
                         },
                         "yaxes": [
                             {
-                                "format": "rps",
-                                "label": null,
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
+                                "format": "rds",
                                 "label": null,
                                 "logBase": 1,
                                 "max": null,
                                 "min": null,
-                                "show": false
+                                "show": true
+                            },
+                            {
+                                "format": "rds",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
                             }
                         ]
                     }
@@ -401,11 +437,12 @@ data:
                 "repeatRowId": null,
                 "showTitle": true,
                 "title": "Memory",
-                "titleSize": "h6"
+                "titleSize": "h6",
+                "type": "row"
             },
             {
                 "collapse": false,
-                "height": "250px",
+                "collapsed": false,
                 "panels": [
                     {
                         "aliasColors": {
@@ -416,33 +453,41 @@ data:
                         "dashes": false,
                         "datasource": "$datasource",
                         "fill": 10,
-                        "id": 5,
+                        "fillGradient": 0,
+                        "gridPos": {
+
+                        },
+                        "id": 6,
                         "legend": {
+                            "alignAsTable": false,
                             "avg": false,
                             "current": false,
                             "max": false,
                             "min": false,
-                            "show": true,
+                            "rightSide": false,
+                            "show": false,
+                            "sideWidth": null,
                             "total": false,
                             "values": false
                         },
                         "lines": true,
-                        "linewidth": 0,
+                        "linewidth": 1,
                         "links": [
 
                         ],
-                        "nullPointMode": "null as zero",
+                        "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
+                        "repeat": null,
                         "seriesOverrides": [
                             {
-                                "alias": "/ Receive/",
+                                "alias": "/Receive/",
                                 "stack": "A"
                             },
                             {
-                                "alias": "/ Transmit/",
+                                "alias": "/Transmit/",
                                 "stack": "B",
                                 "transform": "negative-Y"
                             }
@@ -453,20 +498,18 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "instance:node_network_receive_bytes_excluding_lo:rate5m{job=\"node-exporter\"}",
+                                "expr": "instance:node_network_receive_bytes_excluding_lo:rate5m{job=\"node-exporter\", cluster=\"$cluster\"} != 0",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}instance{{`}}`}} Receive",
-                                "legendLink": "/dashboard/file/node-rsrc-use.json",
-                                "step": 10
+                                "refId": "A"
                             },
                             {
-                                "expr": "instance:node_network_transmit_bytes_excluding_lo:rate5m{job=\"node-exporter\"}",
+                                "expr": "instance:node_network_transmit_bytes_excluding_lo:rate5m{job=\"node-exporter\", cluster=\"$cluster\"} != 0",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}instance{{`}}`}} Transmit",
-                                "legendLink": "/dashboard/file/node-rsrc-use.json",
-                                "step": 10
+                                "refId": "B"
                             }
                         ],
                         "thresholds": [
@@ -474,10 +517,10 @@ data:
                         ],
                         "timeFrom": null,
                         "timeShift": null,
-                        "title": "Net Utilisation (Bytes Receive/Transmit)",
+                        "title": "Network Utilisation (Bytes Receive/Transmit)",
                         "tooltip": {
-                            "shared": false,
-                            "sort": 0,
+                            "shared": true,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -500,12 +543,12 @@ data:
                                 "show": true
                             },
                             {
-                                "format": "short",
+                                "format": "Bps",
                                 "label": null,
                                 "logBase": 1,
                                 "max": null,
                                 "min": null,
-                                "show": false
+                                "show": true
                             }
                         ]
                     },
@@ -518,26 +561,34 @@ data:
                         "dashes": false,
                         "datasource": "$datasource",
                         "fill": 10,
-                        "id": 6,
+                        "fillGradient": 0,
+                        "gridPos": {
+
+                        },
+                        "id": 7,
                         "legend": {
+                            "alignAsTable": false,
                             "avg": false,
                             "current": false,
                             "max": false,
                             "min": false,
-                            "show": true,
+                            "rightSide": false,
+                            "show": false,
+                            "sideWidth": null,
                             "total": false,
                             "values": false
                         },
                         "lines": true,
-                        "linewidth": 0,
+                        "linewidth": 1,
                         "links": [
 
                         ],
-                        "nullPointMode": "null as zero",
+                        "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
+                        "repeat": null,
                         "seriesOverrides": [
                             {
                                 "alias": "/ Receive/",
@@ -555,20 +606,18 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "instance:node_network_receive_drop_excluding_lo:rate5m{job=\"node-exporter\"}",
+                                "expr": "instance:node_network_receive_drop_excluding_lo:rate5m{job=\"node-exporter\", cluster=\"$cluster\"} != 0",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}instance{{`}}`}} Receive",
-                                "legendLink": "/dashboard/file/node-rsrc-use.json",
-                                "step": 10
+                                "refId": "A"
                             },
                             {
-                                "expr": "instance:node_network_transmit_drop_excluding_lo:rate5m{job=\"node-exporter\"}",
+                                "expr": "instance:node_network_transmit_drop_excluding_lo:rate5m{job=\"node-exporter\", cluster=\"$cluster\"} != 0",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}instance{{`}}`}} Transmit",
-                                "legendLink": "/dashboard/file/node-rsrc-use.json",
-                                "step": 10
+                                "refId": "B"
                             }
                         ],
                         "thresholds": [
@@ -576,10 +625,10 @@ data:
                         ],
                         "timeFrom": null,
                         "timeShift": null,
-                        "title": "Net Saturation (Drops Receive/Transmit)",
+                        "title": "Network Saturation (Drops Receive/Transmit)",
                         "tooltip": {
-                            "shared": false,
-                            "sort": 0,
+                            "shared": true,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -594,7 +643,7 @@ data:
                         },
                         "yaxes": [
                             {
-                                "format": "rps",
+                                "format": "Bps",
                                 "label": null,
                                 "logBase": 1,
                                 "max": null,
@@ -602,12 +651,12 @@ data:
                                 "show": true
                             },
                             {
-                                "format": "short",
+                                "format": "Bps",
                                 "label": null,
                                 "logBase": 1,
                                 "max": null,
                                 "min": null,
-                                "show": false
+                                "show": true
                             }
                         ]
                     }
@@ -617,11 +666,12 @@ data:
                 "repeatRowId": null,
                 "showTitle": true,
                 "title": "Network",
-                "titleSize": "h6"
+                "titleSize": "h6",
+                "type": "row"
             },
             {
                 "collapse": false,
-                "height": "250px",
+                "collapsed": false,
                 "panels": [
                     {
                         "aliasColors": {
@@ -632,26 +682,34 @@ data:
                         "dashes": false,
                         "datasource": "$datasource",
                         "fill": 10,
-                        "id": 7,
+                        "fillGradient": 0,
+                        "gridPos": {
+
+                        },
+                        "id": 8,
                         "legend": {
+                            "alignAsTable": false,
                             "avg": false,
                             "current": false,
                             "max": false,
                             "min": false,
-                            "show": true,
+                            "rightSide": false,
+                            "show": false,
+                            "sideWidth": null,
                             "total": false,
                             "values": false
                         },
                         "lines": true,
-                        "linewidth": 0,
+                        "linewidth": 1,
                         "links": [
 
                         ],
-                        "nullPointMode": "null as zero",
+                        "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
+                        "repeat": null,
                         "seriesOverrides": [
 
                         ],
@@ -661,12 +719,11 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "instance_device:node_disk_io_time_seconds:rate5m{job=\"node-exporter\"}\n/ scalar(count(instance_device:node_disk_io_time_seconds:rate5m{job=\"node-exporter\"}))\n",
+                                "expr": "(\n  instance_device:node_disk_io_time_seconds:rate5m{job=\"node-exporter\", cluster=\"$cluster\"}\n  / scalar(count(instance_device:node_disk_io_time_seconds:rate5m{job=\"node-exporter\", cluster=\"$cluster\"}))\n) != 0\n",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}instance{{`}}`}} {{`{{`}}device{{`}}`}}",
-                                "legendLink": "/dashboard/file/node-rsrc-use.json",
-                                "step": 10
+                                "refId": "A"
                             }
                         ],
                         "thresholds": [
@@ -676,8 +733,8 @@ data:
                         "timeShift": null,
                         "title": "Disk IO Utilisation",
                         "tooltip": {
-                            "shared": false,
-                            "sort": 0,
+                            "shared": true,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -695,17 +752,17 @@ data:
                                 "format": "percentunit",
                                 "label": null,
                                 "logBase": 1,
-                                "max": 1,
-                                "min": 0,
+                                "max": null,
+                                "min": null,
                                 "show": true
                             },
                             {
-                                "format": "short",
+                                "format": "percentunit",
                                 "label": null,
                                 "logBase": 1,
                                 "max": null,
                                 "min": null,
-                                "show": false
+                                "show": true
                             }
                         ]
                     },
@@ -718,26 +775,34 @@ data:
                         "dashes": false,
                         "datasource": "$datasource",
                         "fill": 10,
-                        "id": 8,
+                        "fillGradient": 0,
+                        "gridPos": {
+
+                        },
+                        "id": 9,
                         "legend": {
+                            "alignAsTable": false,
                             "avg": false,
                             "current": false,
                             "max": false,
                             "min": false,
-                            "show": true,
+                            "rightSide": false,
+                            "show": false,
+                            "sideWidth": null,
                             "total": false,
                             "values": false
                         },
                         "lines": true,
-                        "linewidth": 0,
+                        "linewidth": 1,
                         "links": [
 
                         ],
-                        "nullPointMode": "null as zero",
+                        "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
+                        "repeat": null,
                         "seriesOverrides": [
 
                         ],
@@ -747,12 +812,11 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "instance_device:node_disk_io_time_weighted_seconds:rate5m{job=\"node-exporter\"}\n/ scalar(count(instance_device:node_disk_io_time_weighted_seconds:rate5m{job=\"node-exporter\"}))\n",
+                                "expr": "(\n  instance_device:node_disk_io_time_weighted_seconds:rate5m{job=\"node-exporter\", cluster=\"$cluster\"}\n  / scalar(count(instance_device:node_disk_io_time_weighted_seconds:rate5m{job=\"node-exporter\", cluster=\"$cluster\"}))\n) != 0\n",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}instance{{`}}`}} {{`{{`}}device{{`}}`}}",
-                                "legendLink": "/dashboard/file/node-rsrc-use.json",
-                                "step": 10
+                                "refId": "A"
                             }
                         ],
                         "thresholds": [
@@ -762,8 +826,8 @@ data:
                         "timeShift": null,
                         "title": "Disk IO Saturation",
                         "tooltip": {
-                            "shared": false,
-                            "sort": 0,
+                            "shared": true,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -781,17 +845,17 @@ data:
                                 "format": "percentunit",
                                 "label": null,
                                 "logBase": 1,
-                                "max": 1,
-                                "min": 0,
+                                "max": null,
+                                "min": null,
                                 "show": true
                             },
                             {
-                                "format": "short",
+                                "format": "percentunit",
                                 "label": null,
                                 "logBase": 1,
                                 "max": null,
                                 "min": null,
-                                "show": false
+                                "show": true
                             }
                         ]
                     }
@@ -801,11 +865,12 @@ data:
                 "repeatRowId": null,
                 "showTitle": true,
                 "title": "Disk IO",
-                "titleSize": "h6"
+                "titleSize": "h6",
+                "type": "row"
             },
             {
                 "collapse": false,
-                "height": "250px",
+                "collapsed": false,
                 "panels": [
                     {
                         "aliasColors": {
@@ -816,26 +881,34 @@ data:
                         "dashes": false,
                         "datasource": "$datasource",
                         "fill": 10,
-                        "id": 9,
+                        "fillGradient": 0,
+                        "gridPos": {
+
+                        },
+                        "id": 10,
                         "legend": {
+                            "alignAsTable": false,
                             "avg": false,
                             "current": false,
                             "max": false,
                             "min": false,
-                            "show": true,
+                            "rightSide": false,
+                            "show": false,
+                            "sideWidth": null,
                             "total": false,
                             "values": false
                         },
                         "lines": true,
-                        "linewidth": 0,
+                        "linewidth": 1,
                         "links": [
 
                         ],
-                        "nullPointMode": "null as zero",
+                        "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
+                        "repeat": null,
                         "seriesOverrides": [
 
                         ],
@@ -845,12 +918,11 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum without (device) (\n  max without (fstype, mountpoint) (\n    node_filesystem_size_bytes{job=\"node-exporter\", fstype!=\"\"} - node_filesystem_avail_bytes{job=\"node-exporter\", fstype!=\"\"}\n  )\n) \n/ scalar(sum(max without (fstype, mountpoint) (node_filesystem_size_bytes{job=\"node-exporter\", fstype!=\"\"})))\n",
+                                "expr": "sum without (device) (\n  max without (fstype, mountpoint) ((\n    node_filesystem_size_bytes{job=\"node-exporter\", fstype!=\"\", cluster=\"$cluster\"}\n    -\n    node_filesystem_avail_bytes{job=\"node-exporter\", fstype!=\"\", cluster=\"$cluster\"}\n  ) != 0)\n)\n/ scalar(sum(max without (fstype, mountpoint) (node_filesystem_size_bytes{job=\"node-exporter\", fstype!=\"\", cluster=\"$cluster\"})))\n",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}instance{{`}}`}}",
-                                "legendLink": "/dashboard/file/node-rsrc-use.json",
-                                "step": 10
+                                "refId": "A"
                             }
                         ],
                         "thresholds": [
@@ -860,8 +932,8 @@ data:
                         "timeShift": null,
                         "title": "Disk Space Utilisation",
                         "tooltip": {
-                            "shared": false,
-                            "sort": 0,
+                            "shared": true,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -879,17 +951,17 @@ data:
                                 "format": "percentunit",
                                 "label": null,
                                 "logBase": 1,
-                                "max": 1,
-                                "min": 0,
+                                "max": null,
+                                "min": null,
                                 "show": true
                             },
                             {
-                                "format": "short",
+                                "format": "percentunit",
                                 "label": null,
                                 "logBase": 1,
                                 "max": null,
                                 "min": null,
-                                "show": false
+                                "show": true
                             }
                         ]
                     }
@@ -899,20 +971,21 @@ data:
                 "repeatRowId": null,
                 "showTitle": true,
                 "title": "Disk Space",
-                "titleSize": "h6"
+                "titleSize": "h6",
+                "type": "row"
             }
         ],
         "schemaVersion": 14,
         "style": "dark",
         "tags": [
-
+            "node-exporter-mixin"
         ],
         "templating": {
             "list": [
                 {
                     "current": {
-                        "text": "default",
-                        "value": "default"
+                        "text": "Prometheus",
+                        "value": "Prometheus"
                     },
                     "hide": 0,
                     "label": null,
@@ -924,6 +997,33 @@ data:
                     "refresh": 1,
                     "regex": "",
                     "type": "datasource"
+                },
+                {
+                    "allValue": null,
+                    "current": {
+                        "text": "",
+                        "value": ""
+                    },
+                    "datasource": "$datasource",
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster.global.enabled }}0{{ else }}2{{ end }},
+                    "includeAll": false,
+                    "label": null,
+                    "multi": false,
+                    "name": "cluster",
+                    "options": [
+
+                    ],
+                    "query": "label_values(node_time_seconds, cluster)",
+                    "refresh": 2,
+                    "regex": "",
+                    "sort": 1,
+                    "tagValuesQuery": "",
+                    "tags": [
+
+                    ],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
                 }
             ]
         },
@@ -957,8 +1057,7 @@ data:
             ]
         },
         "timezone": "utc",
-        "title": "USE Method / Cluster",
-        "uid": "",
+        "title": "Node Exporter / USE Method / Cluster",
         "version": 0
     }
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/node-rsrc-use.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/node-rsrc-use.yaml
@@ -21,23 +21,30 @@ metadata:
 data:
   node-rsrc-use.json: |-
     {
+        "__inputs": [
+
+        ],
+        "__requires": [
+
+        ],
         "annotations": {
             "list": [
 
             ]
         },
-        "editable": true,
+        "editable": false,
         "gnetId": null,
-        "graphTooltip": 0,
+        "graphTooltip": 1,
         "hideControls": false,
+        "id": null,
         "links": [
 
         ],
-        "refresh": "10s",
+        "refresh": "30s",
         "rows": [
             {
                 "collapse": false,
-                "height": "250px",
+                "collapsed": false,
                 "panels": [
                     {
                         "aliasColors": {
@@ -47,14 +54,21 @@ data:
                         "dashLength": 10,
                         "dashes": false,
                         "datasource": "$datasource",
-                        "fill": 1,
-                        "id": 1,
+                        "fill": 10,
+                        "fillGradient": 0,
+                        "gridPos": {
+
+                        },
+                        "id": 2,
                         "legend": {
+                            "alignAsTable": false,
                             "avg": false,
                             "current": false,
                             "max": false,
                             "min": false,
+                            "rightSide": false,
                             "show": false,
+                            "sideWidth": null,
                             "total": false,
                             "values": false
                         },
@@ -63,26 +77,26 @@ data:
                         "links": [
 
                         ],
-                        "nullPointMode": "null as zero",
+                        "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
+                        "repeat": null,
                         "seriesOverrides": [
 
                         ],
                         "spaceLength": 10,
                         "span": 6,
-                        "stack": false,
+                        "stack": true,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "instance:node_cpu_utilisation:rate5m{job=\"node-exporter\", instance=\"$instance\"}",
+                                "expr": "instance:node_cpu_utilisation:rate5m{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} != 0",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "Utilisation",
-                                "legendLink": null,
-                                "step": 10
+                                "refId": "A"
                             }
                         ],
                         "thresholds": [
@@ -92,8 +106,8 @@ data:
                         "timeShift": null,
                         "title": "CPU Utilisation",
                         "tooltip": {
-                            "shared": false,
-                            "sort": 0,
+                            "shared": true,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -112,16 +126,16 @@ data:
                                 "label": null,
                                 "logBase": 1,
                                 "max": null,
-                                "min": 0,
+                                "min": null,
                                 "show": true
                             },
                             {
-                                "format": "short",
+                                "format": "percentunit",
                                 "label": null,
                                 "logBase": 1,
                                 "max": null,
                                 "min": null,
-                                "show": false
+                                "show": true
                             }
                         ]
                     },
@@ -133,14 +147,21 @@ data:
                         "dashLength": 10,
                         "dashes": false,
                         "datasource": "$datasource",
-                        "fill": 1,
-                        "id": 2,
+                        "fill": 10,
+                        "fillGradient": 0,
+                        "gridPos": {
+
+                        },
+                        "id": 3,
                         "legend": {
+                            "alignAsTable": false,
                             "avg": false,
                             "current": false,
                             "max": false,
                             "min": false,
+                            "rightSide": false,
                             "show": false,
+                            "sideWidth": null,
                             "total": false,
                             "values": false
                         },
@@ -149,26 +170,26 @@ data:
                         "links": [
 
                         ],
-                        "nullPointMode": "null as zero",
+                        "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
+                        "repeat": null,
                         "seriesOverrides": [
 
                         ],
                         "spaceLength": 10,
                         "span": 6,
-                        "stack": false,
+                        "stack": true,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "instance:node_load1_per_cpu:ratio{job=\"node-exporter\", instance=\"$instance\"}",
+                                "expr": "instance:node_load1_per_cpu:ratio{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} != 0",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "Saturation",
-                                "legendLink": null,
-                                "step": 10
+                                "refId": "A"
                             }
                         ],
                         "thresholds": [
@@ -178,8 +199,8 @@ data:
                         "timeShift": null,
                         "title": "CPU Saturation (Load1 per CPU)",
                         "tooltip": {
-                            "shared": false,
-                            "sort": 0,
+                            "shared": true,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -198,16 +219,16 @@ data:
                                 "label": null,
                                 "logBase": 1,
                                 "max": null,
-                                "min": 0,
+                                "min": null,
                                 "show": true
                             },
                             {
-                                "format": "short",
+                                "format": "percentunit",
                                 "label": null,
                                 "logBase": 1,
                                 "max": null,
                                 "min": null,
-                                "show": false
+                                "show": true
                             }
                         ]
                     }
@@ -217,11 +238,12 @@ data:
                 "repeatRowId": null,
                 "showTitle": true,
                 "title": "CPU",
-                "titleSize": "h6"
+                "titleSize": "h6",
+                "type": "row"
             },
             {
                 "collapse": false,
-                "height": "250px",
+                "collapsed": false,
                 "panels": [
                     {
                         "aliasColors": {
@@ -231,14 +253,21 @@ data:
                         "dashLength": 10,
                         "dashes": false,
                         "datasource": "$datasource",
-                        "fill": 1,
-                        "id": 3,
+                        "fill": 10,
+                        "fillGradient": 0,
+                        "gridPos": {
+
+                        },
+                        "id": 4,
                         "legend": {
+                            "alignAsTable": false,
                             "avg": false,
                             "current": false,
                             "max": false,
                             "min": false,
-                            "show": true,
+                            "rightSide": false,
+                            "show": false,
+                            "sideWidth": null,
                             "total": false,
                             "values": false
                         },
@@ -247,26 +276,26 @@ data:
                         "links": [
 
                         ],
-                        "nullPointMode": "null as zero",
+                        "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
+                        "repeat": null,
                         "seriesOverrides": [
 
                         ],
                         "spaceLength": 10,
                         "span": 6,
-                        "stack": false,
+                        "stack": true,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "instance:node_memory_utilisation:ratio{job=\"node-exporter\", job=\"node-exporter\", instance=\"$instance\"}",
+                                "expr": "instance:node_memory_utilisation:ratio{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} != 0",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "Memory",
-                                "legendLink": null,
-                                "step": 10
+                                "legendFormat": "Utilisation",
+                                "refId": "A"
                             }
                         ],
                         "thresholds": [
@@ -276,8 +305,8 @@ data:
                         "timeShift": null,
                         "title": "Memory Utilisation",
                         "tooltip": {
-                            "shared": false,
-                            "sort": 0,
+                            "shared": true,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -296,16 +325,16 @@ data:
                                 "label": null,
                                 "logBase": 1,
                                 "max": null,
-                                "min": 0,
+                                "min": null,
                                 "show": true
                             },
                             {
-                                "format": "short",
+                                "format": "percentunit",
                                 "label": null,
                                 "logBase": 1,
                                 "max": null,
                                 "min": null,
-                                "show": false
+                                "show": true
                             }
                         ]
                     },
@@ -317,14 +346,21 @@ data:
                         "dashLength": 10,
                         "dashes": false,
                         "datasource": "$datasource",
-                        "fill": 1,
-                        "id": 4,
+                        "fill": 10,
+                        "fillGradient": 0,
+                        "gridPos": {
+
+                        },
+                        "id": 5,
                         "legend": {
+                            "alignAsTable": false,
                             "avg": false,
                             "current": false,
                             "max": false,
                             "min": false,
+                            "rightSide": false,
                             "show": false,
+                            "sideWidth": null,
                             "total": false,
                             "values": false
                         },
@@ -333,26 +369,26 @@ data:
                         "links": [
 
                         ],
-                        "nullPointMode": "null as zero",
+                        "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
+                        "repeat": null,
                         "seriesOverrides": [
 
                         ],
                         "spaceLength": 10,
                         "span": 6,
-                        "stack": false,
+                        "stack": true,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "instance:node_vmstat_pgmajfault:rate5m{job=\"node-exporter\", instance=\"$instance\"}",
+                                "expr": "instance:node_vmstat_pgmajfault:rate5m{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} != 0",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "Major page faults",
-                                "legendLink": null,
-                                "step": 10
+                                "legendFormat": "Major page Faults",
+                                "refId": "A"
                             }
                         ],
                         "thresholds": [
@@ -362,8 +398,8 @@ data:
                         "timeShift": null,
                         "title": "Memory Saturation (Major Page Faults)",
                         "tooltip": {
-                            "shared": false,
-                            "sort": 0,
+                            "shared": true,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -378,20 +414,20 @@ data:
                         },
                         "yaxes": [
                             {
-                                "format": "short",
-                                "label": null,
-                                "logBase": 1,
-                                "max": null,
-                                "min": 0,
-                                "show": true
-                            },
-                            {
-                                "format": "short",
+                                "format": "rds",
                                 "label": null,
                                 "logBase": 1,
                                 "max": null,
                                 "min": null,
-                                "show": false
+                                "show": true
+                            },
+                            {
+                                "format": "rds",
+                                "label": null,
+                                "logBase": 1,
+                                "max": null,
+                                "min": null,
+                                "show": true
                             }
                         ]
                     }
@@ -401,11 +437,12 @@ data:
                 "repeatRowId": null,
                 "showTitle": true,
                 "title": "Memory",
-                "titleSize": "h6"
+                "titleSize": "h6",
+                "type": "row"
             },
             {
                 "collapse": false,
-                "height": "250px",
+                "collapsed": false,
                 "panels": [
                     {
                         "aliasColors": {
@@ -415,14 +452,21 @@ data:
                         "dashLength": 10,
                         "dashes": false,
                         "datasource": "$datasource",
-                        "fill": 1,
-                        "id": 5,
+                        "fill": 10,
+                        "fillGradient": 0,
+                        "gridPos": {
+
+                        },
+                        "id": 6,
                         "legend": {
+                            "alignAsTable": false,
                             "avg": false,
                             "current": false,
                             "max": false,
                             "min": false,
-                            "show": true,
+                            "rightSide": false,
+                            "show": false,
+                            "sideWidth": null,
                             "total": false,
                             "values": false
                         },
@@ -431,11 +475,12 @@ data:
                         "links": [
 
                         ],
-                        "nullPointMode": "null as zero",
+                        "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
+                        "repeat": null,
                         "seriesOverrides": [
                             {
                                 "alias": "/Receive/",
@@ -449,24 +494,22 @@ data:
                         ],
                         "spaceLength": 10,
                         "span": 6,
-                        "stack": false,
+                        "stack": true,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "instance:node_network_receive_bytes_excluding_lo:rate5m{job=\"node-exporter\", instance=\"$instance\"}",
+                                "expr": "instance:node_network_receive_bytes_excluding_lo:rate5m{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} != 0",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "Receive",
-                                "legendLink": null,
-                                "step": 10
+                                "refId": "A"
                             },
                             {
-                                "expr": "instance:node_network_transmit_bytes_excluding_lo:rate5m{job=\"node-exporter\", instance=\"$instance\"}",
+                                "expr": "instance:node_network_transmit_bytes_excluding_lo:rate5m{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} != 0",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "Transmit",
-                                "legendLink": null,
-                                "step": 10
+                                "refId": "B"
                             }
                         ],
                         "thresholds": [
@@ -474,10 +517,10 @@ data:
                         ],
                         "timeFrom": null,
                         "timeShift": null,
-                        "title": "Net Utilisation (Bytes Receive/Transmit)",
+                        "title": "Network Utilisation (Bytes Receive/Transmit)",
                         "tooltip": {
-                            "shared": false,
-                            "sort": 0,
+                            "shared": true,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -500,12 +543,12 @@ data:
                                 "show": true
                             },
                             {
-                                "format": "short",
+                                "format": "Bps",
                                 "label": null,
                                 "logBase": 1,
                                 "max": null,
                                 "min": null,
-                                "show": false
+                                "show": true
                             }
                         ]
                     },
@@ -517,14 +560,21 @@ data:
                         "dashLength": 10,
                         "dashes": false,
                         "datasource": "$datasource",
-                        "fill": 1,
-                        "id": 6,
+                        "fill": 10,
+                        "fillGradient": 0,
+                        "gridPos": {
+
+                        },
+                        "id": 7,
                         "legend": {
+                            "alignAsTable": false,
                             "avg": false,
                             "current": false,
                             "max": false,
                             "min": false,
-                            "show": true,
+                            "rightSide": false,
+                            "show": false,
+                            "sideWidth": null,
                             "total": false,
                             "values": false
                         },
@@ -533,42 +583,41 @@ data:
                         "links": [
 
                         ],
-                        "nullPointMode": "null as zero",
+                        "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
+                        "repeat": null,
                         "seriesOverrides": [
                             {
-                                "alias": "/Receive/",
+                                "alias": "/ Receive/",
                                 "stack": "A"
                             },
                             {
-                                "alias": "/Transmit/",
+                                "alias": "/ Transmit/",
                                 "stack": "B",
                                 "transform": "negative-Y"
                             }
                         ],
                         "spaceLength": 10,
                         "span": 6,
-                        "stack": false,
+                        "stack": true,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "instance:node_network_receive_drop_excluding_lo:rate5m{job=\"node-exporter\", instance=\"$instance\"}",
+                                "expr": "instance:node_network_receive_drop_excluding_lo:rate5m{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} != 0",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "Receive drops",
-                                "legendLink": null,
-                                "step": 10
+                                "legendFormat": "Receive",
+                                "refId": "A"
                             },
                             {
-                                "expr": "instance:node_network_transmit_drop_excluding_lo:rate5m{job=\"node-exporter\", instance=\"$instance\"}",
+                                "expr": "instance:node_network_transmit_drop_excluding_lo:rate5m{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} != 0",
                                 "format": "time_series",
                                 "intervalFactor": 2,
-                                "legendFormat": "Transmit drops",
-                                "legendLink": null,
-                                "step": 10
+                                "legendFormat": "Transmit",
+                                "refId": "B"
                             }
                         ],
                         "thresholds": [
@@ -576,10 +625,10 @@ data:
                         ],
                         "timeFrom": null,
                         "timeShift": null,
-                        "title": "Net Saturation (Drops Receive/Transmit)",
+                        "title": "Network Saturation (Drops Receive/Transmit)",
                         "tooltip": {
-                            "shared": false,
-                            "sort": 0,
+                            "shared": true,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -594,7 +643,7 @@ data:
                         },
                         "yaxes": [
                             {
-                                "format": "rps",
+                                "format": "Bps",
                                 "label": null,
                                 "logBase": 1,
                                 "max": null,
@@ -602,12 +651,12 @@ data:
                                 "show": true
                             },
                             {
-                                "format": "short",
+                                "format": "Bps",
                                 "label": null,
                                 "logBase": 1,
                                 "max": null,
                                 "min": null,
-                                "show": false
+                                "show": true
                             }
                         ]
                     }
@@ -616,12 +665,13 @@ data:
                 "repeatIteration": null,
                 "repeatRowId": null,
                 "showTitle": true,
-                "title": "Net",
-                "titleSize": "h6"
+                "title": "Network",
+                "titleSize": "h6",
+                "type": "row"
             },
             {
                 "collapse": false,
-                "height": "250px",
+                "collapsed": false,
                 "panels": [
                     {
                         "aliasColors": {
@@ -631,14 +681,21 @@ data:
                         "dashLength": 10,
                         "dashes": false,
                         "datasource": "$datasource",
-                        "fill": 1,
-                        "id": 7,
+                        "fill": 10,
+                        "fillGradient": 0,
+                        "gridPos": {
+
+                        },
+                        "id": 8,
                         "legend": {
+                            "alignAsTable": false,
                             "avg": false,
                             "current": false,
                             "max": false,
                             "min": false,
-                            "show": true,
+                            "rightSide": false,
+                            "show": false,
+                            "sideWidth": null,
                             "total": false,
                             "values": false
                         },
@@ -647,26 +704,26 @@ data:
                         "links": [
 
                         ],
-                        "nullPointMode": "null as zero",
+                        "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
+                        "repeat": null,
                         "seriesOverrides": [
 
                         ],
                         "spaceLength": 10,
                         "span": 6,
-                        "stack": false,
+                        "stack": true,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "instance_device:node_disk_io_time_seconds:rate5m{job=\"node-exporter\", instance=\"$instance\"}",
+                                "expr": "instance_device:node_disk_io_time_seconds:rate5m{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} != 0",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}device{{`}}`}}",
-                                "legendLink": null,
-                                "step": 10
+                                "refId": "A"
                             }
                         ],
                         "thresholds": [
@@ -676,8 +733,8 @@ data:
                         "timeShift": null,
                         "title": "Disk IO Utilisation",
                         "tooltip": {
-                            "shared": false,
-                            "sort": 0,
+                            "shared": true,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -696,16 +753,16 @@ data:
                                 "label": null,
                                 "logBase": 1,
                                 "max": null,
-                                "min": 0,
+                                "min": null,
                                 "show": true
                             },
                             {
-                                "format": "short",
+                                "format": "percentunit",
                                 "label": null,
                                 "logBase": 1,
                                 "max": null,
                                 "min": null,
-                                "show": false
+                                "show": true
                             }
                         ]
                     },
@@ -717,14 +774,21 @@ data:
                         "dashLength": 10,
                         "dashes": false,
                         "datasource": "$datasource",
-                        "fill": 1,
-                        "id": 8,
+                        "fill": 10,
+                        "fillGradient": 0,
+                        "gridPos": {
+
+                        },
+                        "id": 9,
                         "legend": {
+                            "alignAsTable": false,
                             "avg": false,
                             "current": false,
                             "max": false,
                             "min": false,
-                            "show": true,
+                            "rightSide": false,
+                            "show": false,
+                            "sideWidth": null,
                             "total": false,
                             "values": false
                         },
@@ -733,26 +797,26 @@ data:
                         "links": [
 
                         ],
-                        "nullPointMode": "null as zero",
+                        "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
+                        "repeat": null,
                         "seriesOverrides": [
 
                         ],
                         "spaceLength": 10,
                         "span": 6,
-                        "stack": false,
+                        "stack": true,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "instance_device:node_disk_io_time_weighted_seconds:rate5m{job=\"node-exporter\", instance=\"$instance\"}",
+                                "expr": "instance_device:node_disk_io_time_weighted_seconds:rate5m{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} != 0",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}device{{`}}`}}",
-                                "legendLink": null,
-                                "step": 10
+                                "refId": "A"
                             }
                         ],
                         "thresholds": [
@@ -762,8 +826,8 @@ data:
                         "timeShift": null,
                         "title": "Disk IO Saturation",
                         "tooltip": {
-                            "shared": false,
-                            "sort": 0,
+                            "shared": true,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -782,16 +846,16 @@ data:
                                 "label": null,
                                 "logBase": 1,
                                 "max": null,
-                                "min": 0,
+                                "min": null,
                                 "show": true
                             },
                             {
-                                "format": "short",
+                                "format": "percentunit",
                                 "label": null,
                                 "logBase": 1,
                                 "max": null,
                                 "min": null,
-                                "show": false
+                                "show": true
                             }
                         ]
                     }
@@ -801,11 +865,12 @@ data:
                 "repeatRowId": null,
                 "showTitle": true,
                 "title": "Disk IO",
-                "titleSize": "h6"
+                "titleSize": "h6",
+                "type": "row"
             },
             {
                 "collapse": false,
-                "height": "250px",
+                "collapsed": false,
                 "panels": [
                     {
                         "aliasColors": {
@@ -815,14 +880,21 @@ data:
                         "dashLength": 10,
                         "dashes": false,
                         "datasource": "$datasource",
-                        "fill": 1,
-                        "id": 9,
+                        "fill": 10,
+                        "fillGradient": 0,
+                        "gridPos": {
+
+                        },
+                        "id": 10,
                         "legend": {
+                            "alignAsTable": false,
                             "avg": false,
                             "current": false,
                             "max": false,
                             "min": false,
+                            "rightSide": false,
                             "show": false,
+                            "sideWidth": null,
                             "total": false,
                             "values": false
                         },
@@ -831,26 +903,26 @@ data:
                         "links": [
 
                         ],
-                        "nullPointMode": "null as zero",
+                        "nullPointMode": "null",
                         "percentage": false,
                         "pointradius": 5,
                         "points": false,
                         "renderer": "flot",
+                        "repeat": null,
                         "seriesOverrides": [
 
                         ],
                         "spaceLength": 10,
                         "span": 12,
-                        "stack": false,
+                        "stack": true,
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "1 -\n(\n  max without (mountpoint, fstype) (node_filesystem_avail_bytes{job=\"node-exporter\", fstype!=\"\", instance=\"$instance\"})\n/\n  max without (mountpoint, fstype) (node_filesystem_size_bytes{job=\"node-exporter\", fstype!=\"\", instance=\"$instance\"})\n)\n",
+                                "expr": "sort_desc(1 -\n  (\n   max without (mountpoint, fstype) (node_filesystem_avail_bytes{job=\"node-exporter\", fstype!=\"\", instance=\"$instance\", cluster=\"$cluster\"})\n   /\n   max without (mountpoint, fstype) (node_filesystem_size_bytes{job=\"node-exporter\", fstype!=\"\", instance=\"$instance\", cluster=\"$cluster\"})\n  ) != 0\n)\n",
                                 "format": "time_series",
                                 "intervalFactor": 2,
                                 "legendFormat": "{{`{{`}}device{{`}}`}}",
-                                "legendLink": null,
-                                "step": 10
+                                "refId": "A"
                             }
                         ],
                         "thresholds": [
@@ -860,8 +932,8 @@ data:
                         "timeShift": null,
                         "title": "Disk Space Utilisation",
                         "tooltip": {
-                            "shared": false,
-                            "sort": 0,
+                            "shared": true,
+                            "sort": 2,
                             "value_type": "individual"
                         },
                         "type": "graph",
@@ -880,16 +952,16 @@ data:
                                 "label": null,
                                 "logBase": 1,
                                 "max": null,
-                                "min": 0,
+                                "min": null,
                                 "show": true
                             },
                             {
-                                "format": "short",
+                                "format": "percentunit",
                                 "label": null,
                                 "logBase": 1,
                                 "max": null,
                                 "min": null,
-                                "show": false
+                                "show": true
                             }
                         ]
                     }
@@ -899,20 +971,21 @@ data:
                 "repeatRowId": null,
                 "showTitle": true,
                 "title": "Disk Space",
-                "titleSize": "h6"
+                "titleSize": "h6",
+                "type": "row"
             }
         ],
         "schemaVersion": 14,
         "style": "dark",
         "tags": [
-
+            "node-exporter-mixin"
         ],
         "templating": {
             "list": [
                 {
                     "current": {
-                        "text": "default",
-                        "value": "default"
+                        "text": "Prometheus",
+                        "value": "Prometheus"
                     },
                     "hide": 0,
                     "label": null,
@@ -928,22 +1001,48 @@ data:
                 {
                     "allValue": null,
                     "current": {
-                        "text": "prod",
-                        "value": "prod"
+                        "text": "",
+                        "value": ""
+                    },
+                    "datasource": "$datasource",
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster.global.enabled }}0{{ else }}2{{ end }},
+                    "includeAll": false,
+                    "label": null,
+                    "multi": false,
+                    "name": "cluster",
+                    "options": [
+
+                    ],
+                    "query": "label_values(node_time_seconds, cluster)",
+                    "refresh": 2,
+                    "regex": "",
+                    "sort": 1,
+                    "tagValuesQuery": "",
+                    "tags": [
+
+                    ],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                },
+                {
+                    "allValue": null,
+                    "current": {
+
                     },
                     "datasource": "$datasource",
                     "hide": 0,
                     "includeAll": false,
-                    "label": "instance",
+                    "label": null,
                     "multi": false,
                     "name": "instance",
                     "options": [
 
                     ],
-                    "query": "label_values(up{job=\"node-exporter\"}, instance)",
-                    "refresh": 1,
+                    "query": "label_values(node_exporter_build_info{job=\"node-exporter\", cluster=\"$cluster\"}, instance)",
+                    "refresh": 2,
                     "regex": "",
-                    "sort": 2,
+                    "sort": 1,
                     "tagValuesQuery": "",
                     "tags": [
 
@@ -984,8 +1083,7 @@ data:
             ]
         },
         "timezone": "utc",
-        "title": "USE Method / Node",
-        "uid": "",
+        "title": "Node Exporter / USE Method / Node",
         "version": 0
     }
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/nodes.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/nodes.yaml
@@ -34,13 +34,13 @@ data:
         },
         "editable": false,
         "gnetId": null,
-        "graphTooltip": 0,
+        "graphTooltip": 1,
         "hideControls": false,
         "id": null,
         "links": [
 
         ],
-        "refresh": "",
+        "refresh": "30s",
         "rows": [
             {
                 "collapse": false,
@@ -907,7 +907,7 @@ data:
         "schemaVersion": 14,
         "style": "dark",
         "tags": [
-
+            "node-exporter-mixin"
         ],
         "templating": {
             "list": [
@@ -984,8 +984,8 @@ data:
                 "30d"
             ]
         },
-        "timezone": "browser",
-        "title": "Nodes",
+        "timezone": "utc",
+        "title": "Node Exporter / Nodes",
         "version": 0
     }
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/persistentvolumesusage.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/persistentvolumesusage.yaml
@@ -466,7 +466,7 @@ data:
 
                     },
                     "datasource": "$datasource",
-                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster.global.enabled }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": "cluster",
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/pod-total.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/pod-total.yaml
@@ -1025,7 +1025,7 @@ data:
 
                     },
                     "datasource": "$datasource",
-                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster.global.enabled }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": null,
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/prometheus-remote-write.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/prometheus-remote-write.yaml
@@ -1586,7 +1586,7 @@ data:
                         }
                     },
                     "datasource": "$datasource",
-                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster.global.enabled }}0{{ else }}2{{ end }},
                     "includeAll": true,
                     "label": null,
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/proxy.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/proxy.yaml
@@ -1172,7 +1172,7 @@ data:
 
                     },
                     "datasource": "$datasource",
-                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster.global.enabled }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": "cluster",
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/scheduler.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/scheduler.yaml
@@ -1015,7 +1015,7 @@ data:
 
                     },
                     "datasource": "$datasource",
-                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster.global.enabled }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": "cluster",
                     "multi": false,

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/workload-total.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/workload-total.yaml
@@ -1203,7 +1203,7 @@ data:
 
                     },
                     "datasource": "$datasource",
-                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster }}0{{ else }}2{{ end }},
+                    "hide": {{ if .Values.grafana.sidecar.dashboards.multicluster.global.enabled }}0{{ else }}2{{ end }},
                     "includeAll": false,
                     "label": null,
                     "multi": false,

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -678,7 +678,11 @@ grafana:
       ## Annotations for Grafana dashboard configmaps
       ##
       annotations: {}
-      multicluster: false
+      multicluster:
+        global:
+          enabled: false
+        etcd:
+          enabled: false
     datasources:
       enabled: true
       defaultDatasourceEnabled: true

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -197,7 +197,7 @@ alertmanager:
   #       {{- $root := . -}}
   #       {{ range .Alerts }}
   #         *Alert:* {{ .Annotations.summary }} - `{{ .Labels.severity }}`
-  #         *Cluster:*  {{ template "cluster" $root }}
+  #         *Cluster:* {{ template "cluster" $root }}
   #         *Description:* {{ .Annotations.description }}
   #         *Graph:* <{{ .GeneratorURL }}|:chart_with_upwards_trend:>
   #         *Runbook:* <{{ .Annotations.runbook }}|:spiral_note_pad:>
@@ -366,14 +366,14 @@ alertmanager:
 
     bearerTokenFile:
 
-    ## 	metric relabel configs to apply to samples before ingestion.
+    ## Metric relabel configs to apply to samples before ingestion.
     ##
     metricRelabelings: []
     # - action: keep
     #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
     #   sourceLabels: [__name__]
 
-    # 	relabel configs to apply to samples before ingestion.
+    #   relabel configs to apply to samples before ingestion.
     ##
     relabelings: []
     # - sourceLabels: [__meta_kubernetes_pod_node_name]
@@ -486,11 +486,11 @@ alertmanager:
     #   selector: {}
 
 
-    ## 	The external URL the Alertmanager instances will be available under. This is necessary to generate correct URLs. This is necessary if Alertmanager is not served from root of a DNS name.	string	false
+    ## The external URL the Alertmanager instances will be available under. This is necessary to generate correct URLs. This is necessary if Alertmanager is not served from root of a DNS name. string  false
     ##
     externalUrl:
 
-    ## 	The route prefix Alertmanager registers HTTP handlers for. This is useful, if using ExternalURL and a proxy is rewriting HTTP routes of a request, and the actual ExternalURL is still true,
+    ## The route prefix Alertmanager registers HTTP handlers for. This is useful, if using ExternalURL and a proxy is rewriting HTTP routes of a request, and the actual ExternalURL is still true,
     ## but the server serves requests under a different route prefix. For example for use with kubectl proxy.
     ##
     routePrefix: /
@@ -558,7 +558,7 @@ alertmanager:
     #       app: alertmanager
 
     ## SecurityContext holds pod-level security attributes and common container settings.
-    ## This defaults to non root user with uid 1000 and gid 2000.	*v1.PodSecurityContext	false
+    ## This defaults to non root user with uid 1000 and gid 2000. *v1.PodSecurityContext  false
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
     ##
     securityContext:
@@ -740,14 +740,14 @@ grafana:
     # in grafana.ini
     path: "/metrics"
 
-    ## 	metric relabel configs to apply to samples before ingestion.
+    ## Metric relabel configs to apply to samples before ingestion.
     ##
     metricRelabelings: []
     # - action: keep
     #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
     #   sourceLabels: [__name__]
 
-    # 	relabel configs to apply to samples before ingestion.
+    #   relabel configs to apply to samples before ingestion.
     ##
     relabelings: []
     # - sourceLabels: [__meta_kubernetes_pod_node_name]
@@ -778,7 +778,7 @@ kubeApiServer:
         component: apiserver
         provider: kubernetes
 
-    ## 	metric relabel configs to apply to samples before ingestion.
+    ## Metric relabel configs to apply to samples before ingestion.
     ##
     metricRelabelings: []
     # - action: keep
@@ -856,7 +856,7 @@ kubelet:
     #   replacement: $1
     #   action: drop
 
-    # 	relabel configs to apply to samples before ingestion.
+    #   relabel configs to apply to samples before ingestion.
     #   metrics_path is required to match upstream rules and charts
     ##
     cAdvisorRelabelings:
@@ -901,7 +901,7 @@ kubelet:
     #   replacement: $1
     #   action: drop
 
-    # 	relabel configs to apply to samples before ingestion.
+    #   relabel configs to apply to samples before ingestion.
     #   metrics_path is required to match upstream rules and charts
     ##
     relabelings:
@@ -956,14 +956,14 @@ kubeControllerManager:
     # Name of the server to use when validating TLS certificate
     serverName: null
 
-    ## 	metric relabel configs to apply to samples before ingestion.
+    ## Metric relabel configs to apply to samples before ingestion.
     ##
     metricRelabelings: []
     # - action: keep
     #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
     #   sourceLabels: [__name__]
 
-    # 	relabel configs to apply to samples before ingestion.
+    #   relabel configs to apply to samples before ingestion.
     ##
     relabelings: []
     # - sourceLabels: [__meta_kubernetes_pod_node_name]
@@ -991,14 +991,14 @@ coreDns:
     ##
     proxyUrl: ""
 
-    ## 	metric relabel configs to apply to samples before ingestion.
+    ## Metric relabel configs to apply to samples before ingestion.
     ##
     metricRelabelings: []
     # - action: keep
     #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
     #   sourceLabels: [__name__]
 
-    # 	relabel configs to apply to samples before ingestion.
+    #   relabel configs to apply to samples before ingestion.
     ##
     relabelings: []
     # - sourceLabels: [__meta_kubernetes_pod_node_name]
@@ -1030,14 +1030,14 @@ kubeDns:
     ##
     proxyUrl: ""
 
-    ## 	metric relabel configs to apply to samples before ingestion.
+    ## Metric relabel configs to apply to samples before ingestion.
     ##
     metricRelabelings: []
     # - action: keep
     #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
     #   sourceLabels: [__name__]
 
-    # 	relabel configs to apply to samples before ingestion.
+    #   relabel configs to apply to samples before ingestion.
     ##
     relabelings: []
     # - sourceLabels: [__meta_kubernetes_pod_node_name]
@@ -1051,7 +1051,7 @@ kubeDns:
     #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
     #   sourceLabels: [__name__]
 
-    # 	relabel configs to apply to samples before ingestion.
+    #   relabel configs to apply to samples before ingestion.
     ##
     dnsmasqRelabelings: []
     # - sourceLabels: [__meta_kubernetes_pod_node_name]
@@ -1108,14 +1108,14 @@ kubeEtcd:
     certFile: ""
     keyFile: ""
 
-    ## 	metric relabel configs to apply to samples before ingestion.
+    ## Metric relabel configs to apply to samples before ingestion.
     ##
     metricRelabelings: []
     # - action: keep
     #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
     #   sourceLabels: [__name__]
 
-    # 	relabel configs to apply to samples before ingestion.
+    #   relabel configs to apply to samples before ingestion.
     ##
     relabelings: []
     # - sourceLabels: [__meta_kubernetes_pod_node_name]
@@ -1166,14 +1166,14 @@ kubeScheduler:
     ## Name of the server to use when validating TLS certificate
     serverName: null
 
-    ## 	metric relabel configs to apply to samples before ingestion.
+    ## Metric relabel configs to apply to samples before ingestion.
     ##
     metricRelabelings: []
     # - action: keep
     #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
     #   sourceLabels: [__name__]
 
-    # 	relabel configs to apply to samples before ingestion.
+    #   relabel configs to apply to samples before ingestion.
     ##
     relabelings: []
     # - sourceLabels: [__meta_kubernetes_pod_node_name]
@@ -1218,14 +1218,14 @@ kubeProxy:
     ##
     https: false
 
-    ## 	metric relabel configs to apply to samples before ingestion.
+    ## Metric relabel configs to apply to samples before ingestion.
     ##
     metricRelabelings: []
     # - action: keep
     #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
     #   sourceLabels: [__name__]
 
-    # 	relabel configs to apply to samples before ingestion.
+    #   relabel configs to apply to samples before ingestion.
     ##
     relabelings: []
     # - action: keep
@@ -1251,14 +1251,14 @@ kubeStateMetrics:
     ##
     namespaceOverride: ""
 
-    ## 	metric relabel configs to apply to samples before ingestion.
+    ## Metric relabel configs to apply to samples before ingestion.
     ##
     metricRelabelings: []
     # - action: keep
     #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
     #   sourceLabels: [__name__]
 
-    # 	relabel configs to apply to samples before ingestion.
+    #   relabel configs to apply to samples before ingestion.
     ##
     relabelings: []
     # - sourceLabels: [__meta_kubernetes_pod_node_name]
@@ -1303,7 +1303,7 @@ nodeExporter:
     ##
     scrapeTimeout: ""
 
-    ## 	metric relabel configs to apply to samples before ingestion.
+    ## Metric relabel configs to apply to samples before ingestion.
     ##
     metricRelabelings: []
     # - sourceLabels: [__name__]
@@ -1312,7 +1312,7 @@ nodeExporter:
     #   replacement: $1
     #   action: drop
 
-    ## 	relabel configs to apply to samples before ingestion.
+    ## relabel configs to apply to samples before ingestion.
     ##
     relabelings: []
     # - sourceLabels: [__meta_kubernetes_pod_node_name]
@@ -1377,7 +1377,7 @@ prometheusOperator:
       tolerations: []
 
       ## SecurityContext holds pod-level security attributes and common container settings.
-      ## This defaults to non root user with uid 2000 and gid 2000.	*v1.PodSecurityContext	false
+      ## This defaults to non root user with uid 2000 and gid 2000. *v1.PodSecurityContext  false
       ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
       ##
       securityContext:
@@ -1493,14 +1493,14 @@ prometheusOperator:
     scrapeTimeout: ""
     selfMonitor: true
 
-    ## 	metric relabel configs to apply to samples before ingestion.
+    ## Metric relabel configs to apply to samples before ingestion.
     ##
     metricRelabelings: []
     # - action: keep
     #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
     #   sourceLabels: [__name__]
 
-    # 	relabel configs to apply to samples before ingestion.
+    #   relabel configs to apply to samples before ingestion.
     ##
     relabelings: []
     # - sourceLabels: [__meta_kubernetes_pod_node_name]
@@ -1890,14 +1890,14 @@ prometheus:
 
     bearerTokenFile:
 
-    ## 	metric relabel configs to apply to samples before ingestion.
+    ## Metric relabel configs to apply to samples before ingestion.
     ##
     metricRelabelings: []
     # - action: keep
     #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
     #   sourceLabels: [__name__]
 
-    # 	relabel configs to apply to samples before ingestion.
+    #   relabel configs to apply to samples before ingestion.
     ##
     relabelings: []
     # - sourceLabels: [__meta_kubernetes_pod_node_name]
@@ -2358,7 +2358,7 @@ prometheus:
       runAsUser: 1000
       fsGroup: 2000
 
-    ## 	Priority class assigned to the Pods
+    ## Priority class assigned to the Pods
     ##
     priorityClassName: ""
 
@@ -2370,7 +2370,7 @@ prometheus:
     thanos: {}
 
     ## Containers allows injecting additional containers. This is meant to allow adding an authentication proxy to a Prometheus pod.
-    ##  if using proxy extraContainer  update targetPort with proxy container port
+    ## if using proxy extraContainer update targetPort with proxy container port
     containers: []
 
     ## InitContainers allows injecting additional initContainers. This is meant to allow doing some changes


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds ability to only enable multicluster option for etcd
dashboard, so it doesn't have to be enabled for all Kubernetes
dashboards.

If one collects metrics from more than one etcd cluster on single
Kubernetes cluster, e.g. when having Loki deployed, which use etcd
internally, etcd dashboard in Grafana becomes useless without
multicluster option enabled.

This PR also syncs Grafana dashboards and does some styling improvements to kube-prometheus-stack values.yaml file.

#### Which issue this PR fixes
  - Closes #965

#### Notes for the reviewer

I tested it manually on my cluster and everything works as expected.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
