### PR TITLE
Adding Helm Syntax into the Grafana Dashboards

### DIFF
--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -655,6 +655,10 @@ grafana:
     ##
     pspEnabled: false
 
+  ## If true, the Grafana Dashboards will recording rules
+  ## If false, the recording rules will be disabled and replaced with the original queries
+  recordingRules: false
+
   ingress:
     ## If true, Grafana Ingress will be created
     ##


### PR DESCRIPTION
This would be the approach of having an option to disable all recording rules in the Grafana templates.

`sync_prometheus_rules.py` needs to be called first.

Current issue is that there are recording rules that contain recording rules.