### PR TITLE
[prometheus] Fix AlertManager deploy.yaml missing `cluster.listen-address`

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.26.0
-version: 14.6.0
+version: 14.6.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/templates/alertmanager/deploy.yaml
+++ b/charts/prometheus/templates/alertmanager/deploy.yaml
@@ -73,7 +73,7 @@ spec:
             - --web.external-url={{ .Values.alertmanager.baseURL }}
           {{- end }}
           {{- range .Values.alertmanager.clusterPeers }}
-          - --clusterPeer={{ . }}
+          - --cluster.peer={{ . }}
           {{- end }}
 
           ports:

--- a/charts/prometheus/templates/alertmanager/deploy.yaml
+++ b/charts/prometheus/templates/alertmanager/deploy.yaml
@@ -73,7 +73,7 @@ spec:
             - --web.external-url={{ .Values.alertmanager.baseURL }}
           {{- end }}
           {{- range .Values.alertmanager.clusterPeers }}
-          - --cluster.peer={{ . }}
+            - --cluster.peer={{ . }}
           {{- end }}
 
           ports:

--- a/charts/prometheus/templates/alertmanager/deploy.yaml
+++ b/charts/prometheus/templates/alertmanager/deploy.yaml
@@ -60,7 +60,12 @@ spec:
           args:
             - --config.file=/etc/config/{{ .Values.alertmanager.configFileName }}
             - --storage.path={{ .Values.alertmanager.persistentVolume.mountPath }}
+          {{- if .Values.alertmanager.service.enableMeshPeer }}
+            - --cluster.listen-address=0.0.0.0:6783
             - --cluster.advertise-address=[$(POD_IP)]:6783
+          {{- else }}
+            - --cluster.listen-address=
+          {{- end }}
           {{- range $key, $value := .Values.alertmanager.extraArgs }}
             - --{{ $key }}={{ $value }}
           {{- end }}

--- a/charts/prometheus/templates/alertmanager/deploy.yaml
+++ b/charts/prometheus/templates/alertmanager/deploy.yaml
@@ -72,6 +72,9 @@ spec:
           {{- if .Values.alertmanager.baseURL }}
             - --web.external-url={{ .Values.alertmanager.baseURL }}
           {{- end }}
+          {{- range .Values.alertmanager.clusterPeers }}
+          - --clusterPeer={{ . }}
+          {{- end }}
 
           ports:
             - containerPort: 9093

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -347,6 +347,10 @@ alertmanager:
     sessionAffinity: None
     type: ClusterIP
 
+  ## List of initial peers, enableMeshPeer must be true
+  ## Ref: https://github.com/prometheus/alertmanager/blob/main/README.md#high-availability
+  clusterPeers: []
+
 ## Monitors ConfigMap changes and POSTs to a URL
 ## Ref: https://github.com/jimmidyson/configmap-reload
 ##

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -347,7 +347,7 @@ alertmanager:
     sessionAffinity: None
     type: ClusterIP
 
-  ## List of initial peers, enableMeshPeer must be true
+  ## List of initial peers
   ## Ref: https://github.com/prometheus/alertmanager/blob/main/README.md#high-availability
   clusterPeers: []
 


### PR DESCRIPTION
#### What this PR does / why we need it:

* Fix in prometheus chart `alertmanager/deploy.yaml` missing `cluster.listen-address` when `alertmanager.service.enableMeshPeer` it's `true`.

Alertmanager `--cluster.listen-address` default value is `0.0.0.0:9094` so we need to overwrite it to `0.0.0.0:6783`

* Fix in prometheus chart when adding multiple `clusterPeer=` at Alertmanager `extraArgs`

example:

```
alertmanager.extraArgs:
  cluster.peer: "foo:6783"
  cluster.peer: "bar:6783"
```

Because extraArgs it's defined as a Map, Helm will only render the last `clusterPeer` defined when executing the `range` command

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name
