### PR TITLE
[kube-state-metrics] added dotdc as a maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 
 /charts/alertmanager/ @monotek @naseemkullah
 /charts/kube-prometheus-stack/ @andrewgkew @bismarck @gianrubio @gkarthiks @scottrigby @Xtigyro
-/charts/kube-state-metrics/ @mrueg @tariq1890
+/charts/kube-state-metrics/ @dotdc @mrueg @tariq1890
 /charts/prometheus/ @gianrubio @monotek @naseemkullah @Xtigyro @zanhsieh
 /charts/prometheus-adapter/ @hectorj2f @mattiasgees @steven-sheehy
 /charts/prometheus-blackbox-exporter/ @desaintmartin @gianrubio @monotek @rsotnychenko

--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 4.2.1
+version: 4.2.2
 appVersion: 2.3.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:
@@ -17,3 +17,5 @@ maintainers:
   email: tariq.ibrahim@mulesoft.com
 - name: mrueg
   email: manuel@rueg.eu
+- name: dotdc
+  email: davidcalvertfr@gmail.com

--- a/charts/kube-state-metrics/OWNERS
+++ b/charts/kube-state-metrics/OWNERS
@@ -1,6 +1,0 @@
-approvers:
-- tariq1890
-- mrueg
-reviewers:
-- tariq1890
-- mrueg


### PR DESCRIPTION
#### What this PR does / why we need it:

Added dotdc as a maintainer for kube-state-metrics

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
