### PR TITLE
[kube-prometheus-stack] Regenerate lock file

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 4.7.0
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
-  version: 3.0.1
+  version: 3.0.2
 - name: grafana
   repository: https://grafana.github.io/helm-charts
   version: 6.24.1
-digest: sha256:7f802959a6527e342a64f9ff5a8c7d6264268f1b134cf8fde376c272b2347bb4
-generated: "2022-03-15T13:47:53.058334723+01:00"
+digest: sha256:b8f8667cbbc9fb48898850d28a656e8a434df1d1e3d9efb497ff33ef5b0dbc47
+generated: "2022-03-28T13:04:43.251596-04:00"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 34.5.0
+version: 34.5.1
 appVersion: 0.55.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus


### PR DESCRIPTION
#### What this PR does / why we need it:
prometheus-node-exporter will not be upgraded without a regeneration of the `Chart.lock` file.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
