### PR TITLE
[prometheus-adapter] Fix missing namespace field

### DIFF
--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 3.0.1
+version: 3.0.2
 appVersion: v0.9.1
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/kubernetes-sigs/prometheus-adapter

--- a/charts/prometheus-adapter/templates/certmanager.yaml
+++ b/charts/prometheus-adapter/templates/certmanager.yaml
@@ -6,6 +6,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ template "k8s-prometheus-adapter.fullname" . }}-self-signed-issuer
+  namespace: {{ .Release.Namespace }}
   {{- if .Values.customAnnotations }}
   annotations:
   {{- toYaml .Values.customAnnotations | nindent 4 }}
@@ -20,6 +21,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ template "k8s-prometheus-adapter.fullname" . }}-root-cert
+  namespace: {{ .Release.Namespace }}
   {{- if .Values.customAnnotations }}
   annotations:
   {{- toYaml .Values.customAnnotations | nindent 4 }}
@@ -39,6 +41,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ template "k8s-prometheus-adapter.fullname" . }}-root-issuer
+  namespace: {{ .Release.Namespace }}
   {{- if .Values.customAnnotations }}
   annotations:
   {{- toYaml .Values.customAnnotations | nindent 4 }}
@@ -54,6 +57,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ template "k8s-prometheus-adapter.fullname" . }}-cert
+  namespace: {{ .Release.Namespace }}
   {{- if .Values.customAnnotations }}
   annotations:
   {{- toYaml .Values.customAnnotations | nindent 4 }}

--- a/charts/prometheus-adapter/templates/pdb.yaml
+++ b/charts/prometheus-adapter/templates/pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "k8s-prometheus-adapter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   {{- if .Values.customAnnotations }}
   annotations:
   {{- toYaml .Values.customAnnotations | nindent 4 }}

--- a/charts/prometheus-adapter/templates/secret.yaml
+++ b/charts/prometheus-adapter/templates/secret.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}
   name: {{ template "k8s-prometheus-adapter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 type: kubernetes.io/tls
 data:
   tls.crt: {{ b64enc .Values.tls.certificate }}


### PR DESCRIPTION
Signed-off-by: Kazuki Suda <kazuki.suda@gmail.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

This PR fixes missing namespace field in some manifests. if there is no namespace field, there is no meaning if we use `--namespace` option to specify namespace with `helm template` command.

~This PR fixes a bug that cert-manager resources included in prometheus-adapter chart do not have namespace, so it is not set if namespace is specified.~

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)

cc/ @mattiasgees @steven-sheehy @hectorj2f