### PR TITLE
[prometheus-stackdriver-exporter] Add option to enable metrics ingest delay

### DIFF
--- a/charts/prometheus-stackdriver-exporter/Chart.yaml
+++ b/charts/prometheus-stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: prometheus-stackdriver-exporter
-version: 2.1.1
+version: 2.2.0
 appVersion: 0.12.0
 home: https://www.stackdriver.com/
 sources:

--- a/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
@@ -84,6 +84,9 @@ spec:
           {{- if .Values.stackdriver.dropDelegatedProjects }}
             - --monitoring.drop-delegated-projects
           {{- end }}
+          {{- if .Values.stackdriver.metrics.ingestDelay }}
+            - --monitoring.metrics-ingest-delay
+          {{- end }}
           {{- if .Values.extraArgs }}
           {{- range $key, $value := .Values.extraArgs }}
             {{- if $value }}

--- a/charts/prometheus-stackdriver-exporter/values.yaml
+++ b/charts/prometheus-stackdriver-exporter/values.yaml
@@ -68,6 +68,8 @@ stackdriver:
     interval: '5m'
     # How far into the past to offset
     offset: '0s'
+    # Offset for the Google Stackdriver Monitoring Metrics interval into the past by the ingest delay from the metric's metadata.
+    ingestDelay: false
 
 web:
   # Port to listen on


### PR DESCRIPTION
#### What this PR does / why we need it:

Google Stackdriver Prometheus Exporter v0.12.0 introduces new option to [include ingestion delay to pulled metrics](https://github.com/prometheus-community/stackdriver_exporter/pull/129). It is a boolean flag and [kingpin](https://github.com/alecthomas/kingpin) flag parser used in Google Stackdriver Prometheus Exporter doesn't support a format like `--monitoring.metrics-ingest-delay=true`, so I cannot set it via `extraArgs` option. This PR adds an option to enable metrics ingest delay in the same way as `--monitoring.drop-delegated-projects` flag.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
