### PR TITLE
[prometheus] add ruleFiles value to insert rule files with label interpolation

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.31.1
-version: 15.4.0
+version: 15.5.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/templates/server/cm.yaml
+++ b/charts/prometheus/templates/server/cm.yaml
@@ -9,6 +9,9 @@ metadata:
 {{ include "prometheus.namespace" . | indent 2 }}
 data:
 {{- $root := . -}}
+{{- range $key, $value := .Values.ruleFiles }}
+  {{ $key }}: {{- toYaml $value | indent 2 }}
+{{- end }}
 {{- range $key, $value := .Values.serverFiles }}
   {{ $key }}: |
 {{- if eq $key "prometheus.yml" }}

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -1366,6 +1366,9 @@ alertmanagerFiles:
       receiver: default-receiver
       repeat_interval: 3h
 
+## Prometheus server ConfigMap entries for rule files (allow prometheus labels interpolation)
+ruleFiles: {}
+
 ## Prometheus server ConfigMap entries
 ##
 serverFiles:


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

This PR will allow us to insert rules files (record and alert) by using prometheus internal label interpolation (eg `{{ $labels.namespace }}` without conflicting with helm rendering mechanism

#### Which issue this PR fixes
Currently the chart give us the ability to split the rule files (alert and record) and insert in the prometheus-server pod through the configmap, which is pretty cool to organize the rules accross mulitple files (by group, by theme, ...)

We currently do it by adding a key named with the rule file name under the `serverFiles` root field in the `values.yaml`
Example:
```
# alert-kubernetes-jobs.yml
serverFiles:
  alert-jobs.yaml:
    groups:
    - name: KubeJobs
      rules:
        - alert: jobs-not-healthy
          expr: kube_job_failed > 0
          for: 5m
          labels:
            severity: critical
            alerttype: general
          annotations:
            description: "job is in a non-ready state"
```
```
# alert-kubernetes-pods.yaml
serverFiles:
  alert-pods.yml:
    groups:
    - name: Pods
      rules:
        - alert: Pods-not-healthy
          annotations:
            description: "Pod is in a non-ready state for longer than 10 minutes."
          expr: min_over_time(sum by (namespace, pod) (kube_pod_status_phase{phase=~"Pending|Unknown|Failed"})[5m:1m]) > 0 and count by (namespace, pod) (kube_pod_owner{owner_kind!="Job"})
          for: 10m
          labels:
            severity: critical
            alerttype: general
```
Then we deploy the chart by running a command like that:
```
helm upgrade myRelease prometheus-community/prometheus -f myValues.yaml -f alert-kubernetes-pods.yaml -f alert-kubernetes-jobs.yml ...
```
Until that point it works like a charm

The issue comes when we want to include prometheus label interpolation in the rules (eg. `{{ $labels.namespace }}`)
Example:
```
# alert-kubernetes-jobs.yaml
serverFiles:
  alert-jobs.yml:
    groups:
    - name: KubeJobs
      rules:
        - alert: jobs-not-healthy
          expr: kube_job_failed > 0
          for: 5m
          labels:
            severity: critical
            alerttype: general
          annotations:
            description: "job is in a non-ready state"
            entity: {{ $labels.job_name }}
```
By a using a values file like that it will break the helm rendering step
```
Error: failed to parse prometheus-infra-rules/alert-kubernetes-jobs.yaml: error converting YAML to JSON: yaml: invalid map key: map[interface {}]interface {}{"$labels.job_name":interface {}(nil)}
```
We can add the content of the rule file as a document value `|` in the helm values files like that:
Example:
```
# alert-kubernetes-jobs.yaml
serverFiles:
  alert-jobs.yml: | <-----
    groups:
    - name: KubeJobs
      rules:
        - alert: jobs-not-healthy
          expr: kube_job_failed > 0
          for: 5m
          labels:
            severity: critical
            alerttype: general
          annotations:
            description: "job is in a non-ready state"
            entity: {{ $labels.job_name }}
```
Problem it will duplicate the symbols `|` and make the rule file invalid from a yaml point of view because of that[ line in the chart](https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/templates/server/cm.yaml#L13)
Rendered entry in the configmap:
```
alert-jobs.yml: | <-------
    | <------
    groups:
    - name: KubeJobs
      rules:
        - alert: jobs-not-healthy
          expr: kube_job_failed > 0
          for: 5m
          labels:
            severity: critical
            alerttype: general
          annotations:
            description: "job is in a non-ready state"
            entity: {{ $labels.job_name }}
 ```
 Given the problem, the solution proposed will give us the possibility to insert rules via a values file like that:
 ```
 # alert-kubernetes-jobs.yaml
 ruleFiles:
  alert-jobs.yml: |
    groups:
    - name: KubeJobs
      rules:
        - alert: jobs-not-healthy
          expr: kube_job_failed > 0
          for: 5m
          labels:
            severity: critical
            alerttype: general
          annotations:
            description: "job is in a non-ready state"
            entity: {{ $labels.job_name }}
 ```
#### Special notes for your reviewer:

Don't hesitate to ask details if needed
Thanks in advance for the review

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
