### PR TITLE
[prometheus] Set sidecarContainers in a default values.yaml to {}

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.31.1
-version: 15.0.2
+version: 15.0.3
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -634,7 +634,7 @@ server:
   #   sidecarContainers:
   #      webserver:
   #        image: nginx
-  sidecarContainers: []
+  sidecarContainers: {}
 
   # sidecarTemplateValues - context to be used in template for sidecarContainers
   # Example:


### PR DESCRIPTION
#### What this PR does / why we need it:
Fix to avoid a warning on a chart install/upgrade:
```
coalesce.go:199: warning: destination for sidecarContainers is a table. Ignoring non-table value []
```
Since `sidecarContainers` in [sts.yaml](https://github.com/prometheus-community/helm-charts/blob/d50ef73002549f30368143a918c2dfc374e0db6d/charts/prometheus/templates/server/sts.yaml#L175) expects map, not a list. 

#### Which issue this PR fixes
`---`

#### Special notes for your reviewer:
@gianrubio 
@zanhsieh 
@Xtigyro 
@monotek 
@naseemkullah 

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
