### PR TITLE
[kube-prometheus-stack] Fix deprecated policy/v1beta1 version

### DIFF
--- a/charts/kube-prometheus-stack/templates/alertmanager/psp.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/psp.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.alertmanager.enabled .Values.global.rbac.create .Values.global.rbac.pspEnabled }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "kube-prometheus-stack.fullname" . }}-alertmanager

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/psp.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/psp.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.prometheusOperator.enabled .Values.prometheusOperator.admissionWebhooks.enabled .Values.prometheusOperator.admissionWebhooks.patch.enabled .Values.global.rbac.create .Values.global.rbac.pspEnabled (not .Values.prometheusOperator.admissionWebhooks.certManager.enabled) }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "kube-prometheus-stack.fullname" . }}-admission

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/psp.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/psp.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.prometheusOperator.enabled .Values.global.rbac.create .Values.global.rbac.pspEnabled }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "kube-prometheus-stack.fullname" . }}-operator

--- a/charts/kube-prometheus-stack/templates/prometheus/psp.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/psp.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.prometheus.enabled .Values.global.rbac.create .Values.global.rbac.pspEnabled }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "kube-prometheus-stack.fullname" . }}-prometheus


### PR DESCRIPTION
#### What this PR does / why we need it:
Helm 3.8 lint say`s
[WARNING] templates/alertmanager/psp.yaml: policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
[WARNING] templates/prometheus/psp.yaml: policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
[WARNING] templates/prometheus-operator/admission-webhooks/job-patch/psp.yaml:policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
[WARNING] templates/prometheus-operator/psp.yaml: policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+

PR fix `policy/v1beta1`  to  `policy/v1`

#### Which issue this PR fixes
No issue

#### Special notes for your reviewer:
@andrewgkew 
@bismarck 

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
