### PR TITLE
prometheus-postgres-exporter added pgpassfile configuration value

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.10.0"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 2.7.0
+version: 2.8.0
 home: https://github.com/prometheus-community/postgres_exporter
 sources:
 - https://github.com/prometheus-community/postgres_exporter

--- a/charts/prometheus-postgres-exporter/README.md
+++ b/charts/prometheus-postgres-exporter/README.md
@@ -24,7 +24,7 @@ _See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation
 helm install [RELEASE_NAME] prometheus-community/prometheus-postgres-exporter
 ```
 
-_See [configuration](#configuration) below._
+_See [configuration](#configuring) below._
 
 _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
 

--- a/charts/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/charts/prometheus-postgres-exporter/templates/deployment.yaml
@@ -84,6 +84,12 @@ spec:
             value: {{ template "prometheus-postgres-exporter.data_source_uri" . }}
           - name: DATA_SOURCE_USER
             value: {{ .Values.config.datasource.user }}
+          {{- if .Values.config.datasource.pgpassfile }}
+          - name: PGPASSFILE
+            value: {{ .Values.config.datasource.pgpassfile }}
+          - name: DATA_SOURCE_PASS
+            value: ""
+          {{- else }}
           - name: DATA_SOURCE_PASS
             valueFrom:
               secretKeyRef:
@@ -93,6 +99,7 @@ spec:
           {{- else }}
                 name: {{ template "prometheus-postgres-exporter.fullname" . }}
                 key: data_source_password
+          {{- end }}
           {{- end }}
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -95,7 +95,7 @@ config:
     # Specify one of both datasource or datasourceSecret
     host:
     user: postgres
-    # Only one of password and passwordSecret can be specified
+    # Only one of password, passwordSecret and pgpassfile can be specified
     password:
     # Specify passwordSecret if DB password is stored in secret.
     passwordSecret: {}
@@ -103,6 +103,9 @@ config:
     #  name:
     # Password key inside secret
     #  key:
+    pgpassfile: ''
+    # If pgpassfile is set, it is used to initialize the PGPASSFILE environment variable.
+    # See https://www.postgresql.org/docs/14/libpq-pgpass.html for more info.
     port: "5432"
     database: ''
     sslmode: disable


### PR DESCRIPTION
Based on the idea in https://github.com/prometheus-community/postgres_exporter/issues/498.

Signed-off-by: Jiri Bramburek <jiribr01@gmail.com>

#### What this PR does / why we need it:
- Added pgpassfile configuration value to the Prometheus Postgres Exporter to allow password to be sourced from a file. The password file can be maintained by an extra container (e.g. aws cli to get password for an AWS IAM role mapped to AWS EKS service account - IRSA).  It is already supported by the libpq from version 9.0 (https://www.postgresql.org/docs/14/libpq-pgpass.html), so the only missing piece is to expose this to values.yaml for users to configure it.
- Fixed configuration link in Prometheus Postgres Exporter README.md

#### Which issue this PR fixes
  - fixes none

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)


@gianrubio @zanhsieh please review, thanks!
