### PR TITLE
[prometheus-adapter] conditionally use the policy/v1 apiversion for PDBs

### DIFF
--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 3.3.0
+version: 3.3.1
 appVersion: v0.9.1
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/kubernetes-sigs/prometheus-adapter

--- a/charts/prometheus-adapter/templates/_helpers.tpl
+++ b/charts/prometheus-adapter/templates/_helpers.tpl
@@ -73,3 +73,12 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/* Get Policy API Version */}}
+{{- define "k8s-prometheus-adapter.pdb.apiVersion" -}}
+{{- if and (.Capabilities.APIVersions.Has "policy/v1") (semverCompare ">= 1.21-0" .Capabilities.KubeVersion.Version) -}}
+    {{- print "policy/v1" -}}
+{{- else -}}
+    {{- print "policy/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/prometheus-adapter/templates/pdb.yaml
+++ b/charts/prometheus-adapter/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "k8s-prometheus-adapter.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "k8s-prometheus-adapter.fullname" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Concerning the prometheus-adapter chart, this PR enables using the policy/v1 apiversion for pod disruption budgets, if the apiversion exists on the given cluster.

This is being added because the policy/v1beta1 apiversion is being removed in Kubernetes 1.25.

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
