### PR TITLE
[prometheus-pushgateway] give the pushgateway live/ready probes the ability to add httpHeaders

### DIFF
--- a/charts/prometheus-pushgateway/Chart.yaml
+++ b/charts/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.4.2"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 1.15.0
+version: 1.16.0
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/charts/prometheus-pushgateway/templates/deployment.yaml
+++ b/charts/prometheus-pushgateway/templates/deployment.yaml
@@ -46,18 +46,30 @@ spec:
             - name: metrics
               containerPort: 9091
               protocol: TCP
+{{- if .Values.liveness.enabled }}
           livenessProbe:
             httpGet:
+        {{- if .Values.liveness.httpHeaders }}
+              httpHeaders:
+{{ toYaml .Values.liveness.httpHeaders | indent 16 }}
+        {{- end }}
               path: /-/healthy
               port: 9091
             initialDelaySeconds: 10
             timeoutSeconds: 10
+        {{- end }}
+{{- if .Values.readiness.enabled }}
           readinessProbe:
             httpGet:
+        {{- if .Values.readiness.httpHeaders }}
+              httpHeaders:
+{{ toYaml .Values.readiness.httpHeaders | indent 16 }}
+        {{- end }}
               path: /-/ready
               port: 9091
             initialDelaySeconds: 10
             timeoutSeconds: 10
+        {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
         {{- if .Values.containerSecurityContext }}

--- a/charts/prometheus-pushgateway/templates/deployment.yaml
+++ b/charts/prometheus-pushgateway/templates/deployment.yaml
@@ -48,27 +48,11 @@ spec:
               protocol: TCP
 {{- if .Values.liveness.enabled }}
           livenessProbe:
-            httpGet:
-        {{- if .Values.liveness.httpHeaders }}
-              httpHeaders:
-{{ toYaml .Values.liveness.httpHeaders | indent 16 }}
-        {{- end }}
-              path: /-/healthy
-              port: 9091
-            initialDelaySeconds: 10
-            timeoutSeconds: 10
+{{ toYaml .Values.liveness.probe | indent 12 }}
         {{- end }}
 {{- if .Values.readiness.enabled }}
           readinessProbe:
-            httpGet:
-        {{- if .Values.readiness.httpHeaders }}
-              httpHeaders:
-{{ toYaml .Values.readiness.httpHeaders | indent 16 }}
-        {{- end }}
-              path: /-/ready
-              port: 9091
-            initialDelaySeconds: 10
-            timeoutSeconds: 10
+{{ toYaml .Values.readiness.probe | indent 12 }}
         {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/charts/prometheus-pushgateway/values.yaml
+++ b/charts/prometheus-pushgateway/values.yaml
@@ -68,6 +68,18 @@ resources: {}
   #   cpu: 100m
   #   memory: 30Mi
 
+liveness:
+  enabled: true
+  httpHeaders: []
+    # - name: Authorization
+    #   value: Basic <base64-encoding of username:password>
+
+readiness:
+  enabled: true
+  httpHeaders: []
+    # - name: Authorization
+    #   value: Basic <base64-encoding of username:password>
+
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true

--- a/charts/prometheus-pushgateway/values.yaml
+++ b/charts/prometheus-pushgateway/values.yaml
@@ -70,15 +70,21 @@ resources: {}
 
 liveness:
   enabled: true
-  httpHeaders: []
-    # - name: Authorization
-    #   value: Basic <base64-encoding of username:password>
+  probe:
+    httpGet:
+      path: /-/ready
+      port: 9091
+    initialDelaySeconds: 10
+    timeoutSeconds: 10
 
 readiness:
   enabled: true
-  httpHeaders: []
-    # - name: Authorization
-    #   value: Basic <base64-encoding of username:password>
+  probe:
+    httpGet:
+      path: /-/ready
+      port: 9091
+    initialDelaySeconds: 10
+    timeoutSeconds: 10
 
 serviceAccount:
   # Specifies whether a ServiceAccount should be created


### PR DESCRIPTION
Signed-off-by: Jürgen Weber <jurgen.weber@massive.co>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
This PR gives you the ability in the chart to manipulate httpHeaders for the live and ready probe. This is required when you attempt to turn on basic http auth with the pushgateway as it turns it on for [ALL http endpoints](https://github.com/prometheus/pushgateway#tls-and-basic-authentication).

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
