### PR TITLE
[prometheus-stackdriver-exporter] Add: README instructions to upgrade 2.x to 3.x

### DIFF
--- a/charts/prometheus-stackdriver-exporter/Chart.yaml
+++ b/charts/prometheus-stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: prometheus-stackdriver-exporter
-version: 3.0.0
+version: 3.0.1
 appVersion: 0.12.0
 home: https://www.stackdriver.com/
 sources:

--- a/charts/prometheus-stackdriver-exporter/README.md
+++ b/charts/prometheus-stackdriver-exporter/README.md
@@ -72,6 +72,32 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 
 A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an incompatible breaking change needing manual actions.
 
+#### 2.x to 3.x
+
+Since chart version 2.x, [Kubernetes recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/) have been **added**.
+
+The following labels are now **removed** in all manifests (including labels used as selector for `Deployment` kind):
+
+```yaml
+...
+metadata:
+  labels:
+    app: prometheus-stackdriver-exporter
+    chart: prometheus-stackdriver-exporter-2.X.X
+    heritage: Helm
+    release: example
+...
+spec:
+  ...
+  selector:
+    matchLabels:
+      app: prometheus-stackdriver-exporter
+      release: example
+...
+```
+
+If you use your own custom [ServiceMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor) or [PodMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#podmonitor), please ensure to upgrade their `selector` fields accordingly to the new labels.
+
 #### 1.x to 2.x
 
 Since chart version 2.0.0, the exporter is configured via flags/arguments instead of environment variables due to a [breaking change in the exporter](https://github.com/prometheus-community/stackdriver_exporter/pull/142).

--- a/charts/prometheus-stackdriver-exporter/README.md
+++ b/charts/prometheus-stackdriver-exporter/README.md
@@ -18,9 +18,9 @@ package manager.
 
 ## Prerequisites
 
-- Kubernetes 1.8+ with Beta APIs enabled
+* Kubernetes 1.8+ with Beta APIs enabled
 
-## Get Repo Info
+## Get Repository Info
 
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts

--- a/charts/prometheus-stackdriver-exporter/README.md
+++ b/charts/prometheus-stackdriver-exporter/README.md
@@ -74,7 +74,7 @@ A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an 
 
 #### 2.x to 3.x
 
-Due to a change in deployment labels, the upgrade requires to **delete** the deployment manifest in order to re-create the deployment:
+Due to a change in deployment labels, **removal** of its deployment needs to done manually prior to upgrading:
 
 ```console
 kubectl delete deployments.apps -l app=prometheus-stackdriver-exporter --cascade=orphan

--- a/charts/prometheus-stackdriver-exporter/README.md
+++ b/charts/prometheus-stackdriver-exporter/README.md
@@ -83,7 +83,7 @@ kubectl delete deployments.apps -l app=prometheus-stackdriver-exporter --cascade
 If this is not done, when upgrading via helm (even with `helm upgrade --force`) an error will occur indicating that the deployment cannot be modified:
 
 ```
-invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app.kubernetes.io/name":"kube-state-metrics"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable
+invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app.kubernetes.io/instance":"example", "app.kubernetes.io/name":"prometheus-stackdriver-exporter"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable
 ```
 
 Since chart version 3.x, [Kubernetes recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/) have been **added**.

--- a/charts/prometheus-stackdriver-exporter/README.md
+++ b/charts/prometheus-stackdriver-exporter/README.md
@@ -82,7 +82,7 @@ kubectl delete deployments.apps -l app=prometheus-stackdriver-exporter --cascade
 
 If this is not done, when upgrading via helm (even with `helm upgrade --force`) an error will occur indicating that the deployment cannot be modified:
 
-```
+```console
 invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app.kubernetes.io/instance":"example", "app.kubernetes.io/name":"prometheus-stackdriver-exporter"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable
 ```
 

--- a/charts/prometheus-stackdriver-exporter/README.md
+++ b/charts/prometheus-stackdriver-exporter/README.md
@@ -20,14 +20,14 @@ package manager.
 
 * Kubernetes 1.8+ with Beta APIs enabled
 
-## Get Repository Info
+## Get Helm Repository Info
 
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update
 ```
 
-_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
+_See [`helm repo`](https://helm.sh/docs/helm/helm_repo/) for command documentation._
 
 ## Install Chart
 

--- a/charts/prometheus-stackdriver-exporter/README.md
+++ b/charts/prometheus-stackdriver-exporter/README.md
@@ -74,7 +74,19 @@ A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an 
 
 #### 2.x to 3.x
 
-Since chart version 2.x, [Kubernetes recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/) have been **added**.
+Due to a change in deployment labels, the upgrade requires to **delete** the deployment manifest in order to re-create the deployment:
+
+```console
+kubectl delete deployments.apps -l app=prometheus-stackdriver-exporter --cascade=orphan
+```
+
+If this is not done, when upgrading via helm (even with `helm upgrade --force`) an error will occur indicating that the deployment cannot be modified:
+
+```
+invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app.kubernetes.io/name":"kube-state-metrics"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable
+```
+
+Since chart version 3.x, [Kubernetes recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/) have been **added**.
 
 The following labels are now **removed** in all manifests (including labels used as selector for `Deployment` kind):
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Adding instructions about how to upgrade chart from version 2.x to 3.x (missed on previous [PR](https://github.com/prometheus-community/helm-charts/pull/2125)).

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - none

#### Special notes for your reviewer:

None.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
