### PR TITLE
[kube-prometheus-stack] add scheme and tlsConfig to node exporter ServiceMonitor

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 20.0.1
+version: 20.1.0
 appVersion: 0.52.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/exporters/node-exporter/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/node-exporter/servicemonitor.yaml
@@ -26,8 +26,14 @@ spec:
     {{- if .Values.nodeExporter.serviceMonitor.proxyUrl }}
     proxyUrl: {{ .Values.nodeExporter.serviceMonitor.proxyUrl}}
     {{- end }}
+    {{- if .Values.nodeExporter.serviceMonitor.scheme }}
+    scheme: {{ .Values.nodeExporter.serviceMonitor.scheme }}
+    {{- end }}
     {{- if .Values.nodeExporter.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.nodeExporter.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+    {{- if .Values.nodeExporter.serviceMonitor.tlsConfig }}
+    tlsConfig: {{ toYaml .Values.nodeExporter.serviceMonitor.tlsConfig | nindent 6 }}
     {{- end }}
 {{- if .Values.nodeExporter.serviceMonitor.metricRelabelings }}
     metricRelabelings:

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1356,6 +1356,13 @@ nodeExporter:
     ##
     proxyUrl: ""
 
+    ## scheme: HTTP scheme to use for scraping. Can be used with `tlsConfig` for example if using istio mTLS.
+    scheme: ""
+
+    ## tlsConfig: TLS configuration to use when scraping the endpoint. For example if using istio mTLS.
+    ## Of type: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#tlsconfig
+    tlsConfig: {}
+
     ## How long until a scrape request times out. If not set, the Prometheus default scape timeout is used.
     ##
     scrapeTimeout: ""


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
This adds the ability to configure TLS and scheme to the node exporter ServiceMonitor.

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
