### PR TITLE
[prometheus-rabbitmq-exporter] Introduce a new field to add additional labels for prometheus-rabbitmq-exporter deployment object

### DIFF
--- a/charts/prometheus-rabbitmq-exporter/Chart.yaml
+++ b/charts/prometheus-rabbitmq-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Rabbitmq metrics exporter for prometheus
 name: prometheus-rabbitmq-exporter
-version: 1.0.0
+version: 1.0.1
 appVersion: v0.29.0
 home: https://github.com/kbudde/rabbitmq_exporter
 sources:

--- a/charts/prometheus-rabbitmq-exporter/Chart.yaml
+++ b/charts/prometheus-rabbitmq-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Rabbitmq metrics exporter for prometheus
 name: prometheus-rabbitmq-exporter
-version: 1.0.1
+version: 1.1.0
 appVersion: v0.29.0
 home: https://github.com/kbudde/rabbitmq_exporter
 sources:

--- a/charts/prometheus-rabbitmq-exporter/templates/deployment.yaml
+++ b/charts/prometheus-rabbitmq-exporter/templates/deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: {{ template "prometheus-rabbitmq-exporter.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- if .Values.additionalLabels }}
+{{ toYaml .Values.additionalLabels | indent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/prometheus-rabbitmq-exporter/values.yaml
+++ b/charts/prometheus-rabbitmq-exporter/values.yaml
@@ -49,6 +49,10 @@ rabbitmq:
   timeout: 30
   max_queues: 0
 
+## Additional labels to set in the Deployment object. Together with standard labels from
+## the chart
+additionalLabels: {}
+
 podLabels: {}
 
 annotations: {}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
This PR introduces a new field in the `prometheus-rabbitmq-exporter` chart to add additional labels to the deployment object. This is useful for installations of this chart which requires custom labels to be present on the k8s objects, for reasons like auditing/monitoring, etc.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
