### PR TITLE
[kube-prometheus-stack] Remove extra label from pdb selector for alertmanager

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 30.0.1
+version: 30.0.2
 appVersion: 0.53.1
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/alertmanager/podDisruptionBudget.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/podDisruptionBudget.yaml
@@ -16,6 +16,6 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app: alertmanager
+      app.kubernetes.io/name: alertmanager
       alertmanager: {{ template "kube-prometheus-stack.fullname" . }}-alertmanager
 {{- end }}


### PR DESCRIPTION

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
The [pod disruption budget](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/templates/alertmanager/podDisruptionBudget.yaml) for alertmanager in kube-prometheus-stack does not work because it has an [extra label](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/templates/alertmanager/podDisruptionBudget.yaml#L19) in the selector which is not present on the pods

This PR removes the label which will make the PDB work again.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
