### PR TITLE
Upgrade PodDisruptionBudget api version to support 1.22+ Kubernetes

### DIFF
--- a/charts/alertmanager/templates/pdb.yaml
+++ b/charts/alertmanager/templates/pdb.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.podDisruptionBudget -}}
+{{ if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
+apiVersion: policy/v1
+{{- else -}}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "alertmanager.fullname" . }}

--- a/charts/kube-state-metrics/templates/pdb.yaml
+++ b/charts/kube-state-metrics/templates/pdb.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.podDisruptionBudget -}}
+{{ if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
+apiVersion: policy/v1
+{{- else -}}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "kube-state-metrics.fullname" . }}

--- a/charts/prometheus-adapter/templates/pdb.yaml
+++ b/charts/prometheus-adapter/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget.enabled }}
-{{ if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
+{{- if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
 apiVersion: policy/v1
 {{- else -}}
 apiVersion: policy/v1beta1

--- a/charts/prometheus-adapter/templates/pdb.yaml
+++ b/charts/prometheus-adapter/templates/pdb.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.podDisruptionBudget.enabled }}
+{{ if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
+apiVersion: policy/v1
+{{- else -}}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "k8s-prometheus-adapter.fullname" . }}

--- a/charts/prometheus-blackbox-exporter/templates/poddisruptionbudget.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/poddisruptionbudget.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.podDisruptionBudget -}}
+{{ if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
+apiVersion: policy/v1
+{{- else -}}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "prometheus-blackbox-exporter.fullname" . }}

--- a/charts/prometheus-postgres-exporter/templates/pdb.yaml
+++ b/charts/prometheus-postgres-exporter/templates/pdb.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.podDisruptionBudget.enabled }}
+{{ if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
+apiVersion: policy/v1
+{{- else -}}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "prometheus-postgres-exporter.fullname" . }}

--- a/charts/prometheus-postgres-exporter/templates/pdb.yaml
+++ b/charts/prometheus-postgres-exporter/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget.enabled }}
-{{ if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
+{{- if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
 apiVersion: policy/v1
 {{- else -}}
 apiVersion: policy/v1beta1

--- a/charts/prometheus-pushgateway/templates/pdb.yaml
+++ b/charts/prometheus-pushgateway/templates/pdb.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.podDisruptionBudget -}}
+{{ if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
+apiVersion: policy/v1
+{{- else -}}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "prometheus-pushgateway.fullname" . }}

--- a/charts/prometheus/templates/alertmanager/pdb.yaml
+++ b/charts/prometheus/templates/alertmanager/pdb.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.alertmanager.podDisruptionBudget.enabled }}
+{{- if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
+apiVersion: policy/v1
+{{- else -}}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "prometheus.alertmanager.fullname" . }}

--- a/charts/prometheus/templates/pushgateway/pdb.yaml
+++ b/charts/prometheus/templates/pushgateway/pdb.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.pushgateway.podDisruptionBudget.enabled }}
+{{- if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
+apiVersion: policy/v1
+{{- else -}}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "prometheus.pushgateway.fullname" . }}

--- a/charts/prometheus/templates/server/pdb.yaml
+++ b/charts/prometheus/templates/server/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.server.podDisruptionBudget.enabled }}
-{{ if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
+{{- if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
 apiVersion: policy/v1
 {{- else -}}
 apiVersion: policy/v1beta1

--- a/charts/prometheus/templates/server/pdb.yaml
+++ b/charts/prometheus/templates/server/pdb.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.server.podDisruptionBudget.enabled }}
+{{ if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
+apiVersion: policy/v1
+{{- else -}}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "prometheus.server.fullname" . }}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
from https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125:
The policy/v1beta1 API version of PodDisruptionBudget will no longer be served in v1.25.
Migrate manifests and API clients to use the policy/v1 API version, available since v1.21.

files in chart that still use policy/v1beta1:
prometheus/charts/kube-state-metrics/templates/pdb.yaml-apiVersion: policy/v1beta1
prometheus/templates/alertmanager/pdb.yaml-apiVersion: policy/v1beta1
prometheus/templates/pushgateway/pdb.yaml-apiVersion: policy/v1beta1
prometheus/templates/server/pdb.yaml-apiVersion: policy/v1beta1
...
all files are listed in PR.

therefore, something like this

{{ if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
apiVersion: policy/v1
{{- else -}}
apiVersion: policy/v1beta1
{{- end }}
kind: PodDisruptionBudget

#### Which issue this PR fixes
  - fixes #1967 

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
