### PR TITLE
[prometheus-mysql-exporter] add annotations to service account

### DIFF
--- a/charts/prometheus-mysql-exporter/Chart.yaml
+++ b/charts/prometheus-mysql-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for prometheus mysql exporter with cloudsqlproxy
 name: prometheus-mysql-exporter
-version: 1.4.1
+version: 1.5.0
 home: https://github.com/prometheus/mysqld_exporter
 appVersion: v0.12.1
 sources:

--- a/charts/prometheus-mysql-exporter/Chart.yaml
+++ b/charts/prometheus-mysql-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for prometheus mysql exporter with cloudsqlproxy
 name: prometheus-mysql-exporter
-version: 1.4.0
+version: 1.4.1
 home: https://github.com/prometheus/mysqld_exporter
 appVersion: v0.12.1
 sources:

--- a/charts/prometheus-mysql-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-mysql-exporter/templates/serviceaccount.yaml
@@ -8,4 +8,8 @@ metadata:
     chart: {{ template "prometheus-mysql-exporter.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end -}}

--- a/charts/prometheus-mysql-exporter/values.yaml
+++ b/charts/prometheus-mysql-exporter/values.yaml
@@ -38,6 +38,7 @@ serviceAccount:
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
+  annotations: {}
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This Pr adds annotations to prometheus-mysql-exporter service account, this in my case is to add google workload identity

