### PR TITLE
[kube-prometheus-stack] Upgrade Grafana to 6.26

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 3.1.0
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.24.1
-digest: sha256:45d634af859824b416f428057a3f4bae2546af3c6a0a831cd802078f52e1ba21
-generated: "2022-03-29T13:49:24.692048054+02:00"
+  version: 6.26.0
+digest: sha256:76ac2ed510a0807c248e61cccc081e8b07a79d39a6c135e64a7986c9a42ef1ad
+generated: "2022-04-06T14:29:39.2511+02:00"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 34.8.0
+version: 34.9.0
 appVersion: 0.55.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus
@@ -49,6 +49,6 @@ dependencies:
   repository: https://prometheus-community.github.io/helm-charts
   condition: nodeExporter.enabled
 - name: grafana
-  version: "6.24.*"
+  version: "6.26.*"
   repository: https://grafana.github.io/helm-charts
   condition: grafana.enabled


### PR DESCRIPTION
#### What this PR does / why we need it:
Upgrades dependency Grafana to 6.26.0 to fix grafana/grafana#47240. 
Do not merge before 6.26.0 is released! See grafana/helm-charts#1185

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
