### PR TITLE
[kube-prometheus-stack] add option to configure Prometheus image using tag and/or sha256

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 18.0.3
+version: 18.0.4
 appVersion: 0.50.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -32,7 +32,15 @@ spec:
 {{ toYaml .Values.prometheus.prometheusSpec.apiserverConfig | indent 4}}
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.image }}
-  image: {{ .Values.prometheus.prometheusSpec.image.repository }}:{{ .Values.prometheus.prometheusSpec.image.tag }}
+  {{- if and .Values.prometheus.prometheusSpec.image.tag .Values.prometheus.prometheusSpec.image.sha }}
+  image: "{{ .Values.prometheus.prometheusSpec.image.repository }}:{{ .Values.prometheus.prometheusSpec.image.tag }}@sha256:{{ .Values.prometheus.prometheusSpec.image.sha }}"
+  {{- else if .Values.prometheus.prometheusSpec.image.sha }}
+  image: "{{ .Values.prometheus.prometheusSpec.image.repository }}@sha256:{{ .Values.prometheus.prometheusSpec.image.sha }}"
+  {{- else if .Values.prometheus.prometheusSpec.image.tag }}
+  image: "{{ .Values.prometheus.prometheusSpec.image.repository }}:{{ .Values.prometheus.prometheusSpec.image.tag }}"
+  {{- else }}
+  image: "{{ .Values.prometheus.prometheusSpec.image.repository }}"
+  {{- end }}
   version: {{ .Values.prometheus.prometheusSpec.image.tag }}
   {{- if .Values.prometheus.prometheusSpec.image.sha }}
   sha: {{ .Values.prometheus.prometheusSpec.image.sha }}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it: It enables to configure Prometheus image using tag and/or sha256.

Prometheus operator uses [BuildImagePath](https://github.com/prometheus-operator/prometheus-operator/blob/e2867fc585d77d08c6ed3c02ed8b3df4ee6b1445/pkg/operator/image.go#L30) function to define image path, please see also [here](https://github.com/prometheus-operator/prometheus-operator/blob/e2867fc585d77d08c6ed3c02ed8b3df4ee6b1445/pkg/prometheus/statefulset.go#L321).

`image` in Prometheus definition has precedence over baseImage, tag, and sha combinations, see [this](https://github.com/prometheus-community/helm-charts/blob/466e1228adb88142d8ac0cde26366f8b79953737/charts/kube-prometheus-stack/crds/crd-prometheuses.yaml#L2263-L2267), so currently `sha` is ignored, e.g
```
helm upgrade --install kube-prometheus-stack-test charts/kube-prometheus-stack/ \
    --set prometheus.prometheusSpec.image.repository=quay.io/prometheus/prometheus \
    --set prometheus.prometheusSpec.image.tag=v2.28.0 \
    --set prometheus.prometheusSpec.image.sha=d5db4b724a53ec7135df90bdb908e00439522539156df2697d969c5931c673a4
```
for above settings currently image is set to `quay.io/prometheus/prometheus:v2.28.0`.

`tag` and `sha` in Prometheus specification are deprecated, see [tag deprecation note](https://github.com/prometheus-community/helm-charts/blob/466e1228adb88142d8ac0cde26366f8b79953737/charts/kube-prometheus-stack/crds/crd-prometheuses.yaml#L4862-L4866) and [sha deprecation note](https://github.com/prometheus-community/helm-charts/blob/466e1228adb88142d8ac0cde26366f8b79953737/charts/kube-prometheus-stack/crds/crd-prometheuses.yaml#L4570-L4575).




#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

Tested scenarios:

1.
```
helm upgrade --install kube-prometheus-stack-test charts/kube-prometheus-stack/ \
    --set prometheus.prometheusSpec.image.repository=ghcr.io/kkujawa-sumo/prometheus
```
Result: 
```
image: ghcr.io/kkujawa-sumo/prometheus:v2.28.1
```

2.
```
helm upgrade --install kube-prometheus-stack-test charts/kube-prometheus-stack/ \
    --set prometheus.prometheusSpec.image.repository=quay.io/prometheus/prometheus \
    --set prometheus.prometheusSpec.image.tag=v2.28.0 \
    --set prometheus.prometheusSpec.image.sha=d5db4b724a53ec7135df90bdb908e00439522539156df2697d969c5931c673a4
```
Result: 
```
image: quay.io/prometheus/prometheus:v2.28.0@sha256:d5db4b724a53ec7135df90bdb908e00439522539156df2697d969c5931c673a4
```

3.
```
helm upgrade --install kube-prometheus-stack-test charts/kube-prometheus-stack/ \
    --set prometheus.prometheusSpec.image.repository=quay.io/prometheus/prometheus \
    --set prometheus.prometheusSpec.image.tag=v2.28.0
```

Result: 
```
image: quay.io/prometheus/prometheus:v2.28.0
```

4.
```
helm upgrade --install kube-prometheus-stack-test charts/kube-prometheus-stack/ \
    --set prometheus.prometheusSpec.image.repository=quay.io/prometheus/prometheus \
    --set prometheus.prometheusSpec.image.sha=d5db4b724a53ec7135df90bdb908e00439522539156df2697d969c5931c673a4
```

Result: 
```
quay.io/prometheus/prometheus:v2.28.1@sha256:d5db4b724a53ec7135df90bdb908e00439522539156df2697d969c5931c673a4
```


#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
