### PR TITLE
make targetDown rule namespace restricted to reduce noise from not prod namespaces if needed

### DIFF
--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/general.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/general.rules.yaml
@@ -5,6 +5,7 @@ https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-promet
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.defaultRules.rules.general }}
+{{- $targetNamespace := .Values.defaultRules.appNamespacesTarget }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -30,7 +31,7 @@ spec:
         description: '{{`{{`}} printf "%.4g" $value {{`}}`}}% of the {{`{{`}} $labels.job {{`}}`}}/{{`{{`}} $labels.service {{`}}`}} targets in {{`{{`}} $labels.namespace {{`}}`}} namespace are down.'
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/general/targetdown
         summary: One or more targets are unreachable.
-      expr: 100 * (count(up == 0) BY (job, namespace, service) / count(up) BY (job, namespace, service)) > 10
+      expr: 100 * (count(up{namespace=~"{{ $targetNamespace }}"} == 0) BY (job, namespace, service) / count(up{namespace=~"{{ $targetNamespace }}"}) BY (job, namespace, service)) > 10
       for: 10m
       labels:
         severity: warning


### PR DESCRIPTION
Signed-off-by: Vlad Paciu <vlad.paciu@adgear.com>

This PR is making targetDown rule namespace restricted if needed.
This might help to reduce alert noise.
