### PR TITLE
[kube-prometheus-stack] Passed Env, Grafana.ini and Pluging values to subchart

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 17.1.3
+version: 17.1.4
 appVersion: 0.49.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -637,6 +637,22 @@ grafana:
 
   adminPassword: prom-operator
 
+  env: {}
+
+  ## "valueFrom" environment variable references that will be added to deployment pods
+  ## ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#envvarsource-v1-core
+  ## Renders in container spec as:
+  ##   env:
+  ##     ...
+  ##     - name: <key>
+  ##       valueFrom:
+  ##         <value rendered as YAML>
+  envValueFrom: {}
+
+  ## The name of a secret in the same kubernetes namespace which contain values to be added to the environment
+  ## This can be useful for auth tokens, etc. Value is templated.
+  envFromSecret: ""
+
   ingress:
     ## If true, Grafana Ingress will be created
     ##
@@ -700,6 +716,72 @@ grafana:
       ## ref: https://git.io/fjaBS
       createPrometheusReplicasDatasources: false
       label: grafana_datasource
+
+  grafana.ini:
+    paths:
+      data: /var/lib/grafana/
+      logs: /var/log/grafana
+      plugins: /var/lib/grafana/plugins
+      provisioning: /etc/grafana/provisioning
+    analytics:
+      check_for_updates: true
+    log:
+      mode: console
+    grafana_net:
+      url: https://grafana.net
+    ## grafana Authentication can be enabled with the following values on grafana.ini
+    # server:
+          # The full public facing url you use in browser, used for redirects and emails
+    #    root_url:
+    # https://grafana.com/docs/grafana/latest/auth/github/#enable-github-in-grafana
+    # auth.github:
+    #    enabled: false
+    #    allow_sign_up: false
+    #    scopes: user:email,read:org
+    #    auth_url: https://github.com/login/oauth/authorize
+    #    token_url: https://github.com/login/oauth/access_token
+    #    api_url: https://api.github.com/user
+    #    team_ids:
+    #    allowed_organizations:
+    #    client_id:
+    #    client_secret:
+    ## LDAP Authentication can be enabled with the following values on grafana.ini
+    ## NOTE: Grafana will fail to start if the value for ldap.toml is invalid
+      # auth.ldap:
+      #   enabled: true
+      #   allow_sign_up: true
+      #   config_file: /etc/grafana/ldap.toml
+
+  ## Grafana's LDAP configuration
+  ## Templated by the template in _helpers.tpl
+  ## NOTE: To enable the grafana.ini must be configured with auth.ldap.enabled
+  ## ref: http://docs.grafana.org/installation/configuration/#auth-ldap
+  ## ref: http://docs.grafana.org/installation/ldap/#configuration
+
+  ldap:
+    enabled: false
+    # `existingSecret` is a reference to an existing secret containing the ldap configuration
+    # for Grafana in a key `ldap-toml`.
+    existingSecret: ""
+    # `config` is the content of `ldap.toml` that will be stored in the created secret
+    config: ""
+    # config: |-
+    #   verbose_logging = true
+
+    #   [[servers]]
+    #   host = "my-ldap-server"
+    #   port = 636
+    #   use_ssl = true
+    #   start_tls = false
+    #   ssl_skip_verify = false
+    #   bind_dn = "uid=%s,ou=users,dc=myorg,dc=com"
+
+  ## Pass the plugins you want installed as a list.
+  ##
+
+  plugins: []
+  # - digrich-bubblechart-panel
+  # - grafana-clock-panel
 
   extraConfigmapMounts: []
   # - name: certs-configmap


### PR DESCRIPTION

#### What this PR does / why we need it:
This passes additional values to the Grafana subchart,
env
envValuesFrom
envFromSecret
grafana.ini
ldap
plugins


- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
