### PR TITLE
[prometheus-snmp-exporter] Changed chart to support multiple endpoints

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "0.9.0"
+appVersion: "0.10.0"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 2.3.5
+version: 2.3.6
 home: https://github.com/prometheus-community/postgres_exporter
 sources:
 - https://github.com/prometheus-community/postgres_exporter

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: quay.io/prometheuscommunity/postgres-exporter
-  tag: v0.9.0
+  tag: v0.10.0
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/prometheus-snmp-exporter/Chart.yaml
+++ b/charts/prometheus-snmp-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus SNMP Exporter
 name: prometheus-snmp-exporter
-version: 0.1.4
+version: 0.1.5
 appVersion: 0.19.0
 home: https://github.com/prometheus/snmp_exporter
 sources:

--- a/charts/prometheus-snmp-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-snmp-exporter/templates/servicemonitor.yaml
@@ -19,9 +19,6 @@ spec:
     {{- end }}
     honorLabels: {{ .Values.serviceMonitor.honorLabels }}
     path: {{ .Values.serviceMonitor.path }}
-    {{- if .Values.serviceMonitor.interval }}
-    interval: {{ .Values.serviceMonitor.interval }}
-    {{- end }}
     {{- if .Values.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
     {{- end }}

--- a/charts/prometheus-snmp-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-snmp-exporter/templates/servicemonitor.yaml
@@ -13,25 +13,34 @@ metadata:
     {{- end }}
 spec:
   endpoints:
+  {{- if not (empty .Values.serviceMonitor.endPoints)}}
+  {{ range  .Values.serviceMonitor.endPoints}}
   - port: http
-    {{- if .Values.serviceMonitor.interval }}
-    interval: {{ .Values.serviceMonitor.interval }}
+    {{- if .interval }}
+    interval: {{ .interval }}
     {{- end }}
-    honorLabels: {{ .Values.serviceMonitor.honorLabels }}
-    path: {{ .Values.serviceMonitor.path }}
-    {{- if .Values.serviceMonitor.scrapeTimeout }}
-    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+    honorLabels: {{ .honorLabels }}
+    path: {{ .path }}
+    {{- if .scrapeTimeout }}
+    scrapeTimeout: {{ .scrapeTimeout }}
     {{- end }}
-    {{- if .Values.serviceMonitor.params.enabled }}
     params:
-{{ toYaml .Values.serviceMonitor.params.conf | indent 6 }}
+      module:
+      - {{ .module }}
+      target:
+      - {{ .target }}
+    {{- if .metricRelabelings }}
+    metricRelabelings: {{ toYaml .metricRelabelings | nindent 8 }}
     {{- end }}
-    {{- if .Values.serviceMonitor.metricRelabelings }}
-    metricRelabelings: {{ toYaml .Values.serviceMonitor.metricRelabelings | nindent 8 }}
+    {{- if .relabelings }}
+    relabelings: {{ toYaml .relabelings | nindent 8 }}
     {{- end }}
-    {{- if .Values.serviceMonitor.relabelings }}
-    relabelings: {{ toYaml .Values.serviceMonitor.relabelings | nindent 8 }}
-    {{- end }}
+  {{- end }}
+  {{- else }}
+  - port: http
+    honorLabels: true
+    path: /snmp
+  {{- end }}
   selector:
     matchLabels:
       {{- include "prometheus-snmp-exporter.selectorLabels" . | indent 6 }}

--- a/charts/prometheus-snmp-exporter/values.yaml
+++ b/charts/prometheus-snmp-exporter/values.yaml
@@ -104,9 +104,6 @@ serviceMonitor:
   enabled: false
   namespace: monitoring
 
-  # fallback to the prometheus default unless specified
-  # interval: 10s
-
   ## Defaults to what's used if you follow CoreOS [Prometheus Install Instructions](https://github.com/helm/charts/tree/master/stable/prometheus-operator#tldr)
   ## [Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#prometheus-operator-1)
   ## [Kube Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#exporters)
@@ -114,15 +111,14 @@ serviceMonitor:
     prometheus: kube-prometheus
   # Retain the job and instance labels of the metrics pushed to the snmp-exporter
   # [Scraping SNMP-exporter](https://github.com/prometheus/snmp_exporter#configure-the-snmp_exporter-as-a-target-to-scrape)
-  honorLabels: true
 
-  params:
-    enabled: false
-    conf:
-      module:
-      - if_mib
-      target:
-      - 127.0.0.1
-
-  path: /snmp
-  scrapeTimeout: 10s
+  endPoints:
+  - # fallback to the prometheus default unless specified
+    # interval: 10s
+    module: if_mib
+    target: 127.0.0.1
+    honorLabels: true
+    path: /snmp
+    scrapeTimeout: 10s
+    # metricRelabelings: 
+    # relabelings: 


### PR DESCRIPTION
#### What this PR does / why we need it:
In case you have more than one device of a single kind to be monitored with SNMP, when you define multiple targets on chart, it generates an invalid Url to be scraped by Prometheus.(ie: http://X.X.X.X:9116/snmp?module=if_mib&target=host1&&target=host2&&target=host3) This Url raise error on Prometheus(server returned HTTP status 400 Bad Request). I changed the chart in a way to define one endpoint per target, this way you could monitor multiple devices on a single snmp-exporter deployment.

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
