### PR TITLE
[prometheus] [alertmanager] Allow exposing configmap reloaders port

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 0.16.0
+version: 0.17.0
 appVersion: v0.23.0
 maintainers:
   - name: monotek

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -62,6 +62,10 @@ spec:
             - --webhook-url=http://127.0.0.1:{{ .Values.service.port }}/-/reload
           resources:
             {{- toYaml .Values.configmapReload.resources | nindent 12 }}
+          {{- if .Values.configmapReload.port }}
+          ports:
+            - containerPort: {{ .Values.configmapReload.port }}
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: /etc/alertmanager

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -172,6 +172,10 @@ configmapReload:
     tag: v0.5.0
     pullPolicy: IfNotPresent
 
+  ## container port
+  ##
+  # port: 9533
+
   ## configmap-reload resource requests and limits
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.34.0
-version: 15.6.0
+version: 15.7.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/templates/alertmanager/deploy.yaml
+++ b/charts/prometheus/templates/alertmanager/deploy.yaml
@@ -125,6 +125,10 @@ spec:
           {{- range .Values.configmapReload.alertmanager.extraVolumeDirs }}
             - --volume-dir={{ . }}
           {{- end }}
+          {{- if .Values.configmapReload.alertmanager.port }}
+          ports:
+            - containerPort: {{ .Values.configmapReload.alertmanager.port }}
+          {{- end }}
           resources:
 {{ toYaml .Values.configmapReload.alertmanager.resources | indent 12 }}
           volumeMounts:

--- a/charts/prometheus/templates/alertmanager/sts.yaml
+++ b/charts/prometheus/templates/alertmanager/sts.yaml
@@ -108,6 +108,10 @@ spec:
           args:
             - --volume-dir=/etc/config
             - --webhook-url=http://localhost:9093{{ .Values.alertmanager.prefixURL }}/-/reload
+          {{- if .Values.configmapReload.alertmanager.port }}
+          ports:
+            - containerPort: {{ .Values.configmapReload.alertmanager.port }}
+          {{- end }}
           resources:
 {{ toYaml .Values.configmapReload.alertmanager.resources | indent 12 }}
           volumeMounts:

--- a/charts/prometheus/templates/server/deploy.yaml
+++ b/charts/prometheus/templates/server/deploy.yaml
@@ -65,6 +65,10 @@ spec:
           {{- range .Values.configmapReload.prometheus.extraVolumeDirs }}
             - --volume-dir={{ . }}
           {{- end }}
+          {{- if .Values.configmapReload.prometheus.port }}
+          ports:
+            - containerPort: {{ .Values.configmapReload.prometheus.port }}
+          {{- end }}
           resources:
 {{ toYaml .Values.configmapReload.prometheus.resources | indent 12 }}
           volumeMounts:

--- a/charts/prometheus/templates/server/sts.yaml
+++ b/charts/prometheus/templates/server/sts.yaml
@@ -65,6 +65,10 @@ spec:
           {{- range .Values.configmapReload.prometheus.extraVolumeDirs }}
             - --volume-dir={{ . }}
           {{- end }}
+          {{- if .Values.configmapReload.prometheus.port }}
+          ports:
+            - containerPort: {{ .Values.configmapReload.prometheus.port }}
+          {{- end }}
           resources:
 {{ toYaml .Values.configmapReload.prometheus.resources | indent 12 }}
           volumeMounts:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -393,6 +393,10 @@ configmapReload:
       tag: v0.5.0
       pullPolicy: IfNotPresent
 
+    ## container port
+    ##
+    # port: 9533
+
     ## Additional configmap-reload container arguments
     ##
     extraArgs: {}
@@ -430,6 +434,10 @@ configmapReload:
       repository: jimmidyson/configmap-reload
       tag: v0.5.0
       pullPolicy: IfNotPresent
+
+    ## container port
+    ##
+    # port: 9533
 
     ## Additional configmap-reload container arguments
     ##


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
This allows exposing ports on the configmapreloaders containers. It is necessary to allow scraping the reloaders metrics.

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
