### PR TITLE
[prometheus-elasticsearch-exporter] Allow to set global imagePullSecrets

### DIFF
--- a/charts/prometheus-elasticsearch-exporter/Chart.yaml
+++ b/charts/prometheus-elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: prometheus-elasticsearch-exporter
-version: 4.12.0
+version: 4.13.0
 kubeVersion: ">=1.10.0-0"
 appVersion: 1.3.0
 home: https://github.com/prometheus-community/elasticsearch_exporter

--- a/charts/prometheus-elasticsearch-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-elasticsearch-exporter/templates/_helpers.tpl
@@ -34,10 +34,12 @@ Create chart name and version as used by the chart label.
 {{/*
 Return the appropriate apiVersion for rbac.
 */}}
+{{- define "rbac.apiVersion" -}}
 {{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
 {{- print "rbac.authorization.k8s.io/v1" -}}
 {{- else -}}
 {{- print "rbac.authorization.k8s.io/v1beta1" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
+++ b/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
@@ -43,10 +43,7 @@ spec:
 {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
 {{- end }}
-{{- if .Values.image.pullSecret }}
-      imagePullSecrets:
-        - name: {{ .Values.image.pullSecret }}
-{{- end }}
+      {{- include "elasticsearch-exporter.image.pullSecret.name" (dict "images" (list .Values.image) "context" $) | nindent 6 }}
       restartPolicy: {{ .Values.restartPolicy }}
       {{- if .Values.securityContext.enabled }}
       securityContext:

--- a/charts/prometheus-elasticsearch-exporter/templates/podsecuritypolicies.yaml
+++ b/charts/prometheus-elasticsearch-exporter/templates/podsecuritypolicies.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.podSecurityPolicies.enabled -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodSecurityPolicy" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "elasticsearch-exporter.fullname" . }}

--- a/charts/prometheus-elasticsearch-exporter/values.yaml
+++ b/charts/prometheus-elasticsearch-exporter/values.yaml
@@ -1,3 +1,9 @@
+## Global settings for all charts in a tree of dependent charts
+## This allows to set the same values for the imagePullSecrets, obviating the need
+## to set the same values for each chart (and image) separately
+global:
+  imagePullSecrets: []
+
 ## number of exporter instances
 ##
 replicaCount: 1


### PR DESCRIPTION

#### What this PR does / why we need it:
The Bitnami charts have a convention that allows one to set a set of global imagePullSecrets which are inherited if you depend on a specific chart from another chart. This obviates the need to repetitively specify the same image pull secrets for all images and charts. This PR adds that same functionality to the elasticsearch-exporter.

Also this PR updates the PodSecurityPolicy to use the non-deprecated apiGroup if it is available, making the chart compatible with modern K8s versions.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
