### PR TITLE
[prometheus] Add ability to define PushGateway node port number

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.34.0
-version: 15.8.7
+version: 15.9.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/templates/pushgateway/service.yaml
+++ b/charts/prometheus/templates/pushgateway/service.yaml
@@ -35,6 +35,9 @@ spec:
       port: {{ .Values.pushgateway.service.servicePort }}
       protocol: TCP
       targetPort: 9091
+    {{- if .Values.pushgateway.service.nodePort }}
+      nodePort: {{ .Values.pushgateway.service.nodePort }}
+    {{- end }}
   selector:
     {{- include "prometheus.pushgateway.matchLabels" . | nindent 4 }}
   type: "{{ .Values.pushgateway.service.type }}"


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

This simple PR adds the ability to define the PushGateway service node port number in the same way as Prometheus and AlertManager, by adding a ```nodePort``` parameter: ```pushgateway.service.nodePort```. This is an important feature to our projects for integration testing with microclusters where we open ports on clusters before testing, so must know and set the application ports in advance in order to connect through to the API/frontend.

#### Special notes for your reviewer:

Full backwards compatibility, doesn't affect any deployments where ```pushgateway.service.nodePort``` is not explicity defined as it will still randomise. Minor version update.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
