### PR TITLE
[prometheus-cloudwatch-exporter] update the cloudwatch-exporter image from 0.10.0 to 0.12.2

### DIFF
--- a/charts/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/charts/prometheus-cloudwatch-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.10.0"
+appVersion: "0.12.2"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.17.2
+version: 0.18.0
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/charts/prometheus-cloudwatch-exporter/values.yaml
+++ b/charts/prometheus-cloudwatch-exporter/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: prom/cloudwatch-exporter
-  tag: cloudwatch_exporter-0.10.0
+  tag: v0.12.2
   pullPolicy: IfNotPresent
   pullSecrets:
   # - name: "image-pull-secret"


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR is to propose an update of the docker image used by this chart to be aligned with the current latest

#### Special notes for your reviewer:

From the changelog, no breaking changes are introduced.
Just removal of possible security issues coming from dependencies.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
