### PR TITLE
[kube-prometheus-stack] add support for enableRemoteWriteReceiver in the prometheuses crd and…

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 34.9.0
+version: 34.9.1
 appVersion: 0.55.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/crds/crd-prometheuses.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-prometheuses.yaml
@@ -2736,6 +2736,16 @@ spec:
                   under. This is necessary to generate correct URLs. This is necessary
                   if Prometheus is not served from root of a DNS name.
                 type: string
+              enableRemoteWriteReceiver:
+                description: Enable Prometheus to be used as a receiver for the Prometheus
+                  remote write protocol. Defaults to the value of false. WARNING 
+                  This is not considered an efficient way of ingesting samples. Use it with 
+                  caution for specific low-volume use cases. It is not suitable for replacing the 
+                  ingestion via scraping and turning Prometheus into a push-based metrics collection 
+                  system. For more information
+                   see https://prometheus.io/docs/prometheus/latest/querying/api/#remote-write-receiver 
+                   Only valid in Prometheus versions 2.33.0 and newer.	
+                type: boolean
               ignoreNamespaceSelectors:
                 description: IgnoreNamespaceSelectors if set to true will ignore NamespaceSelector
                   settings from all PodMonitor, ServiceMonitor and Probe objects.

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -60,6 +60,9 @@ spec:
 {{- else if .Values.prometheus.prometheusSpec.replicaExternalLabelName }}
   replicaExternalLabelName: "{{ .Values.prometheus.prometheusSpec.replicaExternalLabelName }}"
 {{- end }}
+{{- else if .Values.prometheus.prometheusSpec.enableRemoteWriteReceiver }}
+  enableRemoteWriteReceiver: "{{ .Values.prometheus.prometheusSpec.enableRemoteWriteReceiver }}"
+{{- end }}
 {{- if .Values.prometheus.prometheusSpec.externalUrl }}
   externalUrl: "{{ tpl .Values.prometheus.prometheusSpec.externalUrl . }}"
 {{- else if and .Values.prometheus.ingress.enabled .Values.prometheus.ingress.hosts }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -2202,6 +2202,10 @@ prometheus:
     ##
     externalLabels: {}
 
+    ## enable --web.enable-remote-write-receiver flag on prometheus-server
+    ##
+    enableRemoteWriteReceiver: false
+    
     ## Name of the external label used to denote replica name
     ##
     replicaExternalLabelName: ""


### PR DESCRIPTION
… write that out into our crd if its in our values file
\#### What this PR does / why we need it:
the prometheus operator supposedly supports this field in prometheusSpec, but we aren't passing it to the prometheus object via the kube-prometheus-stack helm chart, its also notably missing in the crd.

https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#prometheusspec

#### Which issue this PR fixes
- fixes https://github.com/prometheus-community/helm-charts/issues/1961
#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
