### PR TITLE
[kube-prometheus-stack] Bump grafana to 6.17.10

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 2.2.0
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.17.5
-digest: sha256:644ac674cc4f6ce5d6d31b8f0d308ea8f5ac13c2b44f7379238ea37258ce4061
-generated: "2021-11-12T10:49:25.704170319+01:00"
+  version: 6.17.9
+digest: sha256:775b86c08926d7b61817e3968bd7749b46ebc69188a6035418f59dd90f91508f
+generated: "2021-11-29T12:02:24.968117+01:00"

--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 2.2.1
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.17.9
-digest: sha256:775b86c08926d7b61817e3968bd7749b46ebc69188a6035418f59dd90f91508f
-generated: "2021-11-30T09:52:23.817067+01:00"
+  version: 6.17.10
+digest: sha256:2bf445d1234aff03121fefeed00b5744edf51f89ba1deec176092b6ce5ede255
+generated: "2021-12-01T08:58:43.3466742Z"

--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 3.5.2
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
-  version: 2.2.0
+  version: 2.2.1
 - name: grafana
   repository: https://grafana.github.io/helm-charts
   version: 6.17.9
 digest: sha256:775b86c08926d7b61817e3968bd7749b46ebc69188a6035418f59dd90f91508f
-generated: "2021-11-29T12:02:24.968117+01:00"
+generated: "2021-11-30T09:52:23.817067+01:00"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 21.0.2
+version: 21.0.3
 appVersion: 0.52.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus


### PR DESCRIPTION
#### What this PR does / why we need it:
* Update grafana helm chart to 6.17.10
* Update prometheus-node-exporter helm chart to 2.2.1

### Special notes for your reviewer:
* It adds the possibility to configure a new variable in the grafana dashboard sidecar container: https://github.com/grafana/helm-charts/pull/847
* Bump grafana to 8.2.5 by default: https://github.com/grafana/helm-charts/pull/834
* Make security context configurable for sidecars: https://github.com/grafana/helm-charts/pull/845
* Make configurable datasource sidecar watch method: https://github.com/grafana/helm-charts/pull/807
* Allow to add extra volumes on dashboard sidecar container: https://github.com/grafana/helm-charts/pull/862

I also had to update the prometheus-node-exporter chart:
* Allow to deploy ServiceMonitor in specific namespace: https://github.com/prometheus-community/helm-charts/pull/1526

Is it mandatory to update all the dependencies of a chart at once or did I miss something ?

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
