### PR TITLE
[kube-prometheus-stack] Configure Thanos Sidecar monitoring

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 18.0.9
+version: 18.0.10
 appVersion: 0.50.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/serviceThanosSidecar.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/serviceThanosSidecar.yaml
@@ -24,6 +24,12 @@ spec:
     {{- if eq .Values.prometheus.thanosService.type "NodePort" }}
     nodePort: {{ .Values.prometheus.thanosService.nodePort }}
     {{- end }}
+  - name: {{ .Values.prometheus.thanosService.httpPortName }}
+    port: {{ .Values.prometheus.thanosService.httpPort }}
+    targetPort: {{ .Values.prometheus.thanosService.targetHttpPort }}
+    {{- if eq .Values.prometheus.thanosService.type "NodePort" }}
+    nodePort: {{ .Values.prometheus.thanosService.httpNodePort }}
+    {{- end }}
   selector:
     app.kubernetes.io/name: prometheus
     prometheus: {{ template "kube-prometheus-stack.fullname" . }}-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/serviceThanosSidecarExternal.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/serviceThanosSidecarExternal.yaml
@@ -31,6 +31,12 @@ spec:
     {{- if eq .Values.prometheus.thanosServiceExternal.type "NodePort" }}
     nodePort: {{ .Values.prometheus.thanosServiceExternal.nodePort }}
     {{- end }}
+  - name: {{ .Values.prometheus.thanosServiceExternal.httpPortName }}
+    port: {{ .Values.prometheus.thanosServiceExternal.httpPort }}
+    targetPort: {{ .Values.prometheus.thanosServiceExternal.targetHttpPort }}
+    {{- if eq .Values.prometheus.thanosServiceExternal.type "NodePort" }}
+    nodePort: {{ .Values.prometheus.thanosServiceExternal.httpNodePort }}
+    {{- end }}
   selector:
     app.kubernetes.io/name: prometheus
     prometheus: {{ template "kube-prometheus-stack.fullname" . }}-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/servicemonitorThanosSidecar.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/servicemonitorThanosSidecar.yaml
@@ -1,0 +1,41 @@
+{{- if and .Values.prometheus.thanosService.enabled .Values.prometheus.thanosServiceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "kube-prometheus-stack.fullname" . }}-thanos-discovery
+  namespace: {{ template "kube-prometheus-stack.namespace" . }}
+  labels:
+    app: {{ template "kube-prometheus-stack.name" . }}-thanos-discovery
+{{ include "kube-prometheus-stack.labels" . | indent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "kube-prometheus-stack.name" . }}-thanos-discovery
+      release: {{ $.Release.Name | quote }}
+  namespaceSelector:
+    matchNames:
+      - {{ printf "%s" (include "kube-prometheus-stack.namespace" .) | quote }}
+  endpoints:
+  - port: {{ .Values.prometheus.thanosService.httpPortName }}
+    {{- if .Values.prometheus.thanosServiceMonitor.interval }}
+    interval: {{ .Values.prometheus.thanosServiceMonitor.interval }}
+    {{- end }}
+    {{- if .Values.prometheus.thanosServiceMonitor.scheme }}
+    scheme: {{ .Values.prometheus.thanosServiceMonitor.scheme }}
+    {{- end }}
+    {{- if .Values.prometheus.thanosServiceMonitor.tlsConfig }}
+    tlsConfig: {{ toYaml .Values.prometheus.thanosServiceMonitor.tlsConfig | nindent 6 }}
+    {{- end }}
+    {{- if .Values.prometheus.thanosServiceMonitor.bearerTokenFile }}
+    bearerTokenFile: {{ .Values.prometheus.thanosServiceMonitor.bearerTokenFile }}
+    {{- end }}
+    path: "/metrics"
+{{- if .Values.prometheus.thanosServiceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ tpl (toYaml .Values.prometheus.thanosServiceMonitor.metricRelabelings | indent 6) . }}
+{{- end }}
+{{- if .Values.prometheus.thanosServiceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.prometheus.thanosServiceMonitor.relabelings | indent 6 }}
+{{- end }}
+{{- end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1649,18 +1649,50 @@ prometheus:
     enabled: false
     annotations: {}
     labels: {}
-    portName: grpc
-    port: 10901
-    targetPort: "grpc"
-    clusterIP: "None"
 
     ## Service type
     ##
     type: ClusterIP
 
-    ## Port to expose on each node
+    ## gRPC port config
+    portName: grpc
+    port: 10901
+    targetPort: "grpc"
+
+    ## HTTP port config (for metrics)
+    httpPortName: http
+    httpPort: 10902
+    targetHttpPort: "http"
+
+    ## ClusterIP to assign
+    # Default is to make this a headless service ("None")
+    clusterIP: "None"
+
+    ## Port to expose on each node, if service type is NodePort
     ##
     nodePort: 30901
+    httpNodePort: 30902
+
+  # ServiceMonitor to scrape Sidecar metrics
+  # Needs thanosService to be enabled as well
+  thanosServiceMonitor:
+    enabled: false
+    interval: ""
+
+    ## scheme: HTTP scheme to use for scraping. Can be used with `tlsConfig` for example if using istio mTLS.
+    scheme: ""
+
+    ## tlsConfig: TLS configuration to use when scraping the endpoint. For example if using istio mTLS.
+    ## Of type: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#tlsconfig
+    tlsConfig: {}
+
+    bearerTokenFile:
+
+    ## Metric relabel configs to apply to samples before ingestion.
+    metricRelabelings: []
+
+    ## relabel configs to apply to samples before ingestion.
+    relabelings: []
 
   # Service for external access to sidecar
   # Enabling this creates a service to expose thanos-sidecar outside the cluster.
@@ -1668,11 +1700,18 @@ prometheus:
     enabled: false
     annotations: {}
     labels: {}
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
+
+    ## gRPC port config
     portName: grpc
     port: 10901
     targetPort: "grpc"
-    loadBalancerIP: ""
-    loadBalancerSourceRanges: []
+
+    ## HTTP port config (for metrics)
+    httpPortName: http
+    httpPort: 10902
+    targetHttpPort: "http"
 
     ## Service type
     ##
@@ -1681,6 +1720,7 @@ prometheus:
     ## Port to expose on each node
     ##
     nodePort: 30901
+    httpNodePort: 30902
 
   ## Configuration for Prometheus service
   ##


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds the http port to the Thanos discovery service, and a ServiceMonitor
pointing to that port to scrape Thanos sidecar metrics.

The current workaround is to create an extra port on the main Prometheus
service, and separately add a ServiceMonitor (see #560), but imo it's
cleaner if we support this as a first-class construct?

#### Which issue this PR fixes

- fixes #1291
- fixes #1055

#### Special notes for your reviewer:

Ping @vsliouniaev @bismarck @gianrubio @gkarthiks @scottrigby @Xtigyro 🙏 

Let me know if anything seems wrong here; I've tested the chart locally and it works nicely in our Prometheus + Thanos install, but I'm not sure whether the port naming etc is as good as it could be!

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
