### PR TITLE
[prometheus-pgbouncer-exporter] Add chart for pgbouncer-exporter

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,7 +22,7 @@
 /charts/prometheus-mysql-exporter/ @juanchimienti @monotek
 /charts/prometheus-nats-exporter/ @caarlos0 @okgolove
 /charts/prometheus-node-exporter/ @bismarck @gianrubio @vsliouniaev
-/charts/prometheus-pgbouncer-exporter/ @Pluggi
+/charts/prometheus-pgbouncer-exporter/ @Pluggi @zanhsieh
 /charts/prometheus-pingdom-exporter/ @monotek @rpahli
 /charts/prometheus-postgres-exporter/ @gianrubio @zanhsieh
 /charts/prometheus-pushgateway/ @cstaud @gianrubio

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,6 +22,7 @@
 /charts/prometheus-mysql-exporter/ @juanchimienti @monotek
 /charts/prometheus-nats-exporter/ @caarlos0 @okgolove
 /charts/prometheus-node-exporter/ @bismarck @gianrubio @vsliouniaev
+/charts/prometheus-pgbouncer-exporter/ @Pluggi
 /charts/prometheus-pingdom-exporter/ @monotek @rpahli
 /charts/prometheus-postgres-exporter/ @gianrubio @zanhsieh
 /charts/prometheus-pushgateway/ @cstaud @gianrubio

--- a/charts/prometheus-pgbouncer-exporter/.helmignore
+++ b/charts/prometheus-pgbouncer-exporter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/prometheus-pgbouncer-exporter/Chart.yaml
+++ b/charts/prometheus-pgbouncer-exporter/Chart.yaml
@@ -12,6 +12,8 @@ keywords:
 maintainers:
   - name: Pluggi
     email: pluggi512@gmail.com
+  - name: zanhsieh
+    email: zanhsieh@gmail.com
 
 type: application
 

--- a/charts/prometheus-pgbouncer-exporter/Chart.yaml
+++ b/charts/prometheus-pgbouncer-exporter/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: prometheus-pgbouncer-exporter
+description: Prometheus exporter for pgbouncer metrics
+home: https://github.com/prometheus-community/helm-charts
+sources:
+  - https://github.com/prometheus-community/pgbouncer_exporter
+
+keywords:
+  - prometheus
+  - pgbouncer
+
+maintainers:
+  - name: Pluggi
+    email: pluggi512@gmail.com
+
+type: application
+
+version: "1.0.0"
+
+appVersion: "0.4.0"

--- a/charts/prometheus-pgbouncer-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-pgbouncer-exporter/templates/_helpers.tpl
@@ -1,0 +1,74 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "prometheus-pgbouncer-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "prometheus-pgbouncer-exporter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "prometheus-pgbouncer-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "prometheus-pgbouncer-exporter.labels" -}}
+helm.sh/chart: {{ include "prometheus-pgbouncer-exporter.chart" . }}
+{{ include "prometheus-pgbouncer-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "prometheus-pgbouncer-exporter.selectorLabels" -}}
+app: {{ template "prometheus-pgbouncer-exporter.name" . }}
+app.kubernetes.io/name: {{ include "prometheus-pgbouncer-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "prometheus-pgbouncer-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "prometheus-pgbouncer-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Determine secret name, can either be self-created or an existing one
+*/}}
+{{- define "prometheus-pgbouncer-exporter.secretName" -}}
+{{- if .Values.existingSecret -}}
+{{- .Values.existingSecret }}
+{{- else }}
+{{- include "prometheus-pgbouncer-exporter.fullname" . }}
+{{- end }}
+{{- end }}

--- a/charts/prometheus-pgbouncer-exporter/templates/deployment.yaml
+++ b/charts/prometheus-pgbouncer-exporter/templates/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "prometheus-pgbouncer-exporter.fullname" . }}
+  labels:
+    {{- include "prometheus-pgbouncer-exporter.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "prometheus-pgbouncer-exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "prometheus-pgbouncer-exporter.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - --log.level={{ .Values.logLevel }}
+            - --log.format={{ .Values.logFormat }}
+            - --pgBouncer.connectionString=$(CONNECTION_STRING)
+          env:
+            - name: CONNECTION_STRING
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "prometheus-pgbouncer-exporter.secretName" . }}
+                  key: connectionString
+          ports:
+            - name: exporter-port
+              containerPort: 9127
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: exporter-port
+          readinessProbe:
+            httpGet:
+              path: /
+              port: exporter-port
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/prometheus-pgbouncer-exporter/templates/secret.yaml
+++ b/charts/prometheus-pgbouncer-exporter/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if not .Values.existingSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "prometheus-pgbouncer-exporter.secretName" . }}
+  labels:
+    {{- include "prometheus-pgbouncer-exporter.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- with .Values.connection }}
+  connectionString: {{ printf "postgres://%s:%s@%s:%v/%s?sslmode=%s" .user .password .host .port .database .sslmode | b64enc }}
+  {{- end }}
+{{- end }}

--- a/charts/prometheus-pgbouncer-exporter/templates/service.yaml
+++ b/charts/prometheus-pgbouncer-exporter/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "prometheus-pgbouncer-exporter.fullname" . }}
+  labels:
+    {{- include "prometheus-pgbouncer-exporter.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: exporter-port
+      protocol: TCP
+      name: exporter-port
+  selector:
+    {{- include "prometheus-pgbouncer-exporter.selectorLabels" . | nindent 4 }}

--- a/charts/prometheus-pgbouncer-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-pgbouncer-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+{{- if .Values.serviceMonitor.labels }}
+  labels:
+{{ toYaml .Values.serviceMonitor.labels | indent 4}}
+{{- end }}
+  name: {{ template "prometheus-pgbouncer-exporter.fullname" . }}
+{{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+{{- end }}
+spec:
+  endpoints:
+  - targetPort: exporter-port
+{{- if .Values.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
+{{- end }}
+{{- if .Values.serviceMonitor.telemetryPath }}
+    path: {{ .Values.serviceMonitor.telemetryPath }}
+{{- end }}
+{{- if .Values.serviceMonitor.timeout }}
+    scrapeTimeout: {{ .Values.serviceMonitor.timeout }}
+{{- end }}
+{{- if .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ toYaml .Values.serviceMonitor.metricRelabelings | indent 4 }}
+{{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "prometheus-pgbouncer-exporter.name" . }}
+{{- if .Values.serviceMonitor.targetLabels }}
+  targetLabels:
+{{- range .Values.serviceMonitor.targetLabels }}
+  - {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/prometheus-pgbouncer-exporter/values.yaml
+++ b/charts/prometheus-pgbouncer-exporter/values.yaml
@@ -1,0 +1,59 @@
+logLevel: info
+logFormat: json
+connection:
+  user: postgres
+  password: ""
+  host: localhost
+  port: 6543
+  database: pgbouncer
+  sslmode: disable
+
+# Name of a secret containing a connection string as described in
+# https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+# existingSecret: ""
+
+replicaCount: 1
+
+image:
+  repository: prometheuscommunity/pgbouncer-exporter
+  tag: v0.4.0
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+podAnnotations: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+service:
+  type: ClusterIP
+  port: 9127
+
+serviceMonitor:
+  # When set true then use a ServiceMonitor to configure scraping
+  enabled: false
+  # Set path to pgbouncer-exporter telemetry-path
+  telemetryPath: /metrics
+  # Set the namespace the ServiceMonitor should be deployed
+  # namespace: monitoring
+  # Set how frequently Prometheus should scrape
+  # interval: 30s
+  # Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator
+  # labels:
+  # Set timeout for scrape
+  # timeout: 10s
+  # Set relabel_configs as per https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+  # relabelings: []
+  # Set of labels to transfer on the Kubernetes Service onto the target.
+  # targetLabels: []
+  # metricRelabelings: []
+
+resources: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds a chart for pgbouncer_exporter.

#### Special notes for your reviewer:

I am not sure if the way I pass the connection string is okay?

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
