### PR TITLE
[prometheus-adapter] remove default rules which are causing resource spikes

### DIFF
--- a/charts/prometheus-adapter/templates/configmap.yaml
+++ b/charts/prometheus-adapter/templates/configmap.yaml
@@ -12,79 +12,9 @@ metadata:
     {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}
 data:
   config.yaml: |
-{{- if or .Values.rules.default .Values.rules.custom }}
-    rules:
-{{- if .Values.rules.default }}
-    - seriesQuery: '{__name__=~"^container_.*",container!="POD",namespace!="",pod!=""}'
-      seriesFilters: []
-      resources:
-        overrides:
-          namespace:
-            resource: namespace
-          pod:
-            resource: pod
-      name:
-        matches: ^container_(.*)_seconds_total$
-        as: ""
-      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[5m]))
-        by (<<.GroupBy>>)
-    - seriesQuery: '{__name__=~"^container_.*",container!="POD",namespace!="",pod!=""}'
-      seriesFilters:
-      - isNot: ^container_.*_seconds_total$
-      resources:
-        overrides:
-          namespace:
-            resource: namespace
-          pod:
-            resource: pod
-      name:
-        matches: ^container_(.*)_total$
-        as: ""
-      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[5m]))
-        by (<<.GroupBy>>)
-    - seriesQuery: '{__name__=~"^container_.*",container!="POD",namespace!="",pod!=""}'
-      seriesFilters:
-      - isNot: ^container_.*_total$
-      resources:
-        overrides:
-          namespace:
-            resource: namespace
-          pod:
-            resource: pod
-      name:
-        matches: ^container_(.*)$
-        as: ""
-      metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>,container!="POD"}) by (<<.GroupBy>>)
-    - seriesQuery: '{namespace!="",__name__!~"^container_.*"}'
-      seriesFilters:
-      - isNot: .*_total$
-      resources:
-        template: <<.Resource>>
-      name:
-        matches: ""
-        as: ""
-      metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
-    - seriesQuery: '{namespace!="",__name__!~"^container_.*"}'
-      seriesFilters:
-      - isNot: .*_seconds_total
-      resources:
-        template: <<.Resource>>
-      name:
-        matches: ^(.*)_total$
-        as: ""
-      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>}[5m])) by (<<.GroupBy>>)
-    - seriesQuery: '{namespace!="",__name__!~"^container_.*"}'
-      seriesFilters: []
-      resources:
-        template: <<.Resource>>
-      name:
-        matches: ^(.*)_seconds_total$
-        as: ""
-      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>}[5m])) by (<<.GroupBy>>)
-{{- end -}}
 {{- if .Values.rules.custom }}
+    rules:
 {{ toYaml .Values.rules.custom | indent 4 }}
-{{- end -}}
 {{- end -}}
 {{- if .Values.rules.external }}
     externalRules:

--- a/charts/prometheus-adapter/values.yaml
+++ b/charts/prometheus-adapter/values.yaml
@@ -82,8 +82,6 @@ resources: {}
   #   memory: 128Mi
 
 rules:
-  default: true
-
   custom: []
     # - seriesQuery: '{__name__=~"^some_metric_count$"}'
     #   resources:


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

The default rules as described in this issue #2052 causing spikes in CPU and particularly for memory as the cluster grows. The metrics fetched due to those rules doesn't seem to be much related/needed for prometheus adapter. We essentially would only need resource rules, alongside any custom metrics. This PR removes those default rules from adapter chart.

#### Which issue this PR fixes
  - fixes #2052 

#### Special notes for your reviewer:

`kubectl` top pods/nodes alongside any HPA that depends on custom metrics are working as expected.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
