### PR TITLE
[prometheus] Added Security Context at container level in NodeExporter daemonset to set allowPrivilegeEscalation attribute

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.34.0
-version: 15.8.1
+version: 15.8.2
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/templates/node-exporter/daemonset.yaml
+++ b/charts/prometheus/templates/node-exporter/daemonset.yaml
@@ -68,6 +68,10 @@ spec:
               hostPort: {{ .Values.nodeExporter.service.hostPort }}
           resources:
 {{ toYaml .Values.nodeExporter.resources | indent 12 }}
+          {{- if .Values.nodeExporter.container.securityContext }}
+          securityContext:
+{{ toYaml .Values.nodeExporter.container.securityContext | indent 12 }}
+          {{- end }}
           volumeMounts:
             - name: proc
               mountPath: /host/proc

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -583,7 +583,6 @@ nodeExporter:
     #   cpu: 100m
     #   memory: 30Mi
 
-# Security context to be added at container level
   container:
     securityContext:
       allowPrivilegeEscalation: false  

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -583,6 +583,10 @@ nodeExporter:
     #   cpu: 100m
     #   memory: 30Mi
 
+  container:
+    securityContext:
+      allowPrivilegeEscalation: false  
+
   # Custom DNS configuration to be added to node-exporter pods
   dnsConfig: {}
     # nameservers:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -583,6 +583,7 @@ nodeExporter:
     #   cpu: 100m
     #   memory: 30Mi
 
+# Security context to be added at container level
   container:
     securityContext:
       allowPrivilegeEscalation: false  


### PR DESCRIPTION


<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
We're using **kyverno** as a Validation Admission Controller on EKS cluster. And one of the rule that we have configured there is to prevent the admisison of Pods on the cluster which doesn't specify `allowPrivilegeEscalation` attribute in **securityContext section at container level**. Since NodeExporter pods doesn't provide that capability so we were unable to deploy the prometheus helm chart on EKS cluster. 

This PR addresses that problem. 

#### Which issue this PR fixes
I haven't created any issue to address this problem. Please let me know if you want me to create one. 

#### Special notes for your reviewer:
@gianrubio @zanhsieh @Xtigyro @naseemkullah - Please review this PR and let me know if any change is required. For now, we have disabled the kyverno on EKS cluster in Dev environment. I'll greatly appreciate if you can quickly review this and merge this PR if it looks good to you. Thank you. 

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
