### PR TITLE
[prometheus-node-exporter] Parameterise host root FS mount propagation

### DIFF
--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.2
 description: A Helm chart for prometheus node-exporter
 name: prometheus-node-exporter
-version: 2.3.0
+version: 2.3.1
 type: application
 home: https://github.com/prometheus/node_exporter/
 sources:

--- a/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -41,7 +41,7 @@ spec:
           args:
             - --path.procfs=/host/proc
             - --path.sysfs=/host/sys
-            {{- if .Values.hostRootFsMount }}
+            {{- if .Values.hostRootFsMount.enabled }}
             - --path.rootfs=/host/root
             {{- end }}
             - --web.listen-address=$(HOST_IP):{{ .Values.service.port }}
@@ -82,10 +82,12 @@ spec:
             - name: sys
               mountPath: /host/sys
               readOnly: true
-            {{- if .Values.hostRootFsMount }}
+            {{- if .Values.hostRootFsMount.enabled }}
             - name: root
               mountPath: /host/root
-              mountPropagation: HostToContainer
+              {{- with .Values.hostRootFsMount.mountPropagation }}
+              mountPropagation: {{ . }}
+              {{- end }}
               readOnly: true
             {{- end }}
             {{- if .Values.extraHostVolumeMounts }}
@@ -153,7 +155,7 @@ spec:
         - name: sys
           hostPath:
             path: /sys
-        {{- if .Values.hostRootFsMount }}
+        {{- if .Values.hostRootFsMount.enabled }}
         - name: root
           hostPath:
             path: /

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -92,9 +92,15 @@ hostNetwork: true
 # Share the host process ID namespace
 hostPID: true
 
-## If true, node-exporter pods mounts host / at /host/root
-##
-hostRootFsMount: true
+# Mount the node's root file system (/) at /host/root in the container
+hostRootFsMount:
+  enabled: true
+  # Defines how new mounts in existing mounts on the node or in the container
+  # are propagated to the container or node, respectively. Possible values are
+  # None, HostToContainer, and Bidirectional. If this field is omitted, then
+  # None is used. More information on:
+  # https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation
+  mountPropagation: HostToContainer
 
 ## Assign a group of affinity scheduling rules
 ##


### PR DESCRIPTION
Signed-off-by: Daniel Weibel <danielmweibel@gmail.com>

#### What this PR does / why we need it:

The mounting of the node's root (`/`) file system was enabled by default in PR #80 and it was made optional in PR #757. However, in the state of PR #757, the [mount propagation](https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation) is still hardcoded to HostToContainer. However, this feature requires certain [settings](https://kubernetes.io/docs/concepts/storage/volumes/#configuration) in the container runtime to work properly. Without these settings, the container may fail to start up with an error of the following form:

```
Error: failed to start container "node-exporter": Error response from daemon: path / is mounted on / but it is not a shared or slave mount
```

This PR allows to freely define the mount propagation type in the values file:

```yaml
hostRootFsMount:
  enabled: true
  mountPropagation: HostToContainer
```

In this way, it's possible to disable mount propagation when mounting the host root file system (by setting the field to None or omitting it), which allows to mount the host root file system on nodes that don't support mount propagation.

The default mount propagation value is set to HostToContainer to maintain backward compatibility with older versions of the chart.

#### Which issue this PR fixes

Various reports of the default mount propagation type causing the container to crash at startup can be found in #467.

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)