### PR TITLE
[prometheus-pushgateway] Use a map for the extraArgs value in the pushgateway chart, handle alternate web prefix

### DIFF
--- a/charts/prometheus-pushgateway/Chart.yaml
+++ b/charts/prometheus-pushgateway/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.4.2"
+appVersion: "1.5.2"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
 version: 1.14.0

--- a/charts/prometheus-pushgateway/templates/deployment.yaml
+++ b/charts/prometheus-pushgateway/templates/deployment.yaml
@@ -40,7 +40,14 @@ spec:
         {{- end }}
         {{- if .Values.extraArgs }}
           args:
-{{ toYaml .Values.extraArgs | indent 12 }}
+          {{- range $key, $value := .Values.extraArgs }}
+          {{- $stringvalue := toString $value }}
+          {{- if eq $stringvalue "true" }}
+            - --{{ $key }}
+          {{- else }}
+            - --{{ $key }}={{ $value }}
+          {{- end }}
+          {{- end }}
         {{- end }}
           ports:
             - name: metrics
@@ -48,13 +55,21 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
+            {{- if (index .Values "extraArgs" "web.route-prefix") }}
+              path: {{ index .Values "extraArgs" "web.route-prefix" }}/-/healthy
+            {{- else }}
               path: /-/healthy
+            {{- end }}
               port: 9091
             initialDelaySeconds: 10
             timeoutSeconds: 10
           readinessProbe:
             httpGet:
+            {{- if (index .Values "extraArgs" "web.route-prefix") }}
+              path: {{ index .Values "extraArgs" "web.route-prefix" }}/-/ready
+            {{- else }}
               path: /-/ready
+            {{- end }}
               port: 9091
             initialDelaySeconds: 10
             timeoutSeconds: 10

--- a/charts/prometheus-pushgateway/templates/servicemonitor.yaml
+++ b/charts/prometheus-pushgateway/templates/servicemonitor.yaml
@@ -17,7 +17,11 @@ spec:
     {{- if .Values.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
     {{- end }}
+    {{- if (index .Values "extraArgs" "web.route-prefix") }}
+    path: {{ index .Values "extraArgs" "web.route-prefix" }}/metrics
+    {{- else }}
     path: /metrics
+    {{- end }}
     honorLabels: {{ .Values.serviceMonitor.honorLabels }}
     {{- if .Values.serviceMonitor.metricRelabelings }}
     metricRelabelings:

--- a/charts/prometheus-pushgateway/values.yaml
+++ b/charts/prometheus-pushgateway/values.yaml
@@ -52,9 +52,10 @@ extraVars: []
 ##
 ## example:
 ## extraArgs:
-##  - --persistence.file=/data/pushgateway.data
-##  - --persistence.interval=5m
-extraArgs: []
+##  web.route-prefix: /pushgateway
+##  persistence.file: /data/pushgateway.data
+##  persistence.interval: 5m
+extraArgs: {}
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This PR allows the use of an alternate web prefix, using the same mechanism as the standalone prometheus chart to conditionally modify the liveness and readiness checks on the pushgateway deployment if an alternate web root is configured.

This is required as otherwise, the checks fail with a 404 error using the current hard-coded check paths, as these paths must change if the web prefix is customised.

Signed-off-by: James Hebden <james@ec0.io>

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
