### PR TITLE
kube-prometheus-stack - dashboard templates; only remove lines with defaults

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 16.13.0
+version: 16.13.1
 appVersion: 0.48.1
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/hack/sync_grafana_dashboards.py
+++ b/charts/kube-prometheus-stack/hack/sync_grafana_dashboards.py
@@ -116,7 +116,7 @@ def patch_json_for_multicluster_configuration(content):
         content_array = []
         original_content_lines = content.split('\n')
         for i, line in enumerate(json.dumps(content_struct, indent=4).split('\n')):
-            if ('[]' not in line and '{}' not in line) or line == original_content_lines[i]:
+            if (' []' not in line and ' {}' not in line) or line == original_content_lines[i]:
                 content_array.append(line)
                 continue
 


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes

  - fixes #1159 

#### Special notes for your reviewer:

Tested by running the python script and the only change in the generated templates is that the expressions with `{}` are back in the templates.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)

chart maintainers: @vsliouniaev @bismarck @gianrubio @gkarthiks @scottrigby @Xtigyro