### PR TITLE
[prometheus-mongodb-exporter] Add tls configuration option for service monitor

### DIFF
--- a/charts/prometheus-mongodb-exporter/Chart.yaml
+++ b/charts/prometheus-mongodb-exporter/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 name: prometheus-mongodb-exporter
 sources:
 - https://github.com/percona/mongodb_exporter
-version: 3.0.0
+version: 3.1.0

--- a/charts/prometheus-mongodb-exporter/templates/service.yaml
+++ b/charts/prometheus-mongodb-exporter/templates/service.yaml
@@ -14,7 +14,7 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: metrics
       protocol: TCP
-      name: metrics
+      name: {{ .Values.service.portName }}
   selector:
     {{- include "prometheus-mongodb-exporter.selectorLabels" . | nindent 4 }}
   type: {{ .Values.service.type }}

--- a/charts/prometheus-mongodb-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-mongodb-exporter/templates/servicemonitor.yaml
@@ -13,11 +13,18 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-  - port: metrics
+  - port: {{ .Values.service.portName }}
     interval: {{ .Values.serviceMonitor.interval }}
     scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
     {{- if .Values.serviceMonitor.metricRelabelings }}
     metricRelabelings: {{ toYaml .Values.serviceMonitor.metricRelabelings | nindent 4 }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.scheme }}
+    scheme: {{ .Values.serviceMonitor.scheme }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.tlsConfig }}
+    tlsConfig:
+      {{- toYaml .Values.serviceMonitor.tlsConfig | nindent 6 }}
     {{- end }}
   namespaceSelector:
     matchNames:

--- a/charts/prometheus-mongodb-exporter/values.yaml
+++ b/charts/prometheus-mongodb-exporter/values.yaml
@@ -83,6 +83,7 @@ service:
   annotations: {}
   port: 9216
   type: ClusterIP
+  portName: metrics
 
 serviceAccount:
   create: true
@@ -98,5 +99,7 @@ serviceMonitor:
   additionalLabels: {}
   targetLabels: []
   metricRelabelings: []
+  scheme: ""
+  tlsConfig: {}
 
 tolerations: []


### PR DESCRIPTION
#### What this PR does / why we need it:

Add service monitor arguments to define TLS configuration which is necessary when using Istio in mTls strict mode. Also, add a new argument to change the service name once Istio needs a protocol prefix.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
