### PR TITLE
[prometheus-stackdriver-exporter] Add support for imagePullSecrets

### DIFF
--- a/charts/prometheus-stackdriver-exporter/Chart.yaml
+++ b/charts/prometheus-stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: prometheus-stackdriver-exporter
-version: 1.12.2
+version: 1.13.0
 appVersion: 0.11.0
 home: https://www.stackdriver.com/
 sources:

--- a/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
@@ -36,6 +36,12 @@ spec:
       affinity:
         {{- toYaml .Values.affinity | nindent 8 }}
       {{- end }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       serviceAccount: {{ template "stackdriver-exporter.serviceAccountName" . }}
       restartPolicy: {{ .Values.restartPolicy }}
       volumes:

--- a/charts/prometheus-stackdriver-exporter/values.yaml
+++ b/charts/prometheus-stackdriver-exporter/values.yaml
@@ -15,6 +15,13 @@ image:
   tag: v0.11.0
   pullPolicy: IfNotPresent
 
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # pullSecrets:
+  #   - myDockerConfigJsonSecretName
+
 resources: {}
   # requests:
   #   cpu: 100m


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds support for `imagePullSecrets`, in order to pull the Stackdriver Exporter image from private container registries.

#### Checklist
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
