### PR TITLE
[kube-prometheus-stack] Add alertmanager alertmanager configuration

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 34.0.1
+version: 34.1.0
 appVersion: 0.55.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 34.0.0
+version: 34.0.1
 appVersion: 0.55.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/alertmanager/alertmanager.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/alertmanager.yaml
@@ -68,6 +68,10 @@ spec:
 {{ else }}
   alertmanagerConfigNamespaceSelector: {}
 {{- end }}
+{{- if .Values.alertmanager.alertmanagerSpec.alertmanagerConfiguration }}
+  alertmanagerConfiguration:
+{{ toYaml .Values.alertmanager.alertmanagerSpec.alertmanagerConfiguration | indent 4 }}
+{{- end }}
 {{- if .Values.alertmanager.alertmanagerSpec.resources }}
   resources:
 {{ toYaml .Values.alertmanager.alertmanagerSpec.resources | indent 4 }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -473,6 +473,11 @@ alertmanager:
     #   matchLabels:
     #     alertmanagerconfig: enabled
 
+    ## AlermanagerConfig to be used as top level configuration
+    ##
+    altermanagerConfiguration: {}
+    # - name: global-alertmanager-Configuration
+
     ## Define Log Format
     # Use logfmt (default) or json logging
     logFormat: logfmt


### PR DESCRIPTION
#### What this PR does / why we need it:

prometheus-operator 0.55 introduced a new config key in alertmanager (alertmanagerConfiguration). Routing this new key from the chart value.

`helm template foo . --show-only templates/alertmanager/alertmanager.yaml`
```
  [...]
  logFormat: "logfmt"
  logLevel:  "info"
  retention: "120h"
  alertmanagerConfigSelector: {}
  alertmanagerConfigNamespaceSelector: {}
  routePrefix: "/"
  [...]
```

and with new value

`helm template foo . --show-only templates/alertmanager/alertmanager.yaml --set alertmanager.alertmanagerSpec.alertmanagerConfiguration.name=foo`

```
[...]
logFormat: "logfmt"
logLevel:  "info"
retention: "120h"
alertmanagerConfigSelector: {}
alertmanagerConfigNamespaceSelector: {}
alertmanagerConfiguration:
  name: foo
routePrefix: "/"
[...]
```

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
