### PR TITLE
[prometheus-elasticsearch-exporter] Allow jobLabel configuration

### DIFF
--- a/charts/prometheus-elasticsearch-exporter/Chart.yaml
+++ b/charts/prometheus-elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: prometheus-elasticsearch-exporter
-version: 4.11.1
+version: 4.12.0
 kubeVersion: ">=1.10.0-0"
 appVersion: 1.3.0
 home: https://github.com/prometheus-community/elasticsearch_exporter

--- a/charts/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
@@ -33,7 +33,7 @@ spec:
     metricRelabelings:
     {{ toYaml .Values.serviceMonitor.metricRelabelings | nindent 4 }}
     {{- end }}
-  jobLabel: "{{ .Release.Name }}"
+  jobLabel: {{ default "app.kubernetes.io/name" .Values.serviceMonitor.jobLabel }}
   selector:
     matchLabels:
       app: {{ template "elasticsearch-exporter.name" . }}

--- a/charts/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
@@ -33,7 +33,7 @@ spec:
     metricRelabelings:
     {{ toYaml .Values.serviceMonitor.metricRelabelings | nindent 4 }}
     {{- end }}
-  jobLabel: {{ default "app.kubernetes.io/name" .Values.serviceMonitor.jobLabel }}
+  jobLabel: {{ default .Release.Name .Values.serviceMonitor.jobLabel }}
   selector:
     matchLabels:
       app: {{ template "elasticsearch-exporter.name" . }}

--- a/charts/prometheus-elasticsearch-exporter/values.yaml
+++ b/charts/prometheus-elasticsearch-exporter/values.yaml
@@ -17,7 +17,7 @@ image:
 ## The below values are the default for kubernetes.
 ## Openshift won't deploy with runAsUser: 1000 without additional permissions.
 securityContext:
-  enabled: true  # Should be set to false when running on OpenShift
+  enabled: true # Should be set to false when running on OpenShift
   runAsUser: 1000
 
 # Custom DNS configuration to be added to prometheus-elasticsearch-exporter pods
@@ -36,7 +36,8 @@ log:
   format: logfmt
   level: info
 
-resources: {}
+resources:
+  {}
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
@@ -73,7 +74,6 @@ deployment:
 ##   KEY_1: value1
 ##   KEY_2: value2
 env: {}
-
 
 ## Extra arguments to pass to the container's executable
 ## example:
@@ -165,7 +165,6 @@ es:
   ##
   sslSkipVerify: false
 
-
   ssl:
     ## If true, a secure connection to ES cluster is used
     ##
@@ -176,7 +175,6 @@ es:
     useExistingSecrets: false
 
     ca:
-
       ## PEM that contains trusted CAs used for setting up secure Elasticsearch connection
       ##
       # pem:
@@ -214,6 +212,7 @@ serviceMonitor:
   #  namespace: monitoring
   labels: {}
   interval: 10s
+  jobLabel: ""
   scrapeTimeout: 10s
   scheme: http
   relabelings: []
@@ -229,7 +228,8 @@ prometheusRule:
   enabled: false
   #  namespace: monitoring
   labels: {}
-  rules: []
+  rules:
+    []
     # - record: elasticsearch_filesystem_data_used_percent
     #   expr: |
     #     100 * (elasticsearch_filesystem_data_size_bytes{service="{{ template "elasticsearch-exporter.fullname" . }}"} - elasticsearch_filesystem_data_free_bytes{service="{{ template "elasticsearch-exporter.fullname" . }}"})

--- a/charts/prometheus-elasticsearch-exporter/values.yaml
+++ b/charts/prometheus-elasticsearch-exporter/values.yaml
@@ -36,8 +36,7 @@ log:
   format: logfmt
   level: info
 
-resources:
-  {}
+resources: {}
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
@@ -228,8 +227,7 @@ prometheusRule:
   enabled: false
   #  namespace: monitoring
   labels: {}
-  rules:
-    []
+  rules: []
     # - record: elasticsearch_filesystem_data_used_percent
     #   expr: |
     #     100 * (elasticsearch_filesystem_data_size_bytes{service="{{ template "elasticsearch-exporter.fullname" . }}"} - elasticsearch_filesystem_data_free_bytes{service="{{ template "elasticsearch-exporter.fullname" . }}"})

--- a/charts/prometheus-elasticsearch-exporter/values.yaml
+++ b/charts/prometheus-elasticsearch-exporter/values.yaml
@@ -17,7 +17,7 @@ image:
 ## The below values are the default for kubernetes.
 ## Openshift won't deploy with runAsUser: 1000 without additional permissions.
 securityContext:
-  enabled: true # Should be set to false when running on OpenShift
+  enabled: true  # Should be set to false when running on OpenShift
   runAsUser: 1000
 
 # Custom DNS configuration to be added to prometheus-elasticsearch-exporter pods


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

Current configuration of `jobLabel` in Elasticsearch Exporter ServiceMonitor does not allow users to define this value themselves. Also its current values has no effect as it tries to use the release name as a value whereas this parameter is supposed to match a Kubernetes Endpoints label to let Prometheus Operator use its value for Prometheus `job` label.

This PR uses the same strategy as available in prometheus-node-exporter chart:

* allow users to provide `jobLabel` in helm values
* default value refers to Endpoints label `app.kubernetes.io/name`: a [well-known Kubernetes label](https://kubernetes.io/docs/reference/labels-annotations-taints/#app-kubernetes-io-name)
* since this label is not set to the service resource as of now: default behavior for elasticsearch-exporter would remain the same (Prometheus `job` label valued with the Endpoint name)

#### Which issue this PR fixes

No opened issues for this.

#### Special notes for your reviewer:

I choosed to apply the same strategy as in prometheus-node-exporter with the same implicit behavior regarding the absence of the `app.kubernetes.io/name` label on the Service/Endpoint resource.

As a consequence this does not change the overall default behavior of the chart for users out of the box: I suppose there is no need for a major/breaking change version bump.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
