### PR TITLE
[prometheus-stackdriver-exporter] Switch exporter config to agrs instead of env variables.

### DIFF
--- a/charts/prometheus-stackdriver-exporter/Chart.yaml
+++ b/charts/prometheus-stackdriver-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: prometheus-stackdriver-exporter
-version: 1.12.2
-appVersion: 0.11.0
+version: 2.0.0
+appVersion: 0.12.0
 home: https://www.stackdriver.com/
 sources:
   - https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-stackdriver-exporter

--- a/charts/prometheus-stackdriver-exporter/README.md
+++ b/charts/prometheus-stackdriver-exporter/README.md
@@ -68,6 +68,8 @@ $ helm upgrade [RELEASE_NAME] [CHART] --install
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
+**WARNING:** since chart version 2.0.0, the exporter is configured via flags/arguments instead of environment variables due to a [breaking change in the exporter](https://github.com/prometheus-community/stackdriver_exporter/pull/142).
+
 ## Configuration
 
 See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing).

--- a/charts/prometheus-stackdriver-exporter/README.md
+++ b/charts/prometheus-stackdriver-exporter/README.md
@@ -68,7 +68,15 @@ $ helm upgrade [RELEASE_NAME] [CHART] --install
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
-**WARNING:** since chart version 2.0.0, the exporter is configured via flags/arguments instead of environment variables due to a [breaking change in the exporter](https://github.com/prometheus-community/stackdriver_exporter/pull/142).
+### Upgrading an existing Release to a new major version
+
+A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an incompatible breaking change needing manual actions.
+
+#### 1.x to 2.x
+
+Since chart version 2.0.0, the exporter is configured via flags/arguments instead of environment variables due to a [breaking change in the exporter](https://github.com/prometheus-community/stackdriver_exporter/pull/142).
+
+If you already use `.Values.extraArgs` you might want to check for conflicting command arguments.
 
 ## Configuration
 

--- a/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
@@ -65,12 +65,12 @@ spec:
           {{- end}}
           args:
             - --google.project-id={{ .Values.stackdriver.projectId | quote }}
-            - --monitoring.metrics-interval={{ .Values.stackdriver.metrics.interval | quote }}
-            - --monitoring.metrics-offset={{ .Values.stackdriver.metrics.offset | quote }}
+            - --monitoring.metrics-interval={{ .Values.stackdriver.metrics.interval }}
+            - --monitoring.metrics-offset={{ .Values.stackdriver.metrics.offset }}
             - --monitoring.metrics-type-prefixes={{ .Values.stackdriver.metrics.typePrefixes | quote }}
-            - --stackdriver.backoff-jitter={{ .Values.stackdriver.backoffJitter | quote }}
-            - --stackdriver.http-timeout={{ .Values.stackdriver.httpTimeout | quote }}
-            - --stackdriver.max-backoff={{ .Values.stackdriver.maxBackoff | quote }}
+            - --stackdriver.backoff-jitter={{ .Values.stackdriver.backoffJitter }}
+            - --stackdriver.http-timeout={{ .Values.stackdriver.httpTimeout }}
+            - --stackdriver.max-backoff={{ .Values.stackdriver.maxBackoff }}
             - --stackdriver.max-retries={{ .Values.stackdriver.maxRetries | quote }}
             - --stackdriver.retry-statuses={{ .Values.stackdriver.retryStatuses | quote}}
             - --web.listen-address={{ .Values.web.listenAddress | quote }}

--- a/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
@@ -65,7 +65,6 @@ spec:
           {{- end}}
           args:
             - --google.project-id={{ .Values.stackdriver.projectId | quote }}
-            - --monitoring.drop-delegated-projects={{ .Values.stackdriver.dropDelegatedProjects | quote}}
             - --monitoring.metrics-interval={{ .Values.stackdriver.metrics.interval | quote }}
             - --monitoring.metrics-offset={{ .Values.stackdriver.metrics.offset | quote }}
             - --monitoring.metrics-type-prefixes={{ .Values.stackdriver.metrics.typePrefixes | quote }}
@@ -76,6 +75,9 @@ spec:
             - --stackdriver.retry-statuses={{ .Values.stackdriver.retryStatuses | quote}}
             - --web.listen-address={{ .Values.web.listenAddress | quote }}
             - --web.telemetry-path={{ .Values.web.path | quote }}
+          {{- if .Values.stackdriver.dropDelegatedProjects }}
+            - --monitoring.drop-delegated-projects
+          {{- end }}
           {{- if .Values.extraArgs }}
           {{- range $key, $value := .Values.extraArgs }}
             {{- if $value }}

--- a/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
@@ -64,17 +64,17 @@ spec:
               mountPath: /etc/secrets/service-account/
           {{- end}}
           args:
-            - --google.project-id={{ .Values.stackdriver.projectId | quote }}
+            - --google.project-id={{ .Values.stackdriver.projectId }}
             - --monitoring.metrics-interval={{ .Values.stackdriver.metrics.interval }}
             - --monitoring.metrics-offset={{ .Values.stackdriver.metrics.offset }}
-            - --monitoring.metrics-type-prefixes={{ .Values.stackdriver.metrics.typePrefixes | quote }}
+            - --monitoring.metrics-type-prefixes={{ .Values.stackdriver.metrics.typePrefixes }}
             - --stackdriver.backoff-jitter={{ .Values.stackdriver.backoffJitter }}
             - --stackdriver.http-timeout={{ .Values.stackdriver.httpTimeout }}
             - --stackdriver.max-backoff={{ .Values.stackdriver.maxBackoff }}
             - --stackdriver.max-retries={{ .Values.stackdriver.maxRetries }}
             - --stackdriver.retry-statuses={{ .Values.stackdriver.retryStatuses }}
-            - --web.listen-address={{ .Values.web.listenAddress | quote }}
-            - --web.telemetry-path={{ .Values.web.path | quote }}
+            - --web.listen-address={{ .Values.web.listenAddress }}
+            - --web.telemetry-path={{ .Values.web.path }}
           {{- if .Values.stackdriver.dropDelegatedProjects }}
             - --monitoring.drop-delegated-projects
           {{- end }}

--- a/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
@@ -71,8 +71,8 @@ spec:
             - --stackdriver.backoff-jitter={{ .Values.stackdriver.backoffJitter }}
             - --stackdriver.http-timeout={{ .Values.stackdriver.httpTimeout }}
             - --stackdriver.max-backoff={{ .Values.stackdriver.maxBackoff }}
-            - --stackdriver.max-retries={{ .Values.stackdriver.maxRetries | quote }}
-            - --stackdriver.retry-statuses={{ .Values.stackdriver.retryStatuses | quote}}
+            - --stackdriver.max-retries={{ .Values.stackdriver.maxRetries }}
+            - --stackdriver.retry-statuses={{ .Values.stackdriver.retryStatuses }}
             - --web.listen-address={{ .Values.web.listenAddress | quote }}
             - --web.telemetry-path={{ .Values.web.path | quote }}
           {{- if .Values.stackdriver.dropDelegatedProjects }}

--- a/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
@@ -63,43 +63,31 @@ spec:
             - name: stackdriver-service-account
               mountPath: /etc/secrets/service-account/
           {{- end}}
-          {{- if .Values.extraArgs }}
           args:
+            - --google.project-id={{ .Values.stackdriver.projectId | quote }}
+            - --monitoring.drop-delegated-projects={{ .Values.stackdriver.dropDelegatedProjects | quote}}
+            - --monitoring.metrics-interval={{ .Values.stackdriver.metrics.interval | quote }}
+            - --monitoring.metrics-offset={{ .Values.stackdriver.metrics.offset | quote }}
+            - --monitoring.metrics-type-prefixes={{ .Values.stackdriver.metrics.typePrefixes | quote }}
+            - --stackdriver.backoff-jitter={{ .Values.stackdriver.backoffJitter | quote }}
+            - --stackdriver.http-timeout={{ .Values.stackdriver.httpTimeout | quote }}
+            - --stackdriver.max-backoff={{ .Values.stackdriver.maxBackoff | quote }}
+            - --stackdriver.max-retries={{ .Values.stackdriver.maxRetries | quote }}
+            - --stackdriver.retry-statuses={{ .Values.stackdriver.retryStatuses | quote}}
+            - --web.listen-address={{ .Values.web.listenAddress | quote }}
+            - --web.telemetry-path={{ .Values.web.path | quote }}
+          {{- if .Values.extraArgs }}
           {{- range $key, $value := .Values.extraArgs }}
             {{- if $value }}
             - --{{ $key }}={{ $value }}
             {{- end }}
           {{- end }}
           {{- end }}
-          env:
           {{- if or .Values.stackdriver.serviceAccountSecret .Values.stackdriver.serviceAccountKey }}
+          env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/secrets/service-account/credentials.json
           {{- end }}
-            - name: STACKDRIVER_EXPORTER_GOOGLE_PROJECT_ID
-              value: {{ .Values.stackdriver.projectId | quote }}
-            - name: STACKDRIVER_EXPORTER_MONITORING_METRICS_TYPE_PREFIXES
-              value: {{ .Values.stackdriver.metrics.typePrefixes | quote }}
-            - name: STACKDRIVER_EXPORTER_MONITORING_METRICS_INTERVAL
-              value: {{ .Values.stackdriver.metrics.interval | quote }}
-            - name: STACKDRIVER_EXPORTER_MONITORING_METRICS_OFFSET
-              value: {{ .Values.stackdriver.metrics.offset | quote }}
-            - name: STACKDRIVER_EXPORTER_WEB_LISTEN_ADDRESS
-              value: {{ .Values.web.listenAddress | quote }}
-            - name: STACKDRIVER_EXPORTER_WEB_TELEMETRY_PATH
-              value: {{ .Values.web.path | quote }}
-            - name: STACKDRIVER_EXPORTER_MAX_RETRIES
-              value: {{ .Values.stackdriver.maxRetries | quote }}
-            - name: STACKDRIVER_EXPORTER_HTTP_TIMEOUT
-              value: {{ .Values.stackdriver.httpTimeout | quote }}
-            - name: STACKDRIVER_EXPORTER_MAX_BACKOFF_DURATION
-              value: {{ .Values.stackdriver.maxBackoff | quote }}
-            - name: STACKDRIVER_EXPORTER_BACKODFF_JITTER_BASE
-              value: {{ .Values.stackdriver.backoffJitter | quote }}
-            - name: STACKDRIVER_EXPORTER_RETRY_STATUSES
-              value: {{ .Values.stackdriver.retryStatuses | quote}}
-            - name: STACKDRIVER_EXPORTER_DROP_DELEGATED_PROJECTS
-              value: {{ .Values.stackdriver.dropDelegatedProjects | quote}}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           ports:

--- a/charts/prometheus-stackdriver-exporter/values.yaml
+++ b/charts/prometheus-stackdriver-exporter/values.yaml
@@ -12,7 +12,7 @@ restartPolicy: Always
 
 image:
   repository: prometheuscommunity/stackdriver-exporter
-  tag: v0.11.0
+  tag: v0.12.0
   pullPolicy: IfNotPresent
 
 resources: {}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
Upgrade app version to 0.12.0 https://github.com/prometheus-community/stackdriver_exporter/releases/tag/v0.12.0
This version comes with a breaking change of dropping env variables config for this exporter: https://github.com/prometheus-community/stackdriver_exporter/pull/142

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
I bumped the chart version to 2.0.0 due to the change in how config is passed to the exporter.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
