### PR TITLE
[kube-state-metrics] Fix cluster role generation

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 4.4.1
+version: 4.4.2
 appVersion: 2.3.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/role.yaml
+++ b/charts/kube-state-metrics/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- if and (eq .Values.rbac.create true) (not .Values.rbac.useExistingRole) -}}
-{{- range (split "," .Values.namespaces) }}
+{{- range (ternary (split "," .Values.namespaces) (list "") (eq $.Values.rbac.useClusterRole false)) }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if eq $.Values.rbac.useClusterRole false }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix an issue where cluster role would be generated multiple times when "namespaces" value is set (i.e. when only collecting information about
specific namespaces).

#### Which issue this PR fixes
* Fixes an issue introduced in #953

#### Special notes for your reviewer:

Just adding a condition to loop only once when using cluster roles.
@mrueg  @tariq1890 @dotdc 

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
