### PR TITLE
[prometheus-adapter] Add runAsUser value to Deployment

### DIFF
--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 3.2.2
+version: 3.3.0
 appVersion: v0.9.1
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/kubernetes-sigs/prometheus-adapter

--- a/charts/prometheus-adapter/templates/deployment.yaml
+++ b/charts/prometheus-adapter/templates/deployment.yaml
@@ -91,7 +91,9 @@ spec:
             drop: ["all"]
           readOnlyRootFilesystem: true
           runAsNonRoot: true
-          runAsUser: 10001
+          {{- if .Values.runAsUser }}
+          runAsUser: {{ .Values.runAsUser }}
+          {{- end }}
         volumeMounts:
         {{- if .Values.extraVolumeMounts }}
         {{ toYaml .Values.extraVolumeMounts | trim | nindent 8 }}

--- a/charts/prometheus-adapter/values.yaml
+++ b/charts/prometheus-adapter/values.yaml
@@ -13,6 +13,9 @@ metricsRelistInterval: 1m
 
 listenPort: 6443
 
+# User to run adapter container as
+runAsUser: 10001
+
 nodeSelector: {}
 
 priorityClassName: ""


### PR DESCRIPTION
Signed-off-by: sepaper <sepaper@naver.com>

#### What this PR does / why we need it:
Depending on a k8s cluster environment, runAsUser in Deployment is determined by the cluster security policy. 
For example, when setting runAsUser as 10001 in my openshift cluster, it occurs a policy violation error of runAsUser range.
Considering the policy difference between each cluster, I think it is better to allow runAsUser in Deployment to be configurable as a chart value. 

#### Which issue this PR fixes
None

#### Special notes for your reviewer:
I guess fsGroup in Deployment is in the same case as runAsUser is, and it is already configurable as a chart value.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
