### PR TITLE
[prometheus-druid-exporter] Add nodeSelector, tolerations, and affinity

### DIFF
--- a/charts/prometheus-druid-exporter/Chart.yaml
+++ b/charts/prometheus-druid-exporter/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: "v0.8.0"
 description: Druid exporter to monitor druid metrics with Prometheus
 engine: gotpl
 name: prometheus-druid-exporter
-version: 0.10.0
+version: 0.11.0
 home: https://github.com/opstree/druid-exporter
 maintainers:
 - email: abhishekbhardwaj510@gmail.com

--- a/charts/prometheus-druid-exporter/Chart.yaml
+++ b/charts/prometheus-druid-exporter/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: "v0.8.0"
 description: Druid exporter to monitor druid metrics with Prometheus
 engine: gotpl
 name: prometheus-druid-exporter
-version: 0.11.0
+version: 0.10.0
 home: https://github.com/opstree/druid-exporter
 maintainers:
 - email: abhishekbhardwaj510@gmail.com

--- a/charts/prometheus-druid-exporter/templates/deployment.yaml
+++ b/charts/prometheus-druid-exporter/templates/deployment.yaml
@@ -56,6 +56,18 @@ spec:
       serviceAccount: {{ include "prometheus-druid-exporter.fullname" . }}
       serviceAccountName: {{ include "prometheus-druid-exporter.fullname" . }}
 {{- end }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+    {{- end }}
+    {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
+    {{- end }}
   {{- with .Values.securityContext }}
   securityContext:
 {{- toYaml . | nindent 4 }}

--- a/charts/prometheus-druid-exporter/values.yaml
+++ b/charts/prometheus-druid-exporter/values.yaml
@@ -32,3 +32,9 @@ serviceMonitor:
 securityContext: {}
 
 containerSecurityContext: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
Signed-off-by: Jake Becker <jbecker@conviva.com>

#### What this PR does / why we need it:
I'm using prometheus-druid-exporter but I can't assign it to run on the same node pools as our druid workload so I added the `nodeSelector`.  The `affinity` and `tolerations` are just as helpful so I added them too (basically just copied the relevant sections from blackbox-exporter).

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
