### PR TITLE
[prometheus-statsd-exporter] add ability to set host networking for statsd exporter

### DIFF
--- a/charts/prometheus-statsd-exporter/Chart.yaml
+++ b/charts/prometheus-statsd-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus-statsd-exporter
 description: A Helm chart for prometheus stats-exporter
-version: 0.4.1
+version: 0.4.2
 appVersion: 0.22.1
 home: https://github.com/prometheus/statsd_exporter
 sources:

--- a/charts/prometheus-statsd-exporter/Chart.yaml
+++ b/charts/prometheus-statsd-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus-statsd-exporter
 description: A Helm chart for prometheus stats-exporter
-version: 0.4.2
+version: 0.5.1
 appVersion: 0.22.1
 home: https://github.com/prometheus/statsd_exporter
 sources:

--- a/charts/prometheus-statsd-exporter/Chart.yaml
+++ b/charts/prometheus-statsd-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus-statsd-exporter
 description: A Helm chart for prometheus stats-exporter
-version: 0.5.1
+version: 0.5.0
 appVersion: 0.22.1
 home: https://github.com/prometheus/statsd_exporter
 sources:

--- a/charts/prometheus-statsd-exporter/templates/deployment.yaml
+++ b/charts/prometheus-statsd-exporter/templates/deployment.yaml
@@ -21,6 +21,10 @@ spec:
       labels:
         {{- include "prometheus-statsd-exporter.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.hostNetwork }}
+        hostNetwork: true
+        dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/prometheus-statsd-exporter/templates/deployment.yaml
+++ b/charts/prometheus-statsd-exporter/templates/deployment.yaml
@@ -22,8 +22,8 @@ spec:
         {{- include "prometheus-statsd-exporter.selectorLabels" . | nindent 8 }}
     spec:
       {{- if .Values.hostNetwork }}
-        hostNetwork: true
-        dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/prometheus-statsd-exporter/values.yaml
+++ b/charts/prometheus-statsd-exporter/values.yaml
@@ -15,6 +15,7 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+hostNetwork: false
 
 statsd:
   # The UDP port on which to receive statsd metric lines.


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
Add chart option to enable host networking for statsd exporter
#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - N/A

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
