### PR TITLE
[prometheus-redis-exporter] Add tls config options for servicemonitor

### DIFF
--- a/charts/prometheus-redis-exporter/Chart.yaml
+++ b/charts/prometheus-redis-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.27.0
 description: Prometheus exporter for Redis metrics
 name: prometheus-redis-exporter
-version: 4.7.0
+version: 4.8.0
 home: https://github.com/oliver006/redis_exporter
 sources:
   - https://github.com/oliver006/redis_exporter

--- a/charts/prometheus-redis-exporter/templates/service.yaml
+++ b/charts/prometheus-redis-exporter/templates/service.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - name: redis-exporter
+    - name: {{ .Values.service.portName }}
       port: {{ .Values.service.port }}
       targetPort: exporter-port
       protocol: TCP

--- a/charts/prometheus-redis-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-redis-exporter/templates/servicemonitor.yaml
@@ -31,6 +31,13 @@ spec:
     relabelings:
 {{ toYaml .Values.serviceMonitor.relabelings | indent 4 }}
 {{- end }}
+{{- if .Values.serviceMonitor.scheme }}
+    scheme: {{ .Values.serviceMonitor.scheme }}
+{{- end }}
+{{- if .Values.serviceMonitor.tlsConfig }}
+    tlsConfig:
+{{ toYaml .Values.serviceMonitor.tlsConfig | indent 6 }}
+{{- end }}
   jobLabel: {{ template "prometheus-redis-exporter.fullname" . }}
   namespaceSelector:
     matchNames:

--- a/charts/prometheus-redis-exporter/values.yaml
+++ b/charts/prometheus-redis-exporter/values.yaml
@@ -77,6 +77,9 @@ serviceMonitor:
   # Set of labels to transfer on the Kubernetes Service onto the target.
   # targetLabels: []
   # metricRelabelings: []
+  # Set tls options
+  # scheme: ""
+  # tlsConfig: {}
 
 ## Custom PrometheusRules to be defined
 ## The value is evaluated as a template, so, for example, the value can depend on .Release or .Chart

--- a/charts/prometheus-redis-exporter/values.yaml
+++ b/charts/prometheus-redis-exporter/values.yaml
@@ -31,6 +31,7 @@ env: {}
 service:
   type: ClusterIP
   port: 9121
+  portName: redis-exporter
   annotations: {}
   labels: {}
     # prometheus.io/path: /metrics


### PR DESCRIPTION
#### What this PR does / why we need it:

Add scheme and tlsConfig arguments to service monitor which allows to set up special settings to work with istio in mtls strict mode, and add an option to allow custom service port name.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
