### PR TITLE
[prometheus-elasticsearch-exporter] add optional annotations to deployment

### DIFF
--- a/charts/prometheus-elasticsearch-exporter/Chart.yaml
+++ b/charts/prometheus-elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: prometheus-elasticsearch-exporter
-version: 4.5.0
+version: 4.5.1
 kubeVersion: ">=1.10.0-0"
 appVersion: 1.2.1
 home: https://github.com/prometheus-community/elasticsearch_exporter

--- a/charts/prometheus-elasticsearch-exporter/Chart.yaml
+++ b/charts/prometheus-elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: prometheus-elasticsearch-exporter
-version: 4.5.1
+version: 4.6.0
 kubeVersion: ">=1.10.0-0"
 appVersion: 1.2.1
 home: https://github.com/prometheus-community/elasticsearch_exporter

--- a/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
+++ b/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
@@ -7,6 +7,10 @@ metadata:
     app: {{ template "elasticsearch-exporter.name" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.deployment.annotations }}
+  annotations:
+{{- toYaml .Values.deployment.annotations | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/prometheus-elasticsearch-exporter/values.yaml
+++ b/charts/prometheus-elasticsearch-exporter/values.yaml
@@ -64,6 +64,9 @@ service:
   annotations: {}
   labels: {}
 
+deployment:
+  annotations: {}
+
 ## Extra environment variables that will be passed into the exporter pod
 ## example:
 ## env:


### PR DESCRIPTION
Signed-off-by: Geisler, James D <geislerjamesd@gmail.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
This provides the ability to add arbitrary annotations to the prometheus-elasticsearch-exporter deployment. This will enable the use of any operators that rely on deployment annotations.

Example values.yaml:
```yaml
deployment:
  annotations:
    wave.pusher.com/update-on-config-change: "true"
```

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
