### PR TITLE
[prometheus-blackbox-exporter] Upgrade blackbox exporter from v0.19.0 to v0.20.0

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 5.6.0
-appVersion: 0.19.0
+version: 5.7.0
+appVersion: 0.20.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:
   - https://github.com/prometheus/blackbox_exporter

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -72,7 +72,7 @@ strategy:
 
 image:
   repository: prom/blackbox-exporter
-  tag: v0.19.0
+  tag: v0.20.0
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION

#### What this PR does / why we need it:
Routine minor upgrade of blackbox exporter. Change set: https://github.com/prometheus/blackbox_exporter/releases/tag/v0.20.0

#### Which issue this PR fixes
n/a

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x ] Chart Version bumped
- [x ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
