### PR TITLE
[prometheus-elasticsearch-exporter] remove me from elasticsearch chart

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,7 +17,7 @@
 /charts/prometheus-consul-exporter/ @gkarthiks @timm088
 /charts/prometheus-couchdb-exporter/ @gkarthiks
 /charts/prometheus-druid-exporter/ @iamabhishek-dubey @sandy724
-/charts/prometheus-elasticsearch-exporter/ @caarlos0 @desaintmartin @svenmueller
+/charts/prometheus-elasticsearch-exporter/ @desaintmartin @svenmueller
 /charts/prometheus-json-exporter/ @schmiddim @zanhsieh
 /charts/prometheus-kafka-exporter/ @gkarthiks @golgoth31
 /charts/prometheus-mongodb-exporter/ @steven-sheehy

--- a/charts/prometheus-elasticsearch-exporter/Chart.yaml
+++ b/charts/prometheus-elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: prometheus-elasticsearch-exporter
-version: 4.11.1
+version: 4.11.2
 kubeVersion: ">=1.10.0-0"
 appVersion: 1.3.0
 home: https://github.com/prometheus-community/elasticsearch_exporter

--- a/charts/prometheus-elasticsearch-exporter/Chart.yaml
+++ b/charts/prometheus-elasticsearch-exporter/Chart.yaml
@@ -14,7 +14,5 @@ keywords:
 maintainers:
   - name: svenmueller
     email: sven.mueller@commercetools.com
-  - name: caarlos0
-    email: carlos@carlosbecker.com
   - name: desaintmartin
     email: cedric@desaintmartin.fr


### PR DESCRIPTION
#### What this PR does / why we need it:

removing myself from es exporter maintainers list.

not sure if this requires a chart version bump as well

#### Which issue this PR fixes


#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
