### PR TITLE
[prometheus-node-exporter] Update image to v1.3.1 & enable custom ServiceMonitor jobLabel

### DIFF
--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -1,16 +1,16 @@
 apiVersion: v2
-appVersion: 1.2.2
-description: A Helm chart for prometheus node-exporter
 name: prometheus-node-exporter
-version: 2.3.0
-type: application
-home: https://github.com/prometheus/node_exporter/
-sources:
-- https://github.com/prometheus/node_exporter/
+description: A Helm chart for prometheus node-exporter
 keywords:
 - node-exporter
 - prometheus
 - exporter
+type: application
+version: 2.4.0
+appVersion: 1.3.1
+home: https://github.com/prometheus/node_exporter/
+sources:
+- https://github.com/prometheus/node_exporter/
 maintainers:
 - email: gianrubio@gmail.com
   name: gianrubio

--- a/charts/prometheus-node-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-node-exporter/templates/_helpers.tpl
@@ -55,6 +55,13 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
+The image to use
+*/}}
+{{- define "prometheus-node-exporter.image" -}}
+{{- printf "%s:%s" .Values.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) }}
+{{- end }}
+
+{{/*
 Allow the release namespace to be overridden for multi-namespace deployments in combined charts
 */}}
 {{- define "prometheus-node-exporter.namespace" -}}

--- a/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -36,7 +36,7 @@ spec:
       {{- end }}
       containers:
         - name: node-exporter
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: {{ include "prometheus-node-exporter.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --path.procfs=/host/proc

--- a/charts/prometheus-node-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-node-exporter/templates/servicemonitor.yaml
@@ -9,6 +9,7 @@ metadata:
     {{- toYaml .Values.prometheus.monitor.additionalLabels | nindent 4 }}
   {{- end }}
 spec:
+  jobLabel: {{ default "app.kubernetes.io/name" .Values.prometheus.monitor.jobLabel }}
   selector:
     matchLabels:
       app: {{ template "prometheus-node-exporter.name" . }}

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -3,7 +3,8 @@
 # Declare variables to be passed into your templates.
 image:
   repository: quay.io/prometheus/node-exporter
-  tag: v1.2.2
+  # Overrides the image tag whose default is {{ printf "v%s" .Chart.AppVersion }}
+  tag: ""
   pullPolicy: IfNotPresent
 
 service:
@@ -21,6 +22,9 @@ prometheus:
     enabled: false
     additionalLabels: {}
     namespace: ""
+
+    jobLabel: ""
+
     scheme: http
     bearerTokenFile:
     tlsConfig: {}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

This PR updates the _Prometheus Node Exporter_ image to [v1.3.1](https://github.com/prometheus/node_exporter/releases/tag/v1.3.1) and enables the `ServiceMonitor` `jobLabel` to be overridden. Overriding the `ServiceMonitor` `jobLabel` and is required to enable the use of the chart `ServiceMonitor` by the _kube-prometheus-stack_ chart.

#### Which issue this PR fixes:

Fixes #1605.

This PR is is required for for #1425 and is an extension of #1566.

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
