### PR TITLE
[prometheus-kafka-exporter] Bump kafka-exporter to 1.4.2, bump bitnami kafka

### DIFF
--- a/charts/prometheus-kafka-exporter/Chart.yaml
+++ b/charts/prometheus-kafka-exporter/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: "v1.4.1"
+appVersion: "v1.4.2"
 description: A Helm chart to export the metrics from Kafka in Prometheus format using the kafka-exporter from https://github.com/danielqsj/kafka_exporter
 name: prometheus-kafka-exporter
 home: https://github.com/danielqsj/kafka_exporter
-version: 1.5.0
+version: 1.6.0
 sources:
   - https://gkarthiks.github.io/helm-charts/charts/prometheus-kafka-exporter
 keywords:
@@ -21,6 +21,6 @@ annotations:
       url: https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-kafka-exporter
 dependencies:
 - name: kafka
-  version: "12.6.3"
+  version: "14.9.3"
   repository: https://charts.bitnami.com/bitnami
   condition: kafka.enabled

--- a/charts/prometheus-kafka-exporter/templates/deployment.yaml
+++ b/charts/prometheus-kafka-exporter/templates/deployment.yaml
@@ -47,6 +47,8 @@ spec:
           {{- end }}
           {{- if .Values.tls.insecureSkipVerify }}
             - '--tls.insecure-skip-tls-verify'
+          {{- else if .Values.tls.serverName }}
+            - '--tls.server-name={{ .Values.tls.serverName }}'
           {{- end }}
           {{- end }}
           {{- if .Values.sasl.enabled }}
@@ -65,6 +67,12 @@ spec:
             - '--sasl.realm={{ .Values.sasl.kerberos.realm }}'
             - '--sasl.keytab-path={{ .Values.sasl.kerberos.mountPath }}/kerberos.keytab'
             - '--sasl.kerberos-auth-type={{ .Values.sasl.kerberos.kerberosAuthType }}'
+          {{- end }}
+          {{- if .Values.server.tls.enabled }}
+            - '--server.tls.ca-file={{ .Values.server.tls.mountPath }}/ca.crt'
+            - '--server.tls.cert-file={{ .Values.server.tls.mountPath }}/tls.crt'
+            - '--server.tls.key-file={{ .Values.server.tls.mountPath }}/tls.key'
+            - '--server.tls.mutual-auth-enabled={{ .Values.server.tls.mutualAuthEnabled }}'
           {{- end }}
           {{- end }}
           {{- if .Values.extraArgs }}
@@ -118,6 +126,11 @@ spec:
               name: kerberos
               readOnly: true
             {{- end }}
+            {{- if .Values.server.tls.mountPath }}
+            - mountPath: {{ .Values.server.tls.mountPath }}
+              name: server-certs
+              readOnly: true
+            {{- end }}
           {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -142,5 +155,10 @@ spec:
         - name: kerberos
           secret:
             secretName: {{ .Values.sasl.kerberos.secretName }}
+        {{- end }}
+        {{- if .Values.server.tls.mountPath }}
+        - name: server-certs
+          secret:
+            secretName: {{ .Values.server.tls.secretName }}
         {{- end }}
       {{- end }}

--- a/charts/prometheus-kafka-exporter/values.yaml
+++ b/charts/prometheus-kafka-exporter/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: danielqsj/kafka-exporter
-  tag: v1.4.1
+  tag: v1.4.2
   pullPolicy: IfNotPresent
 
 replicaCount: 1
@@ -102,6 +102,8 @@ affinity: {}
 tls:
   enabled: false
   insecureSkipVerify: false
+  # The kafka server's name. Used to verify the hostname on the returned certificates unless tls.insecureSkipVerify is set to true.
+  serverName: ""
   # mountPath: /secret/certs
   # secretName: <name of an existing secret>
 
@@ -126,6 +128,14 @@ sasl:
     # kerberosAuthType: <keytabAuth|userAuth>
     # mountPath: /secret/kerberos
     # secretName: <name of an existing secret>
+
+# This enables TLS for web server
+server:
+  tls:
+    enabled: false
+    mutualAuthEnabled: false
+  # mountPath: /secret/certs
+  # secretName: <name of an existing secret>
 
 # If enabled Kafka dependency chart will be used.
 # This is only needed for the CI job so it should always be disabled.


### PR DESCRIPTION
Signed-off-by: czomo <tomaszjdul@gmail.com>

#### What this PR does / why we need it:
- Bump kafka-exporter to 1.4.2 acording to https://github.com/danielqsj/kafka_exporter/releases/tag/v1.4.2 along with new flags
- Bump kafka to highest 2.*.* release from bitnami
#### Which issue this PR fixes
Fixes https://github.com/bitnami/charts/issues/10539 as kafka dependency is no longer available from index

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
