### PR TITLE
[prometheus-elasticsearch-exporter] Adds tpl function to ES URI injection

### DIFF
--- a/charts/prometheus-elasticsearch-exporter/Chart.yaml
+++ b/charts/prometheus-elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: prometheus-elasticsearch-exporter
-version: 4.5.0
+version: 4.5.1
 kubeVersion: ">=1.10.0-0"
 appVersion: 1.2.1
 home: https://github.com/prometheus-community/elasticsearch_exporter

--- a/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
+++ b/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
@@ -82,7 +82,7 @@ spec:
                     "--log.level={{ . }}",
                     {{- end }}
                     {{- if .Values.es.uri }}
-                    "--es.uri={{ .Values.es.uri }}",
+                    "--es.uri={{ tpl .Values.es.uri . }}",
                     {{- end }}
                     {{- if .Values.es.all }}
                     "--es.all",


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds Helm tpl function to ES URI injection on the command line so this value can expand values, really useful when using this as a subchart.
#### Which issue this PR fixes
  - fixes #1224

#### Special notes for your reviewer:
Check https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
