### PR TITLE
[prometheus-mysql-exporter] Add namespace support to service monitor of MySQL exporter

### DIFF
--- a/charts/prometheus-mysql-exporter/Chart.yaml
+++ b/charts/prometheus-mysql-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for prometheus mysql exporter with cloudsqlproxy
 name: prometheus-mysql-exporter
-version: 1.3.0
+version: 1.4.0
 home: https://github.com/prometheus/mysqld_exporter
 appVersion: v0.12.1
 sources:

--- a/charts/prometheus-mysql-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-mysql-exporter/templates/servicemonitor.yaml
@@ -8,6 +8,9 @@ metadata:
   {{- if .Values.serviceMonitor.additionalLabels }}
 {{ toYaml .Values.serviceMonitor.additionalLabels | indent 4 }}
   {{- end }}
+{{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+{{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/prometheus-mysql-exporter/values.yaml
+++ b/charts/prometheus-mysql-exporter/values.yaml
@@ -25,6 +25,7 @@ serviceMonitor:
   # scrapeTimeout is the timeout after which the scrape is ended
   # scrapeTimeout: 10s
   # additionalLabels is the set of additional labels to add to the ServiceMonitor
+  # namespace: monitoring
   additionalLabels: {}
   jobLabel: ""
   targetLabels: []


### PR DESCRIPTION
#### What this PR does / why we need it:

Every Charts' service monitor supports namespace except MySQL exporter.

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
