### PR TITLE
[prometheus-postgres-exporter] allow set DATA_SOURCE_URI_FILE

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.9.0"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 2.3.5
+version: 2.3.6
 home: https://github.com/prometheus-community/postgres_exporter
 sources:
 - https://github.com/prometheus-community/postgres_exporter

--- a/charts/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/charts/prometheus-postgres-exporter/templates/deployment.yaml
@@ -70,9 +70,13 @@ spec:
           - "--log.level={{ .Values.config.logLevel }}"
           {{- end}}
           env:
-          {{- if .Values.config.datasourceUriFile }}
-          - name: DATA_SOURCE_URI_FILE
-            value: {{ .Values.config.datasourceUriFile }}
+          {{- if and .Values.config.datasourceUserVaultFile .Values.config.datasourcePassVaultFile }}
+          - name: DATA_SOURCE_USER_FILE
+            value: {{ default "/vault/secrets/database-user.txt" .Values.config.datasourceUserVaultFile }}
+          - name: DATA_SOURCE_PASS_FILE
+            value: {{ default "/vault/secrets/database-pass.txt" .Values.config.datasourcePassVaultFile }}
+          - name: DATA_SOURCE_URI
+            value: {{ template "prometheus-postgres-exporter.data_source_uri" . }}
           {{- else }}
           {{- if .Values.config.datasourceSecret }}
           - name: DATA_SOURCE_NAME

--- a/charts/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/charts/prometheus-postgres-exporter/templates/deployment.yaml
@@ -70,6 +70,10 @@ spec:
           - "--log.level={{ .Values.config.logLevel }}"
           {{- end}}
           env:
+          {{- if .Values.config.datasourceUriFile }}
+          - name: DATA_SOURCE_URI_FILE
+            value: {{ .Values.config.datasourceUriFile }}
+          {{- else }}
           {{- if .Values.config.datasourceSecret }}
           - name: DATA_SOURCE_NAME
             valueFrom:
@@ -90,6 +94,7 @@ spec:
           {{- else }}
                 name: {{ template "prometheus-postgres-exporter.fullname" . }}
                 key: data_source_password
+          {{- end }}
           {{- end }}
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -104,6 +104,9 @@ config:
     port: "5432"
     database: ''
     sslmode: disable
+  datasourceUriFile: ""
+    # Defines local file to read datasource uri and credentials from.
+    # Useful when credentials are provided by Vault agent-injector.
   datasourceSecret: {}
     # Specifies if datasource should be sourced from secret value in format: postgresql://login:password@hostname:port/dbname?sslmode=disable
     # Multiple Postgres databases can be configured by comma separated postgres connection strings
@@ -403,6 +406,8 @@ tolerations: []
 affinity: {}
 
 annotations: {}
+  # When defining annotations for vault-agent-injector, credentials filepath
+  # can be set with value "config.datasourceUriFile"
 
 podLabels: {}
 

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -407,7 +407,26 @@ affinity: {}
 
 annotations: {}
   # When defining annotations for vault-agent-injector, credentials filepath
-  # can be set with value "config.datasourceUriFile"
+  # can be set with values "config.datasourceUserVaultFile" and "config.datasourcePassVaultFile"
+  # Example:
+  # ```yaml
+  #   annotations:
+  #     prometheus.io/scrape: "true"
+  #     prometheus.io/port: "9187"
+  #     vault.hashicorp.com/agent-inject: "true"
+  #     vault.hashicorp.com/tls-skip-verify: "false"
+  #     vault.hashicorp.com/auth-path: "auth/eks"
+  #     vault.hashicorp.com/role: "postgres-exporter"
+  #     vault.hashicorp.com/agent-inject-secret-database-user.txt: 'postgres/creds/readonly'
+  #     vault.hashicorp.com/agent-inject-template-database-user.txt: |
+  #       {{- with secret "postgres/creds/readonly" -}}
+  #       {{.Data.username}}
+  #       {{- end -}}
+  #     vault.hashicorp.com/agent-inject-secret-database-pass.txt: 'postgres/creds/readonly'
+  #     vault.hashicorp.com/agent-inject-template-database-pass.txt: |
+  #       {{- with secret "postgres/creds/readonly" -}}
+  #       {{.Data.password}}
+  # ```
 
 podLabels: {}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
allow for defining DATA_SOURCE_URI_FILE, most helpful when using vault-agent-injector

#### Which issue this PR fixes
  - fixes #1309 

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
