### PR TITLE
[kube-prometheus-stack]: Update prometheus-operator ref URL

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 35.0.0
+version: 35.0.1
 appVersion: 0.56.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -748,7 +748,7 @@ grafana:
       ## Create datasource for each Pod of Prometheus StatefulSet;
       ## this uses headless service `prometheus-operated` which is
       ## created by Prometheus Operator
-      ## ref: https://git.io/fjaBS
+      ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/0fee93e12dc7c2ea1218f19ae25ec6b893460590/pkg/prometheus/statefulset.go#L255-L286
       createPrometheusReplicasDatasources: false
       label: grafana_datasource
       labelValue: "1"


### PR DESCRIPTION
#### What this PR does / why we need it:

This is a tiny, cosmetic PR, addressing the [deprecation of the `git.io` URL shortener service](https://github.blog/changelog/2022-04-25-git-io-deprecation/) by replacing the Prometheus StatefulSet datasource reference of the `prometheus-operator` to an unshortened link.

#### Which issue this PR fixes

n/a

#### Special notes for your reviewer:

~I've not bumped the Chart version as I'm not sure it should be bumped even for such a cosmetic update.~

EDIT: The chart version bumped as requested

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
