### PR TITLE
[kube-prometheus-stack] Adding support for extra K8s manifests

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 2.4.1
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.20.5
-digest: sha256:174b47db4f99815c7803c89cc6f64b1b1cf80f6d10741f9be1f3bc3dbd6d067e
-generated: "2022-01-07T18:04:42.636601419+01:00"
+  version: 6.20.8
+digest: sha256:a1ddb4775b795144ad2865bac7abd7fa11832e2cbd0c85ec8be0d172f63b740f
+generated: "2022-03-03T14:13:46.217221-05:00"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 30.0.1
+version: 30.1.0
 appVersion: 0.53.1
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/extra-manifests.yaml
+++ b/charts/kube-prometheus-stack/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -118,6 +118,25 @@ global:
   imagePullSecrets: []
   # - name: "image-pull-secret"
 
+## Array of extra K8s manifests to deploy
+##
+extraObjects: []
+  # - apiVersion: secrets-store.csi.x-k8s.io/v1
+  #   kind: SecretProviderClass
+  #   metadata:
+  #     name: kube-prometheus-stack-secrets-store
+  #   spec:
+  #     provider: aws
+  #     parameters:
+  #       objects: |
+  #         - objectName: "kube-prometheus-stack"
+  #           objectType: "secretsmanager"
+  #           jmesPath:
+  #               - path: "client_id"
+  #                 objectAlias: "client_id"
+  #               - path: "client_secret"
+  #                 objectAlias: "client_secret"
+
 ## Configuration for alertmanager
 ## ref: https://prometheus.io/docs/alerting/alertmanager/
 ##


### PR DESCRIPTION
Signed-off-by: Nick Fisher <nxf5025@gmail.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
This PR adds support for deploying extra kubernetes resources alongside the chart. This can be used for example when integrating with some of the open source K8s secrets add-ons:

- https://github.com/external-secrets/kubernetes-external-secrets
- https://github.com/kubernetes-sigs/secrets-store-csi-driver

The same thing was done in a few other charts such as the below:
- https://github.com/grafana/helm-charts/pull/928
- https://github.com/argoproj/argo-helm/pull/1094

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
