### PR TITLE
[prometheus-snmp-exporter] Merge duplicate security context in deployment

### DIFF
--- a/charts/prometheus-snmp-exporter/Chart.yaml
+++ b/charts/prometheus-snmp-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus SNMP Exporter
 name: prometheus-snmp-exporter
-version: 0.1.2
+version: 0.1.3
 appVersion: 0.19.0
 home: https://github.com/prometheus/snmp_exporter
 sources:

--- a/charts/prometheus-snmp-exporter/templates/deployment.yaml
+++ b/charts/prometheus-snmp-exporter/templates/deployment.yaml
@@ -51,6 +51,7 @@ spec:
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
+            readOnlyRootFilesystem: true
           args:
 {{- if .Values.config }}
             - "--config.file=/config/snmp.yaml"
@@ -58,8 +59,6 @@ spec:
         {{- if .Values.extraArgs }}
 {{ toYaml .Values.extraArgs | indent 12 }}
         {{- end }}
-          securityContext:
-            readOnlyRootFilesystem: true
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           ports:


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
The current deployment yaml for `prometheus-snmp-exporter` is syntactically invalid and although it does not fail while doing a `helm install` it will error with other tooling that makes sure the rendered chart is valid i.e. `fluxcd`. This PR adds support for merging both `securityContext` yaml stanzas.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
