### PR TITLE
[prometheus-kafka-exporter] Configure log level and extra args

### DIFF
--- a/charts/prometheus-kafka-exporter/Chart.yaml
+++ b/charts/prometheus-kafka-exporter/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v1.2.0"
 description: A Helm chart to export the metrics from Kafka in Prometheus format using the kafka-exporter from https://github.com/danielqsj/kafka_exporter
 name: prometheus-kafka-exporter
 home: https://github.com/danielqsj/kafka_exporter
-version: 1.1.1
+version: 1.1.2
 sources:
   - https://gkarthiks.github.io/helm-charts/charts/prometheus-kafka-exporter
 keywords:

--- a/charts/prometheus-kafka-exporter/Chart.yaml
+++ b/charts/prometheus-kafka-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "v1.2.0"
+appVersion: "v1.3.1"
 description: A Helm chart to export the metrics from Kafka in Prometheus format using the kafka-exporter from https://github.com/danielqsj/kafka_exporter
 name: prometheus-kafka-exporter
 home: https://github.com/danielqsj/kafka_exporter

--- a/charts/prometheus-kafka-exporter/Chart.yaml
+++ b/charts/prometheus-kafka-exporter/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v1.3.1"
 description: A Helm chart to export the metrics from Kafka in Prometheus format using the kafka-exporter from https://github.com/danielqsj/kafka_exporter
 name: prometheus-kafka-exporter
 home: https://github.com/danielqsj/kafka_exporter
-version: 1.1.2
+version: 1.2.0
 sources:
   - https://gkarthiks.github.io/helm-charts/charts/prometheus-kafka-exporter
 keywords:

--- a/charts/prometheus-kafka-exporter/templates/deployment.yaml
+++ b/charts/prometheus-kafka-exporter/templates/deployment.yaml
@@ -24,6 +24,10 @@ spec:
       serviceAccountName: {{ template "prometheus-kafka-exporter.serviceAccountName" . }}
       containers:
         - args:
+            - '--log.level={{ .Values.logLevel }}'
+          {{- if .Values.sarama.logEnabled }}
+            - '--log.enable-sarama'
+          {{- end }}
           {{- range $server := .Values.kafkaServer }}
             - '--kafka.server={{ $server }}'
           {{- end }}
@@ -35,6 +39,14 @@ spec:
             - '--tls.ca-file={{ .Values.tls.mountPath }}/ca.crt'
             - '--tls.cert-file={{ .Values.tls.mountPath }}/tls.crt'
             - '--tls.key-file={{ .Values.tls.mountPath }}/tls.key'
+          {{- if .Values.tls.insecureSkipVerify }}
+            - '--tls.insecure-skip-tls-verify'
+          {{- end }}
+          {{- end }}
+          {{- if .Values.extraArgs }}
+          {{- range .Values.extraArgs  }}
+            - {{ . }}
+          {{- end }}
           {{- end }}
           env:
 {{- toYaml .Values.env | trim | nindent 12 }}

--- a/charts/prometheus-kafka-exporter/values.yaml
+++ b/charts/prometheus-kafka-exporter/values.yaml
@@ -11,6 +11,13 @@ kafkaServer:
 # Specifies broker version to use, leave empty for default
 kafkaBrokerVersion:
 
+# Valid levels: [debug, info, warn, error, fatal]
+logLevel: info
+
+# Sarama logging
+sarama:
+  logEnabled: false
+
 rbac:
   # Specifies whether RBAC resources should be created
   create: true
@@ -25,6 +32,11 @@ serviceAccount:
   name:
 
 env: []
+
+# List of additional cli arguments to configure kafka-exporter
+# for example: --log.enable-sarama, --log.level=debug, etc.
+# all the possible args can be found here: https://github.com/danielqsj/kafka_exporter#flags
+extraArgs: []
 
 service:
   type: ClusterIP
@@ -85,6 +97,7 @@ affinity: {}
 # tls.key
 tls:
   enabled: false
+  insecureSkipVerify: false
   # mountPath: /secret/certs
   # secretName: <name of an existing secret>
 

--- a/charts/prometheus-kafka-exporter/values.yaml
+++ b/charts/prometheus-kafka-exporter/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: danielqsj/kafka-exporter
-  tag: latest
+  tag: v1.3.1
   pullPolicy: IfNotPresent
 
 replicaCount: 1


### PR DESCRIPTION
Signed-off-by: Edwin Hobor <edwinhobor@gmail.com>

#### What this PR does / why we need it:

Added the possibility to configure:
- log level
- sarama log level
- insecureSkipVerify for TLS
- any other extra args that are listed under https://github.com/danielqsj/kafka_exporter#flags

Also used proper version `image.tag` instead of using `latest`.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #1272

#### Special notes for your reviewer:

@gkarthiks, @golgoth31 would you please take a look? Thanks!

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
