### PR TITLE
[kube-prometheus-stack] Pass additional values to grafana subchart

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 17.2.1
+version: 17.2.2
 appVersion: 0.49.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -670,6 +670,121 @@ grafana:
     #   hosts:
     #   - grafana.example.com
 
+  grafana.ini:
+    paths:
+      data: /var/lib/grafana/
+      logs: /var/log/grafana
+      plugins: /var/lib/grafana/plugins
+      provisioning: /etc/grafana/provisioning
+    analytics:
+      check_for_updates: true
+    log:
+      mode: console
+    grafana_net:
+      url: https://grafana.net
+    ## grafana Authentication can be enabled with the following values on grafana.ini
+    # server:
+    # The full public facing url you use in browser, used for redirects and emails
+    #    root_url:
+    # https://grafana.com/docs/grafana/latest/auth/github/#enable-github-in-grafana
+    # auth.github:
+    #    enabled: false
+    #    allow_sign_up: false
+    #    scopes: user:email,read:org
+    #    auth_url: https://github.com/login/oauth/authorize
+    #    token_url: https://github.com/login/oauth/access_token
+    #    api_url: https://api.github.com/user
+    #    team_ids:
+    #    allowed_organizations:
+    #    client_id:
+    #    client_secret:
+    ## LDAP Authentication can be enabled with the following values on grafana.ini
+    ## NOTE: Grafana will fail to start if the value for ldap.toml is invalid
+    # auth.ldap:
+    #   enabled: true
+    #   allow_sign_up: true
+    #   config_file: /etc/grafana/ldap.toml
+
+  ## Grafana's LDAP configuration
+  ## Templated by the template in _helpers.tpl
+  ## NOTE: To enable the grafana.ini must be configured with auth.ldap.enabled
+  ## ref: http://docs.grafana.org/installation/configuration/#auth-ldap
+  ## ref: http://docs.grafana.org/installation/ldap/#configuration
+  ldap:
+    enabled: false
+    # `existingSecret` is a reference to an existing secret containing the ldap configuration
+    # for Grafana in a key `ldap-toml`.
+    existingSecret: ""
+    # `config` is the content of `ldap.toml` that will be stored in the created secret
+    config: ""
+    # config: |-
+    #   verbose_logging = true
+
+    #   [[servers]]
+    #   host = "my-ldap-server"
+    #   port = 636
+    #   use_ssl = true
+    #   start_tls = false
+    #   ssl_skip_verify = false
+    #   bind_dn = "uid=%s,ou=users,dc=myorg,dc=com"
+
+  ## Grafana's SMTP configuration
+  ## NOTE: To enable, grafana.ini must be configured with smtp.enabled
+  ## ref: http://docs.grafana.org/installation/configuration/#smtp
+  smtp:
+    # `existingSecret` is a reference to an existing secret containing the smtp configuration
+    # for Grafana.
+    existingSecret: ""
+    userKey: "user"
+    passwordKey: "password"
+
+  plugins: []
+    # - digrich-bubblechart-panel
+    # - grafana-clock-panel
+
+
+  ## Extra environment variables that will be pass onto deployment pods
+  ##
+  ## to provide grafana with access to CloudWatch on AWS EKS:
+  ## 1. create an iam role of type "Web identity" with provider oidc.eks.* (note the provider for later)
+  ## 2. edit the "Trust relationships" of the role, add a line inside the StringEquals clause using the
+  ## same oidc eks provider as noted before (same as the existing line)
+  ## also, replace NAMESPACE and prometheus-operator-grafana with the service account namespace and name
+  ##
+  ##  "oidc.eks.us-east-1.amazonaws.com/id/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:sub": "system:serviceaccount:NAMESPACE:prometheus-operator-grafana",
+  ##
+  ## 3. attach a policy to the role, you can use a built in policy called CloudWatchReadOnlyAccess
+  ## 4. use the following env: (replace 123456789000 and iam-role-name-here with your aws account number and role name)
+  ##
+  ## env:
+  ##   AWS_ROLE_ARN: arn:aws:iam::123456789000:role/iam-role-name-here
+  ##   AWS_WEB_IDENTITY_TOKEN_FILE: /var/run/secrets/eks.amazonaws.com/serviceaccount/token
+  ##   AWS_REGION: us-east-1
+  ##
+  ## 5. uncomment the EKS section in extraSecretMounts: below
+  ## 6. uncomment the annotation section in the serviceAccount: above
+  ## make sure to replace arn:aws:iam::123456789000:role/iam-role-name-here with your role arn
+
+  env: {}
+
+  ## "valueFrom" environment variable references that will be added to deployment pods
+  ## ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#envvarsource-v1-core
+  ## Renders in container spec as:
+  ##   env:
+  ##     ...
+  ##     - name: <key>
+  ##       valueFrom:
+  ##         <value rendered as YAML>
+  envValueFrom: {}
+
+  ## The name of a secret in the same kubernetes namespace which contain values to be added to the environment
+  ## This can be useful for auth tokens, etc. Value is templated.
+  envFromSecret: ""
+
+  ## Configure grafana datasources
+  ## ref: http://docs.grafana.org/administration/provisioning/#datasources
+  ##
+
   sidecar:
     dashboards:
       enabled: true


### PR DESCRIPTION
Signed-off-by: Corey Sprung <Corey.Sprung@TELUS.com>

#### What this PR does / why we need it:

Passing additional values to the grafana subchart
grafana.ini
ldap
smtp
plugins
env
envValueFrom
envFromSecret



#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
