### PR TITLE
[kube-prometheus-stack] Optional honorLabels for kube-state-metrics ServiceMonitor

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 18.0.5
+version: 18.0.7
 appVersion: 0.50.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/exporters/kube-state-metrics/serviceMonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-state-metrics/serviceMonitor.yaml
@@ -17,7 +17,7 @@ spec:
     {{- if .Values.kubeStateMetrics.serviceMonitor.proxyUrl }}
     proxyUrl: {{ .Values.kubeStateMetrics.serviceMonitor.proxyUrl}}
     {{- end }}
-    honorLabels: true
+    honorLabels: {{ .Values.kubeStateMetrics.serviceMonitor.honorLabels }}
 {{- if .Values.kubeStateMetrics.serviceMonitor.metricRelabelings }}
     metricRelabelings:
 {{ tpl (toYaml .Values.kubeStateMetrics.serviceMonitor.metricRelabelings | indent 4) . }}
@@ -34,7 +34,7 @@ spec:
     {{- if .Values.kubeStateMetrics.serviceMonitor.proxyUrl }}
     proxyUrl: {{ .Values.kubeStateMetrics.serviceMonitor.proxyUrl}}
     {{- end }}
-    honorLabels: true
+    honorLabels: {{ .Values.kubeStateMetrics.serviceMonitor.honorLabels }}
 {{- if .Values.kubeStateMetrics.serviceMonitor.metricRelabelings }}
     metricRelabelings:
 {{ tpl (toYaml .Values.kubeStateMetrics.serviceMonitor.metricRelabelings | indent 4) . }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1274,6 +1274,9 @@ kubeStateMetrics:
     #   replacement: $1
     #   action: replace
 
+    # Keep labels from scraped data, overriding server-side labels
+    honorLabels: true
+
     # Enable self metrics configuration for Service Monitor
     selfMonitor:
       enabled: false


### PR DESCRIPTION
#### What this PR does / why we need it:
Switch kube-state-metrics ServiceMonitor static `honorLabels` value from to parametrized value in `kube-prometheus-stack` like in `kube-state-metrics` helm chart.

Required for moving old infrastructure on kube-prometheus-stack to not break existing rules, dashboards and historical data.
Most ServiceMonitors affects system and prometheus-related data and easy to handle, when kube-state-metrics is in wide use by customers with own rules and dashboards.

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
