### PR TITLE
[prometheus-pushgateway] Adding extra containers

### DIFF
--- a/charts/prometheus-pushgateway/Chart.yaml
+++ b/charts/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.4.2"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 1.16.1
+version: 1.17.0
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/charts/prometheus-pushgateway/templates/deployment.yaml
+++ b/charts/prometheus-pushgateway/templates/deployment.yaml
@@ -31,6 +31,9 @@ spec:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
     {{- end }}
       containers:
+        {{- if .Values.extraContainers }}
+{{ toYaml .Values.extraContainers | indent 8 }}
+        {{- end }}
         - name: pushgateway
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/prometheus-pushgateway/templates/serviceaccount.yaml
+++ b/charts/prometheus-pushgateway/templates/serviceaccount.yaml
@@ -5,4 +5,8 @@ metadata:
   name: {{ template "prometheus-pushgateway.serviceAccountName" . }}
   labels:
 {{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.serviceAccountLabels) .  }}
+{{- if .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+{{- end }}
 {{- end -}}

--- a/charts/prometheus-pushgateway/templates/servicemonitor.yaml
+++ b/charts/prometheus-pushgateway/templates/servicemonitor.yaml
@@ -14,6 +14,15 @@ spec:
     {{- if .Values.serviceMonitor.interval }}
     interval: {{ .Values.serviceMonitor.interval }}
     {{- end }}
+    {{- if .Values.serviceMonitor.scheme }}
+    scheme: {{ .Values.serviceMonitor.scheme }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.bearerTokenFile }}
+    bearerTokenFile: {{ .Values.serviceMonitor.bearerTokenFile }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.tlsConfig }}
+    tlsConfig: {{ toYaml .Values.serviceMonitor.tlsConfig | nindent 6 }}
+    {{- end }}
     {{- if .Values.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
     {{- end }}

--- a/charts/prometheus-pushgateway/values.yaml
+++ b/charts/prometheus-pushgateway/values.yaml
@@ -56,6 +56,28 @@ extraVars: []
 ##  - --persistence.interval=5m
 extraArgs: []
 
+# Optional additional containers (sidecar)
+extraContainers: []
+  # - name: oAuth2-proxy
+  #   args:
+  #     - -https-address=:9092
+  #     - -upstream=http://localhost:9091
+  #     - -skip-auth-regex=^/metrics
+  #     - -openshift-delegate-urls={"/":{"group":"monitoring.coreos.com","resource":"prometheuses","verb":"get"}}
+  #   image: openshift/oauth-proxy:v1.1.0
+  #   ports:
+  #       - containerPort: 9092
+  #         name: proxy
+  #   resources:
+  #       limits:
+  #         memory: 16Mi
+  #       requests:
+  #         memory: 4Mi
+  #         cpu: 20m
+  #   volumeMounts:
+  #     - mountPath: /etc/prometheus/secrets/pushgateway-tls
+  #       name: secret-pushgateway-tls
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
@@ -164,6 +186,14 @@ serviceMonitor:
   # Fallback to the prometheus default unless specified
   # interval: 10s
 
+  ## scheme: HTTP scheme to use for scraping. Can be used with `tlsConfig` for example if using istio mTLS.
+  # scheme: ""
+
+  ## tlsConfig: TLS configuration to use when scraping the endpoint. For example if using istio mTLS.
+  ## Of type: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#tlsconfig
+  # tlsConfig: {}
+
+  # bearerTokenFile:
   # Fallback to the prometheus default unless specified
   # scrapeTimeout: 30s
 


### PR DESCRIPTION
Signed-off-by: Philippe <philippe.burgisser@camptocamp.com>

#### What this PR does / why we need it:
- Support of side car containers to run for example the oAuth proxy.
- Adding annotations to SA (used in OpenShift for internal TLS certification generation)
- Adding support of authentication in ServiceMonitor when the pushproxy is behind a proxy like the oAuth proxy

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
