### PR TITLE
[kube-prometheus-stack] Fix dynamic port assignment for exporters' Endpoints

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 36.0.1
+version: 36.0.2
 appVersion: 0.57.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/endpoints.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/endpoints.yaml
@@ -7,7 +7,7 @@ metadata:
     app: {{ template "kube-prometheus-stack.name" . }}-kube-controller-manager
     k8s-app: kube-controller-manager
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
-  namespace: kube-system 
+  namespace: kube-system
 subsets:
   - addresses:
       {{- range .Values.kubeControllerManager.endpoints }}
@@ -15,6 +15,8 @@ subsets:
       {{- end }}
     ports:
       - name: http-metrics
-        port: {{ .Values.kubeControllerManager.service.port }}
+        {{- $kubeControllerManagerDefaultInsecurePort := 10252 }}
+        {{- $kubeControllerManagerDefaultSecurePort := 10257 }}
+        port: {{ include "kube-prometheus-stack.kubeControllerManager.insecureScrape" (list . $kubeControllerManagerDefaultInsecurePort $kubeControllerManagerDefaultSecurePort .Values.kubeControllerManager.service.port) }}
         protocol: TCP
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/endpoints.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/endpoints.yaml
@@ -15,6 +15,8 @@ subsets:
       {{- end }}
     ports:
       - name: http-metrics
-        port: {{ .Values.kubeScheduler.service.port }}
+        {{- $kubeSchedulerDefaultInsecurePort := 10251 }}
+        {{- $kubeSchedulerDefaultSecurePort := 10259 }}
+        port: {{ include "kube-prometheus-stack.kubeScheduler.insecureScrape" (list . $kubeSchedulerDefaultInsecurePort $kubeSchedulerDefaultSecurePort .Values.kubeScheduler.service.port)  }}
         protocol: TCP
 {{- end }}


### PR DESCRIPTION
This PR fixes #1801.

The issue is reproduced when the value of `(kubeControllerManager|kubeScheduler).endpoints` is not empty, and `(kubeControllerManager|kubeScheduler).service.port` is `null` (which is the default value). In this situation, the rendered chart contains invalid resources of kind `Endpoints`. The validation process fails with the following error:

```
ValidationError(Endpoints.subsets[0].ports[0]): missing required field "port" in io.k8s.api.core.v1.EndpointPort
```

By default, `endpoints` values are empty and the template, which is rendering `Endpoints` resources for kube-controller-manager and for kube-scheduler, renders into an empty document. Hence, the issue is not reproducible using the default `values.yaml`.

#### Demo

First, I change the default values in the following way (the changed key is `kubeControllerManager.endpoints`, it is not visible in the diff):

```diff
--- values.yaml 2022-06-15 19:58:10.167201668 +0200
+++ values.changed.yaml 2022-06-15 20:26:35.880160843 +0200
@@ -1029,10 +1029,10 @@

   ## If your kube controller manager is not deployed as a pod, specify IPs it can be found on
   ##
-  endpoints: []
-  # - 10.141.4.22
-  # - 10.141.4.23
-  # - 10.141.4.24
+  endpoints:
+  - 10.141.4.22
+  - 10.141.4.23
+  - 10.141.4.24

   ## If using kubeControllerManager.endpoints only the port and targetPort are used
   ##
```

Next, I render the chart using both versions of values file and take a diff:

```diff
--- rendered.yaml       2022-06-15 20:31:46.496539105 +0200
+++ rendered.changed.yaml       2022-06-15 20:32:02.600009809 +0200
@@ -39525,8 +39525,6 @@
       port: 10257
       protocol: TCP
       targetPort: 10257
-  selector:
-    component: kube-controller-manager
   type: ClusterIP
 ---
 # Source: kube-prometheus-stack/templates/exporters/kube-etcd/service.yaml
@@ -40115,6 +40113,33 @@
     runAsUser: 1000
   portName: http-web
 ---
+# Source: kube-prometheus-stack/templates/exporters/kube-controller-manager/endpoints.yaml
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: release-name-kube-promethe-kube-controller-manager
+  labels:
+    app: kube-prometheus-stack-kube-controller-manager
+    k8s-app: kube-controller-manager
+
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "36.0.1"
+    app.kubernetes.io/part-of: kube-prometheus-stack
+    chart: kube-prometheus-stack-36.0.1
+    release: "release-name"
+    heritage: "Helm"
+  namespace: kube-system
+subsets:
+  - addresses:
+      - ip: 10.141.4.22
+      - ip: 10.141.4.23
+      - ip: 10.141.4.24
+    ports:
+      - name: http-metrics
+        port:
+        protocol: TCP
+---
 # Source: kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/mutatingWebhookConfiguration.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
```

Notice the absent value of the `subsets[0].ports[0].port` key.

It looks the same way for kube-scheduler.

With the changes of this PR, however, the port is set correctly:

```diff
--- rendered.yaml       2022-06-15 20:38:53.357079713 +0200
+++ rendered.changed.yaml       2022-06-15 20:38:41.960304766 +0200
@@ -39525,8 +39525,6 @@
       port: 10257
       protocol: TCP
       targetPort: 10257
-  selector:
-    component: kube-controller-manager
   type: ClusterIP
 ---
 # Source: kube-prometheus-stack/templates/exporters/kube-etcd/service.yaml
@@ -40115,6 +40113,33 @@
     runAsUser: 1000
   portName: http-web
 ---
+# Source: kube-prometheus-stack/templates/exporters/kube-controller-manager/endpoints.yaml
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: release-name-kube-promethe-kube-controller-manager
+  labels:
+    app: kube-prometheus-stack-kube-controller-manager
+    k8s-app: kube-controller-manager
+
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "36.0.2"
+    app.kubernetes.io/part-of: kube-prometheus-stack
+    chart: kube-prometheus-stack-36.0.2
+    release: "release-name"
+    heritage: "Helm"
+  namespace: kube-system
+subsets:
+  - addresses:
+      - ip: 10.141.4.22
+      - ip: 10.141.4.23
+      - ip: 10.141.4.24
+    ports:
+      - name: http-metrics
+        port: 10257
+        protocol: TCP
+---
 # Source: kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/mutatingWebhookConfiguration.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
```


#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
