### PR TITLE
[kube-state-metrics] role & rolebinding namespace issues

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 4.1.1
+version: 4.1.2
 appVersion: 2.2.4
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/role.yaml
+++ b/charts/kube-state-metrics/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.rbac.create true) (not .Values.rbac.useExistingRole) -}}
+{{- if and (eq .Values.rbac.create true) (not .Values.rbac.useExistingRole) .Values.namespaces -}}
 {{- range (split "," .Values.namespaces) }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/kube-state-metrics/templates/rolebinding.yaml
+++ b/charts/kube-state-metrics/templates/rolebinding.yaml
@@ -1,11 +1,11 @@
-{{- if and (eq  .Values.rbac.create true) (eq .Values.rbac.useClusterRole false) -}}
-{{- range (split "," $.Values.namespaces) }}
+{{- if and (eq  .Values.rbac.create true) (eq .Values.rbac.useClusterRole false) .Values.namespaces -}}
+{{- range (split "," .Values.namespaces) }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    {{- include "kube-state-metrics.labels" . | indent 4 }}
+    {{- include "kube-state-metrics.labels" $ | indent 4 }}
   name: {{ template "kube-state-metrics.fullname" $ }}
   namespace: {{ . }}
 roleRef:

--- a/charts/kube-state-metrics/unittests/role_test.yaml
+++ b/charts/kube-state-metrics/unittests/role_test.yaml
@@ -1,0 +1,37 @@
+suite: test role
+templates:
+  - role.yaml
+tests:
+  - it: should be empty if no namespaces are defined
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should generate one role
+    set:
+      rbac.useClusterRole: false
+      namespaces: ns1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.namespace
+          value: ns1
+  - it: should generate one role per namespace
+    set:
+      rbac.useClusterRole: false
+      namespaces: ns1,ns2,ns3
+    asserts:
+      - hasDocuments:
+          count: 3
+      - equal:
+          path: metadata.namespace
+          value: ns1
+        documentIndex: 0
+      - equal:
+          path: metadata.namespace
+          value: ns2
+        documentIndex: 1
+      - equal:
+          path: metadata.namespace
+          value: ns3
+        documentIndex: 2

--- a/charts/kube-state-metrics/unittests/rolebinding_test.yaml
+++ b/charts/kube-state-metrics/unittests/rolebinding_test.yaml
@@ -1,0 +1,39 @@
+suite: test role binding
+templates:
+  - rolebinding.yaml
+tests:
+  - it: should be empty if no namespaces are defined
+    set:
+      rbac.useClusterRole: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should generate one rolebinding
+    set:
+      rbac.useClusterRole: false
+      namespaces: ns1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.namespace
+          value: ns1
+  - it: should generate one rolebinding per namespace
+    set:
+      rbac.useClusterRole: false
+      namespaces: ns1,ns2,ns3
+    asserts:
+      - hasDocuments:
+          count: 3
+      - equal:
+          path: metadata.namespace
+          value: ns1
+        documentIndex: 0
+      - equal:
+          path: metadata.namespace
+          value: ns2
+        documentIndex: 1
+      - equal:
+          path: metadata.namespace
+          value: ns3
+        documentIndex: 2


### PR DESCRIPTION
Signed-off-by: Cyril Jouve <jv.cyril@gmail.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
fix for #1561
when adding the unittest, I noticed that if namespaces is empty, produces a role/rolebinding with `namespace: null`, so I added that too to this patch


#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #1561

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
