### PR TITLE
kube-prometheus-stack jvanson/support ingress class name kubeversion 1.18

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 18.0.5
+version: 18.0.6
 appVersion: 0.50.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/_helpers.tpl
+++ b/charts/kube-prometheus-stack/templates/_helpers.tpl
@@ -123,6 +123,11 @@ Allow the release namespace to be overridden for multi-namespace deployments in 
   {{- or (eq (include "kube-prometheus-stack.ingress.isStable" .) "true") (and (eq (include "kube-prometheus-stack.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" (include "kube-prometheus-stack.kubeVersion" .))) -}}
 {{- end -}}
 
+{{/* Check Ingress supports className */}}
+{{- define "kube-prometheus-stack.ingress.supportsClassName" -}}
+  {{- or (eq (include "kube-prometheus-stack.ingress.isStable" .) "true") (and (eq (include "kube-prometheus-stack.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18.x" .Capabilities.KubeVersion.Version)) -}}
+{{- end -}}
+
 {{/* Get Policy API Version */}}
 {{- define "kube-prometheus-stack.pdb.apiVersion" -}}
   {{- if and (.Capabilities.APIVersions.Has "policy/v1") (semverCompare ">= 1.21-0" (include "kube-prometheus-stack.kubeVersion" .)) -}}

--- a/charts/kube-prometheus-stack/templates/_helpers.tpl
+++ b/charts/kube-prometheus-stack/templates/_helpers.tpl
@@ -124,8 +124,9 @@ Allow the release namespace to be overridden for multi-namespace deployments in 
 {{- end -}}
 
 {{/* Check Ingress supports className */}}
+{{/* className was added to networking.k8s.io/v1beta1 in Kubernetes 1.18 */}}
 {{- define "kube-prometheus-stack.ingress.supportsClassName" -}}
-  {{- or (eq (include "kube-prometheus-stack.ingress.isStable" .) "true") (and (eq (include "kube-prometheus-stack.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18.x" .Capabilities.KubeVersion.Version)) -}}
+  {{- or (eq (include "kube-prometheus-stack.ingress.isStable" .) "true") (and (eq (include "kube-prometheus-stack.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" (include "kube-prometheus-stack.kubeVersion" .))) -}}
 {{- end -}}
 
 {{/* Get Policy API Version */}}

--- a/charts/kube-prometheus-stack/templates/alertmanager/ingress.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/ingress.yaml
@@ -6,6 +6,7 @@
 {{- $paths := .Values.alertmanager.ingress.paths | default $routePrefix -}}
 {{- $apiIsStable := eq (include "kube-prometheus-stack.ingress.isStable" .) "true" -}}
 {{- $ingressSupportsPathType := eq (include "kube-prometheus-stack.ingress.supportsPathType" .) "true" -}}
+{{- $ingressSupportsClassName := eq (include "kube-prometheus-stack.ingress.supportsClassName" .) "true" -}}
 apiVersion: {{ include "kube-prometheus-stack.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
@@ -22,10 +23,8 @@ metadata:
 {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
-  {{- if $apiIsStable }}
-  {{- if .Values.alertmanager.ingress.ingressClassName }}
+  {{- if and $ingressSupportsClassName .Values.alertmanager.ingress.ingressClassName }}
   ingressClassName: {{ .Values.alertmanager.ingress.ingressClassName }}
-  {{- end }}
   {{- end }}
   rules:
   {{- if .Values.alertmanager.ingress.hosts }}

--- a/charts/kube-prometheus-stack/templates/alertmanager/ingressperreplica.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/ingressperreplica.yaml
@@ -5,6 +5,7 @@
 {{- $ingressValues := .Values.alertmanager.ingressPerReplica -}}
 {{- $apiIsStable := eq (include "kube-prometheus-stack.ingress.isStable" .) "true" -}}
 {{- $ingressSupportsPathType := eq (include "kube-prometheus-stack.ingress.supportsPathType" .) "true" -}}
+{{- $ingressSupportsClassName := eq (include "kube-prometheus-stack.ingress.supportsClassName" .) "true" -}}
 apiVersion: v1
 kind: List
 metadata:
@@ -28,10 +29,8 @@ items:
 {{ toYaml $ingressValues.annotations | indent 8 }}
       {{- end }}
     spec:
-      {{- if $apiIsStable }}
-      {{- if $ingressValues.ingressClassName }}
+      {{- if and $ingressSupportsClassName $ingressValues.ingressClassName }}
       ingressClassName: {{ $ingressValues.ingressClassName }}
-      {{- end }}
       {{- end }}
       rules:
         - host: {{ $ingressValues.hostPrefix }}-{{ $i }}.{{ $ingressValues.hostDomain }}

--- a/charts/kube-prometheus-stack/templates/prometheus/ingress.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/ingress.yaml
@@ -6,6 +6,7 @@
   {{- $paths := .Values.prometheus.ingress.paths | default $routePrefix -}}
   {{- $apiIsStable := eq (include "kube-prometheus-stack.ingress.isStable" .) "true" -}}
   {{- $ingressSupportsPathType := eq (include "kube-prometheus-stack.ingress.supportsPathType" .) "true" -}}
+  {{- $ingressSupportsClassName := eq (include "kube-prometheus-stack.ingress.supportsClassName" .) "true" -}}
 apiVersion: {{ include "kube-prometheus-stack.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
@@ -22,10 +23,8 @@ metadata:
 {{ toYaml .Values.prometheus.ingress.labels | indent 4 }}
 {{- end }}
 spec:
-  {{- if $apiIsStable }}
-  {{- if .Values.prometheus.ingress.ingressClassName }}
+  {{- if and $ingressSupportsClassName .Values.prometheus.ingress.ingressClassName }}
   ingressClassName: {{ .Values.prometheus.ingress.ingressClassName }}
-  {{- end }}
   {{- end }}
   rules:
   {{- if .Values.prometheus.ingress.hosts }}

--- a/charts/kube-prometheus-stack/templates/prometheus/ingressThanosSidecar.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/ingressThanosSidecar.yaml
@@ -6,6 +6,7 @@
 {{- $paths := .Values.prometheus.thanosIngress.paths | default $routePrefix -}}
 {{- $apiIsStable := eq (include "kube-prometheus-stack.ingress.isStable" .) "true" -}}
 {{- $ingressSupportsPathType := eq (include "kube-prometheus-stack.ingress.supportsPathType" .) "true" -}}
+{{- $ingressSupportsClassName := eq (include "kube-prometheus-stack.ingress.supportsClassName" .) "true" -}}
 apiVersion: {{ include "kube-prometheus-stack.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
@@ -21,10 +22,8 @@ metadata:
 {{ toYaml .Values.prometheus.thanosIngress.labels | indent 4 }}
 {{- end }}
 spec:
-  {{- if $apiIsStable }}
-  {{- if .Values.prometheus.thanosIngress.ingressClassName }}
+  {{- if and $ingressSupportsClassName .Values.prometheus.thanosIngress.ingressClassName }}
   ingressClassName: {{ .Values.prometheus.thanosIngress.ingressClassName }}
-  {{- end }}
   {{- end }}
   rules:
   {{- if .Values.prometheus.thanosIngress.hosts }}

--- a/charts/kube-prometheus-stack/templates/prometheus/ingressperreplica.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/ingressperreplica.yaml
@@ -5,6 +5,7 @@
 {{- $ingressValues := .Values.prometheus.ingressPerReplica -}}
 {{- $apiIsStable := eq (include "kube-prometheus-stack.ingress.isStable" .) "true" -}}
 {{- $ingressSupportsPathType := eq (include "kube-prometheus-stack.ingress.supportsPathType" .) "true" -}}
+{{- $ingressSupportsClassName := eq (include "kube-prometheus-stack.ingress.supportsClassName" .) "true" -}}
 apiVersion: v1
 kind: List
 metadata:
@@ -28,10 +29,8 @@ items:
 {{ toYaml $ingressValues.annotations | indent 8 }}
       {{- end }}
     spec:
-      {{- if $apiIsStable }}
-      {{- if $ingressValues.ingressClassName }}
+      {{- if and $ingressSupportsClassName $ingressValues.ingressClassName }}
       ingressClassName: {{ $ingressValues.ingressClassName }}
-      {{- end }}
       {{- end }}
       rules:
         - host: {{ $ingressValues.hostPrefix }}-{{ $i }}.{{ $ingressValues.hostDomain }}


### PR DESCRIPTION
Kubernetes version 1.18 introduced suport for  ingressClass[1] so add a helper function to detect if ingressClass is supported `kube-prometheus-stack.ingress.supportsClassName` for alertmanager and prometheus in kube-prometheus-stack chart. Modify `if` condition to leverage this helper function to determine whether ingressClassName is available.
 

[1] https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/
#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
