### PR TITLE
[kube-prometheus-stack] bump grafana to 6.16.10

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 2.0.4
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.16.9
-digest: sha256:cb65f7087c26bba381fdf1478dd8d710b5257855b5c9de67a48997a932112838
-generated: "2021-09-23T16:19:49.942745722+03:00"
+  version: 6.16.10
+digest: sha256:e5cdca7154e10f9303b45eee8f3914be971488a21b0b80819da03290a8022c0f
+generated: "2021-09-27T11:14:35.784587+03:00"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 19.0.0
+version: 19.0.1
 appVersion: 0.50.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus


### PR DESCRIPTION
Signed-off-by: birca <birca@adobe.com>

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
