### PR TITLE
[kube-state-metrics] Add metricRelabelings and relabelings options

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 3.5.1
+version: 3.5.2
 appVersion: 2.2.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/servicemonitor.yaml
+++ b/charts/kube-state-metrics/templates/servicemonitor.yaml
@@ -25,10 +25,26 @@ spec:
       {{- if .Values.prometheus.monitor.honorLabels }}
       honorLabels: true
       {{- end }}
+      {{- if .Values.prometheus.monitor.metricRelabelings }}
+      metricRelabelings:
+      {{- toYaml .Values.prometheus.monitor.metricRelabelings | nindent 6 }}
+      {{- end }}
+      {{- if .Values.prometheus.monitor.relabelings }}
+      relabelings:
+      {{- toYaml .Values.prometheus.monitor.relabelings | nindent 6 }}
+      {{- end }}
     {{ if .Values.selfMonitor.enabled }}
     - port: metrics
       {{- if .Values.prometheus.monitor.honorLabels }}
       honorLabels: true
+      {{- end }}
+      {{- if .Values.prometheus.monitor.metricRelabelings }}
+      metricRelabelings:
+      {{- toYaml .Values.prometheus.monitor.metricRelabelings | nindent 6 }}
+      {{- end }}
+      {{- if .Values.prometheus.monitor.relabelings }}
+      relabelings:
+      {{- toYaml .Values.prometheus.monitor.relabelings | nindent 6 }}
       {{- end }}
     {{ end }}
 {{- end }}

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -64,6 +64,8 @@ prometheus:
     additionalLabels: {}
     namespace: ""
     honorLabels: false
+    metricRelabelings: []
+    relabelings: []
 
 ## Specify if a Pod Security Policy for kube-state-metrics must be created
 ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

This PR intents to add the metricRelabelings and relabelings options. We need it to override some important labels like the node name to instance.

Example:

For values.yaml:

```yaml
prometheus:
  monitor:
    enabled: true
    relabelings:
    - targetLabel: instance
      sourceLabels:
      - __meta_kubernetes_pod_node_nam
```

Template result:
```yaml
kind: ServiceMonitor
metadata:
  name: RELEASE-NAME-kube-state-metrics
  namespace: default
  labels:
    app.kubernetes.io/name: kube-state-metrics
    helm.sh/chart: "kube-state-metrics-3.5.2"
    app.kubernetes.io/instance: "RELEASE-NAME"
    app.kubernetes.io/managed-by: "Helm"
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: kube-state-metrics
      app.kubernetes.io/instance: RELEASE-NAME
  endpoints:
    - port: http
      relabelings:
      - sourceLabels:
        - __meta_kubernetes_pod_node_name
        targetLabel: instance
```
#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
