### PR TITLE
[prometheus-elasticsearch-exporter] fixed pre-stop lifecycle hook

### DIFF
--- a/charts/prometheus-elasticsearch-exporter/Chart.yaml
+++ b/charts/prometheus-elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: prometheus-elasticsearch-exporter
-version: 4.11.0
+version: 4.11.1
 kubeVersion: ">=1.10.0-0"
 appVersion: 1.3.0
 home: https://github.com/prometheus-community/elasticsearch_exporter

--- a/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
+++ b/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
@@ -165,7 +165,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/bash", "-c", "sleep 20"]
+                command: ["/bin/ash", "-c", "sleep 20"]
           volumeMounts:
             {{- if and .Values.es.ssl.enabled (eq .Values.es.ssl.useExistingSecrets false) }}
             - mountPath: /ssl


### PR DESCRIPTION
Signed-off-by: Sebastian Struß <struss@justtrack.io>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

We are getting errors in our k8s event logs like
```
Exec lifecycle hook ([/bin/bash -c sleep 20]) for Container "exporter" in Pod "prometheus-elasticsearch-exporter-654596b9d5-qb7gx_elasticsearch(bd9d0706-fd45-45c9-af18-0ecf86819142)" failed - error: command '/bin/bash -c sleep 20' exited with 126: , message: "OCI runtime exec failed: exec failed: container_linux.go:380: starting container process caused: exec: \"/bin/bash\": stat /bin/bash: no such file or directory: unknown\r\n"
```

We need this pr to get less errors in the logs.

Prove:
```
$ docker run --rm --entrypoint /bin/bash quay.io/prometheuscommunity/elasticsearch-exporter:v1.3.0 && echo $?
docker: Error response from daemon: OCI runtime create failed: container_linux.go:380: starting container process caused: exec: "/bin/bash": stat /bin/bash: no such file or directory: unknown.

$ docker run --rm --entrypoint /bin/ash quay.io/prometheuscommunity/elasticsearch-exporter:v1.3.0 && echo $?
0
```

#### Which issue this PR fixes
* wrong shell used in pre-stop lifecycle hook. There is no bash in the image.

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
