### PR TITLE
[kube-prometheus-stack] final PR to finalise selectorOverrider

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
-  version: 4.3.0
+  version: 4.4.0
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
-  version: 2.4.1
+  version: 2.5.0
 - name: grafana
   repository: https://grafana.github.io/helm-charts
   version: 6.20.5
-digest: sha256:174b47db4f99815c7803c89cc6f64b1b1cf80f6d10741f9be1f3bc3dbd6d067e
-generated: "2022-01-07T18:04:42.636601419+01:00"
+digest: sha256:6259031d8078fd93acf637ed9f223dadf187d17440acca5eece82c39c871a871
+generated: "2022-01-14T08:50:38.080863+11:00"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 30.0.1
+version: 30.1.0
 appVersion: 0.53.1
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus
@@ -39,11 +39,11 @@ annotations:
 
 dependencies:
 - name: kube-state-metrics
-  version: "4.3.*"
+  version: "4.5.*"
   repository: https://prometheus-community.github.io/helm-charts
   condition: kubeStateMetrics.enabled
 - name: prometheus-node-exporter
-  version: "2.4.*"
+  version: "2.5.*"
   repository: https://prometheus-community.github.io/helm-charts
   condition: nodeExporter.enabled
 - name: grafana

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -39,7 +39,7 @@ annotations:
 
 dependencies:
 - name: kube-state-metrics
-  version: "4.5.*"
+  version: "4.4.*"
   repository: https://prometheus-community.github.io/helm-charts
   condition: kubeStateMetrics.enabled
 - name: prometheus-node-exporter

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1336,10 +1336,6 @@ kube-state-metrics:
       ##
       proxyUrl: ""
 
-      ## Override serviceMonitor selector
-      ##
-      selectorOverride: {}
-
       # Keep labels from scraped data, overriding server-side labels
       ##
       honorLabels: true
@@ -1401,10 +1397,6 @@ prometheus-node-exporter:
       ## proxyUrl: URL of a proxy that should be used for scraping.
       ##
       proxyUrl: ""
-
-      ## Override serviceMonitor selector
-      ##
-      selectorOverride: {}
 
       ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
       ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1336,6 +1336,10 @@ kube-state-metrics:
       ##
       proxyUrl: ""
 
+      ## Override serviceMonitor selector
+      ##
+      selectorOverride: {}
+
       # Keep labels from scraped data, overriding server-side labels
       ##
       honorLabels: true
@@ -1397,6 +1401,10 @@ prometheus-node-exporter:
       ## proxyUrl: URL of a proxy that should be used for scraping.
       ##
       proxyUrl: ""
+
+      ## Override serviceMonitor selector
+      ##
+      selectorOverride: {}
 
       ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
       ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
I am bringing back the service monitor selectorOverride option that were removed in v24 (https://github.com/prometheus-community/helm-charts/commit/c75ec1c8ead17a745b9e141da4ebd51922626794) when deprecating the kube-prom-stack Service Monitors in favour of the tools specific chart Service Monitors.

#### Which issue this PR fixes
While I could not find the old issue from many years ago, this override was introduced to solve problems with various deployment tools that take over labels. In our case ArgoCD which changes the value the instance label. Once I upgraded to 24 I realised I lost a lot of metrics and that is because the service monitor labels were all wrong and I could find no equivalent new field.

#### Special notes for your reviewer:
Now that prometheus-node-exporter and kube-state-metrics charts have been updated, update prom stack.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
