### PR TITLE
[prometheus-statsd-exporter] Bump statsd-exporter to version to 0.22.1

### DIFF
--- a/charts/prometheus-statsd-exporter/Chart.yaml
+++ b/charts/prometheus-statsd-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: prometheus-statsd-exporter
 description: A Helm chart for prometheus stats-exporter
-version: 0.3.1
-appVersion: 0.20.0
+version: 0.4.0
+appVersion: 0.21.0
 home: https://github.com/prometheus/statsd_exporter
 sources:
   - https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus-statsd-exporter

--- a/charts/prometheus-statsd-exporter/Chart.yaml
+++ b/charts/prometheus-statsd-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-statsd-exporter
 description: A Helm chart for prometheus stats-exporter
 version: 0.4.0
-appVersion: 0.21.0
+appVersion: 0.22.1
 home: https://github.com/prometheus/statsd_exporter
 sources:
   - https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus-statsd-exporter

--- a/charts/prometheus-statsd-exporter/values.yaml
+++ b/charts/prometheus-statsd-exporter/values.yaml
@@ -9,7 +9,7 @@ image:
   repository: prom/statsd-exporter
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: v0.21.0
+  tag: v0.22.1
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/prometheus-statsd-exporter/values.yaml
+++ b/charts/prometheus-statsd-exporter/values.yaml
@@ -9,7 +9,7 @@ image:
   repository: prom/statsd-exporter
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: v0.20.0
+  tag: v0.21.0
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
#### What this PR does / why we need it:
Version bumps statsd-exporter to v0.22.1

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
