### PR TITLE
[prometheus-blackbox-exporter] Allow automount of the serviceaccount token for sidecar containers

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 5.0.3
+version: 5.0.4
 appVersion: 0.19.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 5.0.4
+version: 5.1.0
 appVersion: 0.19.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/charts/prometheus-blackbox-exporter/templates/deployment.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
         {{- end }}
     spec:
-      automountServiceAccountToken: false
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       serviceAccountName: {{ template "prometheus-blackbox-exporter.serviceAccountName" . }}
     {{- if .Values.nodeSelector }}
       nodeSelector:

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -5,6 +5,9 @@ kind: Deployment
 podDisruptionBudget: {}
   # maxUnavailable: 0
 
+## Allow automount the serviceaccount token for sidecar container (eg: oauthproxy)
+automountServiceAccountToken: false
+
 ## Additional blackbox-exporter container environment variables
 ## For instance to add a http_proxy
 ##


### PR DESCRIPTION
Signed-off-by: Philippe Bürgisser <philippe.burgisser@camptocamp.com>

#### What this PR does / why we need it:
It allows the serviceaccount to automount its secret, needed in case of a sidecar container like oauthproxy to have its token to exchange with the API

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
