### PR TITLE
[prometheus-stackdriver-exporter] Fix servicemonitor name

### DIFF
--- a/charts/prometheus-stackdriver-exporter/Chart.yaml
+++ b/charts/prometheus-stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: prometheus-stackdriver-exporter
-version: 1.12.1
+version: 1.12.2
 appVersion: 0.11.0
 home: https://www.stackdriver.com/
 sources:

--- a/charts/prometheus-stackdriver-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ template "stackdriver-exporter.name" .  }}
+  name: {{ template "stackdriver-exporter.fullname" .  }}
   {{- if .Values.serviceMonitor.namespace }}
   namespace: {{ .Values.serviceMonitor.namespace }}
   {{- end }}


### PR DESCRIPTION
cc: @apenney @rpahli 

#### What this PR does / why we need it:
Updates `ServiceMonitor` to use `fullname` instead of `name`. This was preventing multiple releases of the chart to be deployed in a single namespace.

#### Which issue this PR fixes

Prevents error: `Unable to continue with install: ServiceMonitor "prometheus-stackdriver-exporter" in namespace "ns" exists and cannot be imported into the current release`

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
