### PR TITLE
[kube-prometheus-stack] Update Grafana Chart version to 6.21.5

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 2.5.0
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.21.2
-digest: sha256:a269c9b0db3d51919159cc5f001b6bd77ab0c0a518b5082d95bd62dd1e9ffb1e
-generated: "2022-02-07T13:03:04.53094609+01:00"
+  version: 6.21.5
+digest: sha256:0651500b89901e55f8e145ef735a0bf6dadea17050cb07b1bc72c4a40b512fbf
+generated: "2022-02-14T12:58:06.311861Z"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 32.2.0
+version: 32.2.1
 appVersion: 0.54.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus


### PR DESCRIPTION
#### What this PR does / why we need it:

- Update Grafana Helm Chart to version 6.21.5

#### Which issue this PR fixes
- fixes #1803

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
