### PR TITLE
[prometheus-blackbox-exporter] need default for additionalRelabeling

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 5.8.0
+version: 5.8.1
 appVersion: 0.20.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/charts/prometheus-blackbox-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/servicemonitor.yaml
@@ -41,7 +41,7 @@ spec:
         replacement: {{ $replacement | quote }}
         {{- end }}
 {{- if concat (.additionalRelabeling | default list) $.Values.serviceMonitor.defaults.additionalRelabeling }}
-{{ toYaml (concat .additionalRelabeling $.Values.serviceMonitor.defaults.additionalRelabeling) | indent 6 }}
+{{ toYaml (concat (.additionalRelabeling | default list) $.Values.serviceMonitor.defaults.additionalRelabeling) | indent 6 }}
 {{- end }}
   jobLabel: "{{ $.Release.Name }}"
   selector:

--- a/charts/prometheus-blackbox-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/servicemonitor.yaml
@@ -40,7 +40,7 @@ spec:
       - targetLabel: {{ $targetLabel | quote }}
         replacement: {{ $replacement | quote }}
         {{- end }}
-{{- if concat .additionalRelabeling $.Values.serviceMonitor.defaults.additionalRelabeling }}
+{{- if concat (.additionalRelabeling | default list) $.Values.serviceMonitor.defaults.additionalRelabeling }}
 {{ toYaml (concat .additionalRelabeling $.Values.serviceMonitor.defaults.additionalRelabeling) | indent 6 }}
 {{- end }}
   jobLabel: "{{ $.Release.Name }}"


### PR DESCRIPTION
#2033 caused Helm errors if users didn't define `additionalRelabeling` for each rule because there wasn't a default.

@desaintmartin 

Signed-off-by: Evan Pitstick <epitstick@paloaltonetworks.com>

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
