### PR TITLE
[kube-prometheus-stack] multi tenant alert routing

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 18.0.2
+version: 18.1.0
 appVersion: 0.50.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 18.0.0
+version: 18.0.2
 appVersion: 0.50.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/general.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/general.rules.yaml
@@ -29,7 +29,10 @@ spec:
         description: '{{`{{`}} printf "%.4g" $value {{`}}`}}% of the {{`{{`}} $labels.job {{`}}`}}/{{`{{`}} $labels.service {{`}}`}} targets in {{`{{`}} $labels.namespace {{`}}`}} namespace are down.'
         runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-targetdown
         summary: One or more targets are unreachable.
-      expr: 100 * (count(up == 0) BY (job, namespace, service) / count(up) BY (job, namespace, service)) > 10
+      expr: |-
+        {{ .Values.defaultRules.expressionPrefix }}
+        100 * (count(up == 0) BY (job, namespace, service) / count(up) BY (job, namespace, service)) > 10
+        {{ .Values.defaultRules.expressionSufix }}
       for: 10m
       labels:
         severity: warning

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-apps.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-apps.yaml
@@ -31,9 +31,11 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-kubepodcrashlooping
         summary: Pod is crash looping.
       expr: |-
+        {{ .Values.defaultRules.expressionPrefix }}
         increase(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}[10m]) > 0
         and
         kube_pod_container_status_waiting{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"} == 1
+        {{ .Values.defaultRules.expressionSufix }}
       for: 15m
       labels:
         severity: warning
@@ -46,6 +48,7 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-kubepodnotready
         summary: Pod has been in a non-ready state for more than 15 minutes.
       expr: |-
+        {{ .Values.defaultRules.expressionPrefix }}
         sum by (namespace, pod) (
           max by(namespace, pod) (
             kube_pod_status_phase{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}", phase=~"Pending|Unknown"}
@@ -53,6 +56,7 @@ spec:
             1, max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!="Job"})
           )
         ) > 0
+        {{ .Values.defaultRules.expressionSufix }}
       for: 15m
       labels:
         severity: warning
@@ -65,9 +69,11 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-kubedeploymentgenerationmismatch
         summary: Deployment generation mismatch due to possible roll-back
       expr: |-
+        {{ .Values.defaultRules.expressionPrefix }}
         kube_deployment_status_observed_generation{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
           !=
         kube_deployment_metadata_generation{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
+        {{ .Values.defaultRules.expressionSufix }}
       for: 15m
       labels:
         severity: warning
@@ -80,6 +86,7 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-kubedeploymentreplicasmismatch
         summary: Deployment has not matched the expected number of replicas.
       expr: |-
+        {{ .Values.defaultRules.expressionPrefix }}
         (
           kube_deployment_spec_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
             >
@@ -89,6 +96,7 @@ spec:
             ==
           0
         )
+        {{ .Values.defaultRules.expressionSufix }}
       for: 15m
       labels:
         severity: warning
@@ -101,6 +109,7 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-kubestatefulsetreplicasmismatch
         summary: Deployment has not matched the expected number of replicas.
       expr: |-
+        {{ .Values.defaultRules.expressionPrefix }}
         (
           kube_statefulset_status_replicas_ready{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
             !=
@@ -110,6 +119,7 @@ spec:
             ==
           0
         )
+        {{ .Values.defaultRules.expressionSufix }}
       for: 15m
       labels:
         severity: warning
@@ -122,9 +132,11 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-kubestatefulsetgenerationmismatch
         summary: StatefulSet generation mismatch due to possible roll-back
       expr: |-
+        {{ .Values.defaultRules.expressionPrefix }}
         kube_statefulset_status_observed_generation{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
           !=
         kube_statefulset_metadata_generation{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
+        {{ .Values.defaultRules.expressionSufix }}
       for: 15m
       labels:
         severity: warning
@@ -137,6 +149,7 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-kubestatefulsetupdatenotrolledout
         summary: StatefulSet update has not been rolled out.
       expr: |-
+        {{ .Values.defaultRules.expressionPrefix }}
         (
           max without (revision) (
             kube_statefulset_status_current_revision{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
@@ -154,6 +167,7 @@ spec:
             ==
           0
         )
+        {{ .Values.defaultRules.expressionSufix }}
       for: 15m
       labels:
         severity: warning
@@ -166,6 +180,7 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-kubedaemonsetrolloutstuck
         summary: DaemonSet rollout is stuck.
       expr: |-
+        {{ .Values.defaultRules.expressionPrefix }}
         (
           (
             kube_daemonset_status_current_number_scheduled{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
@@ -189,6 +204,7 @@ spec:
             ==
           0
         )
+        {{ .Values.defaultRules.expressionSufix }}
       for: 15m
       labels:
         severity: warning
@@ -200,7 +216,10 @@ spec:
         description: Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}} container {{`{{`}} $labels.container{{`}}`}} has been in waiting state for longer than 1 hour.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-kubecontainerwaiting
         summary: Pod container waiting longer than 1 hour
-      expr: sum by (namespace, pod, container) (kube_pod_container_status_waiting_reason{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}) > 0
+      expr: |-
+        {{ .Values.defaultRules.expressionPrefix }}
+        sum by (namespace, pod, container) (kube_pod_container_status_waiting_reason{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}) > 0
+        {{ .Values.defaultRules.expressionSufix }}
       for: 1h
       labels:
         severity: warning
@@ -213,9 +232,11 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-kubedaemonsetnotscheduled
         summary: DaemonSet pods are not scheduled.
       expr: |-
+        {{ .Values.defaultRules.expressionPrefix }}
         kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
           -
         kube_daemonset_status_current_number_scheduled{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"} > 0
+        {{ .Values.defaultRules.expressionSufix }}
       for: 10m
       labels:
         severity: warning
@@ -227,7 +248,10 @@ spec:
         description: '{{`{{`}} $value {{`}}`}} Pods of DaemonSet {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.daemonset {{`}}`}} are running where they are not supposed to run.'
         runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-kubedaemonsetmisscheduled
         summary: DaemonSet pods are misscheduled.
-      expr: kube_daemonset_status_number_misscheduled{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"} > 0
+      expr: |-
+        {{ .Values.defaultRules.expressionPrefix }}
+        kube_daemonset_status_number_misscheduled{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"} > 0
+        {{ .Values.defaultRules.expressionSufix }}
       for: 15m
       labels:
         severity: warning
@@ -239,7 +263,10 @@ spec:
         description: Job {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.job_name {{`}}`}} is taking more than 12 hours to complete.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-kubejobcompletion
         summary: Job did not complete in time
-      expr: kube_job_spec_completions{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"} - kube_job_status_succeeded{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}  > 0
+      expr: |-
+        {{ .Values.defaultRules.expressionPrefix }}
+        kube_job_spec_completions{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"} - kube_job_status_succeeded{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}  > 0
+        {{ .Values.defaultRules.expressionSufix }}
       for: 12h
       labels:
         severity: warning
@@ -251,7 +278,10 @@ spec:
         description: Job {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.job_name {{`}}`}} failed to complete. Removing failed job after investigation should clear this alert.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-kubejobfailed
         summary: Job failed to complete.
-      expr: kube_job_failed{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}  > 0
+      expr: |-
+        {{ .Values.defaultRules.expressionPrefix }}
+        kube_job_failed{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}  > 0
+        {{ .Values.defaultRules.expressionSufix }}
       for: 15m
       labels:
         severity: warning
@@ -264,6 +294,7 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-kubehpareplicasmismatch
         summary: HPA has not matched descired number of replicas.
       expr: |-
+        {{ .Values.defaultRules.expressionPrefix }}
         (kube_horizontalpodautoscaler_status_desired_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
           !=
         kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"})
@@ -277,6 +308,7 @@ spec:
         kube_horizontalpodautoscaler_spec_max_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"})
           and
         changes(kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}[15m]) == 0
+        {{ .Values.defaultRules.expressionSufix }}
       for: 15m
       labels:
         severity: warning
@@ -289,9 +321,11 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-kubehpamaxedout
         summary: HPA is running at max replicas
       expr: |-
+        {{ .Values.defaultRules.expressionPrefix }}
         kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
           ==
         kube_horizontalpodautoscaler_spec_max_replicas{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
+        {{ .Values.defaultRules.expressionSufix }}
       for: 15m
       labels:
         severity: warning

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-storage.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-storage.yaml
@@ -31,6 +31,7 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-kubepersistentvolumefillingup
         summary: PersistentVolume is filling up.
       expr: |-
+        {{ .Values.defaultRules.expressionPrefix }}
         (
           kubelet_volume_stats_available_bytes{job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics"}
             /
@@ -38,6 +39,7 @@ spec:
         ) < 0.03
         and
         kubelet_volume_stats_used_bytes{job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics"} > 0
+        {{ .Values.defaultRules.expressionSufix }}
       for: 1m
       labels:
         severity: critical
@@ -50,6 +52,7 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-kubepersistentvolumefillingup
         summary: PersistentVolume is filling up.
       expr: |-
+        {{ .Values.defaultRules.expressionPrefix }}
         (
           kubelet_volume_stats_available_bytes{job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics"}
             /
@@ -59,6 +62,7 @@ spec:
         kubelet_volume_stats_used_bytes{job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics"} > 0
         and
         predict_linear(kubelet_volume_stats_available_bytes{job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics"}[6h], 4 * 24 * 3600) < 0
+        {{ .Values.defaultRules.expressionSufix }}
       for: 1h
       labels:
         severity: warning
@@ -70,7 +74,10 @@ spec:
         description: The persistent volume {{`{{`}} $labels.persistentvolume {{`}}`}} has status {{`{{`}} $labels.phase {{`}}`}}.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-kubepersistentvolumeerrors
         summary: PersistentVolume is having issues with provisioning.
-      expr: kube_persistentvolume_status_phase{phase=~"Failed|Pending",job="kube-state-metrics"} > 0
+      expr: |-
+        {{ .Values.defaultRules.expressionPrefix }}
+        kube_persistentvolume_status_phase{phase=~"Failed|Pending",job="kube-state-metrics"} > 0
+        {{ .Values.defaultRules.expressionSufix }}
       for: 5m
       labels:
         severity: critical

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -71,6 +71,11 @@ defaultRules:
   ## Additional labels for PrometheusRule alerts
   additionalRuleLabels: {}
 
+  ## prefix for workload related expressions
+  expressionPrefix: ""
+  ## suffix for workload related expressions
+  expressionSufix: ""
+
 ## Deprecated way to provide custom recording or alerting rules to be deployed into the cluster.
 ##
 # additionalPrometheusRules: []


### PR DESCRIPTION
Signed-off-by: Robert N <nrobert13@gmail.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
allow alert routing in multi tenant clusters to different teams
#### Which issue this PR fixes
*(optional, in `fixes #<issue_number> (, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #1231 

#### Special notes for your reviewer:
hey @vsliouniaev , @bismarck, @gianrubio , @gkarthiks, @scottrigby, @Xtigyro, would you be so kind to review this change. Thanks in advance.
Cheers,
Robert
#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
