### PR TITLE
[prometheus-elasticsearch-exporter] Add support for PodMonitoring

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -44,5 +44,9 @@ jobs:
         uses: helm/kind-action@v1.2.0
         if: steps.list-changed.outputs.changed == 'true'
 
+      - name: Install GMP CRDs
+        id: gmp
+        run: kubectl apply --server-side -f https://raw.githubusercontent.com/GoogleCloudPlatform/prometheus-engine/v0.4.1/manifests/setup.yaml
+
       - name: Run chart-testing (install)
         run: ct install --config .github/linters/ct.yaml

--- a/charts/prometheus-elasticsearch-exporter/Chart.yaml
+++ b/charts/prometheus-elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: prometheus-elasticsearch-exporter
-version: 4.12.0
+version: 4.13.0
 kubeVersion: ">=1.10.0-0"
 appVersion: 1.3.0
 home: https://github.com/prometheus-community/elasticsearch_exporter

--- a/charts/prometheus-elasticsearch-exporter/ci/pod-monitoring-values.yaml
+++ b/charts/prometheus-elasticsearch-exporter/ci/pod-monitoring-values.yaml
@@ -6,15 +6,15 @@ podMonitoring:
   timeout: 10s
   scheme: http
   metricRelabeling:
-    - action: thing
+    - action: replace
       modulus: 5
       regex: 'foo.*'
       replacement: thing
       separator: ','
       sourceLabels:
-        - app=myapp
-        - label2=another
-      targetLabel: thing=thing
+        - app
+        - label2
+      targetLabel: thing
   proxyUrl: "some-proxy.example.com"
   limits:
     labelNameLength: 10
@@ -30,5 +30,4 @@ podMonitoring:
       - from: foo
         to: bar
     metadata:
-      - one
-      - two
+      - pod

--- a/charts/prometheus-elasticsearch-exporter/ci/pod-monitoring-values.yaml
+++ b/charts/prometheus-elasticsearch-exporter/ci/pod-monitoring-values.yaml
@@ -1,0 +1,35 @@
+podMonitoring:
+  enabled: true
+  #  namespace: monitoring
+  labels: {}
+  interval: 10s
+  timeout: 10s
+  scheme: http
+  metricRelabeling:
+    - action: thing
+      modulus: 5
+      regex: 'foo.*'
+      replacement: thing
+      separator: ','
+      sourceLabels:
+        - app=myapp
+        - label2=another
+      targetLabel: thing=thing
+  proxyUrl: "some-proxy.example.com"
+  limits:
+    labelNameLength: 10
+    labelValueLength: 10
+    labels: 5
+    samples: 5
+  params:
+    foo:
+      - bar
+      - baz
+  targetLabels:
+    fromPod:
+      - from: foo
+        to: bar
+    metadata:
+      - one
+      - two
+

--- a/charts/prometheus-elasticsearch-exporter/ci/pod-monitoring-values.yaml
+++ b/charts/prometheus-elasticsearch-exporter/ci/pod-monitoring-values.yaml
@@ -32,4 +32,3 @@ podMonitoring:
     metadata:
       - one
       - two
-

--- a/charts/prometheus-elasticsearch-exporter/templates/podmonitoring.yaml
+++ b/charts/prometheus-elasticsearch-exporter/templates/podmonitoring.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.podMonitoring.enabled }}
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: {{ template "elasticsearch-exporter.fullname" . }}
+  {{- if .Values.podMonitoring.namespace }}
+  namespace: {{ .Values.podMonitoring.namespace }}
+  {{- end }}
+  labels:
+    chart: {{ template "elasticsearch-exporter.chart" . }}
+    app: {{ template "elasticsearch-exporter.name" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    {{- if .Values.podMonitoring.labels }}
+    {{- toYaml .Values.podMonitoring.labels | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+  - interval: {{ .Values.podMonitoring.interval }}
+    {{- if .Values.podMonitoring.timeout }}
+    timeout: {{ .Values.podMonitoring.timeout }}
+    {{- end }}
+    port: {{ .Values.service.metricsPort.name }}
+    path: {{ .Values.web.path }}
+    scheme: {{ .Values.podMonitoring.scheme }}
+    {{- if .Values.podMonitoring.params }}
+    params:
+    {{- toYaml .Values.podMonitoring.params | nindent 6 }}
+    {{- end }}
+    {{- if .Values.podMonitoring.metricRelabeling }}
+    metricRelabeling:
+    {{- toYaml .Values.podMonitoring.metricRelabeling | nindent 4 }}
+    {{- end }}
+    {{- if .Values.podMonitoring.proxyUrl }}
+    proxyUrl: {{ .Values.podMonitoring.proxyUrl }}
+    {{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "elasticsearch-exporter.name" . }}
+      release: "{{ .Release.Name }}"
+{{- if .Values.podMonitoring.targetLabels }}
+  targetLabels:
+  {{- toYaml .Values.podMonitoring.targetLabels | nindent 4 }}
+{{- end }}
+  {{- if .Values.podMonitoring.limits }}
+  limits:
+  {{- toYaml .Values.podMonitoring.limits | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/prometheus-elasticsearch-exporter/templates/podmonitoring.yaml
+++ b/charts/prometheus-elasticsearch-exporter/templates/podmonitoring.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.podMonitoring.enabled }}
+{{- if and .Values.podMonitoring.enabled (.Capabilities.APIVersions.Has "monitoring.googleapis.com/v1") }}
 ---
 apiVersion: monitoring.googleapis.com/v1
 kind: PodMonitoring

--- a/charts/prometheus-elasticsearch-exporter/values.yaml
+++ b/charts/prometheus-elasticsearch-exporter/values.yaml
@@ -219,6 +219,21 @@ serviceMonitor:
   metricRelabelings: []
   sampleLimit: 0
 
+podMonitoring:
+  ## If true, a PodMonitoring CRD is created for a Google managed prometheus operator
+  ## https://github.com/GoogleCloudPlatform/prometheus-engine/blob/v0.4.1/doc/api.md#podmonitoring
+  ##
+  enabled: false
+  #  namespace: monitoring
+  #  labels: {}
+  interval: 10s
+  timeout: 10s
+  scheme: http
+  targetLabels: {}
+  #  proxyUrl: ""
+  #  limits: {}
+  #  params: {}
+
 prometheusRule:
   ## If true, a PrometheusRule CRD is created for a prometheus operator
   ## https://github.com/coreos/prometheus-operator


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

This PR adds support for optionally creating a `PodMonitoring` resource. This resource is used by GCP's hosted prometheus metrics collection service.

More information can be found [here](https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-managed#gmp-servicemonitor)

[PodMonitoringSpec](https://github.com/GoogleCloudPlatform/prometheus-engine/blob/v0.4.1/doc/api.md#podmonitoringspec)

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
