### PR TITLE
[prometheus-postgres-exporter] Add relabelings to servicemonitor

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.10.0"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 2.6.1
+version: 2.7.0
 home: https://github.com/prometheus-community/postgres_exporter
 sources:
 - https://github.com/prometheus-community/postgres_exporter

--- a/charts/prometheus-postgres-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-postgres-exporter/templates/servicemonitor.yaml
@@ -26,6 +26,10 @@ spec:
     metricRelabelings:
 {{ toYaml .Values.serviceMonitor.metricRelabelings | indent 4 }}
 {{- end }}
+{{- if .Values.serviceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.serviceMonitor.relabelings | nindent 4 }}
+{{- end }}
   jobLabel: {{ template "prometheus-postgres-exporter.fullname" . }}
   namespaceSelector:
     matchNames:

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -41,6 +41,8 @@ serviceMonitor:
   # targetLabels: []
   # MetricRelabelConfigs to apply to samples before ingestion
   # metricRelabelings: []
+  # Set relabel_configs as per https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+  # relabelings: []
 
 prometheusRule:
   enabled: false


### PR DESCRIPTION
#### What this PR does / why we need it:

Add relabelings to servicemonitor to postgres exporter

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
