### PR TITLE
[kube-prometheus-stack]: fix chart aliases

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -8,5 +8,5 @@ dependencies:
 - name: grafana
   repository: https://grafana.github.io/helm-charts
   version: 6.15.0
-digest: sha256:0cc8367cf63d044beb103cc3b8c6cf7504ba47fb19eb8956710548eb9d9c3b96
-generated: "2021-08-19T19:36:26.830041372Z"
+digest: sha256:9bcd5bf74338d830e371070fb2b3732504d68b31b349a9e39fba06423ea1dce2
+generated: "2021-08-31T09:28:29.813454665+02:00"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 18.0.2
+version: 18.0.3
 appVersion: 0.50.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -39,10 +39,12 @@ dependencies:
   version: "3.4.*"
   repository: https://prometheus-community.github.io/helm-charts
   condition: kubeStateMetrics.enabled
+  alias: kubeStateMetrics
 - name: prometheus-node-exporter
   version: "2.0.*"
   repository: https://prometheus-community.github.io/helm-charts
   condition: nodeExporter.enabled
+  alias: nodeExporter
 - name: grafana
   version: "6.15.*"
   repository: https://grafana.github.io/helm-charts


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR fixes the Chart.yaml missing alias making it no really intuitive to configure kube state metrics or other dependant chart beside grafana.

To add a taint to kube-state-metrics:

```
      kube-state-metrics:
        nodeSelector:
          role: monitoring
        tolerations:
        - key: "dedicated"
          operator: "Equal"
          value: "monitoring"
          effect: "NoSchedule"
```

But configuration in values.yaml is done in the key `kubeStateMetrics`, beside `enabled`  none of the settings defined here are applied and they should use `kube-state-metrics` key which is unintuitive. This PR add the following alias:
- `kubeStateMetrics`
- `nodeExporter`

To make the default `values.yaml` work.


#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
