### PR TITLE
[prometheus-node-exporter] Version bump to 1.2.0; drop helm2 support

### DIFF
--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -1,8 +1,9 @@
-apiVersion: v1
-appVersion: 1.1.2
+apiVersion: v2
+appVersion: 1.2.0
 description: A Helm chart for prometheus node-exporter
 name: prometheus-node-exporter
-version: 1.18.2
+version: 2.0.0
+type: application
 home: https://github.com/prometheus/node_exporter/
 sources:
 - https://github.com/prometheus/node_exporter/

--- a/charts/prometheus-node-exporter/README.md
+++ b/charts/prometheus-node-exporter/README.md
@@ -16,11 +16,7 @@ _See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation
 ## Install Chart
 
 ```console
-# Helm 3
-$ helm install [RELEASE_NAME] prometheus-community/prometheus-node-exporter
-
-# Helm 2
-$ helm install --name [RELEASE_NAME] prometheus-community/prometheus-node-exporter
+helm install [RELEASE_NAME] prometheus-community/prometheus-node-exporter
 ```
 
 _See [configuration](#configuration) below._
@@ -30,11 +26,7 @@ _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documen
 ## Uninstall Chart
 
 ```console
-# Helm 3
-$ helm uninstall [RELEASE_NAME]
-
-# Helm 2
-# helm delete --purge [RELEASE_NAME]
+helm uninstall [RELEASE_NAME]
 ```
 
 This removes all the Kubernetes components associated with the chart and deletes the release.
@@ -44,8 +36,7 @@ _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command doc
 ## Upgrading Chart
 
 ```console
-# Helm 3 or 2
-$ helm upgrade [RELEASE_NAME] [CHART] --install
+helm upgrade [RELEASE_NAME] [CHART] --install
 ```
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
@@ -55,9 +46,5 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
 
 ```console
-# Helm 2
-$ helm inspect values prometheus-community/prometheus-node-exporter
-
-# Helm 3
-$ helm show values prometheus-community/prometheus-node-exporter
+helm show values prometheus-community/prometheus-node-exporter
 ```

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: quay.io/prometheus/node-exporter
-  tag: v1.1.2
+  tag: v1.2.0
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
#### What this PR does / why we need it:
* Bumps node exporter to v1.2.0
* Drops support for helm2 by upgrading to Chart apiVersion v2.

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
