### PR TITLE
[prometheus-pushgateway] Fix: Metadata labels consistency

### DIFF
--- a/charts/prometheus-pushgateway/Chart.yaml
+++ b/charts/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.4.2"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 1.18.1
+version: 1.18.2
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/charts/prometheus-pushgateway/templates/deployment.yaml
+++ b/charts/prometheus-pushgateway/templates/deployment.yaml
@@ -18,8 +18,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "prometheus-pushgateway.name" . }}
-        release: {{ .Release.Name }}
+{{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.podLabels "indent" 8) . }}
       annotations:
 {{ toYaml .Values.podAnnotations | indent 8 }}
     spec:

--- a/charts/prometheus-pushgateway/templates/statefulset.yaml
+++ b/charts/prometheus-pushgateway/templates/statefulset.yaml
@@ -15,8 +15,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "prometheus-pushgateway.name" . }}
-        release: {{ .Release.Name }}
+{{ template "prometheus-pushgateway.defaultLabels" merge (dict "extraLabels" .Values.podLabels "indent" 8) . }}
       annotations:
 {{ toYaml .Values.podAnnotations | indent 8 }}
     spec:


### PR DESCRIPTION
#### What this PR does / why we need it:

`Deployment` and `Statefulset` manifests, are using selector labels in `spec.template.metadata.labels` definition.
This PR brings consistency to align labels defined in `metadata.labels` to be same for `spec.template.metadata.labels`.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - none

#### Special notes for your reviewer:
Labels `app` and `release` already existent in template definition, so this is backwards compatible with the fix.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)