### PR TITLE
[prometheus-snmp-exporter] Support for multiple targets when using ServiceMonitor

### DIFF
--- a/charts/prometheus-snmp-exporter/Chart.yaml
+++ b/charts/prometheus-snmp-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus SNMP Exporter
 name: prometheus-snmp-exporter
-version: 0.2.0
+version: 1.0.0
 appVersion: 0.19.0
 home: https://github.com/prometheus/snmp_exporter
 sources:

--- a/charts/prometheus-snmp-exporter/README.md
+++ b/charts/prometheus-snmp-exporter/README.md
@@ -54,6 +54,34 @@ $ helm upgrade [RELEASE_NAME] [CHART] --install
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
+### To 1.0.0
+
+This version allows multiple Targets to be specified when using ServiceMonitor. When you use ServiceMonitor, please rewrite below:
+
+```yaml
+serviceMonitor:
+  enabled: true
+  params:
+    enabled: true
+    conf:
+      module:
+      - if_mib
+      target:
+      - 127.0.0.1
+```
+
+to this:
+```yaml
+serviceMonitor:
+  enabled: true
+  params:
+    module:
+    - if_mib
+    name: device1
+    target: 127.0.0.1
+```
+
+
 ## Configuration
 
 See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:

--- a/charts/prometheus-snmp-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-snmp-exporter/templates/servicemonitor.yaml
@@ -1,41 +1,48 @@
 {{- if .Values.serviceMonitor.enabled }}
+{{- range .Values.serviceMonitor.params }}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ template "prometheus-snmp-exporter.fullname" .  }}
-  {{- if .Values.serviceMonitor.namespace }}
-  namespace: {{ .Values.serviceMonitor.namespace }}
+  name: {{ template "prometheus-snmp-exporter.fullname" $  }}-{{ .name }}
+  {{- if $.Values.serviceMonitor.namespace }}
+  namespace: {{ $.Values.serviceMonitor.namespace }}
   {{- end }}
   labels:
-    {{- include "prometheus-snmp-exporter.labels" . | indent 4 }}
-    {{- range $key, $value := .Values.serviceMonitor.selector }}
+    {{- include "prometheus-snmp-exporter.labels" $ | indent 4 }}
+    {{- range $key, $value := .labels | default $.Values.serviceMonitor.selector }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
   endpoints:
   - port: http
-    {{- if .Values.serviceMonitor.interval }}
-    interval: {{ .Values.serviceMonitor.interval }}
+    honorLabels: {{ $.Values.serviceMonitor.honorLabels }}
+    path: {{ $.Values.serviceMonitor.path }}
+    {{- if or .interval $.Values.serviceMonitor.interval }}
+    interval: {{ .interval | default $.Values.serviceMonitor.interval }}
     {{- end }}
-    honorLabels: {{ .Values.serviceMonitor.honorLabels }}
-    path: {{ .Values.serviceMonitor.path }}
-    {{- if .Values.serviceMonitor.interval }}
-    interval: {{ .Values.serviceMonitor.interval }}
-    {{- end }}
-    {{- if .Values.serviceMonitor.scrapeTimeout }}
-    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
-    {{- end }}
-    {{- if .Values.serviceMonitor.params.enabled }}
+    scrapeTimeout: {{ .scrapeTimeout | default $.Values.serviceMonitor.scrapeTimeout }}
     params:
-{{ toYaml .Values.serviceMonitor.params.conf | indent 6 }}
+      module: {{ .module | default $.Values.serviceMonitor.module }}
+      target:
+      - {{ .target }}
+    metricRelabelings:
+      - sourceLabels: [instance]
+        targetLabel: instance
+        replacement: {{ .target }}
+      - sourceLabels: [target]
+        targetLabel: target
+        replacement: {{ .name }}
+        {{- range $targetLabel, $replacement := .additionalMetricsRelabels | default $.Values.serviceMonitor.additionalMetricsRelabels }}
+      - targetLabel: {{ $targetLabel }}
+        replacement: {{ $replacement }}
+        {{- end }}
+    {{- if or .relabelings }}
+    relabelings: {{ toYaml .relabelings | default $.Values.serviceMonitor.relabelings | nindent 8 }}
     {{- end }}
-    {{- if .Values.serviceMonitor.metricRelabelings }}
-    metricRelabelings: {{ toYaml .Values.serviceMonitor.metricRelabelings | nindent 8 }}
-    {{- end }}
-    {{- if .Values.serviceMonitor.relabelings }}
-    relabelings: {{ toYaml .Values.serviceMonitor.relabelings | nindent 8 }}
-    {{- end }}
+  jobLabel: "{{ $.Release.Name }}"
   selector:
     matchLabels:
-      {{- include "prometheus-snmp-exporter.selectorLabels" . | indent 6 }}
+      {{- include "prometheus-snmp-exporter.selectorLabels" $ | indent 6 }}
+{{- end }}
 {{- end -}}

--- a/charts/prometheus-snmp-exporter/values.yaml
+++ b/charts/prometheus-snmp-exporter/values.yaml
@@ -73,7 +73,7 @@ service:
 ingress:
   enabled: false
   hosts: []
-     # - chart-example.local
+    # - chart-example.local
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
@@ -114,8 +114,15 @@ serviceMonitor:
   enabled: false
   namespace: monitoring
 
+  path: /snmp
+
   # fallback to the prometheus default unless specified
   # interval: 10s
+  scrapeTimeout: 10s
+  module:
+    - if_mib
+  # relabelings: []
+  additionalMetricsRelabels: {}
 
   ## Defaults to what's used if you follow CoreOS [Prometheus Install Instructions](https://github.com/helm/charts/tree/master/stable/prometheus-operator#tldr)
   ## [Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#prometheus-operator-1)
@@ -127,12 +134,12 @@ serviceMonitor:
   honorLabels: true
 
   params:
-    enabled: false
-    conf:
-      module:
-      - if_mib
-      target:
-      - 127.0.0.1
-
-  path: /snmp
-  scrapeTimeout: 10s
+    # - name: localhost                 # Human readable URL that will appear in Prometheus / AlertManager
+    #   target: 127.0.0.1               # The target that snmp will scrape
+    #   module:                         # Module used for scraping. Overrides value set in `serviceMonitor.module`
+    #     - if_mib
+    #   labels: {}                      # Map of labels for ServiceMonitor. Overrides value set in `serviceMonitor.selector`
+    #   interval: 30s                   # Scraping interval. Overrides value set in `serviceMonitor.interval`
+    #   scrapeTimeout: 30s              # Scrape timeout. Overrides value set in `serviceMonitor.scrapeTimeout`
+    #   relabelings: []                 # MetricRelabelConfigs to apply to samples before ingestion. Overrides value set in `serviceMonitor.relabelings`
+    #   additionalMetricsRelabels: {}   # Map of metric labels and values to add


### PR DESCRIPTION
Signed-off-by: Taro Kitano <unchemist@gmail.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

When using ServiceMonitor, it works even if there are multiple targets. This PR is inspired by the implementation of prometheus-blackbox-exporter:

* https://github.com/prometheus-community/helm-charts/blob/prometheus-blackbox-exporter-5.4.1/charts/prometheus-blackbox-exporter/values.yaml#L224-L231
* https://github.com/prometheus-community/helm-charts/blob/prometheus-blackbox-exporter-5.4.1/charts/prometheus-blackbox-exporter/templates/servicemonitor.yaml

In version 0.x, only a single snmp target works, as shown in the following issue.

To maintain compatibility as much as possible, I used existing keys, but version 0.x did not fundamentally support multiple targets, so I had to raise the major version.

#### Which issue this PR fixes

  - fixes #1734

#### Special notes for your reviewer:

I have checked it in my environment and it works fine.

`values.yaml`:
```
serviceMonitor:
  enabled: true
  params:
    - name: device1
      target: 10.131.132.64
      interval: 40s
      scrapeTimeout: 40s
    - name: device2
      target: 10.131.132.65
      module: [dummy]
      labels:
        test: dummy
    - name: device3
      target: 10.131.132.66
    - name: device4
      target: 10.131.132.67
```

```
$ kubectl get servicemonitor -n monitor -l app.kubernetes.io/name=prometheus-snmp-exporter
NAME                               AGE
prometheus-snmp-exporter-device1   80m
prometheus-snmp-exporter-device2   80m
prometheus-snmp-exporter-device3   80m
prometheus-snmp-exporter-device4   80m
```

prometheus
<img width="2204" alt="prometheus" src="https://user-images.githubusercontent.com/5366470/158134643-04e3eeb8-fde7-4b60-a9fc-d7b6447af1b5.png">

device2 is causing an error because it specifies a dummy module that does not exist.

grafana
<img width="2204" alt="grafana" src="https://user-images.githubusercontent.com/5366470/158134713-d7e5bd2d-53ff-4ee6-bd02-202ac1bf523d.png">

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
