### PR TITLE
Upgrade prometheus-operator to v0.52.1

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -17,8 +17,8 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 23.1.5
-appVersion: 0.52.0
+version: 23.1.6
+appVersion: 0.52.1
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus
 keywords:

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1639,7 +1639,7 @@ prometheusOperator:
   ##
   image:
     repository: quay.io/prometheus-operator/prometheus-operator
-    tag: v0.52.0
+    tag: v0.52.1
     sha: ""
     pullPolicy: IfNotPresent
 
@@ -1657,7 +1657,7 @@ prometheusOperator:
     # image to use for config and rule reloading
     image:
       repository: quay.io/prometheus-operator/prometheus-config-reloader
-      tag: v0.52.0
+      tag: v0.52.1
       sha: ""
 
     # resource config for prometheusConfigReloader


### PR DESCRIPTION
Addressing https://github.com/prometheus-operator/prometheus-operator/issues/4435

I am not sure if there is a usual process for releasing appVersion updates between minor chart releases, or if I'd be short-circuiting that, but this one has been in the pipe for a while and we have pinned kube-prometheus-stack at 19.3.0 until it is incorporated here:

* https://github.com/fluxcd/flux2/pull/2194
* https://github.com/fluxcd/flux2/issues/2192