### PR TITLE
[kube-prometheus-stack] Fix alert manager complex config templating

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 18.0.1
+version: 18.0.2
 appVersion: 0.50.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/alertmanager/secret.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/secret.yaml
@@ -13,7 +13,11 @@ metadata:
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 data:
 {{- if .Values.alertmanager.tplConfig }}
+{{- if eq (typeOf .Values.alertmanager.config) "string" }}
+  alertmanager.yaml: {{ tpl (.Values.alertmanager.config) . | b64enc | quote }}
+{{- else }}
   alertmanager.yaml: {{ tpl (toYaml .Values.alertmanager.config) . | b64enc | quote }}
+{{- end }}
 {{- else }}
   alertmanager.yaml: {{ toYaml .Values.alertmanager.config | b64enc | quote }}
 {{- end}}


### PR DESCRIPTION
Addresses #302

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
This allows us to use complex multi-line template strings in the alertmanager config when using `tplConfig` flag. Currently if you attempt to use a multi-line string, it will template but the operator will not be able to parse the default secret `alertmanager.yaml` configuration object due to it being considered a YAML string.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #302

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
-  [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
