### PR TITLE
[prometheus-redis-exporter] Version bump to 1.27.0

### DIFF
--- a/charts/prometheus-redis-exporter/Chart.yaml
+++ b/charts/prometheus-redis-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.27.0
 description: Prometheus exporter for Redis metrics
 name: prometheus-redis-exporter
-version: 4.2.1
+version: 4.3.0
 home: https://github.com/oliver006/redis_exporter
 sources:
   - https://github.com/oliver006/redis_exporter

--- a/charts/prometheus-redis-exporter/Chart.yaml
+++ b/charts/prometheus-redis-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 1.11.1
+appVersion: 1.27.0
 description: Prometheus exporter for Redis metrics
 name: prometheus-redis-exporter
-version: 4.2.0
+version: 4.2.1
 home: https://github.com/oliver006/redis_exporter
 sources:
   - https://github.com/oliver006/redis_exporter

--- a/charts/prometheus-redis-exporter/values.yaml
+++ b/charts/prometheus-redis-exporter/values.yaml
@@ -13,7 +13,7 @@ serviceAccount:
 replicaCount: 1
 image:
   repository: oliver006/redis_exporter
-  tag: v1.11.1
+  tag: v1.27.0
   pullPolicy: IfNotPresent
 extraArgs: {}
 # Additional Environment variables


### PR DESCRIPTION
#### What this PR does / why we need it:
Version bumps redis-exporter to v1.27.0

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-redis-exporter]`)
