### PR TITLE
node-exporter: do not automount service account token

### DIFF
--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart for prometheus node-exporter
 name: prometheus-node-exporter
-version: 2.0.0
+version: 2.0.1
 type: application
 home: https://github.com/prometheus/node_exporter/
 sources:

--- a/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -21,6 +21,7 @@ spec:
       {{- toYaml .Values.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
+      automountServiceAccountToken: false
       serviceAccountName: {{ template "prometheus-node-exporter.serviceAccountName" . }}
 {{- if .Values.securityContext }}
       securityContext:


### PR DESCRIPTION
#### What this PR does / why we need it:
It disables the automounting of the service account token for node exporter. This exporters does not need access to the Kubernetes API (as far as I can tell). By disabling the automount, potential attackers cannot access the Kubernetes API on behalf/through the pod.

#### Which issue this PR fixes
I have not raised an issue. If it helps or is needed otherwise, I'd be glad to do so.

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)