### PR TITLE
[kube-prometheus-stack] removed app:alertmanager label

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 20.0.0
+version: 20.0.1
 appVersion: 0.52.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 19.3.0
+version: 19.3.1
 appVersion: 0.50.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/alertmanager/service.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/service.yaml
@@ -44,7 +44,7 @@ spec:
 {{ toYaml .Values.alertmanager.service.additionalPorts | indent 2 }}
 {{- end }}
   selector:
-    app: alertmanager
+    app.kubernetes.io/name: alertmanager
     alertmanager: {{ template "kube-prometheus-stack.fullname" . }}-alertmanager
   type: "{{ .Values.alertmanager.service.type }}"
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR removes the label selector app:alertmanager from the alertmanager service. As the label has been removed by the Prometheus Operator stateful set in the current version 0.52.2

#### Which issue this PR fixes

The alertmanager service does not have any endpoints after updating the Prometheus Operator image to 0.52.2. Because the label selector as been changed.

https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.52.0
https://github.com/prometheus-operator/prometheus-operator/pull/4350

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
- [x]  Chart Version bumped