### PR TITLE
[kube-prometheus-stack] Adding GMartinez-Sisti as new maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,7 @@
 * @prometheus-community/helm-charts-admins
 
 /charts/alertmanager/ @monotek @naseemkullah
-/charts/kube-prometheus-stack/ @andrewgkew @bismarck @desaintmartin @gianrubio @gkarthiks @scottrigby @Xtigyro
+/charts/kube-prometheus-stack/ @andrewgkew @bismarck @desaintmartin @gianrubio @gkarthiks @GMartinez-Sisti @scottrigby @Xtigyro
 /charts/kube-state-metrics/ @dotdc @mrueg @tariq1890
 /charts/prometheus/ @gianrubio @monotek @naseemkullah @Xtigyro @zanhsieh
 /charts/prometheus-adapter/ @hectorj2f @mattiasgees @steven-sheehy

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -13,6 +13,8 @@ maintainers:
     email: gianrubio@gmail.com
   - name: gkarthiks
     email: github.gkarthiks@gmail.com
+  - name: GMartinez-Sisti
+    email: kube-prometheus-stack@sisti.pt
   - name: scottrigby
     email: scott@r6by.com
   - name: Xtigyro
@@ -21,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 32.0.1
+version: 32.0.2
 appVersion: 0.54.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus


### PR DESCRIPTION
#### What this PR does / why we need it:
Adding GMartinez-Sisti as new maintainer for kube-prometheus-stack

Related to #1656

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
