### PR TITLE
[prometheus-postgres-exporter] Support custom DB connection parameters

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.10.0"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 2.5.0
+version: 2.6.0
 home: https://github.com/prometheus-community/postgres_exporter
 sources:
 - https://github.com/prometheus-community/postgres_exporter

--- a/charts/prometheus-postgres-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-postgres-exporter/templates/_helpers.tpl
@@ -48,7 +48,7 @@ Create the name of the service account to use
 Set DATA_SOURCE_URI environment variable
 */}}
 {{- define "prometheus-postgres-exporter.data_source_uri" -}}
-{{ printf "%s:%s/%s?sslmode=%s" .Values.config.datasource.host .Values.config.datasource.port .Values.config.datasource.database .Values.config.datasource.sslmode | quote }}
+{{ printf "%s:%s/%s?sslmode=%s&%s" .Values.config.datasource.host .Values.config.datasource.port .Values.config.datasource.database .Values.config.datasource.sslmode .Values.config.datasource.extraParams | quote }}
 {{- end }}
 
 {{/*

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -104,6 +104,7 @@ config:
     port: "5432"
     database: ''
     sslmode: disable
+    extraParams: ''
   datasourceSecret: {}
     # Specifies if datasource should be sourced from secret value in format: postgresql://login:password@hostname:port/dbname?sslmode=disable
     # Multiple Postgres databases can be configured by comma separated postgres connection strings


### PR DESCRIPTION
Closes #1845

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
It implements feature request #1845 to support custom DB [connection parameters](https://www.postgresql.org/docs/14/libpq-connect.html#LIBPQ-PARAMKEYWORDS) for DATA_SOURCE_URI

#### Which issue this PR fixes
  - fixes #1845

#### Special notes for your reviewer:
It is backwards compatible.
With default settings (when `.Values.config.datasource.extraParams` is empty) the only side effect is that `DATA_SOURCE_URI` will end with `&` unlike before, but that is ok for Postgres (tested). This allows simpler string concatenation with `.Values.config.datasource.extraParams` without needing to add `&` to the beginning of the value before first parameter

#### Example usage:
In values.yaml override `.Values.config.datasource.extraParams` value for example with `application_name=prometheus-postgres-exporter`. If you want to add multiple parameters, separate them with `&`.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name
