### PR TITLE
[alertmanager] Add support for ingressClassName

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,8 +6,8 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 0.12.2
-appVersion: v0.22.1
+version: 0.13.0
+appVersion: v0.23.0
 maintainers:
   - name: monotek
     email: monotek23@gmail.com

--- a/charts/alertmanager/templates/NOTES.txt
+++ b/charts/alertmanager/templates/NOTES.txt
@@ -2,7 +2,7 @@
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
   {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}

--- a/charts/alertmanager/templates/ingress.yaml
+++ b/charts/alertmanager/templates/ingress.yaml
@@ -1,10 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "alertmanager.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
+{{- $stableAPI := semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if $stableAPI -}}
+apiVersion: networking.k8s.io/v1
 {{- else -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
@@ -16,6 +17,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+{{- if and .Values.ingress.ingressClassName $stableAPI }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}
@@ -32,10 +36,20 @@ spec:
       http:
         paths:
         {{- range .paths }}
-          - path: {{ . }}
+          - path: {{ .path }}
+            {{- if $stableAPI }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
+            {{- if $stableAPI }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+            {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+            {{- end }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/alertmanager/templates/ingress.yaml
+++ b/charts/alertmanager/templates/ingress.yaml
@@ -1,11 +1,17 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "alertmanager.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- $stableAPI := semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- if $stableAPI -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{- else -}}
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
@@ -17,39 +23,39 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if and .Values.ingress.ingressClassName $stableAPI }}
-  ingressClassName: {{ .Values.ingress.ingressClassName }}
-{{- end }}
-{{- if .Values.ingress.tls }}
-  tls:
-  {{- range .Values.ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-        - {{ . | quote }}
-      {{- end }}
-      secretName: {{ .secretName }}
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
-{{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
+    {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:
-        {{- range .paths }}
+          {{- range .paths }}
           - path: {{ .path }}
-            {{- if $stableAPI }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
             pathType: {{ .pathType }}
             {{- end }}
             backend:
-            {{- if $stableAPI }}
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
-            {{- else }}
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
-            {{- end }}
-        {{- end }}
-  {{- end }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
 {{- end }}

--- a/charts/alertmanager/unittests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/alertmanager/unittests/__snapshot__/ingress_test.yaml.snap
@@ -1,6 +1,6 @@
 should match snapshot of default values:
   1: |
-    apiVersion: networking.k8s.io/v1beta1
+    apiVersion: networking.k8s.io/v1
     kind: Ingress
     metadata:
       labels:
@@ -14,4 +14,11 @@ should match snapshot of default values:
       rules:
       - host: alertmanager.domain.com
         http:
-          paths: null
+          paths:
+          - backend:
+              service:
+                name: RELEASE-NAME-alertmanager
+                port:
+                  number: 9093
+            path: /
+            pathType: Prefix

--- a/charts/alertmanager/unittests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/alertmanager/unittests/__snapshot__/ingress_test.yaml.snap
@@ -13,7 +13,7 @@ should match snapshot of default values:
     spec:
       ingressClassName: nginx-test
       rules:
-      - host: chart-example.local
+      - host: alertmanager.domain.com
         http:
           paths:
           - backend:
@@ -39,7 +39,7 @@ should match snapshot of default values with old kubernetes ingress:
       name: RELEASE-NAME-alertmanager
     spec:
       rules:
-      - host: chart-example.local
+      - host: alertmanager.domain.com
         http:
           paths:
           - backend:

--- a/charts/alertmanager/unittests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/alertmanager/unittests/__snapshot__/ingress_test.yaml.snap
@@ -11,8 +11,9 @@ should match snapshot of default values:
         helm.sh/chart: alertmanager-1.0.0
       name: RELEASE-NAME-alertmanager
     spec:
+      ingressClassName: nginx-test
       rules:
-      - host: alertmanager.domain.com
+      - host: chart-example.local
         http:
           paths:
           - backend:
@@ -21,4 +22,27 @@ should match snapshot of default values:
                 port:
                   number: 9093
             path: /
-            pathType: Prefix
+            pathType: ImplementationSpecific
+should match snapshot of default values with old kubernetes ingress:
+  1: |
+    apiVersion: networking.k8s.io/v1beta1
+    kind: Ingress
+    metadata:
+      annotations:
+        kubernetes.io/ingress.class: nginx-test
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: alertmanager
+        app.kubernetes.io/version: 1.0.0
+        helm.sh/chart: alertmanager-1.0.0
+      name: RELEASE-NAME-alertmanager
+    spec:
+      rules:
+      - host: chart-example.local
+        http:
+          paths:
+          - backend:
+              serviceName: RELEASE-NAME-alertmanager
+              servicePort: 9093
+            path: /

--- a/charts/alertmanager/unittests/ingress_test.yaml
+++ b/charts/alertmanager/unittests/ingress_test.yaml
@@ -6,25 +6,12 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
-  - it: should have apiVersion extensions/v1beta1 for k8s < 1.14
+  - it: should have apiVersion networking.k8s.io/v1beta1 for k8s < 1.19
     set:
       ingress.enabled: true
     capabilities:
       majorVersion: 1
-      minorVersion: 13
-    asserts:
-      - hasDocuments:
-          count: 1
-      - isKind:
-          of: Ingress
-      - isAPIVersion:
-          of: extensions/v1beta1
-  - it: should have apiVersion networking.k8s.io/v1beta1 for k8s >= 1.14 < 1.19
-    set:
-      ingress.enabled: true
-    capabilities:
-      majorVersion: 1
-      minorVersion: 15
+      minorVersion: 18
     asserts:
       - hasDocuments:
           count: 1
@@ -32,6 +19,32 @@ tests:
           of: Ingress
       - isAPIVersion:
           of: networking.k8s.io/v1beta1
+  - it: should have apiVersion networking.k8s.io/v1 for k8s >= 1.19
+    set:
+      ingress.enabled: true
+    capabilities:
+      majorVersion: 1
+      minorVersion: 19
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+  - it: should have an ingressClassName for k8s >= 1.19
+    set:
+      ingress.enabled: true
+      ingress.ingressClassName: testit
+    capabilities:
+      majorVersion: 1
+      minorVersion: 19
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.ingressClassName
+          value: testit
   - it: should match snapshot of default values
     set:
       ingress.enabled: true

--- a/charts/alertmanager/unittests/ingress_test.yaml
+++ b/charts/alertmanager/unittests/ingress_test.yaml
@@ -6,6 +6,19 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+  - it: should have apiVersion extensions/v1beta1 for k8s < 1.14
+    set:
+      ingress.enabled: true
+    capabilities:
+      majorVersion: 1
+      minorVersion: 13
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: extensions/v1beta1
   - it: should have apiVersion networking.k8s.io/v1beta1 for k8s < 1.19
     set:
       ingress.enabled: true
@@ -35,7 +48,7 @@ tests:
   - it: should have an ingressClassName for k8s >= 1.19
     set:
       ingress.enabled: true
-      ingress.ingressClassName: testit
+      ingress.className: nginx-test
     capabilities:
       majorVersion: 1
       minorVersion: 19
@@ -44,10 +57,23 @@ tests:
           count: 1
       - equal:
           path: spec.ingressClassName
-          value: testit
+          value: nginx-test
   - it: should match snapshot of default values
     set:
       ingress.enabled: true
+      ingress.className: nginx-test
+    chart:
+      version: 1.0.0
+      appVersion: 1.0.0
+    asserts:
+      - matchSnapshot: { }
+  - it: should match snapshot of default values with old kubernetes ingress
+    set:
+      ingress.enabled: true
+      ingress.className: nginx-test
+    capabilities:
+      majorVersion: 1
+      minorVersion: 17
     chart:
       version: 1.0.0
       appVersion: 1.0.0

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -57,13 +57,15 @@ service:
 
 ingress:
   enabled: false
+  className: ""
   annotations: {}
-  ingressClassName: ""
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
   hosts:
     - host: alertmanager.domain.com
       paths:
         - path: /
-          pathType: Prefix
+          pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -58,9 +58,12 @@ service:
 ingress:
   enabled: false
   annotations: {}
+  ingressClassName: ""
   hosts:
     - host: alertmanager.domain.com
-      paths: []
+      paths:
+        - path: /
+          pathType: Prefix
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds support for ingressClassName since the old [ingress.class annotation](https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation) is now considered as deprecated.


#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

#### Special notes for your reviewer:

I had to introduce a breaking change to support the new pathType field.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
