### PR TITLE
[kube-prometheus-stack] bump grafana dependency to 6.19.2

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
-  version: 4.1.1
+  version: 4.1.2
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 2.2.2
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.19.0
-digest: sha256:3437708289e2e35e8de7ac468e0d7fe2df43e2d459857b8855cc84cb18501832
-generated: "2021-12-10T14:28:39.401354003+01:00"
+  version: 6.19.2
+digest: sha256:7a62a4d14ab943171cd939267be146a863b0f7389625ded52274eaa218a14290
+generated: "2021-12-15T09:35:43.8008371+05:30"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -17,7 +17,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 23.3.1
+version: 23.3.2
 appVersion: 0.52.1
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus


### PR DESCRIPTION
Security: Fixes CVE-2021-43813 and CVE-2021-PENDING

Signed-off-by: Amarnath K <amarnath_k@outlook.com>

