### PR TITLE
[kube-state-metrics] Version bump to 2.2.0

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,8 +7,8 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 3.4.2
-appVersion: 2.1.1
+version: 3.5.0
+appVersion: 2.2.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:
 - https://github.com/kubernetes/kube-state-metrics/

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -2,7 +2,7 @@
 prometheusScrape: true
 image:
   repository: k8s.gcr.io/kube-state-metrics/kube-state-metrics
-  tag: v2.1.1
+  tag: v2.2.0
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
#### What this PR does / why we need it:

Version bumps kube-state-metrics to v2.2.0

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
