### PR TITLE
[kube-prometheus-stack] Allow to set a timezone for the default grafana dashboards

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 18.0.11
+version: 18.0.12
 appVersion: 0.50.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 18.0.5
+version: 18.0.6
 appVersion: 0.50.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 18.0.9
+version: 18.0.11
 appVersion: 0.50.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/hack/sync_grafana_dashboards.py
+++ b/charts/kube-prometheus-stack/hack/sync_grafana_dashboards.py
@@ -150,7 +150,7 @@ def patch_json_for_multicluster_configuration(content, multicluster_key):
 
 def patch_json_set_timezone_as_variable(content):
     # content is no more in json format, so we have to replace using regex
-    return re.sub(r'\"timezone\"\s*:\s*\"[^"]*\"\s*,', '"timezone": "\{\{ .Value.grafana.defaultDashboardsTimezone \}\}",', content, flags=re.IGNORECASE|re.MULTILINE)
+    return re.sub(r'\"timezone\"\s*:\s*\"[^"]*\"', '"timezone": "\{\{ .Value.grafana.defaultDashboardsTimezone \}\}"', content, flags=re.IGNORECASE|re.MULTILINE)
 
 
 def write_group_to_file(resource_name, content, url, destination, min_kubernetes, max_kubernetes, multicluster_key):

--- a/charts/kube-prometheus-stack/hack/sync_grafana_dashboards.py
+++ b/charts/kube-prometheus-stack/hack/sync_grafana_dashboards.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Fetch dashboards from provided urls into this chart."""
 import json
+import re
 import textwrap
 from os import makedirs, path
 
@@ -147,6 +148,11 @@ def patch_json_for_multicluster_configuration(content, multicluster_key):
     return content
 
 
+def patch_json_set_timezone_as_variable(content):
+    # content is no more in json format, so we have to replace using regex
+    return re.sub(r'\"timezone\":.*$', '"timezone": "\{\{ .Value.grafana.defaultDashboardsTimezone \}\}",', content, flags=re.IGNORECASE|re.MULTILINE)
+
+
 def write_group_to_file(resource_name, content, url, destination, min_kubernetes, max_kubernetes, multicluster_key):
     # initialize header
     lines = header % {
@@ -158,6 +164,7 @@ def write_group_to_file(resource_name, content, url, destination, min_kubernetes
     }
 
     content = patch_json_for_multicluster_configuration(content, multicluster_key)
+    content = patch_json_set_timezone_as_variable(content)
 
     filename_struct = {resource_name + '.json': (LiteralStr(content))}
     # rules themselves

--- a/charts/kube-prometheus-stack/hack/sync_grafana_dashboards.py
+++ b/charts/kube-prometheus-stack/hack/sync_grafana_dashboards.py
@@ -150,7 +150,7 @@ def patch_json_for_multicluster_configuration(content, multicluster_key):
 
 def patch_json_set_timezone_as_variable(content):
     # content is no more in json format, so we have to replace using regex
-    return re.sub(r'\"timezone\"\s*:\s*\"[^"]*\"', '"timezone": "\{\{ .Value.grafana.defaultDashboardsTimezone \}\}"', content, flags=re.IGNORECASE|re.MULTILINE)
+    return re.sub(r'"timezone"\s*:\s*"(\\.|[^\"])*"', '"timezone": "\{\{ .Value.grafana.defaultDashboardsTimezone \}\}"', content, flags=re.IGNORECASE|re.MULTILINE)
 
 
 def write_group_to_file(resource_name, content, url, destination, min_kubernetes, max_kubernetes, multicluster_key):

--- a/charts/kube-prometheus-stack/hack/sync_grafana_dashboards.py
+++ b/charts/kube-prometheus-stack/hack/sync_grafana_dashboards.py
@@ -150,7 +150,7 @@ def patch_json_for_multicluster_configuration(content, multicluster_key):
 
 def patch_json_set_timezone_as_variable(content):
     # content is no more in json format, so we have to replace using regex
-    return re.sub(r'"timezone"\s*:\s*"(?:\\.|[^\"])*"', '"timezone": "\{\{ .Value.grafana.defaultDashboardsTimezone \}\}"', content, flags=re.IGNORECASE)
+    return re.sub(r'"timezone"\s*:\s*"(?:\\.|[^\"])*"', '"timezone": "\{\{ .Values.grafana.defaultDashboardsTimezone \}\}"', content, flags=re.IGNORECASE)
 
 
 def write_group_to_file(resource_name, content, url, destination, min_kubernetes, max_kubernetes, multicluster_key):

--- a/charts/kube-prometheus-stack/hack/sync_grafana_dashboards.py
+++ b/charts/kube-prometheus-stack/hack/sync_grafana_dashboards.py
@@ -150,7 +150,7 @@ def patch_json_for_multicluster_configuration(content, multicluster_key):
 
 def patch_json_set_timezone_as_variable(content):
     # content is no more in json format, so we have to replace using regex
-    return re.sub(r'"timezone"\s*:\s*"(\\.|[^\"])*"', '"timezone": "\{\{ .Value.grafana.defaultDashboardsTimezone \}\}"', content, flags=re.IGNORECASE|re.MULTILINE)
+    return re.sub(r'"timezone"\s*:\s*"(?:\\.|[^\"])*"', '"timezone": "\{\{ .Value.grafana.defaultDashboardsTimezone \}\}"', content, flags=re.IGNORECASE)
 
 
 def write_group_to_file(resource_name, content, url, destination, min_kubernetes, max_kubernetes, multicluster_key):

--- a/charts/kube-prometheus-stack/hack/sync_grafana_dashboards.py
+++ b/charts/kube-prometheus-stack/hack/sync_grafana_dashboards.py
@@ -150,7 +150,7 @@ def patch_json_for_multicluster_configuration(content, multicluster_key):
 
 def patch_json_set_timezone_as_variable(content):
     # content is no more in json format, so we have to replace using regex
-    return re.sub(r'\"timezone\":.*$', '"timezone": "\{\{ .Value.grafana.defaultDashboardsTimezone \}\}",', content, flags=re.IGNORECASE|re.MULTILINE)
+    return re.sub(r'\"timezone\"\s*:\s*\".*\",$', '"timezone": "\{\{ .Value.grafana.defaultDashboardsTimezone \}\}",', content, flags=re.IGNORECASE|re.MULTILINE)
 
 
 def write_group_to_file(resource_name, content, url, destination, min_kubernetes, max_kubernetes, multicluster_key):

--- a/charts/kube-prometheus-stack/hack/sync_grafana_dashboards.py
+++ b/charts/kube-prometheus-stack/hack/sync_grafana_dashboards.py
@@ -150,7 +150,7 @@ def patch_json_for_multicluster_configuration(content, multicluster_key):
 
 def patch_json_set_timezone_as_variable(content):
     # content is no more in json format, so we have to replace using regex
-    return re.sub(r'\"timezone\"\s*:\s*\".*\",$', '"timezone": "\{\{ .Value.grafana.defaultDashboardsTimezone \}\}",', content, flags=re.IGNORECASE|re.MULTILINE)
+    return re.sub(r'\"timezone\"\s*:\s*\"[^"]*\"\s*,', '"timezone": "\{\{ .Value.grafana.defaultDashboardsTimezone \}\}",', content, flags=re.IGNORECASE|re.MULTILINE)
 
 
 def write_group_to_file(resource_name, content, url, destination, min_kubernetes, max_kubernetes, multicluster_key):

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/alertmanager-overview.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/alertmanager-overview.yaml
@@ -602,7 +602,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "utc",
+        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
         "title": "Alertmanager / Overview",
         "uid": "alertmanager-overview",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/alertmanager-overview.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/alertmanager-overview.yaml
@@ -602,7 +602,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Alertmanager / Overview",
         "uid": "alertmanager-overview",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/apiserver.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/apiserver.yaml
@@ -1739,7 +1739,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / API server",
         "uid": "09ec8aa1e996d6ffcd6817bbaff4db1b",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/apiserver.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/apiserver.yaml
@@ -1739,7 +1739,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / API server",
         "uid": "09ec8aa1e996d6ffcd6817bbaff4db1b",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/cluster-total.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/cluster-total.yaml
@@ -1874,7 +1874,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Networking / Cluster",
         "uid": "ff635a025bcfea7bc3dd4f508990a3e9",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/cluster-total.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/cluster-total.yaml
@@ -1874,7 +1874,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Networking / Cluster",
         "uid": "ff635a025bcfea7bc3dd4f508990a3e9",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/controller-manager.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/controller-manager.yaml
@@ -1169,7 +1169,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Controller Manager",
         "uid": "72e0e05bef5099e5f049b05fdc429ed4",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/controller-manager.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/controller-manager.yaml
@@ -1169,7 +1169,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Controller Manager",
         "uid": "72e0e05bef5099e5f049b05fdc429ed4",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/etcd.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/etcd.yaml
@@ -1109,7 +1109,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "browser",
+        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
         "title": "etcd",
         "version": 215
     }

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/etcd.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/etcd.yaml
@@ -1109,7 +1109,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "etcd",
         "version": 215
     }

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-coredns.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-coredns.yaml
@@ -1523,7 +1523,7 @@ data:
           "1d"
         ]
       },
-      "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
+      "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
       "title": "CoreDNS",
       "uid": "vkQ0UHxik",
       "version": 2

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-coredns.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-coredns.yaml
@@ -1523,7 +1523,7 @@ data:
           "1d"
         ]
       },
-      "timezone": "utc",
+      "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
       "title": "CoreDNS",
       "uid": "vkQ0UHxik",
       "version": 2

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-cluster.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-cluster.yaml
@@ -3016,7 +3016,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Compute Resources / Cluster",
         "uid": "efa86fd1d0c121a26444b636a3f509a8",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-cluster.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-cluster.yaml
@@ -3016,7 +3016,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Compute Resources / Cluster",
         "uid": "efa86fd1d0c121a26444b636a3f509a8",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-namespace.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-namespace.yaml
@@ -2736,7 +2736,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Compute Resources / Namespace (Pods)",
         "uid": "85a562078cdf77779eaa1add43ccec1e",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-namespace.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-namespace.yaml
@@ -2736,7 +2736,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Compute Resources / Namespace (Pods)",
         "uid": "85a562078cdf77779eaa1add43ccec1e",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-node.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-node.yaml
@@ -970,7 +970,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Compute Resources / Node (Pods)",
         "uid": "200ac8fdbfbb74b39aff88118e4d1c2c",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-node.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-node.yaml
@@ -970,7 +970,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Compute Resources / Node (Pods)",
         "uid": "200ac8fdbfbb74b39aff88118e4d1c2c",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-pod.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-pod.yaml
@@ -2419,7 +2419,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Compute Resources / Pod",
         "uid": "6581e46e4e5c7ba40a07646395ef7b23",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-pod.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-pod.yaml
@@ -2419,7 +2419,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Compute Resources / Pod",
         "uid": "6581e46e4e5c7ba40a07646395ef7b23",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-workload.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-workload.yaml
@@ -1978,7 +1978,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Compute Resources / Workload",
         "uid": "a164a7f0339f99e89cea5cb47e9be617",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-workload.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-workload.yaml
@@ -1978,7 +1978,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Compute Resources / Workload",
         "uid": "a164a7f0339f99e89cea5cb47e9be617",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-workloads-namespace.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-workloads-namespace.yaml
@@ -2143,7 +2143,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Compute Resources / Namespace (Workloads)",
         "uid": "a87fb0d919ec0ea5f6543124e16c42a5",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-workloads-namespace.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-workloads-namespace.yaml
@@ -2143,7 +2143,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Compute Resources / Namespace (Workloads)",
         "uid": "a87fb0d919ec0ea5f6543124e16c42a5",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/kubelet.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/kubelet.yaml
@@ -2240,7 +2240,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Kubelet",
         "uid": "3138fa155d5915769fbded898ac09fd9",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/kubelet.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/kubelet.yaml
@@ -2240,7 +2240,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Kubelet",
         "uid": "3138fa155d5915769fbded898ac09fd9",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/namespace-by-pod.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/namespace-by-pod.yaml
@@ -1456,7 +1456,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Networking / Namespace (Pods)",
         "uid": "8b7a8b326d7a6f1f04244066368c67af",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/namespace-by-pod.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/namespace-by-pod.yaml
@@ -1456,7 +1456,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Networking / Namespace (Pods)",
         "uid": "8b7a8b326d7a6f1f04244066368c67af",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/namespace-by-workload.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/namespace-by-workload.yaml
@@ -1728,7 +1728,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Networking / Namespace (Workload)",
         "uid": "bbb2a765a623ae38130206c7d94a160f",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/namespace-by-workload.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/namespace-by-workload.yaml
@@ -1728,7 +1728,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Networking / Namespace (Workload)",
         "uid": "bbb2a765a623ae38130206c7d94a160f",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/node-cluster-rsrc-use.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/node-cluster-rsrc-use.yaml
@@ -1056,7 +1056,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Node Exporter / USE Method / Cluster",
         "version": 0
     }

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/node-cluster-rsrc-use.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/node-cluster-rsrc-use.yaml
@@ -1056,7 +1056,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "utc",
+        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
         "title": "Node Exporter / USE Method / Cluster",
         "version": 0
     }

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/node-rsrc-use.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/node-rsrc-use.yaml
@@ -1082,7 +1082,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Node Exporter / USE Method / Node",
         "version": 0
     }

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/node-rsrc-use.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/node-rsrc-use.yaml
@@ -1082,7 +1082,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "utc",
+        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
         "title": "Node Exporter / USE Method / Node",
         "version": 0
     }

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/nodes.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/nodes.yaml
@@ -984,7 +984,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Node Exporter / Nodes",
         "version": 0
     }

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/nodes.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/nodes.yaml
@@ -984,7 +984,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "utc",
+        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
         "title": "Node Exporter / Nodes",
         "version": 0
     }

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/persistentvolumesusage.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/persistentvolumesusage.yaml
@@ -569,7 +569,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Persistent Volumes",
         "uid": "919b92a8e8041bd567af9edab12c840c",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/persistentvolumesusage.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/persistentvolumesusage.yaml
@@ -569,7 +569,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Persistent Volumes",
         "uid": "919b92a8e8041bd567af9edab12c840c",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/pod-total.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/pod-total.yaml
@@ -1220,7 +1220,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Networking / Pod",
         "uid": "7a18067ce943a40ae25454675c19ff5c",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/pod-total.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/pod-total.yaml
@@ -1220,7 +1220,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Networking / Pod",
         "uid": "7a18067ce943a40ae25454675c19ff5c",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/prometheus-remote-write.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/prometheus-remote-write.yaml
@@ -1663,7 +1663,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "browser",
+        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
         "title": "Prometheus / Remote Write",
         "version": 0
     }

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/prometheus-remote-write.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/prometheus-remote-write.yaml
@@ -1663,7 +1663,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Prometheus / Remote Write",
         "version": 0
     }

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/prometheus.yaml
@@ -1227,7 +1227,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "utc",
+        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
         "title": "Prometheus / Overview",
         "uid": "",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/prometheus.yaml
@@ -1227,7 +1227,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Prometheus / Overview",
         "uid": "",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/proxy.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/proxy.yaml
@@ -1249,7 +1249,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Proxy",
         "uid": "632e265de029684c40b21cb76bca4f94",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/proxy.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/proxy.yaml
@@ -1249,7 +1249,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Proxy",
         "uid": "632e265de029684c40b21cb76bca4f94",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/scheduler.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/scheduler.yaml
@@ -1092,7 +1092,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Scheduler",
         "uid": "2e6b6a3b4bddf1427b3a55aa1311c656",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/scheduler.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/scheduler.yaml
@@ -1092,7 +1092,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Scheduler",
         "uid": "2e6b6a3b4bddf1427b3a55aa1311c656",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/statefulset.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/statefulset.yaml
@@ -920,7 +920,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / StatefulSets",
         "uid": "a31c1f46e6f727cb37c0d731a7245005",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/statefulset.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/statefulset.yaml
@@ -920,7 +920,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / StatefulSets",
         "uid": "a31c1f46e6f727cb37c0d731a7245005",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/workload-total.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/workload-total.yaml
@@ -1430,7 +1430,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "UTC",
+        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Networking / Workload",
         "uid": "728bf77cc1166d2f3133bf25846876cc",
         "version": 0

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/workload-total.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/workload-total.yaml
@@ -1430,7 +1430,7 @@ data:
                 "30d"
             ]
         },
-        "timezone": "{{ .Value.grafana.defaultDashboardsTimezone }}",
+        "timezone": "{{ .Values.grafana.defaultDashboardsTimezone }}",
         "title": "Kubernetes / Networking / Workload",
         "uid": "728bf77cc1166d2f3133bf25846876cc",
         "version": 0

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -631,9 +631,14 @@ grafana:
   ##
   forceDeployDashboards: false
 
-  ## Deploy default dashboards.
+  ## Deploy default dashboards
   ##
   defaultDashboardsEnabled: true
+
+  ## Timezone for the default dashboards
+  ## Other options are: browser or a specific timezone, i.e. Europe/Luxembourg
+  ##
+  defaultDashboardsTimezone: utc
 
   adminPassword: prom-operator
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Allow to set a timezone for the default grafana dashboards.

The default dashboards have different timezones (utc, UTC, browser) and are loaded as read only in Grafana. Therefore, any change the user performs regarding the timezone, it cannot be saved.
This MR gives the user the possibility to set the some default timezone for all the dashboards (i.e. his / her own local timezone), without the need of modifying them.

#### Which issue this PR fixes
Fixes #780 


#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)

Signed-off-by: Fabio Kruger <10956489+krufab@users.noreply.github.com>
