### PR TITLE
[kube-prometheus-stack] bump grafana to 6.16.*

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 2.0.4
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.15.0
-digest: sha256:0cc8367cf63d044beb103cc3b8c6cf7504ba47fb19eb8956710548eb9d9c3b96
-generated: "2021-08-19T19:36:26.830041372Z"
+  version: 6.16.4
+digest: sha256:58f3cc8bad821aed15028f02b642a7c7409584d70a609badaa733ac1386bbae7
+generated: "2021-09-04T16:11:37.453658312+02:00"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 18.0.5
+version: 18.0.6
 appVersion: 0.50.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus
@@ -44,6 +44,6 @@ dependencies:
   repository: https://prometheus-community.github.io/helm-charts
   condition: nodeExporter.enabled
 - name: grafana
-  version: "6.15.*"
+  version: "6.16.*"
   repository: https://grafana.github.io/helm-charts
   condition: grafana.enabled


### PR DESCRIPTION
Signed-off-by: Tim Balzer <tbalzer@bigpoint.net>

#### What this PR does / why we need it:
Updates version of the Grafana dependency.
Version 6.16.x (up until 6.16.4) feature:
* quay.io/kiwigrid/k8s-sidecar update from 1.12.2 to 1.12.3
* Grafana update from 8.1.0 to 8.1.2
* Several documentation updates
* Bugfix that allows specifying multiple files for datasources/notifiers/dashboardProviders to work correctly

#### Which issue this PR fixes
* Upstream issue with multiple files for Grafana datasources/notifiers/dashboardProviders

#### Special notes for your reviewer:
* none

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
