### PR TITLE
[prometheus] Support for selector in persistent volume claims

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.26.0
-version: 14.8.1
+version: 14.8.2
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/templates/alertmanager/pvc.yaml
+++ b/charts/prometheus/templates/alertmanager/pvc.yaml
@@ -28,6 +28,10 @@ spec:
   resources:
     requests:
       storage: "{{ .Values.alertmanager.persistentVolume.size }}"
+{{- if .Values.alertmanager.persistentVolume.selector }}
+  selector:
+  {{- toYaml .Values.alertmanager.persistentVolume.selector | nindent 4 }}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/prometheus/templates/server/pvc.yaml
+++ b/charts/prometheus/templates/server/pvc.yaml
@@ -29,6 +29,10 @@ spec:
   resources:
     requests:
       storage: "{{ .Values.server.persistentVolume.size }}"
+{{- if .Values.server.persistentVolume.selector }}
+  selector:
+  {{- toYaml .Values.server.persistentVolume.selector | nindent 4 }}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -233,6 +233,16 @@ alertmanager:
     ##
     subPath: ""
 
+    ## Persistent Volume Claim Selector
+    ## Useful if Persistent Volumes have been provisioned in advance
+    ## Ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#selector
+    ##
+    # selector:
+    #  matchLabels:
+    #    release: "stable"
+    #  matchExpressions:
+    #    - { key: environment, operator: In, values: [ dev ] }
+
   emptyDir:
     ## alertmanager emptyDir volume size limit
     ##
@@ -900,6 +910,16 @@ server:
     ## Useful if the volume's root directory is not empty
     ##
     subPath: ""
+
+    ## Persistent Volume Claim Selector
+    ## Useful if Persistent Volumes have been provisioned in advance
+    ## Ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#selector
+    ##
+    # selector:
+    #  matchLabels:
+    #    release: "stable"
+    #  matchExpressions:
+    #    - { key: environment, operator: In, values: [ dev ] }
 
   emptyDir:
     ## Prometheus server emptyDir volume size limit


### PR DESCRIPTION
####What this PR does / why we need it:

In many environments, especially when running Kubernetes on-prem, Persistent Volumes are provisioned in advance by operators. Using just _accessModes_ and _resources_ can end with a pod claiming storage from an unwanted Persistent Volume.

Persistent Volume Claim selectors allow to further filter the set of volumes. Only the volumes whose labels match the selector can be bound to the claim.

This PR adds the option to add selector to those Persistent Volume Claim in case is needed.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)

Signed-off-by: Daniel Gallardo Montero <daniel.gallardo92@gmail.com>

@gianrubio @zanhsieh @Xtigyro @monotek @naseemkullah