### PR TITLE
[prometheus-mysql-exporter] Add relabelings to servicemonitor

### DIFF
--- a/charts/prometheus-mysql-exporter/Chart.yaml
+++ b/charts/prometheus-mysql-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for prometheus mysql exporter with cloudsqlproxy
 name: prometheus-mysql-exporter
-version: 1.6.0
+version: 1.7.0
 home: https://github.com/prometheus/mysqld_exporter
 appVersion: v0.12.1
 sources:

--- a/charts/prometheus-mysql-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-mysql-exporter/templates/servicemonitor.yaml
@@ -41,4 +41,7 @@ spec:
   {{- if .Values.serviceMonitor.metricRelabelings }}
       metricRelabelings: {{ toYaml .Values.serviceMonitor.metricRelabelings | nindent 8 }}
   {{- end }}
+  {{- if .Values.serviceMonitor.relabelings }}
+      relabelings: {{ toYaml .Values.serviceMonitor.relabelings | nindent 8 }}
+  {{- end }}
 {{- end }}

--- a/charts/prometheus-mysql-exporter/values.yaml
+++ b/charts/prometheus-mysql-exporter/values.yaml
@@ -24,13 +24,15 @@ serviceMonitor:
   # interval: 30s
   # scrapeTimeout is the timeout after which the scrape is ended
   # scrapeTimeout: 10s
-  # additionalLabels is the set of additional labels to add to the ServiceMonitor
   # namespace: monitoring
+  # additionalLabels is the set of additional labels to add to the ServiceMonitor
   additionalLabels: {}
   jobLabel: ""
   targetLabels: []
   podTargetLabels: []
   metricRelabelings: []
+  # Set relabel_configs as per https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+  relabelings: []
 
 serviceAccount:
   # Specifies whether a ServiceAccount should be created


### PR DESCRIPTION
#### What this PR does / why we need it:

Add relabelings to servicemonitor for prometheus-mysql-exporter like other exporters.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
