### PR TITLE
[prometheus] server: support running in a service mesh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Chart dependencies
 /charts/*/charts
 .idea
+*.iml

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.26.0
-version: 14.5.0
+version: 14.6.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.26.0
-version: 14.6.0
+version: 14.7.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/templates/server/deploy.yaml
+++ b/charts/prometheus/templates/server/deploy.yaml
@@ -110,6 +110,9 @@ spec:
           {{- if .Values.server.baseURL }}
             - --web.external-url={{ .Values.server.baseURL }}
           {{- end }}
+          {{- if .Values.server.listenOnLocalhost }}
+            - --web.listen-address=localhost:9090
+          {{- end }}
           ports:
             - containerPort: 9090
           readinessProbe:

--- a/charts/prometheus/templates/server/deploy.yaml
+++ b/charts/prometheus/templates/server/deploy.yaml
@@ -116,18 +116,26 @@ spec:
           ports:
             - containerPort: 9090
           readinessProbe:
+          {{- if .Values.server.customReadinessProbe }}
+{{ toYaml .Values.server.customReadinessProbe | indent 12}}
+          {{- else }}
             httpGet:
               path: {{ .Values.server.prefixURL }}/-/ready
               port: 9090
+          {{- end }}
             initialDelaySeconds: {{ .Values.server.readinessProbeInitialDelay }}
             periodSeconds: {{ .Values.server.readinessProbePeriodSeconds }}
             timeoutSeconds: {{ .Values.server.readinessProbeTimeout }}
             failureThreshold: {{ .Values.server.readinessProbeFailureThreshold }}
             successThreshold: {{ .Values.server.readinessProbeSuccessThreshold }}
           livenessProbe:
+          {{- if .Values.server.customLivenessProbe }}
+{{ toYaml .Values.server.customLivenessProbe | indent 12}}
+          {{- else }}
             httpGet:
               path: {{ .Values.server.prefixURL }}/-/healthy
               port: 9090
+          {{- end }}
             initialDelaySeconds: {{ .Values.server.livenessProbeInitialDelay }}
             periodSeconds: {{ .Values.server.livenessProbePeriodSeconds }}
             timeoutSeconds: {{ .Values.server.livenessProbeTimeout }}

--- a/charts/prometheus/templates/server/deploy.yaml
+++ b/charts/prometheus/templates/server/deploy.yaml
@@ -110,8 +110,8 @@ spec:
           {{- if .Values.server.baseURL }}
             - --web.external-url={{ .Values.server.baseURL }}
           {{- end }}
-          {{- if .Values.server.listenOnLocalhost }}
-            - --web.listen-address=localhost:9090
+          {{- if .Values.server.listenOnHost }}
+            - --web.listen-address={{ .Values.server.listenOnHost }}:9090
           {{- end }}
           ports:
             - containerPort: 9090

--- a/charts/prometheus/templates/server/deploy.yaml
+++ b/charts/prometheus/templates/server/deploy.yaml
@@ -110,8 +110,8 @@ spec:
           {{- if .Values.server.baseURL }}
             - --web.external-url={{ .Values.server.baseURL }}
           {{- end }}
-          {{- if .Values.server.listenOnHost }}
-            - --web.listen-address={{ .Values.server.listenOnHost }}:9090
+          {{- if .Values.server.listen.host }}
+            - --web.listen-address={{ .Values.server.listen.host }}:9090
           {{- end }}
           ports:
             - containerPort: 9090

--- a/charts/prometheus/templates/server/service.yaml
+++ b/charts/prometheus/templates/server/service.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.server.enabled -}}
+{{- if .Values.server.service.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -57,4 +58,5 @@ spec:
 {{- end }}
   {{- end }}
   type: "{{ .Values.server.service.type }}"
+{{- end -}}
 {{- end -}}

--- a/charts/prometheus/templates/server/sts.yaml
+++ b/charts/prometheus/templates/server/sts.yaml
@@ -110,6 +110,9 @@ spec:
           {{- if .Values.server.baseURL }}
             - --web.external-url={{ .Values.server.baseURL }}
           {{- end }}
+          {{- if .Values.server.listenOnLocalhost }}
+            - --web.listen-address=localhost:9090
+          {{- end }}
           ports:
             - containerPort: 9090
           readinessProbe:

--- a/charts/prometheus/templates/server/sts.yaml
+++ b/charts/prometheus/templates/server/sts.yaml
@@ -116,18 +116,26 @@ spec:
           ports:
             - containerPort: 9090
           readinessProbe:
+          {{- if .Values.server.customReadinessProbe }}
+{{ toYaml .Values.server.customReadinessProbe | indent 12}}
+          {{- else }}
             httpGet:
               path: {{ .Values.server.prefixURL }}/-/ready
               port: 9090
+          {{- end }}
             initialDelaySeconds: {{ .Values.server.readinessProbeInitialDelay }}
             periodSeconds: {{ .Values.server.readinessProbePeriodSeconds }}
             timeoutSeconds: {{ .Values.server.readinessProbeTimeout }}
             failureThreshold: {{ .Values.server.readinessProbeFailureThreshold }}
             successThreshold: {{ .Values.server.readinessProbeSuccessThreshold }}
           livenessProbe:
+          {{- if .Values.server.customLivenessProbe }}
+{{ toYaml .Values.server.customLivenessProbe | indent 12}}
+          {{- else }}
             httpGet:
               path: {{ .Values.server.prefixURL }}/-/healthy
               port: 9090
+          {{- end }}
             initialDelaySeconds: {{ .Values.server.livenessProbeInitialDelay }}
             periodSeconds: {{ .Values.server.livenessProbePeriodSeconds }}
             timeoutSeconds: {{ .Values.server.livenessProbeTimeout }}

--- a/charts/prometheus/templates/server/sts.yaml
+++ b/charts/prometheus/templates/server/sts.yaml
@@ -110,8 +110,8 @@ spec:
           {{- if .Values.server.baseURL }}
             - --web.external-url={{ .Values.server.baseURL }}
           {{- end }}
-          {{- if .Values.server.listenOnLocalhost }}
-            - --web.listen-address=localhost:9090
+          {{- if .Values.server.listenOnHost }}
+            - --web.listen-address={{ .Values.server.listenOnHost }}:9090
           {{- end }}
           ports:
             - containerPort: 9090

--- a/charts/prometheus/templates/server/sts.yaml
+++ b/charts/prometheus/templates/server/sts.yaml
@@ -110,8 +110,8 @@ spec:
           {{- if .Values.server.baseURL }}
             - --web.external-url={{ .Values.server.baseURL }}
           {{- end }}
-          {{- if .Values.server.listenOnHost }}
-            - --web.listen-address={{ .Values.server.listenOnHost }}:9090
+          {{- if .Values.server.listen.host }}
+            - --web.listen-address={{ .Values.server.listen.host }}:9090
           {{- end }}
           ports:
             - containerPort: 9090

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -699,6 +699,8 @@ server:
   ## If true, binds the Prometheus server to localhost and hence does not accept traffic from outside the
   ## Kubernetes Pod. Useful in service mesh setups (e.g. Consul Connect, Istio, ...), where traffic flows through
   ## sidecar proxies.
+  ## If using that feature, you most likely also need to configure "server.customReadinessProbe" and "server.customLivenessProbe"
+  ## and expose the respective HTTP paths on different ports outside of the service mesh (e.g. via Consul's exposed paths feature)
   listenOnLocalhost: false
 
   global:
@@ -977,6 +979,17 @@ server:
   livenessProbeTimeout: 10
   livenessProbeFailureThreshold: 3
   livenessProbeSuccessThreshold: 1
+
+  ## Fully customizable readiness and liveness probes.
+  ## Setting them will replace the defaults, so use with care!
+  # customReadinessProbe:
+  #   httpGet:
+  #     path: "/"
+  #     port: 21250
+  # customLivenessProbe:
+  #   httpGet:
+  #     path: "/"
+  #     port: 21251
 
   ## Prometheus server resource requests and limits
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -704,6 +704,7 @@ server:
   ##
   # listen:
   #   host: localhost
+  listen: {}
 
   global:
     ## How frequently to scrape targets by default

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -1021,6 +1021,8 @@ server:
     fsGroup: 65534
 
   service:
+    ## If false no service will be created. (The server.statefulSet.enabled=true will still create a headless service)
+    enabled: true
     annotations: {}
     labels: {}
     clusterIP: ""

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -701,7 +701,9 @@ server:
   ## sidecar proxies and direct requests to the Prometheus server from outside the Kubernetes Pod are not desired.
   ## If using that feature, you most likely also need to configure "server.customReadinessProbe" and "server.customLivenessProbe"
   ## and expose the respective HTTP paths on different ports outside the service mesh (e.g. via Consul's exposed paths feature)
-  # listenOnHost: localhost
+  ##
+  # listen:
+  #   host: localhost
 
   global:
     ## How frequently to scrape targets by default

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -696,12 +696,12 @@ server:
   ### When empty server.persistentVolume.mountPath is used instead
   storagePath: ""
 
-  ## If true, binds the Prometheus server to localhost and hence does not accept traffic from outside the
-  ## Kubernetes Pod. Useful in service mesh setups (e.g. Consul Connect, Istio, ...), where traffic flows through
-  ## sidecar proxies.
+  ## Binds the Prometheus server to the given host.
+  ## This is useful in service mesh setups (e.g. Consul Connect, Istio, ...), where traffic flows through
+  ## sidecar proxies and direct requests to the Prometheus server from outside the Kubernetes Pod are not desired.
   ## If using that feature, you most likely also need to configure "server.customReadinessProbe" and "server.customLivenessProbe"
-  ## and expose the respective HTTP paths on different ports outside of the service mesh (e.g. via Consul's exposed paths feature)
-  listenOnLocalhost: false
+  ## and expose the respective HTTP paths on different ports outside the service mesh (e.g. via Consul's exposed paths feature)
+  # listenOnHost: localhost
 
   global:
     ## How frequently to scrape targets by default

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -696,6 +696,11 @@ server:
   ### When empty server.persistentVolume.mountPath is used instead
   storagePath: ""
 
+  ## If true, binds the Prometheus server to localhost and hence does not accept traffic from outside the
+  ## Kubernetes Pod. Useful in service mesh setups (e.g. Consul Connect, Istio, ...), where traffic flows through
+  ## sidecar proxies.
+  listenOnLocalhost: false
+
   global:
     ## How frequently to scrape targets by default
     ##


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
I'd like to deploy the Prometheus server into a setup with Consul Connect Service Mesh. That means the main Prometheus API must not be reachable from outside the Pod directly, but only through the so-called "sidecar-proxy". This proxy enforces mutualTLS and only allows authorized traffic to reach the application. To optimally support this setup, I would like to add three changes:
- [x] Add a flag to bind the server only to localhost
- [x] Allow customization of the readiness and liveness probes, to call to the proxy instead of port 9090
- [x] Optionally disable the Kubernetes Service. It's just not needed in our case.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)

Can you please take a look @gianrubio @zanhsieh @Xtigyro @monotek @naseemkullah 