### PR TITLE
[kube-state-metrics] Allow specifying clusterIP

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 4.5.0
+version: 4.6.0
 appVersion: 2.3.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/service.yaml
+++ b/charts/kube-state-metrics/templates/service.yaml
@@ -31,5 +31,8 @@ spec:
 {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: "{{ .Values.service.loadBalancerIP }}"
 {{- end }}
+{{- if .Values.service.clusterIP }}
+  clusterIP: "{{ .Values.service.clusterIP }}"
+{{- end }}
   selector:
     {{- include "kube-state-metrics.selectorLabels" . | indent 4 }}

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -28,6 +28,7 @@ service:
   type: ClusterIP
   nodePort: 0
   loadBalancerIP: ""
+  clusterIP: ""
   annotations: {}
 
 ## Additional labels to add to all resources


### PR DESCRIPTION
Signed-off-by: Michael McLellan <jmikem825@gmail.com>

#### What this PR does / why we need it:

Allow specifying `clusterIP`, which can be set to `None` to create a headless service (useful with sharding so that the service can be used to query multiple replicas).

#### Which issue this PR fixes

  - Related to #1475

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
