### PR TITLE
[kube-prometheus-stack] bump grafana version in umbrella chart #1660

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 4.2.0
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
-  version: 2.4.0
+  version: 2.4.1
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.19.4
-digest: sha256:474b1e145c80c7ad76a608a12c2e5b57539f271b17af35e30778e02d9b6cb0c2
-generated: "2021-12-18T23:52:52.413304629+01:00"
+  version: 6.20.4
+digest: sha256:61a3b9f14d3fd18682f42450ce98816ceea861ca83c844bc12404edc94b4d352
+generated: "2022-01-03T17:28:57.718122+02:00"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -17,7 +17,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 27.1.0
+version: 27.2.0
 appVersion: 0.53.1
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus
@@ -43,6 +43,6 @@ dependencies:
   repository: https://prometheus-community.github.io/helm-charts
   condition: nodeExporter.enabled
 - name: grafana
-  version: "6.19.*"
+  version: "6.20.*"
   repository: https://grafana.github.io/helm-charts
   condition: grafana.enabled


### PR DESCRIPTION
#### What this PR does / why we need it:
increases the minor chart version of grafana

#### Special notes for your reviewer:
sorry for the two PRs, i deleted the old one, I created a new branch because of the signoff, I couldn't amend one of the commits

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
