### PR TITLE
[prometheus-node-exporter] add ability to set scheme if TLS is configured

### DIFF
--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.2
 description: A Helm chart for prometheus node-exporter
 name: prometheus-node-exporter
-version: 2.2.0
+version: 2.2.1
 type: application
 home: https://github.com/prometheus/node_exporter/
 sources:

--- a/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -69,10 +69,16 @@ spec:
             httpGet:
               path: /
               port: {{ .Values.service.port }}
+              {{- if .Values.probeScheme }}
+              scheme: {{ .Values.probeScheme }}
+              {{- end }}
           readinessProbe:
             httpGet:
               path: /
               port: {{ .Values.service.port }}
+              {{- if .Values.probeScheme }}
+              scheme: {{ .Values.probeScheme }}
+              {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:

--- a/charts/prometheus-node-exporter/templates/monitor.yaml
+++ b/charts/prometheus-node-exporter/templates/monitor.yaml
@@ -15,7 +15,7 @@ spec:
       release: {{ .Release.Name }}
   endpoints:
     - port: {{ .Values.service.portName }}
-      scheme: {{ $.Values.prometheus.monitor.scheme }}
+      scheme: {{ default "http" .Values.probeScheme | lower }}
       {{- if $.Values.prometheus.monitor.bearerTokenFile }}
       bearerTokenFile: {{ $.Values.prometheus.monitor.bearerTokenFile }}
       {{- end }}

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -21,7 +21,6 @@ prometheus:
     enabled: false
     additionalLabels: {}
     namespace: ""
-    scheme: http
     bearerTokenFile:
     tlsConfig: {}
 
@@ -93,6 +92,10 @@ hostPID: true
 ## If true, node-exporter pods mounts host / at /host/root
 ##
 hostRootFsMount: true
+
+## Set to HTTPS if using TLS configuration, also configures ServiceMonitor scheme if set
+##
+probeScheme: ""
 
 ## Assign a group of affinity scheduling rules
 ##


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
Adds the ability to configure the probe schemes in case node exporter is configured with TLS. This also defaults the ServiceMonitor to use `http` and will use `https` if the user configures `HTTPS` on `probeScheme`.

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
