### PR TITLE
[kube-state-metrics] Improve ServiceMonitor

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 4.0.2
+version: 4.1.0
 appVersion: 2.2.4
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/servicemonitor.yaml
+++ b/charts/kube-state-metrics/templates/servicemonitor.yaml
@@ -6,38 +6,57 @@ metadata:
   namespace: {{ template "kube-state-metrics.namespace" . }}
   labels:
     {{- include "kube-state-metrics.labels" . | indent 4 }}
-    {{- if .Values.prometheus.monitor.additionalLabels }}
-{{ toYaml .Values.prometheus.monitor.additionalLabels | indent 4 }}
-    {{- end }}
+  {{- with .Values.prometheus.monitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
+  jobLabel: app.kubernetes.io/name
   selector:
     matchLabels:
       {{- include "kube-state-metrics.selectorLabels" . | indent 6 }}
   endpoints:
     - port: http
-      {{- if .Values.prometheus.monitor.honorLabels }}
+    {{- if .Values.prometheus.monitor.interval }}
+      interval: {{ .Values.prometheus.monitor.interval }}
+    {{- end }}
+    {{- if .Values.prometheus.monitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.prometheus.monitor.scrapeTimeout }}
+    {{- end }}
+    {{- if .Values.prometheus.monitor.proxyUrl }}
+      proxyUrl: {{ .Values.prometheus.monitor.proxyUrl}}
+    {{- end }}
+    {{- if .Values.prometheus.monitor.honorLabels }}
       honorLabels: true
-      {{- end }}
-      {{- if .Values.prometheus.monitor.metricRelabelings }}
+    {{- end }}
+    {{- if .Values.prometheus.monitor.metricRelabelings }}
       metricRelabelings:
-      {{- toYaml .Values.prometheus.monitor.metricRelabelings | nindent 6 }}
-      {{- end }}
-      {{- if .Values.prometheus.monitor.relabelings }}
+        {{- toYaml .Values.prometheus.monitor.metricRelabelings | nindent 8 }}
+    {{- end }}
+    {{- if .Values.prometheus.monitor.relabelings }}
       relabelings:
-      {{- toYaml .Values.prometheus.monitor.relabelings | nindent 6 }}
-      {{- end }}
-    {{ if .Values.selfMonitor.enabled }}
+        {{- toYaml .Values.prometheus.monitor.relabelings | nindent 8 }}
+    {{- end }}
+  {{- if .Values.selfMonitor.enabled }}
     - port: metrics
-      {{- if .Values.prometheus.monitor.honorLabels }}
+    {{- if .Values.prometheus.monitor.interval }}
+      interval: {{ .Values.prometheus.monitor.interval }}
+    {{- end }}
+    {{- if .Values.prometheus.monitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.prometheus.monitor.scrapeTimeout }}
+    {{- end }}
+    {{- if .Values.prometheus.monitor.proxyUrl }}
+      proxyUrl: {{ .Values.prometheus.monitor.proxyUrl}}
+    {{- end }}
+    {{- if .Values.prometheus.monitor.honorLabels }}
       honorLabels: true
-      {{- end }}
-      {{- if .Values.prometheus.monitor.metricRelabelings }}
+    {{- end }}
+    {{- if .Values.prometheus.monitor.metricRelabelings }}
       metricRelabelings:
-      {{- toYaml .Values.prometheus.monitor.metricRelabelings | nindent 6 }}
-      {{- end }}
-      {{- if .Values.prometheus.monitor.relabelings }}
+        {{- toYaml .Values.prometheus.monitor.metricRelabelings | nindent 8 }}
+    {{- end }}
+    {{- if .Values.prometheus.monitor.relabelings }}
       relabelings:
-      {{- toYaml .Values.prometheus.monitor.relabelings | nindent 6 }}
-      {{- end }}
-    {{ end }}
+        {{- toYaml .Values.prometheus.monitor.relabelings | nindent 8 }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -65,6 +65,9 @@ prometheus:
     enabled: false
     additionalLabels: {}
     namespace: ""
+    interval: ""
+    scrapeTimeout: ""
+    proxyUrl: ""
     honorLabels: false
     metricRelabelings: []
     relabelings: []


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
This PR add capabilities to the _kube-state-metrics_ chart ServiceMonitor that are present in the override ServiceMonitor in the _kube-prometheus-stack_ chart with the intention that the _kube-prometheus-stack_ should use the _kube-state-metrics_ chart ServiceMonitor.

#### Which issue this PR fixes
This PR is the first PR of 3 for #1425.

#### Special notes for your reviewer:
I've not implemented the template logic from the _kube-prometheus-stack_ as it's not a valid pattern, only strings should be run through the `tpl` command. It's possible to implement it correctly here if required and I'm happy to do so.

I've bumped the chart minor version as this is a feature release.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
