### PR TITLE
[prometheus] Fix link to repo in values.yaml

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.26.0
-version: 14.3.0
+version: 14.3.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -434,7 +434,7 @@ kubeStateMetrics:
   enabled: true
 
 ## kube-state-metrics sub-chart configurable values
-## Please see https://github.com/kubernetes/kube-state-metrics/tree/master/charts/kube-state-metrics
+## Please see https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics
 ##
 # kube-state-metrics:
 


### PR DESCRIPTION
Signed-off-by: Jim DAgostino <dagosti@synopsys.com>

#### What this PR does / why we need it:
Fix link to old helm repo in values.yaml documentation so it points to the correct `prometheus-community` repo.
 
#### Which issue this PR fixes
- fixes n/a

#### Special notes for your reviewer:
- na 
#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
