### PR TITLE
kube-state-metrics servicemonitor relabeling

### DIFF
--- a/charts/kube-state-metrics/templates/servicemonitor.yaml
+++ b/charts/kube-state-metrics/templates/servicemonitor.yaml
@@ -25,6 +25,14 @@ spec:
       {{- if .Values.prometheus.monitor.honorLabels }}
       honorLabels: true
       {{- end }}
+      {{- with .Values.prometheus.monitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+      {{- with .Values.prometheus.monitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
     {{ if .Values.selfMonitor.enabled }}
     - port: metrics
       {{- if .Values.prometheus.monitor.honorLabels }}

--- a/charts/kube-state-metrics/templates/servicemonitor.yaml
+++ b/charts/kube-state-metrics/templates/servicemonitor.yaml
@@ -27,11 +27,11 @@ spec:
       {{- end }}
       {{- with .Values.prometheus.monitor.relabelings }}
       relabelings:
-        {{- toYaml . | nindent 4 }}
+{{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.prometheus.monitor.metricRelabelings }}
       metricRelabelings:
-        {{- toYaml . | nindent 4 }}
+{{- toYaml . | nindent 8 }}
       {{- end }}
     {{ if .Values.selfMonitor.enabled }}
     - port: metrics


### PR DESCRIPTION
Hi,

This change makes kube-state-metrics relabeling/metricsRelabeling possible. Useful thing especially when you configure custom labels in kube-state-metrics, particularly when you want to remove label prefix.

Regards,
Bart