### PR TITLE
[prometheus-blackbox-exporter] Add crds to blackbox exporter

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 5.0.3
+version: 5.0.4
 appVersion: 0.19.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/charts/prometheus-blackbox-exporter/README.md
+++ b/charts/prometheus-blackbox-exporter/README.md
@@ -26,6 +26,8 @@ _See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation
 helm install [RELEASE_NAME] prometheus-community/prometheus-blackbox-exporter
 ```
 
+Use `--skip-crds` not to install prometheus custom resources definitions.
+
 _See [configuration](#configuration) below._
 
 _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._

--- a/charts/prometheus-blackbox-exporter/crds
+++ b/charts/prometheus-blackbox-exporter/crds
@@ -1,0 +1,1 @@
+../kube-prometheus-stack/crds


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes error when only blackbox exporter is installed (https://github.com/prometheus-community/helm-charts/issues/1307). The CRDS are missing. We can fix it like this (symlink to crds in different chart) or create crds only chart and define it as dependency.

#### Which issue this PR fixes

  - fixes #1307

#### Special notes for your reviewer:

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
