### PR TITLE
[prometheus-cloudwatch-exporter] Fix indentation for multiple annotations of ServiceAccounts

### DIFF
--- a/charts/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/charts/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.10.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.17.1
+version: 0.17.2
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/charts/prometheus-cloudwatch-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/serviceaccount.yaml
@@ -10,9 +10,8 @@ metadata:
     chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}    
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  
-  annotations:
   {{- if .Values.serviceAccount.annotations }}
-    {{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+  annotations:
+    {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/prometheus-cloudwatch-exporter/values.yaml
+++ b/charts/prometheus-cloudwatch-exporter/values.yaml
@@ -80,6 +80,7 @@ serviceAccount:
   # e.g.
   # annotations:
   #   eks.amazonaws.com/role-arn: arn:aws:iam::1234567890:role/prom-cloudwatch-exporter-oidc
+  #   eks.amazonaws.com/sts-regional-endpoints: "true"
   # Specifies whether to automount API credentials for the ServiceAccount.
   automountServiceAccountToken: true
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes indentation of ServiceAccount annotations when more than one annotation is provided.
It also excludes the `annotation` key from the manifest if no annotations are provided.

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)

Signed-off-by: Keenan Lorenzo Lawrence <keenan.l.lawrence@gmail.com>