### PR TITLE
[prometheus-redis-exporter] address via configmap

### DIFF
--- a/charts/prometheus-redis-exporter/Chart.yaml
+++ b/charts/prometheus-redis-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.11.1
 description: Prometheus exporter for Redis metrics
 name: prometheus-redis-exporter
-version: 4.1.0
+version: 4.2.0
 home: https://github.com/oliver006/redis_exporter
 sources:
   - https://github.com/oliver006/redis_exporter

--- a/charts/prometheus-redis-exporter/README.md
+++ b/charts/prometheus-redis-exporter/README.md
@@ -67,7 +67,8 @@ For more information please refer to the [redis_exporter](https://github.com/oli
 
 ### Redis Connection
 
-- To configure Redis connection set `redisAddress` string (example format: `redis://myredis:6379`)
+- To configure Redis connection by value set `redisAddress` string (example format: `redis://myredis:6379`)
+- To configure Redis connection by configmap set `redisAddressConfig.enabled` to `true`, set `redisAddressConfig.configmap.name` and `redisAddressConfig.configmap.key` values
 - To configure auth by value, set `auth.enabled` to `true`, and `auth.redisPassword` value
 - To configure auth by secret, set `auth.secret.name` and `auth.secret.key` values
 

--- a/charts/prometheus-redis-exporter/templates/deployment.yaml
+++ b/charts/prometheus-redis-exporter/templates/deployment.yaml
@@ -44,7 +44,14 @@ spec:
               containerPort: 9121
           env:
             - name: REDIS_ADDR
+            {{- if .Values.redisAddressConfig.enabled }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.redisAddressConfig.configmap.name }}
+                  key: {{ .Values.redisAddressConfig.configmap.key }}
+            {{- else }}
               value: {{ .Values.redisAddress }}
+            {{- end }}
           {{- if .Values.auth.enabled }}
             - name: REDIS_PASSWORD
             {{- if .Values.auth.secret.name }}

--- a/charts/prometheus-redis-exporter/values.yaml
+++ b/charts/prometheus-redis-exporter/values.yaml
@@ -46,6 +46,14 @@ labels: {}
 #  prometheus.io/port: "9121"
 #  prometheus.io/scrape: "true"
 
+redisAddressConfig:
+  # Use config from configmap
+  enabled: false
+  # Use existing configmap (ignores redisAddress)
+  configmap:
+    name: ""
+    key: ""
+
 serviceMonitor:
   # When set true then use a ServiceMonitor to configure scraping
   enabled: false


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

This change allows a user to specify a configmap that contains the
address at which a redis server can be reached. Following the same logic
already being used for authentication details from a provided secret.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
