### PR TITLE
[kube-prometheus-stack] Configurable thresholds for KubeQuotaAlmostFull alert rule

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 20.0.1
+version: 20.0.2
 appVersion: 0.52.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-resources.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-resources.yaml
@@ -101,7 +101,7 @@ spec:
         kube_resourcequota{job="kube-state-metrics", type="used"}
           / ignoring(instance, job, type)
         (kube_resourcequota{job="kube-state-metrics", type="hard"} > 0)
-          > 0.9 < 1
+          {{ .Values.defaultRules.thresholds.kubernetesResources.KubeQuotaAlmostFull }}
       for: 15m
       labels:
         severity: info

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -60,6 +60,10 @@ defaultRules:
 
   ## Runbook url prefix for default rules
   runbookUrl: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#
+  ## Alert thresholds
+  thresholds:
+    kubernetesResources:
+      KubeQuotaAlmostFull: '> 0.9 < 1'
   ## Reduce app namespace alert scope
   appNamespacesTarget: ".*"
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Optionally, allow KubeQuotaAlmostFull threshold condition to be overwritten. Defaults to the current hard-coded value.


#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
