### PR TITLE
[prometheus] support using hostPort on prometheus-server

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.31.1
-version: 15.3.0
+version: 15.4.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/templates/server/deploy.yaml
+++ b/charts/prometheus/templates/server/deploy.yaml
@@ -116,6 +116,9 @@ spec:
         {{- end }}
           ports:
             - containerPort: 9090
+          {{- if .Values.server.hostPort }}
+              hostPort: {{ .Values.server.hostPort }}
+          {{- end }}
           readinessProbe:
             {{- if not .Values.server.tcpSocketProbeEnabled }}
             httpGet:

--- a/charts/prometheus/templates/server/sts.yaml
+++ b/charts/prometheus/templates/server/sts.yaml
@@ -116,6 +116,9 @@ spec:
         {{- end }}
           ports:
             - containerPort: 9090
+          {{- if .Values.server.hostPort }}
+              hostPort: {{ .Values.server.hostPort }}
+          {{- end }}
           readinessProbe:
             {{- if not .Values.server.tcpSocketProbeEnabled }}
             httpGet:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -1045,6 +1045,9 @@ server:
   # When hostNetwork is enabled, you probably want to set this to ClusterFirstWithHostNet
   dnsPolicy: ClusterFirst
 
+  # Use hostPort
+  # hostPort: 9090
+
   ## Vertical Pod Autoscaler config
   ## Ref: https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler
   verticalAutoscaler:


### PR DESCRIPTION
#### What this PR does / why we need it:

Support running prometheus-server with hostPort

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
