### PR TITLE
[prometheus-adapter] add pod securityContext

### DIFF
--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 2.15.0
+version: 2.15.1
 appVersion: v0.8.4
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/charts/prometheus-adapter/templates/deployment.yaml
+++ b/charts/prometheus-adapter/templates/deployment.yaml
@@ -110,6 +110,10 @@ spec:
       affinity:
         {{- toYaml .Values.affinity | nindent 8 }}
       priorityClassName: {{ .Values.priorityClassName }}
+      {{- if .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}
       {{- if .Values.image.pullSecrets }}

--- a/charts/prometheus-adapter/values.yaml
+++ b/charts/prometheus-adapter/values.yaml
@@ -25,6 +25,11 @@ prometheus:
 
 replicas: 1
 
+# k8s 1.21 needs fsGroup to be set for non root deployments
+# ref: https://github.com/kubernetes/kubernetes/issues/70679
+podSecurityContext:
+  fsGroup: 10001
+
 rbac:
   # Specifies whether RBAC resources should be created
   create: true


### PR DESCRIPTION
#### What this PR does / why we need it:
with k8s 1.21, we need to set fsGroup for all non-root pods to allow
access to the api token (via projected api).
ref: https://github.com/kubernetes/kubernetes/issues/70679

#### Which issue this PR fixes
  - fixes #1135

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
