### PR TITLE
[kube-prometheus-stack] bump grafana to 6.16.6

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -8,5 +8,5 @@ dependencies:
 - name: grafana
   repository: https://grafana.github.io/helm-charts
   version: 6.16.6
-digest: sha256:23305a9475cbb103dcf408eacbbf27494f344599d33d8c505b80885268dbe4cf
-generated: "2021-09-21T15:07:08.960786004+03:00"
+digest: sha256:fd0a999d6a6c856f37af4d148af103f89c13774676c6922a6f826117a708ceb4
+generated: "2021-09-22T12:10:55.060018985+03:00"

--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 2.0.4
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.16.4
-digest: sha256:58f3cc8bad821aed15028f02b642a7c7409584d70a609badaa733ac1386bbae7
-generated: "2021-09-04T16:11:37.453658312+02:00"
+  version: 6.16.6
+digest: sha256:23305a9475cbb103dcf408eacbbf27494f344599d33d8c505b80885268dbe4cf
+generated: "2021-09-21T15:07:08.960786004+03:00"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 18.0.12
+version: 18.0.13
 appVersion: 0.50.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus


### PR DESCRIPTION
#### What this PR does / why we need it:
Updates version of the Grafana dependency.
Version 6.16.6 feature:
- Adding envFromSecrets to allow multiple optional secrets to provide environment variables

#### Which issue this PR fixes
  - Fix PodSecurityPolicy contradicting the init container settings

#### Special notes for your reviewer:

- none

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
