### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,7 @@ jobs:
       - name: Add dependency chart repos
         run: |
           helm repo add grafana https://grafana.github.io/helm-charts
+          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.2.1


### PR DESCRIPTION
#### What this PR does / why we need it:
Release workflow seems to be [broken](https://github.com/prometheus-community/helm-charts/runs/3018456215?check_suite_focus=true) by the bump of chart-releaser-action. 

```
Packaging chart 'charts/kube-prometheus-stack'...
Error: no repository definition for https://prometheus-community.github.io/helm-charts, https://prometheus-community.github.io/helm-charts
```

Adding prometheus-community repo before running chart-releaser-action should hopefully fix it since kube-prometheus-stack has it as a chart dependency.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
