### PR TITLE
kube-prometheus-stack: Enable IPv6 Kubernetes pods scraping

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 20.0.1
+version: 21.0.1
 appVersion: 0.52.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/README.md
+++ b/charts/kube-prometheus-stack/README.md
@@ -83,6 +83,14 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 
 A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an incompatible breaking change needing manual actions.
 
+### From 20.x to 21.x
+
+Version 21 upgrades prometheus-operator and allows it scraping IPv6 Kuberenets pods. Helm does not automatically upgrade or install new CRDs on a chart upgrade, so you have to install the CRDs manually before updating:
+
+```console
+helm upgrade --install kube-prometheus-stack -n <NAMESPACE> --set ipv6=true
+```
+
 ### From 19.x to 20.x
 
 Version 20 upgrades prometheus-operator from 0.50.x to 0.52.x. Helm does not automatically upgrade or install new CRDs on a chart upgrade, so you have to install the CRDs manually before updating:

--- a/charts/kube-prometheus-stack/templates/prometheus/additionalScrapeConfigs.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/additionalScrapeConfigs.yaml
@@ -12,5 +12,9 @@ metadata:
     app: {{ template "kube-prometheus-stack.name" . }}-prometheus-scrape-confg
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 data:
-  additional-scrape-configs.yaml: {{ tpl (toYaml .Values.prometheus.prometheusSpec.additionalScrapeConfigs) $ | b64enc | quote }}
+{{- if .Values.ipv6 }}
+  additional-scrape-configs.yaml: {{ tpl (toYaml .Values.prometheus.prometheusSpec.additionalScrapeConfigs.ipv6) $ | b64enc | quote }}
+{{- else }}
+  additional-scrape-configs.yaml: {{ tpl (toYaml .Values.prometheus.prometheusSpec.additionalScrapeConfigs.ipv4) $ | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -2372,64 +2372,64 @@ prometheus:
     ## The scrape configuration example below will find master nodes, provided they have the name .*mst.*, relabel the
     ## port to 2379 and allow etcd scraping provided it is running on all Kubernetes master nodes
     ##
-    additionalScrapeConfigs:
-      ipv6:
-        - job_name: 'kubernetes-pods'
-          kubernetes_sd_configs:
-            - role: pod
-          relabel_configs:
-          - action: keep
-            regex: 'true;(\d+)'
-            source_labels:
-            - __meta_kubernetes_pod_annotation_prometheus_io_scrape
-            - __meta_kubernetes_pod_annotation_prometheus_io_port
-          - action: replace
-            regex: (.+)
-            source_labels:
-            - __meta_kubernetes_pod_annotation_prometheus_io_path
-            target_label: __metrics_path__
-          - action: replace
-            regex: '(.*);(\d+)'
-            replacement: '[$1]:$2'
-            source_labels:
-            - __meta_kubernetes_pod_ip
-            - __meta_kubernetes_pod_annotation_prometheus_io_port
-            target_label: __address__
-          - action: labelmap
-            regex: __meta_kubernetes_pod_label_(.+)
-          - action: replace
-            source_labels:
-            - __meta_kubernetes_namespace
-            target_label: kubernetes_namespace
-          - action: replace
-            source_labels:
-            - __meta_kubernetes_pod_name
-            target_label: kubernetes_pod_name
-      ipv4:
-        - job_name: 'kubernetes-pods'
-          kubernetes_sd_configs:
-          - role: pod
-          relabel_configs:
-          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
-            action: keep
-            regex: true
-          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
-            action: replace
-            target_label: __metrics_path__
-            regex: (.+)
-          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
-            action: replace
-            regex: ([^:]+)(?::\d+)?;(\d+)
-            replacement: $1:$2
-            target_label: __address__
-          - action: labelmap
-            regex: __meta_kubernetes_pod_label_(.+)
-          - source_labels: [__meta_kubernetes_namespace]
-            action: replace
-            target_label: kubernetes_namespace
-          - source_labels: [__meta_kubernetes_pod_name]
-            action: replace
-            target_label: kubernetes_pod_name
+    additionalScrapeConfigs: []
+      # ipv6:
+      #   - job_name: 'kubernetes-pods'
+      #     kubernetes_sd_configs:
+      #       - role: pod
+      #     relabel_configs:
+      #     - action: keep
+      #       regex: 'true;(\d+)'
+      #       source_labels:
+      #       - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+      #       - __meta_kubernetes_pod_annotation_prometheus_io_port
+      #     - action: replace
+      #       regex: (.+)
+      #       source_labels:
+      #       - __meta_kubernetes_pod_annotation_prometheus_io_path
+      #       target_label: __metrics_path__
+      #     - action: replace
+      #       regex: '(.*);(\d+)'
+      #       replacement: '[$1]:$2'
+      #       source_labels:
+      #       - __meta_kubernetes_pod_ip
+      #       - __meta_kubernetes_pod_annotation_prometheus_io_port
+      #       target_label: __address__
+      #     - action: labelmap
+      #       regex: __meta_kubernetes_pod_label_(.+)
+      #     - action: replace
+      #       source_labels:
+      #       - __meta_kubernetes_namespace
+      #       target_label: kubernetes_namespace
+      #     - action: replace
+      #       source_labels:
+      #       - __meta_kubernetes_pod_name
+      #       target_label: kubernetes_pod_name
+      # ipv4:
+      #   - job_name: 'kubernetes-pods'
+      #     kubernetes_sd_configs:
+      #     - role: pod
+      #     relabel_configs:
+      #     - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+      #       action: keep
+      #       regex: true
+      #     - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+      #       action: replace
+      #       target_label: __metrics_path__
+      #       regex: (.+)
+      #     - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+      #       action: replace
+      #       regex: ([^:]+)(?::\d+)?;(\d+)
+      #       replacement: $1:$2
+      #       target_label: __address__
+      #     - action: labelmap
+      #       regex: __meta_kubernetes_pod_label_(.+)
+      #     - source_labels: [__meta_kubernetes_namespace]
+      #       action: replace
+      #       target_label: kubernetes_namespace
+      #     - source_labels: [__meta_kubernetes_pod_name]
+      #       action: replace
+      #       target_label: kubernetes_pod_name
     # - job_name: kube-etcd
     #   kubernetes_sd_configs:
     #     - role: node

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -28,6 +28,7 @@ commonLabels: {}
 # scmhash: abc123
 # myLabel: aakkmd
 
+ipv6: False
 ## Create default rules for monitoring the cluster
 ##
 defaultRules:
@@ -2371,7 +2372,64 @@ prometheus:
     ## The scrape configuration example below will find master nodes, provided they have the name .*mst.*, relabel the
     ## port to 2379 and allow etcd scraping provided it is running on all Kubernetes master nodes
     ##
-    additionalScrapeConfigs: []
+    additionalScrapeConfigs:
+      ipv6:
+        - job_name: 'kubernetes-pods'
+          kubernetes_sd_configs:
+            - role: pod
+          relabel_configs:
+          - action: keep
+            regex: 'true;(\d+)'
+            source_labels:
+            - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+            - __meta_kubernetes_pod_annotation_prometheus_io_port
+          - action: replace
+            regex: (.+)
+            source_labels:
+            - __meta_kubernetes_pod_annotation_prometheus_io_path
+            target_label: __metrics_path__
+          - action: replace
+            regex: '(.*);(\d+)'
+            replacement: '[$1]:$2'
+            source_labels:
+            - __meta_kubernetes_pod_ip
+            - __meta_kubernetes_pod_annotation_prometheus_io_port
+            target_label: __address__
+          - action: labelmap
+            regex: __meta_kubernetes_pod_label_(.+)
+          - action: replace
+            source_labels:
+            - __meta_kubernetes_namespace
+            target_label: kubernetes_namespace
+          - action: replace
+            source_labels:
+            - __meta_kubernetes_pod_name
+            target_label: kubernetes_pod_name
+      ipv4:
+        - job_name: 'kubernetes-pods'
+          kubernetes_sd_configs:
+          - role: pod
+          relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+            action: keep
+            regex: true
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+            action: replace
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+            target_label: __address__
+          - action: labelmap
+            regex: __meta_kubernetes_pod_label_(.+)
+          - source_labels: [__meta_kubernetes_namespace]
+            action: replace
+            target_label: kubernetes_namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            action: replace
+            target_label: kubernetes_pod_name
     # - job_name: kube-etcd
     #   kubernetes_sd_configs:
     #     - role: node


### PR DESCRIPTION
#### What this PR does / why we need it: 
This PR includes an option for Prometheus to scrape Kubernetes pods that are running IPv6. 

#### Which issue this PR fixes
  - fixes #1470

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
