### PR TITLE
[kube-state-metrics] Add scheme and tlsConfig arguments to serviceMonitor

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 4.8.2
+version: 4.9.0
 appVersion: 2.5.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 4.8.1
+version: 4.8.2
 appVersion: 2.5.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/servicemonitor.yaml
+++ b/charts/kube-state-metrics/templates/servicemonitor.yaml
@@ -40,6 +40,13 @@ spec:
       relabelings:
         {{- toYaml .Values.prometheus.monitor.relabelings | nindent 8 }}
     {{- end }}
+    {{- if .Values.prometheus.monitor.scheme }}
+      scheme: {{ .Values.prometheus.monitor.scheme }}
+    {{- end }}
+    {{- if .Values.prometheus.monitor.tlsConfig }}
+      tlsConfig:
+        {{- toYaml .Values.prometheus.monitor.tlsConfig | nindent 8 }}
+    {{- end }}
   {{- if .Values.selfMonitor.enabled }}
     - port: metrics
     {{- if .Values.prometheus.monitor.interval }}
@@ -61,6 +68,13 @@ spec:
     {{- if .Values.prometheus.monitor.relabelings }}
       relabelings:
         {{- toYaml .Values.prometheus.monitor.relabelings | nindent 8 }}
+    {{- end }}
+    {{- if .Values.prometheus.monitor.scheme }}
+      scheme: {{ .Values.prometheus.monitor.scheme }}
+    {{- end }}
+    {{- if .Values.prometheus.monitor.tlsConfig }}
+      tlsConfig:
+        {{- toYaml .Values.prometheus.monitor.tlsConfig | nindent 8 }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -77,6 +77,8 @@ prometheus:
     honorLabels: false
     metricRelabelings: []
     relabelings: []
+    scheme: ""
+    tlsConfig: {}
 
 ## Specify if a Pod Security Policy for kube-state-metrics must be created
 ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/


### PR DESCRIPTION
#### What this PR does / why we need it:

Add new arguments for service monitor template files to set up required settings to collect metrics when using Istio in mtls mode.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
