### PR TITLE
[prometheus-druid-exporter] synced with upstream helm chart, updated the image tag and fixed a typo

### DIFF
--- a/charts/prometheus-druid-exporter/Chart.yaml
+++ b/charts/prometheus-druid-exporter/Chart.yaml
@@ -1,16 +1,18 @@
 ---
 apiVersion: v1
-appVersion: "v0.8.0"
+appVersion: "v0.11"
 description: Druid exporter to monitor druid metrics with Prometheus
 engine: gotpl
 name: prometheus-druid-exporter
-version: 0.11.0
+version: 0.12.0
 home: https://github.com/opstree/druid-exporter
 maintainers:
 - email: abhishekbhardwaj510@gmail.com
   name: iamabhishek-dubey
 - email: sandeep@opstree.com
   name: sandy724
+- email: stephan.stiefel@hawk.ai
+  name: Stephan3555
 sources:
   - https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-druid-exporter
 keywords:

--- a/charts/prometheus-druid-exporter/README.md
+++ b/charts/prometheus-druid-exporter/README.md
@@ -82,7 +82,7 @@ http://druid.opstreelabs.in
 
 ### Service Monitor
 
-The chart comes with a ServiceMonitor for use with the [kube-pometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack). If you're not using the Prometheus Operator, you can disable the ServiceMonitor by setting `serviceMonitor.enabled` to `false` and it will auto generate the following `podAnnotations` into deployment.yaml:
+The chart comes with a ServiceMonitor for use with the [kube-pometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack). If you're not using the Prometheus Operator, you can disable the ServiceMonitor by setting `serviceMonitor.enabled` to `false` and instead populate the `podAnnotations` as below:
 
 ```yaml
 podAnnotations:

--- a/charts/prometheus-druid-exporter/templates/deployment.yaml
+++ b/charts/prometheus-druid-exporter/templates/deployment.yaml
@@ -42,12 +42,34 @@ spec:
           value: {{ .Values.logLevel }}
         - name: LOG_FORMAT
           value: {{ .Values.logFormat }}
+        - name: NO_HISTOGRAM
+          value: {{ .Values.noHistogram | quote}}
+{{- if .Values.extraEnv }}
+{{ toYaml .Values.extraEnv | indent 8 }}
+{{- end }}
+{{- if .Values.security.enabled }}
+        - name: DRUID_USER
+          value: {{ .Values.security.druidUser }}
+        - name: DRUID_PASSWORD
+{{- if not .Values.security.druidPassword.secretKeyRef.enabled }}
+          value: {{ .Values.security.druidPassword.value }}
+{{- else }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.security.druidPassword.secretKeyRef.secretName }}
+              key: {{ .Values.security.druidPassword.secretKeyRef.secretKey }}
+{{- end }}
+{{- end }}
         image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: {{ include "prometheus-druid-exporter.fullname" . }}
         ports:
         - containerPort: {{ .Values.exporterPort }}
           protocol: TCP
+        {{- with .Values.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end}}
         {{- with .Values.containerSecurityContext}}
         securityContext:
           {{- toYaml . | nindent 10}}

--- a/charts/prometheus-druid-exporter/templates/tests/connection-test.yaml
+++ b/charts/prometheus-druid-exporter/templates/tests/connection-test.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.testEnabled }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -16,5 +17,5 @@ spec:
     image: busybox
     command: ['wget']
     args:  ['-qO-', '{{ include "prometheus-druid-exporter.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.exporterPort }}/metrics']
-
   restartPolicy: Never
+{{- end }}

--- a/charts/prometheus-druid-exporter/values.yaml
+++ b/charts/prometheus-druid-exporter/values.yaml
@@ -3,7 +3,7 @@ name: druid-exporter
 
 image:
   name: quay.io/opstree/druid-exporter
-  tag: v0.8
+  tag: v0.11
   pullPolicy: IfNotPresent
 
 annotations: {}
@@ -13,8 +13,33 @@ podAnnotations: {}
 druidURL: http://druid.opstreelabs.in
 logLevel: info
 logFormat: json
+noHistogram: false
 
 exporterPort: 8080
+
+extraEnv: {}
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+security:
+  enabled: false
+  druidUser: admin
+  druidPassword:
+    value: admin
+    secretKeyRef:
+      enabled: false
+      secretName: mysecret
+      secretKey: mysecretkey
 
 serviceAccount:
   create: true
@@ -38,3 +63,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+testEnabled: true


### PR DESCRIPTION
#### What this PR does / why we need it:
Sync with the upstream repo the original helm chart came from.
Additionally i updated the image used to reflect the chart version (0.11 => v0.11).
This adds the possibility to disable the `druid_emitted_metrics_histogram_*` metrics which eat up quite a lot of space/memory on our prometheus.
Also fixed a typo from the upstream chart in the connection test.

#### Which issue this PR fixes
This adds the possibility to disable the `druid_emitted_metrics_histogram_*` metrics which eat up quite a lot of space/memory on our prometheus.

#### Special notes for your reviewer:
None

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
