### PR TITLE
[prometheus] Allow to specify custom headers for probes, closes #1255

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.26.0
-version: 14.9.2
+version: 14.10.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/templates/server/deploy.yaml
+++ b/charts/prometheus/templates/server/deploy.yaml
@@ -118,6 +118,13 @@ spec:
               path: {{ .Values.server.prefixURL }}/-/ready
               port: 9090
               scheme: {{ .Values.server.probeScheme }}
+              {{- if .Values.server.probeHeaders }}
+              httpHeaders:
+              {{- range .Values.server.probeHeaders}}
+              - name: {{ .name }}
+                value: {{ .value }}
+              {{- end }}
+              {{- end }}
             {{- else }}
             tcpSocket:
               port: 9090
@@ -133,6 +140,13 @@ spec:
               path: {{ .Values.server.prefixURL }}/-/healthy
               port: 9090
               scheme: {{ .Values.server.probeScheme }}
+              {{- if .Values.server.probeHeaders }}
+              httpHeaders:
+              {{- range .Values.server.probeHeaders}}
+              - name: {{ .name }}
+                value: {{ .value }}
+              {{- end }}
+              {{- end }}
             {{- else }}
             tcpSocket:
               port: 9090
@@ -149,6 +163,13 @@ spec:
               path: {{ .Values.server.prefixURL }}/-/healthy
               port: 9090
               scheme: {{ .Values.server.probeScheme }}
+              {{- if .Values.server.probeHeaders }}
+              httpHeaders:
+              {{- range .Values.server.probeHeaders}}
+              - name: {{ .name }}
+                value: {{ .value }}
+              {{- end }}
+              {{- end }}
             {{- else }}
             tcpSocket:
               port: 9090

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -717,6 +717,11 @@ server:
   ##
   remoteRead: []
 
+  ## Custom HTTP headers for Liveness/Readiness/Startup Probe
+  ##
+  ## Useful for providing HTTP Basic Auth to healthchecks
+  probeHeaders: []
+
   ## Additional Prometheus server container arguments
   ##
   extraArgs: {}


### PR DESCRIPTION
Useful to provide HTTP Basic Auth to healthchecks if Prometheus is setup such way

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
Prometheus has a way to configure HTTP Basic Auth to it, but unfortunately, current Helm Chart doesn't support it in pod probes, so Prometheus is killed by Kubernetes as probe fails when HTTP Auth is enabled on Prometheus Server.

#### Which issue this PR fixes
I got this problem by myself, but I can see there's issue #1255 already for this.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)


#### Example usage:

```yaml
server:
  extraArgs:
    enable-feature: remote-write-receiver
    web.config.file: /etc/config/web.yml

  probeHeaders:
  - name: Authorization
    value: Basic YWRtaW46c29tZXBhc3M=

serverFiles:
  web.yml:
    basic_auth_users:
      # basic auth pass: somepass
      admin: $2b$12$pObGyYVxitg4daonMxu4a.sKL7mC8U98JxkSXtkqmAB1QjNdum1lu
```