### PR TITLE
[prometheus-pushgateway] - Update to latest version

### DIFF
--- a/charts/prometheus-pushgateway/Chart.yaml
+++ b/charts/prometheus-pushgateway/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.3.0"
+appVersion: "1.4.1"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 1.10.1
+version: 1.11.0
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/charts/prometheus-pushgateway/templates/ingress.yaml
+++ b/charts/prometheus-pushgateway/templates/ingress.yaml
@@ -2,7 +2,9 @@
 {{- $serviceName := include "prometheus-pushgateway.fullname" . }}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-{{- if semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.19.0-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io
+{{- else if semverCompare ">=1.14.0-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: networking.k8s.io/v1beta1
 {{- else }}
 apiVersion: extensions/v1beta1

--- a/charts/prometheus-pushgateway/values.yaml
+++ b/charts/prometheus-pushgateway/values.yaml
@@ -10,7 +10,7 @@ fullnameOverride: ""
 
 image:
   repository: prom/pushgateway
-  tag: v1.3.0
+  tag: v1.4.1
   pullPolicy: IfNotPresent
 
 # Optional pod imagePullSecrets


### PR DESCRIPTION
This PR does / why we need it:

Updates push gateway to latest version (1.4.1). Also updates ingress to use the stable release for newer versions of kubernets.

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
