### PR TITLE
[kube-prometheus-stack] add owner_kind Job relabeled as workload_type Job

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -17,7 +17,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 25.1.0
+version: 25.1.1
 appVersion: 0.53.1
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/k8s.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/k8s.rules.yaml
@@ -160,4 +160,14 @@ spec:
       labels:
         workload_type: statefulset
       record: namespace_workload_pod:kube_pod_owner:relabel
+    - expr: |-
+        max by (cluster, namespace, workload, pod) (
+          label_replace(
+            kube_pod_owner{job="kube-state-metrics", owner_kind="Job"},
+            "workload", "$1", "owner_name", "(.*)"
+          )
+        )
+      labels:
+        workload_type: Job
+      record: namespace_workload_pod:kube_pod_owner:relabel
 {{- end }}


### PR DESCRIPTION
Signed-off-by: pin.jin@ga.gov.au <pin.jin@ga.gov.au>

#### What this PR does / why we need it:
Kubernetes Job is a workload type and by default, our k8s.rule contains all other 3 but not Job (https://kubernetes.io/docs/concepts/workloads/)

This pr adds `workload_type: Job` to `k8s.rule`

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #1627 

#### Special notes for your reviewer:

pr raised for `kube-prometheus` repo https://github.com/prometheus-operator/kube-prometheus/pull/1564

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
