### PR TITLE
[prometheus-blackbox-exporter] fix servicemonitor sourceLabels

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 5.4.0
+version: 5.4.1
 appVersion: 0.19.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/charts/prometheus-blackbox-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/servicemonitor.yaml
@@ -29,9 +29,11 @@ spec:
       target:
       - {{ .url }}
     metricRelabelings:
-      - targetLabel: instance
+      - sourceLabels: [instance]
+        targetLabel: instance
         replacement: {{ .url }}
-      - targetLabel: target
+      - sourceLabels: [target]
+        targetLabel: target
         replacement: {{ .name }}
         {{- range $targetLabel, $replacement := .additionalMetricsRelabels | default $.Values.serviceMonitor.defaults.additionalMetricsRelabels }}
       - targetLabel: {{ $targetLabel }}


### PR DESCRIPTION
Signed-off-by: Samarth MK <sam0392in@gmail.com>

#### What this PR does / why we need it:
 - fix missing sourceLabels in servicemonitor.yaml

#### Which issue this PR fixes
when chart is deployed with servicemonitor enabled in values.yaml, it throws below error:
```
Error: UPGRADE FAILED: failed to create resource: ServiceMonitor.monitoring.coreos.com "blackbox-exporter-prometheus-blackbox-exporter" is invalid: spec.endpoints.metricRelabelings.sourceLabels: Required value
```

After adding the sourceLabels, chart deploy successfully.


#### Special notes for your reviewer:
This PR aims to fix the bug in servicemonitor

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
