### PR TITLE
[kube-prometheus-stack] Add scrapeTimeout in kubeStateMetrics

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 18.0.7
+version: 18.0.8
 appVersion: 0.50.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/exporters/kube-state-metrics/serviceMonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-state-metrics/serviceMonitor.yaml
@@ -14,6 +14,9 @@ spec:
     {{- if .Values.kubeStateMetrics.serviceMonitor.interval }}
     interval: {{ .Values.kubeStateMetrics.serviceMonitor.interval }}
     {{- end }}
+    {{- if .Values.kubeStateMetrics.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.kubeStateMetrics.serviceMonitor.scrapeTimeout }}
+    {{- end }}
     {{- if .Values.kubeStateMetrics.serviceMonitor.proxyUrl }}
     proxyUrl: {{ .Values.kubeStateMetrics.serviceMonitor.proxyUrl}}
     {{- end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1247,6 +1247,9 @@ kubeStateMetrics:
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
+    ## Scrape Timeout. If not set, the Prometheus default scrape timeout is used.
+    ##
+    scrapeTimeout: ""
     ## proxyUrl: URL of a proxy that should be used for scraping.
     ##
     proxyUrl: ""


### PR DESCRIPTION
#### What this PR does / why we need it:
This is a simple addition to the ServiceMonitor values of **kube-state-metrics**.

The `scrapeTimeout` is added as an option. The intention is for this value to be configured to something else than the default when needed (for example because of timeouts due to wildcards being used with `--metric-labels-allowlist` etc)

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
