### PR TITLE
[kube-prometheus-stack] Expose the container-specific security context for Prometheus Operator

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 32.2.2
+version: 32.3.0
 appVersion: 0.54.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 32.2.1
+version: 32.2.2
 appVersion: 0.54.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -112,8 +112,7 @@ spec:
           resources:
 {{ toYaml .Values.prometheusOperator.resources | indent 12 }}
           securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
+{{ toYaml .Values.prometheusOperator.containerSecurityContext | indent 12 }}
 {{- if .Values.prometheusOperator.tls.enabled }}
           volumeMounts:
             - name: tls-secret

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1681,6 +1681,13 @@ prometheusOperator:
     runAsNonRoot: true
     runAsUser: 65534
 
+  ## Container-specific security context configuration
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ##
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+
   ## Prometheus-operator image
   ##
   image:


### PR DESCRIPTION
#### What this PR does / why we need it:
We want to further configure the Kubernetes container security context for the Prometheus Operator, so we can set other container-specific settings such as capabilities -> drop -> ALL. Therefore we expose the container-specific security context using `containerSecurityContext` as the input (as used in other prometheus helm-charts e.g. [node-exporter](https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus-node-exporter/values.yaml#L79)).

#### Special notes for your reviewer:
We understand that some other Prometheus containers such as the node-exporter do not support dropping capabilities (in that case, because it did not have any in the first place) - this pull request assumes that isn't the case for Prometheus Operator, but please do let us know if that is an incorrect assumption.

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
