### PR TITLE
[prometheus-node-exporter] Add basicAuth configuration to ServiceMonitor

### DIFF
--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - prometheus
   - exporter
 type: application
-version: 3.1.1
+version: 3.2.0
 appVersion: 1.3.1
 home: https://github.com/prometheus/node_exporter/
 sources:

--- a/charts/prometheus-node-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-node-exporter/templates/servicemonitor.yaml
@@ -21,6 +21,10 @@ spec:
   endpoints:
     - port: {{ .Values.service.portName }}
       scheme: {{ .Values.prometheus.monitor.scheme }}
+    {{- with .Values.prometheus.monitor.basicAuth }}
+      basicAuth:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.prometheus.monitor.bearerTokenFile }}
       bearerTokenFile: {{ . }}
     {{- end }}

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -34,6 +34,7 @@ prometheus:
     jobLabel: ""
 
     scheme: http
+    basicAuth: {}
     bearerTokenFile:
     tlsConfig: {}
 


### PR DESCRIPTION
Signed-off-by: Tomasz Drachenberg <tdrachen@intercars.eu>

#### What this PR does / why we need it:
This PR lets use basic authentication in node-exporter. It's important to protect access to sensitive data about the cluster, especially when these data can't be protected using network policies. The cross-dependency between a service mesh and a monitoring stack is not good for everyone.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
