### PR TITLE
[prometheus-adapter] support facultative use of sha256 hash in container image reference

### DIFF
--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 3.0.3
-appVersion: v0.9.2
+version: 3.0.4
+appVersion: v0.9.1
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/kubernetes-sigs/prometheus-adapter
 keywords:

--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: prometheus-adapter
 version: 3.0.3
-appVersion: v0.9.1
+appVersion: v0.9.2
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/kubernetes-sigs/prometheus-adapter
 keywords:

--- a/charts/prometheus-adapter/templates/deployment.yaml
+++ b/charts/prometheus-adapter/templates/deployment.yaml
@@ -42,7 +42,11 @@ spec:
       {{- end}}
       containers:
       - name: {{ .Chart.Name }}
+        {{- if .Values.image.sha256 }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}@sha256:{{ .Values.image.sha256 }}"
+        {{- else }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
         - /adapter

--- a/charts/prometheus-adapter/values.yaml
+++ b/charts/prometheus-adapter/values.yaml
@@ -4,6 +4,7 @@ affinity: {}
 image:
   repository: k8s.gcr.io/prometheus-adapter/prometheus-adapter
   tag: v0.9.1
+  sha256: ""
   pullPolicy: IfNotPresent
 
 logLevel: 4


### PR DESCRIPTION
For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.
@MattiasGees @steven-sheehy @hectorj2f 

#### What this PR does / why we need it:

We have strict requirements to use sha256 hashes on all our container image used in production, thus this PR allows users of this helm chart to configure that from the values.yaml file. The sha256 is facultative, back-wards compatible and defaults to none so there are no breaking changes.

#### Special notes for your reviewer:

Have a wonderful day

#### Checklist
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
