### PR TITLE
[prometheus-stackdriver-exporter] Add: Kubernetes recommended labels and custom labels

### DIFF
--- a/charts/prometheus-stackdriver-exporter/Chart.yaml
+++ b/charts/prometheus-stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: prometheus-stackdriver-exporter
-version: 2.3.0
+version: 3.0.0
 appVersion: 0.12.0
 home: https://www.stackdriver.com/
 sources:

--- a/charts/prometheus-stackdriver-exporter/Chart.yaml
+++ b/charts/prometheus-stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: prometheus-stackdriver-exporter
-version: 2.2.0
+version: 2.3.0
 appVersion: 0.12.0
 home: https://www.stackdriver.com/
 sources:

--- a/charts/prometheus-stackdriver-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-stackdriver-exporter/templates/_helpers.tpl
@@ -41,3 +41,28 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Generate basic labels
+*/}}
+{{- define "stackdriver-exporter.labels" }}
+helm.sh/chart: {{ template "stackdriver-exporter.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: metrics
+app.kubernetes.io/part-of: {{ template "stackdriver-exporter.name" . }}
+{{- include "stackdriver-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "stackdriver-exporter.selectorLabels" }}
+app.kubernetes.io/name: {{ include "stackdriver-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
@@ -3,16 +3,12 @@ kind: Deployment
 metadata:
   name: {{ template "stackdriver-exporter.fullname" . }}
   labels:
-    chart: {{ template "stackdriver-exporter.chart" . }}
-    app: {{ template "stackdriver-exporter.name" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "stackdriver-exporter.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "stackdriver-exporter.name" . }}
-      release: "{{ .Release.Name }}"
+      {{- include "stackdriver-exporter.selectorLabels" . | indent 6 }}
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -21,8 +17,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "stackdriver-exporter.name" . }}
-        release: "{{ .Release.Name }}"
+        {{- include "stackdriver-exporter.labels" . | indent 8 }}
       {{- if .Values.annotations }}
       annotations:
         {{- toYaml .Values.annotations | nindent 8 }}

--- a/charts/prometheus-stackdriver-exporter/templates/secret.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/secret.yaml
@@ -4,10 +4,7 @@ kind: Secret
 metadata:
   name: {{ template "stackdriver-exporter.fullname" . }}
   labels:
-    chart: {{ template "stackdriver-exporter.chart" . }}
-    app: {{ template "stackdriver-exporter.name" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "stackdriver-exporter.labels" . | indent 4 }}
     {{- if .Values.secret.labels }}
       {{- toYaml .Values.secret.labels | nindent 4 }}
     {{- end }}

--- a/charts/prometheus-stackdriver-exporter/templates/service.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/service.yaml
@@ -3,10 +3,7 @@ apiVersion: v1
 metadata:
   name: {{ template "stackdriver-exporter.fullname" . }}
   labels:
-    chart: {{ template "stackdriver-exporter.chart" . }}
-    app: {{ template "stackdriver-exporter.name" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "stackdriver-exporter.labels" . | indent 4 }}
   {{- if .Values.service.annotations }}
   annotations:
     {{- toYaml .Values.service.annotations | nindent 4 }}
@@ -18,5 +15,4 @@ spec:
       port: {{ .Values.service.httpPort }}
       protocol: TCP
   selector:
-    app: {{ template "stackdriver-exporter.name" . }}
-    release: "{{ .Release.Name }}"
+    {{- include "stackdriver-exporter.selectorLabels" . | indent 4 }}

--- a/charts/prometheus-stackdriver-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/serviceaccount.yaml
@@ -3,10 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    chart: {{ template "stackdriver-exporter.chart" . }}
-    app: {{ template "stackdriver-exporter.name" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "stackdriver-exporter.labels" . | indent 4 }}
   name: {{ template "stackdriver-exporter.serviceAccountName" . }}
   {{- if .Values.serviceAccount.annotations }}
   annotations:

--- a/charts/prometheus-stackdriver-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/servicemonitor.yaml
@@ -7,10 +7,7 @@ metadata:
   namespace: {{ .Values.serviceMonitor.namespace }}
   {{- end }}
   labels:
-    chart: {{ template "stackdriver-exporter.chart" . }}
-    app: {{ template "stackdriver-exporter.name" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "stackdriver-exporter.labels" . | indent 4 }}
     {{- if .Values.serviceMonitor.additionalLabels }}
     {{- toYaml .Values.serviceMonitor.additionalLabels | nindent 4 }}
     {{- end }}
@@ -35,8 +32,5 @@ spec:
     {{- end }}
   selector:
     matchLabels:
-      chart: {{ template "stackdriver-exporter.chart" . }}
-      app: {{ template "stackdriver-exporter.name" . }}
-      release: "{{ .Release.Name }}"
-      heritage: "{{ .Release.Service }}"
+      {{- include "stackdriver-exporter.selectorLabels" . | indent 6 }}
 {{- end }}

--- a/charts/prometheus-stackdriver-exporter/values.yaml
+++ b/charts/prometheus-stackdriver-exporter/values.yaml
@@ -37,6 +37,10 @@ service:
   httpPort: 9255
   annotations: {}
 
+## Additional labels to add to all resources
+customLabels: {}
+  # app: prometheus-stackdriver-exporter
+
 secret:
   labels: {}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Current chart is labelling resources with:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: example-prometheus-stackdriver-exporter
  labels:
    app: prometheus-stackdriver-exporter
    app.kubernetes.io/name: prometheus-stackdriver-exporter
    chart: prometheus-stackdriver-exporter-2.2.0
    heritage: Helm
    release: example
spec:
```

This PR reconciles these labels in favour of using Kubernetes [recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/) to `prometheus-stackdriver-exporter`:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: example-prometheus-stackdriver-exporter
  labels:
    helm.sh/chart: prometheus-stackdriver-exporter-3.0.0
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: metrics
    app.kubernetes.io/part-of: prometheus-stackdriver-exporter
    app.kubernetes.io/name: prometheus-stackdriver-exporter
    app.kubernetes.io/instance: example
    app.kubernetes.io/version: "0.12.0"
spec:
...
```

In addition, **optional** custom user labels can now be added to `prometheus-stackdriver-exporter` resources:

```yaml
...
## Additional labels to add to all resources
customLabels: {}
  # app: prometheus-stackdriver-exporter
...
```

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - none

#### Special notes for your reviewer:
Major has been bumped, since some labels have been removed.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)