### PR TITLE
prometheus-blackbox-exporter: Do not automount service account token

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 5.0.0
+version: 5.0.1
 appVersion: 0.19.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/charts/prometheus-blackbox-exporter/templates/deployment.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
         {{- end }}
     spec:
+      automountServiceAccountToken: false
       serviceAccountName: {{ template "prometheus-blackbox-exporter.serviceAccountName" . }}
     {{- if .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
#### What this PR does / why we need it:
It disables the automounting of the service account token for blackbox exporter. This exporters does not need access to the Kubernetes API (as far as I can tell). By disabling the automount, potential attackers cannot access the Kubernetes API on behalf/through the pod.

#### Which issue this PR fixes
I have not raised an issue. If it helps or is needed otherwise, I'd be glad to do so.

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)