### PR TITLE
[prometheus-mysql-exporter] Add missing namespaceSelector to servicemonitor

### DIFF
--- a/charts/prometheus-mysql-exporter/Chart.yaml
+++ b/charts/prometheus-mysql-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for prometheus mysql exporter with cloudsqlproxy
 name: prometheus-mysql-exporter
-version: 1.5.0
+version: 1.6.0
 home: https://github.com/prometheus/mysqld_exporter
 appVersion: v0.12.1
 sources:

--- a/charts/prometheus-mysql-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-mysql-exporter/templates/servicemonitor.yaml
@@ -12,6 +12,9 @@ metadata:
   namespace: {{ .Values.serviceMonitor.namespace }}
 {{- end }}
 spec:
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
   selector:
     matchLabels:
       {{- include "prometheus-mysql-exporter.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Add missing namespaceSelector to MySQL exporter chart

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
