### PR TITLE
[prometheus-elasticsearch-exporter] Use appropriate apiVersion for rbac

### DIFF
--- a/charts/prometheus-elasticsearch-exporter/Chart.yaml
+++ b/charts/prometheus-elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: prometheus-elasticsearch-exporter
-version: 4.6.1
+version: 4.7.0
 kubeVersion: ">=1.10.0-0"
 appVersion: 1.2.1
 home: https://github.com/prometheus-community/elasticsearch_exporter

--- a/charts/prometheus-elasticsearch-exporter/ci/pod-security-policies.yaml
+++ b/charts/prometheus-elasticsearch-exporter/ci/pod-security-policies.yaml
@@ -1,0 +1,5 @@
+---
+# Enable podSecurityPolicies
+
+podSecurityPolicies:
+  enabled: true

--- a/charts/prometheus-elasticsearch-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-elasticsearch-exporter/templates/_helpers.tpl
@@ -31,3 +31,13 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
+Return the appropriate apiVersion for rbac.
+*/}}
+{{- define "rbac.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
+{{- print "rbac.authorization.k8s.io/v1" -}}
+{{- else -}}
+{{- print "rbac.authorization.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/prometheus-elasticsearch-exporter/templates/role.yaml
+++ b/charts/prometheus-elasticsearch-exporter/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podSecurityPolicies.enabled -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: {{ template "rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ template "elasticsearch-exporter.fullname" . }}

--- a/charts/prometheus-elasticsearch-exporter/templates/rolebinding.yaml
+++ b/charts/prometheus-elasticsearch-exporter/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podSecurityPolicies.enabled }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: {{ template "rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   name: {{ template "elasticsearch-exporter.fullname" . }}


### PR DESCRIPTION
Signed-off-by: Christof Koenig <koenig@crealytics.de>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

Newer versions of Kubernetes deprecated `rbac.authorization.k8s.io/v1beta1` in favor of `rbac.authorization.k8s.io/v1`.

#### Special notes for your reviewer:

The changes in this PR are based on similar changes, which have already been merged for other exporters, e.g. https://github.com/prometheus-community/helm-charts/pull/385.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
