### PR TITLE
[alertmanager] Add alertmanager extraSecretMounts

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 0.14.0
+version: 0.15.0
 appVersion: v0.23.0
 maintainers:
   - name: monotek

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -121,14 +121,28 @@ spec:
             - name: config
               mountPath: /etc/alertmanager
             {{- end }}
+            {{- range .Values.extraSecretMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              subPath: {{ .subPath }}
+              readOnly: {{ .readOnly }}
+            {{- end }}
             - name: storage
               mountPath: /alertmanager
-      {{- if .Values.config }}
       volumes:
+        {{- if .Values.config }}
         - name: config
           configMap:
             name: {{ include "alertmanager.fullname" . }}
-      {{- end }}
+        {{- end }}
+        {{- range .Values.extraSecretMounts }}
+        - name: {{ .name }}
+          secret:
+            secretName: {{ .secretName }}
+            {{- with .optional }}
+            optional: {{ . }}
+            {{- end }}
+        {{- end }}
       {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -12,6 +12,15 @@ image:
 
 extraArgs: {}
 
+## Additional Alertmanager Secret mounts
+# Defines additional mounts with secrets. Secrets must be manually created in the namespace.
+extraSecretMounts: []
+  # - name: secret-files
+  #   mountPath: /etc/secrets
+  #   subPath: ""
+  #   secretName: alertmanager-secret-files
+  #   readOnly: true
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Signed-off-by: heriet <heriet@heriet.info>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

Alertmanager supports [HTTPS and authentication](https://prometheus.io/docs/alerting/latest/https/). It requires `--web.config.file`. Therefore, I think alertmanager chart needs extraSecretMounts.

similar #1193

#### Which issue this PR fixes

#### Special notes for your reviewer:

- This PR enables configure basic_auth_users, but error occurs by liveness/readiness prove. I think needs another fix.

```
  Warning  Unhealthy  15m (x5 over 15m)   kubelet            Liveness probe failed: HTTP probe failed with statuscode: 401
  Warning  Unhealthy  10m (x44 over 15m)  kubelet            Readiness probe failed: HTTP probe failed with statuscode: 401
```

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
