### PR TITLE
[prometheus-redis-exporter] allow using custom labels

### DIFF
--- a/charts/prometheus-redis-exporter/Chart.yaml
+++ b/charts/prometheus-redis-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.27.0
 description: Prometheus exporter for Redis metrics
 name: prometheus-redis-exporter
-version: 4.3.0
+version: 4.4.0
 home: https://github.com/oliver006/redis_exporter
 sources:
   - https://github.com/oliver006/redis_exporter

--- a/charts/prometheus-redis-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-redis-exporter/templates/_helpers.tpl
@@ -31,6 +31,17 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/* Create basic labels */}}
+{{- define "prometheus-redis-exporter.labels" -}}
+chart: {{ template "prometheus-redis-exporter.chart" . }}
+release: {{ $.Release.Name | quote }}
+heritage: {{ $.Release.Service | quote }}
+app: {{ template "prometheus-redis-exporter.name" . }}
+{{- if .Values.customLabels}}
+{{ toYaml .Values.customLabels }}
+{{- end }}
+{{- end }}
+
 {{/*
 Create the name of the service account to use
 */}}

--- a/charts/prometheus-redis-exporter/templates/deployment.yaml
+++ b/charts/prometheus-redis-exporter/templates/deployment.yaml
@@ -3,26 +3,21 @@ kind: Deployment
 metadata:
   name: {{ template "prometheus-redis-exporter.fullname" . }}
   labels:
-    app: {{ template "prometheus-redis-exporter.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+{{ include "prometheus-redis-exporter.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "prometheus-redis-exporter.name" . }}
-      release: {{ .Release.Name }}
+{{ include "prometheus-redis-exporter.labels" . | indent 6 }}
   template:
     metadata:
       annotations:
 {{ toYaml .Values.annotations | indent 8 }}
       labels:
-        app: {{ template "prometheus-redis-exporter.name" . }}
-        release: {{ .Release.Name }}
-        {{- if .Values.labels }}
+{{ include "prometheus-redis-exporter.labels" . | indent 8 }}
+      {{- if .Values.labels }}
 {{ toYaml .Values.labels | indent 8 }}
-        {{- end }}
+      {{- end }}
     spec:
       serviceAccountName: {{ template "prometheus-redis-exporter.serviceAccountName" . }}
       {{- if .Values.image.pullSecrets }}

--- a/charts/prometheus-redis-exporter/templates/podsecuritypolicy.yaml
+++ b/charts/prometheus-redis-exporter/templates/podsecuritypolicy.yaml
@@ -4,10 +4,7 @@ kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus-redis-exporter.fullname" . }}
   labels:
-    app: {{ template "prometheus-redis-exporter.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+{{ include "prometheus-redis-exporter.labels" . | indent 4 }}
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
     apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'

--- a/charts/prometheus-redis-exporter/templates/prometheusrule.yaml
+++ b/charts/prometheus-redis-exporter/templates/prometheusrule.yaml
@@ -7,10 +7,7 @@ metadata:
   namespace: {{ . }}
 {{- end }}
   labels:
-    app: {{ template "prometheus-redis-exporter.name" . }}
-    chart: {{ template "prometheus-redis-exporter.chart" . }}
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+{{ include "prometheus-redis-exporter.labels" . | indent 4 }}
 {{- with .Values.prometheusRule.additionalLabels }}
 {{ toYaml . | indent 4 }}
 {{- end }}

--- a/charts/prometheus-redis-exporter/templates/role.yaml
+++ b/charts/prometheus-redis-exporter/templates/role.yaml
@@ -4,10 +4,7 @@ kind: Role
 metadata:
   name: {{ template "prometheus-redis-exporter.fullname" . }}
   labels:
-    app: {{ template "prometheus-redis-exporter.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+{{ include "prometheus-redis-exporter.labels" . | indent 4 }}
 {{- if .Values.rbac.pspEnabled }}
 rules:
 - apiGroups:      ['extensions']

--- a/charts/prometheus-redis-exporter/templates/rolebinding.yaml
+++ b/charts/prometheus-redis-exporter/templates/rolebinding.yaml
@@ -4,10 +4,7 @@ kind: RoleBinding
 metadata:
   name: {{ template "prometheus-redis-exporter.fullname" . }}
   labels:
-    app: {{ template "prometheus-redis-exporter.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+{{ include "prometheus-redis-exporter.labels" . | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/prometheus-redis-exporter/templates/service.yaml
+++ b/charts/prometheus-redis-exporter/templates/service.yaml
@@ -3,10 +3,7 @@ kind: Service
 metadata:
   name: {{ template "prometheus-redis-exporter.fullname" . }}
   labels:
-    app: {{ template "prometheus-redis-exporter.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+{{ include "prometheus-redis-exporter.labels" . | indent 4 }}
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4 }}
 {{- end }}

--- a/charts/prometheus-redis-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-redis-exporter/templates/serviceaccount.yaml
@@ -4,8 +4,5 @@ kind: ServiceAccount
 metadata:
   name: {{ template "prometheus-redis-exporter.serviceAccountName" . }}
   labels:
-    app: {{ template "prometheus-redis-exporter.name" . }}
-    chart: {{ template "prometheus-redis-exporter.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+{{ include "prometheus-redis-exporter.labels" . | indent 4 }}
 {{- end -}}

--- a/charts/prometheus-redis-exporter/values.yaml
+++ b/charts/prometheus-redis-exporter/values.yaml
@@ -16,6 +16,9 @@ image:
   tag: v1.27.0
   pullPolicy: IfNotPresent
 extraArgs: {}
+
+customLabels: {}
+
 # Additional Environment variables
 env: {}
 # - name: REDIS_PASSWORD


### PR DESCRIPTION
Signed-off-by: Stanislav Chesnovskii <stanislav@chesnovsky.com>

#### What this PR does / why we need it:
This PR allows using custom labels in addition to the basic ones.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
