### PR TITLE
[kube-state-metrics] reintroduce service monitor selectorOverride

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 4.3.0
+version: 4.3.1
 appVersion: 2.3.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 4.3.1
+version: 4.4.0
 appVersion: 2.3.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/servicemonitor.yaml
+++ b/charts/kube-state-metrics/templates/servicemonitor.yaml
@@ -13,7 +13,11 @@ spec:
   jobLabel: {{ default "app.kubernetes.io/name" .Values.prometheus.monitor.jobLabel }}
   selector:
     matchLabels:
+    {{- if .Values.prometheus.monitor.selectorOverride }}
+      {{ toYaml .Values.prometheus.monitor.selectorOverride | indent 6 }}
+    {{ else }}
       {{- include "kube-state-metrics.selectorLabels" . | indent 6 }}
+    {{- end }}
   endpoints:
     - port: http
     {{- if .Values.prometheus.monitor.interval }}

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -72,6 +72,7 @@ prometheus:
     interval: ""
     scrapeTimeout: ""
     proxyUrl: ""
+    selectorOverride: {}
     honorLabels: false
     metricRelabelings: []
     relabelings: []


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
I am bringing back the service monitor selectorOverride option that were removed in v24 (https://github.com/prometheus-community/helm-charts/commit/c75ec1c8ead17a745b9e141da4ebd51922626794) when deprecating the kube-prom-stack Service Monitors in favour of the tools specific chart Service Monitors.

#### Which issue this PR fixes
While I could not find the old issue from many years ago, this override was introduced to solve problems with various deployment tools that take over labels. In our case ArgoCD which changes the value the instance label. Once I upgraded to 24 I realised I lost a lot of metrics and that is because the service monitor labels were all wrong and I could find no equivalent new field.

#### Special notes for your reviewer:
Once merged I Can make a PR for prom stack chart

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
