### PR TITLE
[prometheus-adapter] support for topology spread constraints

### DIFF
--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 3.0.3
+version: 3.0.4
 appVersion: v0.9.1
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/kubernetes-sigs/prometheus-adapter

--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 3.0.4
+version: 3.1.0
 appVersion: v0.9.1
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/kubernetes-sigs/prometheus-adapter

--- a/charts/prometheus-adapter/templates/deployment.yaml
+++ b/charts/prometheus-adapter/templates/deployment.yaml
@@ -110,6 +110,8 @@ spec:
         {{- toYaml .Values.nodeSelector | nindent 8 }}
       affinity:
         {{- toYaml .Values.affinity | nindent 8 }}
+      topologySpreadConstraints:
+        {{- toYaml .Values.topologySpreadConstraints | nindent 8 }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- if .Values.podSecurityContext }}
       securityContext:

--- a/charts/prometheus-adapter/values.yaml
+++ b/charts/prometheus-adapter/values.yaml
@@ -1,6 +1,8 @@
 # Default values for k8s-prometheus-adapter..
 affinity: {}
 
+topologySpreadConstraints: []
+
 image:
   repository: k8s.gcr.io/prometheus-adapter/prometheus-adapter
   tag: v0.9.1


### PR DESCRIPTION
For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.
@MattiasGees @steven-sheehy @hectorj2f

#### What this PR does / why we need it:

As we migrate most of our anti-affinities to topology spread constraints, we need a way to configure them on prometheus-adapter pods. This PR introduces this from the values.yaml. No breaking changes are introduced

#### Special notes for your reviewer:

Cheers!

#### Checklist
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
