### PR TITLE
[prometheus-stackdriver-exporter] add support for secret labels

### DIFF
--- a/charts/prometheus-stackdriver-exporter/Chart.yaml
+++ b/charts/prometheus-stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: prometheus-stackdriver-exporter
-version: 1.11.0
+version: 1.12.0
 appVersion: 0.11.0
 home: https://www.stackdriver.com/
 sources:

--- a/charts/prometheus-stackdriver-exporter/templates/secret.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/secret.yaml
@@ -8,6 +8,9 @@ metadata:
     app: {{ template "stackdriver-exporter.name" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    {{- if .Values.secret.labels }}
+      {{- toYaml .Values.secret.labels | nindent 4 }}
+    {{- end }}
 type: Opaque
 data:
   credentials.json: {{ .Values.stackdriver.serviceAccountKey | b64enc | quote }}

--- a/charts/prometheus-stackdriver-exporter/values.yaml
+++ b/charts/prometheus-stackdriver-exporter/values.yaml
@@ -30,6 +30,9 @@ service:
   httpPort: 9255
   annotations: {}
 
+secret:
+  labels: {}
+
 stackdriver:
   # The Google Project ID to gather metrics for
   projectId: "FALSE"


### PR DESCRIPTION
Signed-off-by: Yu Kato <y.katsew@gmail.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

This PR enables users to append custom labels to the secret used for serviceAccountKey.
We currently use the custom helm chart for stackdriver-exporter, but we want to migrate ours to this one.
However, our chart is integrated with webhook to mutate secrets labelled like `secret-webhook-enabled: true`.
To migrate our chart, I add support for appending custom labels to the secret.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
