### PR TITLE
[alertmanager] Allow exposing configmap reloaders port

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 0.16.0
+version: 0.17.0
 appVersion: v0.23.0
 maintainers:
   - name: monotek

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -62,9 +62,9 @@ spec:
             - --webhook-url=http://127.0.0.1:{{ .Values.service.port }}/-/reload
           resources:
             {{- toYaml .Values.configmapReload.resources | nindent 12 }}
-          {{- if .Values.configmapReload.port }}
+          {{- if .Values.configmapReload.containerPort }}
           ports:
-            - containerPort: {{ .Values.configmapReload.port }}
+            - containerPort: {{ .Values.configmapReload.containerPort }}
           {{- end }}
           volumeMounts:
             - name: config

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -62,6 +62,10 @@ spec:
             - --webhook-url=http://127.0.0.1:{{ .Values.service.port }}/-/reload
           resources:
             {{- toYaml .Values.configmapReload.resources | nindent 12 }}
+          {{- if .Values.configmapReload.port }}
+          ports:
+            - containerPort: {{ .Values.configmapReload.port }}
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: /etc/alertmanager

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -172,6 +172,10 @@ configmapReload:
     tag: v0.5.0
     pullPolicy: IfNotPresent
 
+  ## container port
+  ##
+  # port: 9533
+
   ## configmap-reload resource requests and limits
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -172,9 +172,7 @@ configmapReload:
     tag: v0.5.0
     pullPolicy: IfNotPresent
 
-  ## container port
-  ##
-  # port: 9533
+  # containerPort: 9533
 
   ## configmap-reload resource requests and limits
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
Needed for scraping reloader metrics

Signed-off-by: Alexis Guerville <alexis.guerville@messagebird.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

This allows exposing ports on the configmapreloaders containers. It is necessary to allow scraping the reloaders metrics.

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
