### PR TITLE
[prometheus-statsd-exporter] Fixed a bug that does not add mapping config when configuring a config map

### DIFF
--- a/charts/prometheus-statsd-exporter/Chart.yaml
+++ b/charts/prometheus-statsd-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus-statsd-exporter
 description: A Helm chart for prometheus stats-exporter
-version: 0.4.1
+version: 0.4.2
 appVersion: 0.22.1
 home: https://github.com/prometheus/statsd_exporter
 sources:

--- a/charts/prometheus-statsd-exporter/templates/deployment.yaml
+++ b/charts/prometheus-statsd-exporter/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             - --statsd.event-queue-size={{ .Values.statsd.eventQueueSize }}
             - --statsd.event-flush-threshold={{ .Values.statsd.eventFlushThreshold }}
             - --statsd.event-flush-interval={{ .Values.statsd.eventFlushInterval }}
-            {{- if .Values.statsd.mappingConfig }}
+            {{- if or .Values.statsd.mappingConfigMapName .Values.statsd.mappingConfig }}
             - --statsd.mapping-config=/etc/prometheus-statsd-exporter/statsd-mapping.conf
           {{- end }}
           ports:


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
When configuring statsd exporter and configuring the config mappings using mappingConfigMapName field in values file, so creating a config map with the mappings, the config map gets mounted on the pod but the process is not started with the statsd.mapping-config= parameter because the conditional logic was only checking the mappingConfig field which is setting the config inline in the values file.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
