### PR TITLE
[prometheus-adapter] Add support for configurable service ip

### DIFF
--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 2.16.0
+version: 2.17.0
 appVersion: v0.9.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/kubernetes-sigs/prometheus-adapter

--- a/charts/prometheus-adapter/templates/service.yaml
+++ b/charts/prometheus-adapter/templates/service.yaml
@@ -19,4 +19,6 @@ spec:
     app: {{ template "k8s-prometheus-adapter.name" . }}
     release: {{ .Release.Name }}
   type: {{ .Values.service.type }}
-
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}

--- a/charts/prometheus-adapter/values.yaml
+++ b/charts/prometheus-adapter/values.yaml
@@ -120,6 +120,7 @@ service:
   annotations: {}
   port: 443
   type: ClusterIP
+# clusterIP: 1.2.3.4
 
 tls:
   enable: false


### PR DESCRIPTION
Signed-off-by: Terje Sannum <terje.sannum@nav.no>

#### What this PR does / why we need it:

Add support for specifying the ip-address to use for the prometheus-adapter service

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
