### PR TITLE
[prometheus] Fix field name for PVC volumeBindingMode

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.31.1
-version: 15.0.3
+version: 15.0.4
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/templates/alertmanager/pvc.yaml
+++ b/charts/prometheus/templates/alertmanager/pvc.yaml
@@ -23,7 +23,7 @@ spec:
 {{- end }}
 {{- end }}
 {{- if .Values.alertmanager.persistentVolume.volumeBindingMode }}
-  volumeBindingModeName: "{{ .Values.alertmanager.persistentVolume.volumeBindingMode }}"
+  volumeBindingMode: "{{ .Values.alertmanager.persistentVolume.volumeBindingMode }}"
 {{- end }}
   resources:
     requests:

--- a/charts/prometheus/templates/pushgateway/pvc.yaml
+++ b/charts/prometheus/templates/pushgateway/pvc.yaml
@@ -22,7 +22,7 @@ spec:
 {{- end }}
 {{- end }}
 {{- if .Values.pushgateway.persistentVolume.volumeBindingMode }}
-  volumeBindingModeName: "{{ .Values.pushgateway.persistentVolume.volumeBindingMode }}"
+  volumeBindingMode: "{{ .Values.pushgateway.persistentVolume.volumeBindingMode }}"
 {{- end }}
   resources:
     requests:

--- a/charts/prometheus/templates/server/pvc.yaml
+++ b/charts/prometheus/templates/server/pvc.yaml
@@ -24,7 +24,7 @@ spec:
 {{- end }}
 {{- end }}
 {{- if .Values.server.persistentVolume.volumeBindingMode }}
-  volumeBindingModeName: "{{ .Values.server.persistentVolume.volumeBindingMode }}"
+  volumeBindingMode: "{{ .Values.server.persistentVolume.volumeBindingMode }}"
 {{- end }}
   resources:
     requests:


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR fixes the field name for `volumeBindingMode` in PersistentVolumeClaims

#### Which issue this PR fixes

  - fixes #1713 

#### Special notes for your reviewer:

@gianrubio @Xtigyro @monotek @naseemkullah 

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
