### PR TITLE
fix: bump elastic chart version

### DIFF
--- a/charts/prometheus-elasticsearch-exporter/Chart.yaml
+++ b/charts/prometheus-elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: prometheus-elasticsearch-exporter
-version: 4.6.0
+version: 4.6.1
 kubeVersion: ">=1.10.0-0"
 appVersion: 1.2.1
 home: https://github.com/prometheus-community/elasticsearch_exporter


### PR DESCRIPTION
Signed-off-by: gkarthiks <github.gkarthiks@gmail.com>


#### What this PR does / why we need it:
Increments the path version of the `prometheus-elasticsearch-exporter` chart for a successful release ci. This will resolve the issue reported here https://github.com/prometheus-community/helm-charts/pull/1243#issuecomment-912680021

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #1319

#### Special notes for your reviewer:
This is an urgent fix to rectify the CI issues from failing to release any charts.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
