### PR TITLE
[kube-state-metrics] Bump to v2.2.4

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,8 +7,8 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 4.0.1
-appVersion: 2.2.0
+version: 4.0.2
+appVersion: 2.2.4
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:
 - https://github.com/kubernetes/kube-state-metrics/

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -2,7 +2,7 @@
 prometheusScrape: true
 image:
   repository: k8s.gcr.io/kube-state-metrics/kube-state-metrics
-  tag: v2.2.0
+  tag: v2.2.4
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
#### What this PR does / why we need it:
Bumps from 2.2.0 to 2.2.4
#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
