### PR TITLE
Add support for deleteDatasources

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 2.0.4
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.17.5
-digest: sha256:577da2c166a2227ed0526deacb3f9728be805b79e2534090f21ec6c6abd0606e
-generated: "2021-11-04T15:58:00.235027Z"
+  version: 6.17.7
+digest: sha256:5971f4c7cf40240bba82c1eb6f9026bf46d6d697477a5764afdbbefd8362f336
+generated: "2021-11-23T14:36:16.393082+01:00"

--- a/charts/kube-prometheus-stack/templates/grafana/configmaps-datasources.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/configmaps-datasources.yaml
@@ -15,6 +15,10 @@ metadata:
 data:
   datasource.yaml: |-
     apiVersion: 1
+{{- if .Values.grafana.deleteDatasources }}
+    deleteDatasources:
+{{ tpl (toYaml .Values.grafana.deleteDatasources | indent 6) . }}
+{{- end }}
     datasources:
 {{- $scrapeInterval := .Values.grafana.sidecar.datasources.defaultDatasourceScrapeInterval | default .Values.prometheus.prometheusSpec.scrapeInterval | default "30s" }}
 {{- if .Values.grafana.sidecar.datasources.defaultDatasourceEnabled }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -720,6 +720,10 @@ grafana:
   #   configMap: certs-configmap
   #   readOnly: true
 
+  deleteDatasources: []
+  # - name: example-datasource
+  #   orgId: 1
+
   ## Configure additional grafana datasources (passed through tpl)
   ## ref: http://docs.grafana.org/administration/provisioning/#datasources
   additionalDataSources: []


### PR DESCRIPTION
We like to add support for `deleteDatasources` since it's kind of a pain to remove datasources today the way grafana works right now.