### PR TITLE
[kube-state-metrics] render extraArgs as YAML to allow multi-line string arguments

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 4.9.1
+version: 4.9.2
 appVersion: 2.5.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/kube-state-metrics/templates/deployment.yaml
@@ -50,9 +50,7 @@ spec:
         {{- end }}
         args:
         {{-  if .Values.extraArgs  }}
-        {{- range .Values.extraArgs  }}
-        - {{ . }}
-        {{- end  }}
+        {{- .Values.extraArgs | toYaml | nindent 8 }}
         {{-  end  }}
         {{- if .Values.service.port }}
         - --port={{ .Values.service.port | default 8080}}


### PR DESCRIPTION
The newly introduced `--custom-resource-state-config` argument
(https://github.com/kubernetes/kube-state-metrics/pull/1710) accepts a multi-line string as value.
The deployment.yaml template currently loops over each .Values.extraArgs, which causes indentation
issues when passing a multi-line string. This PR fixes that by rendering .Values.extraArgs as YAML
with proper indentation.

Signed-off-by: Mitch Hulscher <mitch.hulscher@lib.io>

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
