### PR TITLE
[prometheus-redis-exporter] allow using securityContext in containers

### DIFF
--- a/charts/prometheus-redis-exporter/Chart.yaml
+++ b/charts/prometheus-redis-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.27.0
 description: Prometheus exporter for Redis metrics
 name: prometheus-redis-exporter
-version: 4.5.0
+version: 4.6.0
 home: https://github.com/oliver006/redis_exporter
 sources:
   - https://github.com/oliver006/redis_exporter

--- a/charts/prometheus-redis-exporter/templates/deployment.yaml
+++ b/charts/prometheus-redis-exporter/templates/deployment.yaml
@@ -36,6 +36,10 @@ spec:
           {{- range $key, $value := .Values.extraArgs }}
             - --{{ $key }}={{ $value }}
           {{- end }}
+          securityContext:
+          {{- range $key, $value := .Values.securityContext }}
+            {{ $key }}: {{ $value }}
+          {{- end }}
           ports:
             - name: exporter-port
               containerPort: 9121

--- a/charts/prometheus-redis-exporter/templates/deployment.yaml
+++ b/charts/prometheus-redis-exporter/templates/deployment.yaml
@@ -10,7 +10,8 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-{{ include "prometheus-redis-exporter.labels" . | indent 6 }}
+      app: {{ template "prometheus-redis-exporter.name" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       annotations:

--- a/charts/prometheus-redis-exporter/values.yaml
+++ b/charts/prometheus-redis-exporter/values.yaml
@@ -19,6 +19,8 @@ extraArgs: {}
 
 customLabels: {}
 
+securityContext: {}
+
 # Additional Environment variables
 env: {}
 # - name: REDIS_PASSWORD


### PR DESCRIPTION
Signed-off-by: Stanislav Chesnovskiy <s.chesnovskiy@semrush.com>

#### What this PR does / why we need it:
This PR allows using security context in containers

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
