### PR TITLE
[prometheus-elasticsearch-exporter] Support ServiceAccount Annotations

### DIFF
--- a/charts/prometheus-elasticsearch-exporter/Chart.yaml
+++ b/charts/prometheus-elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: prometheus-elasticsearch-exporter
-version: 4.7.0
+version: 4.8.0
 kubeVersion: ">=1.10.0-0"
 appVersion: 1.2.1
 home: https://github.com/prometheus-community/elasticsearch_exporter

--- a/charts/prometheus-elasticsearch-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-elasticsearch-exporter/templates/serviceaccount.yaml
@@ -8,5 +8,9 @@ metadata:
     app: {{ template "elasticsearch-exporter.name" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/charts/prometheus-elasticsearch-exporter/values.yaml
+++ b/charts/prometheus-elasticsearch-exporter/values.yaml
@@ -251,6 +251,7 @@ serviceAccount:
   create: false
   name: default
   automountServiceAccountToken: true
+  annotations: {}
 
 # Creates a PodSecurityPolicy and the role/rolebinding
 # allowing the serviceaccount to use it


### PR DESCRIPTION
Signed-off-by: Jon Winton <jwinton@squareup.com>

#### What this PR does / why we need it:
This PR adds support for annotations on the `ServiceAccount`. In an EKS cluster I'm running I need the pod running the exporter to be able to [assume an AWS IAM role to authenticate with an ElasticSearch cluster](https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html), which requires annotating the service account. 

This PR will make any annotations completely optional and will default to no annotations at all.

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:
N/A

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
