### PR TITLE
[prometheus-blackbox-exporter] Fix namespace override

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 5.5.0
+version: 5.5.1
 appVersion: 0.19.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/charts/prometheus-blackbox-exporter/templates/NOTES.txt
+++ b/charts/prometheus-blackbox-exporter/templates/NOTES.txt
@@ -14,17 +14,17 @@ Therefore the option was not added and the old ingress annotation was set.
 {{ end }}
 
 {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "prometheus-blackbox-exporter.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  export NODE_PORT=$(kubectl get --namespace {{ template "prometheus-blackbox-exporter.namespace" . }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "prometheus-blackbox-exporter.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ template "prometheus-blackbox-exporter.namespace" . }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "prometheus-blackbox-exporter.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "prometheus-blackbox-exporter.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+           You can watch the status of by running 'kubectl get --namespace {{ template "prometheus-blackbox-exporter.namespace" . }} svc -w {{ include "prometheus-blackbox-exporter.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ template "prometheus-blackbox-exporter.namespace" . }} {{ include "prometheus-blackbox-exporter.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "prometheus-blackbox-exporter.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  export POD_NAME=$(kubectl get pods --namespace {{ template "prometheus-blackbox-exporter.namespace" . }} -l "app.kubernetes.io/name={{ include "prometheus-blackbox-exporter.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ template "prometheus-blackbox-exporter.namespace" . }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+  kubectl --namespace {{ template "prometheus-blackbox-exporter.namespace" . }} port-forward $POD_NAME 8080:$CONTAINER_PORT
 {{- end }}

--- a/charts/prometheus-blackbox-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/servicemonitor.yaml
@@ -5,7 +5,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-blackbox-exporter.fullname" $ }}-{{ .name }}
-  namespace: {{ template "prometheus-blackbox-exporter.namespace" . }}
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" $ }}
   labels:
     {{- include "prometheus-blackbox-exporter.labels" $ | nindent 4 }}
     {{- if or $.Values.serviceMonitor.defaults.labels .labels }}
@@ -46,6 +46,6 @@ spec:
       {{- include "prometheus-blackbox-exporter.selectorLabels" $ | nindent 6 }}
   namespaceSelector:
     matchNames:
-      - {{ $.Release.Namespace }}
+      - {{ template "prometheus-blackbox-exporter.namespace" $ }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix a `nil pointer evaluation` and missing namespace update in NOTES.txt introduced by this PR: https://github.com/prometheus-community/helm-charts/pull/1878#issuecomment-1073390542

#### Which issue this PR fixes

```
Error: template: prometheus-blackbox-exporter/templates/_helpers.tpl:77:16: executing "prometheus-blackbox-exporter.namespace" at <.Values.namespaceOverride>: nil pointer evaluating interface {}.namespaceOverride
```


#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
