### PR TITLE
[prometheus] use policy/v1 for poddisruptionbudgets, when available

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.34.0
-version: 15.9.0
+version: 15.9.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/templates/_helpers.tpl
+++ b/charts/prometheus/templates/_helpers.tpl
@@ -184,6 +184,16 @@ Return the appropriate apiVersion for podsecuritypolicy.
 {{- print "policy/v1beta1" -}}
 {{- end -}}
 {{/*
+Return the appropriate apiVersion for poddisruptionbudget.
+*/}}
+{{- define "prometheus.podDisruptionBudget.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+{{- print "policy/v1" -}}
+{{- else -}}
+{{- print "policy/v1beta1" -}}
+{{- end -}}
+{{- end -}}
+{{/*
 Return the appropriate apiVersion for rbac.
 */}}
 {{- define "rbac.apiVersion" -}}

--- a/charts/prometheus/templates/alertmanager/pdb.yaml
+++ b/charts/prometheus/templates/alertmanager/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.alertmanager.podDisruptionBudget.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: {{ template "prometheus.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "prometheus.alertmanager.fullname" . }}

--- a/charts/prometheus/templates/pushgateway/pdb.yaml
+++ b/charts/prometheus/templates/pushgateway/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.pushgateway.podDisruptionBudget.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: {{ template "prometheus.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "prometheus.pushgateway.fullname" . }}

--- a/charts/prometheus/templates/server/pdb.yaml
+++ b/charts/prometheus/templates/server/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.server.podDisruptionBudget.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: {{ template "prometheus.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "prometheus.server.fullname" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Uses policy/v1 apiversion for creating poddisruptionbudgets when running against a cluster using a new enough kubernetes version. This is important because policy/v1beta1 is being removed in kubernetes 1.25.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
