### PR TITLE
[prometheus-mongodb-exporter] use docker image described in readme and chart.yaml

### DIFF
--- a/charts/prometheus-mongodb-exporter/Chart.yaml
+++ b/charts/prometheus-mongodb-exporter/Chart.yaml
@@ -1,5 +1,5 @@
-apiVersion: v1
-appVersion: "v0.11.0"
+apiVersion: v2
+appVersion: "0.31.0"
 description: A Prometheus exporter for MongoDB metrics
 home: https://github.com/percona/mongodb_exporter
 keywords:
@@ -13,4 +13,4 @@ maintainers:
 name: prometheus-mongodb-exporter
 sources:
 - https://github.com/percona/mongodb_exporter
-version: 2.10.0
+version: 3.0.0

--- a/charts/prometheus-mongodb-exporter/README.md
+++ b/charts/prometheus-mongodb-exporter/README.md
@@ -42,6 +42,22 @@ helm upgrade [RELEASE_NAME] [CHART] --install
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
+### Upgrading an existing Release to a new major version
+
+A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an incompatible breaking change needing manual actions.
+
+#### From 2.x to 3.x
+
+This version uses the original percona/mongodb_exporter docker image again, as described in the readme and Chart.yaml. It's maintained and it uses frequent docker builds, so this is preferable for security reasons.
+
+The commnad arguments of the exporter have changed. If you have custom `extraArgs` settings you have to adjust them. Because of the newer version of the exporter image metrics may varry though, so you might need to adjust your dashboard querries or try out the "--compatible-mode" parameter in `extraArgs`.
+
+The `mongodb.uri` variable got "mongodb://monogdb:27017" as default parameter.
+
+Chart API was raisded to v2, so Helm 2 is not supported anymore.
+
+The servicemonitor has been disabled by default as prometheus operator might not be installed in cluster.
+
 ## Configuration
 
 See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:

--- a/charts/prometheus-mongodb-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-mongodb-exporter/templates/_helpers.tpl
@@ -1,10 +1,9 @@
-{{/* vim: set filetype=mustache: */}}
 {{/*
 Expand the name of the chart.
 */}}
 {{- define "prometheus-mongodb-exporter.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/*
 Create a default fully qualified app name.
@@ -12,35 +11,55 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "prometheus-mongodb-exporter.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "prometheus-mongodb-exporter.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "prometheus-mongodb-exporter.labels" -}}
+helm.sh/chart: {{ include "prometheus-mongodb-exporter.chart" . }}
+{{ include "prometheus-mongodb-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "prometheus-mongodb-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "prometheus-mongodb-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
 
 {{/*
 Create the name of the service account to use
 */}}
 {{- define "prometheus-mongodb-exporter.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
-    {{ default (include "prometheus-mongodb-exporter.fullname" .) .Values.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.serviceAccount.name }}
-{{- end -}}
-{{- end -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "prometheus-mongodb-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
 
 {{/*
 Determine secret name, can either be the self-created of an existing one

--- a/charts/prometheus-mongodb-exporter/templates/deployment.yaml
+++ b/charts/prometheus-mongodb-exporter/templates/deployment.yaml
@@ -3,18 +3,14 @@ kind: Deployment
 metadata:
   name: {{ include "prometheus-mongodb-exporter.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "prometheus-mongodb-exporter.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "prometheus-mongodb-exporter.chart" . }}
+    {{- include "prometheus-mongodb-exporter.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.annotations | nindent 4 }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "prometheus-mongodb-exporter.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "prometheus-mongodb-exporter.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -23,46 +19,45 @@ spec:
           {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}
       labels:
-        app.kubernetes.io/name: {{ include "prometheus-mongodb-exporter.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- include "prometheus-mongodb-exporter.selectorLabels" . | nindent 8 }}
         {{- if .Values.podLabels }}
-{{ toYaml .Values.podLabels | indent 8 }}
+          {{- toYaml .Values.podLabels | nindent 8 }}
         {{- end }}
     spec:
       serviceAccountName: {{ template "prometheus-mongodb-exporter.serviceAccountName" . }}
       containers:
-      - name: mongodb-exporter
-        env:
-          - name: MONGODB_URI
-            valueFrom:
-              secretKeyRef:
-                name: {{ include "prometheus-mongodb-exporter.secretName" . }}
-                key: {{ .Values.existingSecret.key }}
-        {{- if .Values.env }}
-        {{- range $key, $value := .Values.env }}
-          - name: "{{ $key }}"
-            value: "{{ $value }}"
-        {{- end }}
-        {{- end }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        args:
-        - --web.listen-address={{ printf ":%s" .Values.port }}
-        {{- toYaml .Values.extraArgs | nindent 8 }}
-        ports:
-        - name: metrics
-          containerPort: {{ .Values.port }}
-          protocol: TCP
-        livenessProbe:
-          {{- toYaml .Values.livenessProbe | nindent 10 }}
-        readinessProbe:
-          {{- toYaml .Values.readinessProbe | nindent 10 }}
-        resources:
-          {{- toYaml .Values.resources | nindent 10 }}
-        securityContext:
-          {{- toYaml .Values.securityContext | nindent 10 }}
-        volumeMounts:
-          {{- toYaml .Values.volumeMounts | nindent 10 }}
+        - name: mongodb-exporter
+          env:
+            - name: MONGODB_URI
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "prometheus-mongodb-exporter.secretName" . }}
+                  key: {{ .Values.existingSecret.key }}
+          {{- if .Values.env }}
+          {{- range $key, $value := .Values.env }}
+            - name: "{{ $key }}"
+              value: "{{ $value }}"
+          {{- end }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - --web.listen-address={{ printf ":%s" .Values.port }}
+            {{- toYaml .Values.extraArgs | nindent 12 }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.port }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            {{- toYaml .Values.volumeMounts | nindent 12 }}
       affinity:
         {{- toYaml .Values.affinity | nindent 8 }}
       imagePullSecrets:

--- a/charts/prometheus-mongodb-exporter/templates/secret.yaml
+++ b/charts/prometheus-mongodb-exporter/templates/secret.yaml
@@ -4,11 +4,8 @@ kind: Secret
 metadata:
   name: {{ include "prometheus-mongodb-exporter.secretName" . }}
   labels:
-    app.kubernetes.io/name: {{ include "prometheus-mongodb-exporter.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "prometheus-mongodb-exporter.chart" . }}
+    {{- include "prometheus-mongodb-exporter.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{ .Values.existingSecret.key }} : {{ required "A MongoDB URI is required" .Values.mongodb.uri | b64enc }}
+  mongodb-uri: {{ required "A MongoDB URI is required" .Values.mongodb.uri | b64enc }}
 {{- end -}}

--- a/charts/prometheus-mongodb-exporter/templates/service.yaml
+++ b/charts/prometheus-mongodb-exporter/templates/service.yaml
@@ -3,10 +3,7 @@ kind: Service
 metadata:
   name: {{ include "prometheus-mongodb-exporter.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "prometheus-mongodb-exporter.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "prometheus-mongodb-exporter.chart" . }}
+    {{- include "prometheus-mongodb-exporter.labels" . | nindent 4 }}
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4 }}
 {{- end }}
@@ -19,6 +16,5 @@ spec:
       protocol: TCP
       name: metrics
   selector:
-    app.kubernetes.io/name: {{ include "prometheus-mongodb-exporter.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "prometheus-mongodb-exporter.selectorLabels" . | nindent 4 }}
   type: {{ .Values.service.type }}

--- a/charts/prometheus-mongodb-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-mongodb-exporter/templates/serviceaccount.yaml
@@ -4,8 +4,5 @@ kind: ServiceAccount
 metadata:
   name: {{ template "prometheus-mongodb-exporter.serviceAccountName" . }}
   labels:
-    app.kubernetes.io/name: {{ include "prometheus-mongodb-exporter.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "prometheus-mongodb-exporter.chart" . }}
+    {{- include "prometheus-mongodb-exporter.labels" . | nindent 4 }}
 {{- end -}}

--- a/charts/prometheus-mongodb-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-mongodb-exporter/templates/servicemonitor.yaml
@@ -4,10 +4,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "prometheus-mongodb-exporter.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "prometheus-mongodb-exporter.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "prometheus-mongodb-exporter.chart" . }}
+    {{- include "prometheus-mongodb-exporter.labels" . | nindent 4 }}
     {{- range $key, $value := .Values.serviceMonitor.additionalLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
@@ -27,8 +24,7 @@ spec:
     - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "prometheus-mongodb-exporter.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "prometheus-mongodb-exporter.selectorLabels" . | nindent 6 }}
 {{- if .Values.serviceMonitor.targetLabels }}
   targetLabels:
 {{- range .Values.serviceMonitor.targetLabels }}
@@ -36,4 +32,3 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
-

--- a/charts/prometheus-mongodb-exporter/templates/tests/test-connection.yaml
+++ b/charts/prometheus-mongodb-exporter/templates/tests/test-connection.yaml
@@ -3,10 +3,7 @@ kind: Pod
 metadata:
   name: "{{ include "prometheus-mongodb-exporter.fullname" . }}-test-connection"
   labels:
-    app.kubernetes.io/name: {{ include "prometheus-mongodb-exporter.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "prometheus-mongodb-exporter.chart" . }}
+    {{- include "prometheus-mongodb-exporter.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test-success
 spec:

--- a/charts/prometheus-mongodb-exporter/values.yaml
+++ b/charts/prometheus-mongodb-exporter/values.yaml
@@ -3,18 +3,14 @@ affinity: {}
 annotations: {}
 
 extraArgs:
-- --collect.collection
-- --collect.database
-- --collect.indexusage
-- --collect.topmetrics
-- --collect.connpoolstats
+  - --collect-all
 
 fullnameOverride: ""
 
 image:
   pullPolicy: IfNotPresent
-  repository: ssheehy/mongodb-exporter
-  tag: 0.11.0
+  repository: percona/mongodb_exporter
+  tag: ""
 
 imagePullSecrets: []
 
@@ -26,7 +22,7 @@ livenessProbe:
 
 # [mongodb[+srv]://][user:pass@]host1[:port1][,host2[:port2],...][/database][?options]
 mongodb:
-  uri: ""
+  uri: "mongodb://monogdb:27017"
 
 # Name of an externally managed secret (in the same namespace) containing the connection uri as key `mongodb-uri`.
 # If this is provided, the value mongodb.uri is ignored.
@@ -57,12 +53,12 @@ readinessProbe:
 replicas: 1
 
 resources: {}
-# limits:
-#   cpu: 250m
-#   memory: 192Mi
-# requests:
-#   cpu: 100m
-#   memory: 128Mi
+  # limits:
+  #   cpu: 250m
+  #   memory: 192Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
 
 # Extra environment variables that will be passed into the exporter pod
 env: {}
@@ -95,7 +91,7 @@ serviceAccount:
   name:
 
 serviceMonitor:
-  enabled: true
+  enabled: false
   interval: 30s
   scrapeTimeout: 10s
   namespace:


### PR DESCRIPTION
Signed-off-by: André Bauer <andre.bauer@staffbase.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
* use percona/mongodb_exporter:0.31.0 docker image
  * readme and chart.yaml are refering to percona/mongodb_exporter but ssheehy/mongodb-exporter is used
  * the currently used ssheehy/mongodb-exporter docker image seems unmaintained -> https://github.com/steven-sheehy/mongodb_exporter
  * newest 0.32.0 image of percona image has a bug and therfore the older one is used. see: https://github.com/percona/mongodb_exporter/issues/483
  * The commnad arguments of the exporter have changed. If you have custom `extraArgs` settings you have to adjust them. Because of the newer version of the exporter image metrics may varry though, so you might need to adjust your dashboard querries or try out the "--compatible-mode" parameter in `extraArgs`.
* use label templates 
* use appVersion as image tag (can be overwrittebn by setting image.tag)
* raised chart.yaml to v2
* the `mongodb.uri` variable got "mongodb://monogdb:27017" as default parameter.
* the servicemonitor has been disabled by default as prometheus operator might not be installed in cluster.



#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
