### PR TITLE
[prometheus] drop Completed pods

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.26.0
-version: 14.4.1
+version: 14.5.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -1646,7 +1646,7 @@ serverFiles:
             action: replace
             target_label: kubernetes_pod_name
           - source_labels: [__meta_kubernetes_pod_phase]
-            regex: Pending|Succeeded|Failed
+            regex: Pending|Succeeded|Failed|Completed
             action: drop
 
       # Example Scrape config for pods which should be scraped slower. An useful example
@@ -1694,7 +1694,7 @@ serverFiles:
             action: replace
             target_label: kubernetes_pod_name
           - source_labels: [__meta_kubernetes_pod_phase]
-            regex: Pending|Succeeded|Failed
+            regex: Pending|Succeeded|Failed|Completed
             action: drop
 
 # adds additional scrape configs to prometheus.yml


### PR DESCRIPTION
#### What this PR does / why we need it:
We often get `TargetDown` alerts for completed jobs. This adds the `Completed` phase to the pod scrape config.

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)

cc chart contributors:

@gianrubio 
@zanhsieh 
@Xtigyro 
@monotek 
@naseemkullah 