### PR TITLE
[kube-prometheus-stack] Re-Bump to prometheus-operator 0.52.1

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -17,8 +17,8 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 23.3.0
-appVersion: 0.52.0
+version: 23.3.1
+appVersion: 0.52.1
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus
 keywords:


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes accidentally committed change in 2e714c1a49582d1db2b82d0f1be3c7d3201fc575 which downgraded to prometheus-operator 0.52.0


#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
