### PR TITLE
[kube-prometheus-stack] Upgrade prometheus-operator to v0.52.0

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,8 +18,8 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 19.3.0
-appVersion: 0.50.0
+version: 19.4.0
+appVersion: 0.52.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus
 keywords:

--- a/charts/kube-prometheus-stack/templates/alertmanager/service.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/service.yaml
@@ -44,7 +44,7 @@ spec:
 {{ toYaml .Values.alertmanager.service.additionalPorts | indent 2 }}
 {{- end }}
   selector:
-    app: alertmanager
+    app.kubernetes.io/name: alertmanager
     alertmanager: {{ template "kube-prometheus-stack.fullname" . }}-alertmanager
   type: "{{ .Values.alertmanager.service.type }}"
 {{- end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1633,7 +1633,7 @@ prometheusOperator:
   ##
   image:
     repository: quay.io/prometheus-operator/prometheus-operator
-    tag: v0.50.0
+    tag: v0.52.0
     sha: ""
     pullPolicy: IfNotPresent
 
@@ -1649,7 +1649,7 @@ prometheusOperator:
   ##
   prometheusConfigReloaderImage:
     repository: quay.io/prometheus-operator/prometheus-config-reloader
-    tag: v0.50.0
+    tag: v0.52.0
     sha: ""
 
   ## Set the prometheus config reloader side-car CPU limit


### PR DESCRIPTION
#### What this PR does / why we need it:

[prometheus-operator v0.52.0](https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.52.0) was released 5 days ago, with some important fixes (like the one I want is support for the alertmanager matchers syntax mentioned in the docs: https://www.prometheus.io/docs/alerting/latest/configuration/#matcher

#### Which issue this PR fixes
  - Makes progress towards #1454

#### Special notes for your reviewer:

The new version of prometheus-operator deprecated the `app` label on the alertmanager pod, so I changed the label in our Service. The new label has been present since [v0.47.0](https://github.com/prometheus-operator/prometheus-operator/blob/v0.47.1/pkg/alertmanager/statefulset.go#L316). Technically, we don't need to create a service since [one is created by the operator](https://github.com/prometheus-operator/prometheus-operator/blob/d866500b016256147c0933c59cbc22e08e7cf680/pkg/alertmanager/statefulset.go#L161), but unsure of the consequences of removing the service now.

Additionally, v0.52.0 now supports a validating webhook for AlertmanagerConfigs, which we might like to add eventually, but I have not set up in this PR: https://github.com/prometheus-operator/prometheus-operator/pull/4338/files#diff-aba79e370243d9f3be0cd17514ab68581a03fee54a61c2d3cce73b163d5d20b2

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
