### PR TITLE
[prometheus-blackbox-exporter] Added runAsGroup to Deployment

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
 version: 5.3.2
-appVersion: 0.19.
+appVersion: 0.19.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:
   - https://github.com/prometheus/blackbox_exporter

--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 5.3.1
-appVersion: 0.19.0
+version: 5.3.2
+appVersion: 0.19.
 home: https://github.com/prometheus/blackbox_exporter
 sources:
   - https://github.com/prometheus/blackbox_exporter

--- a/charts/prometheus-blackbox-exporter/templates/deployment.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/deployment.yaml
@@ -81,6 +81,9 @@ spec:
               {{- if .Values.runAsUser }}
             runAsUser: {{ .Values.runAsUser }}
               {{- end }}
+              {{- if .Values.runAsGroup }}
+            runAsGroup: {{ .Values.runAsGroup }}
+              {{- end }}
             {{- end }}
           env:
           {{- range $key, $value := .Values.extraEnv }}

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -78,8 +78,9 @@ image:
   # pullSecrets:
   #   - myRegistrKeySecretName
 
-## User to run blackbox-exporter container as
+## User and Group to run blackbox-exporter container as
 runAsUser: 1000
+runAsGroup: 1000
 readOnlyRootFilesystem: true
 runAsNonRoot: true
 


### PR DESCRIPTION
Signed-off-by: Sven Haardiek <sven.haardiek@uni-muenster.de>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

It is possible to change the `runAsUser`, but not the `runAsGroup` in the deployment. So despite the fact that the Pod is running as the user 1000, it is still running with the root group. This pull request makes in configurable and also set the default to 1000. Same id as the user.

#### Which issue this PR fixes

I do not this there is an issue about it.

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
