### PR TITLE
[kube-prometheus-stack] update kube-state-metrics and grafana to latest patch version

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
-  version: 4.9.0
+  version: 4.9.2
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 3.3.0
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.29.6
-digest: sha256:8c273cba2d7b0abb5d664f520e5d5f0d9a3f9f0c093845cef98a38e8e57ea69c
-generated: "2022-06-11T01:06:49.564598828+02:00"
+  version: 6.29.11
+digest: sha256:63805fe7ce9942b928b4c5d2d03c0fd0b73f6924e4126c66f658079bd7a8d435
+generated: "2022-06-20T10:09:14.407533489+02:00"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 36.0.2
+version: 36.0.3
 appVersion: 0.57.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus


### PR DESCRIPTION
#### What this PR does / why we need it:

The latest version of the KSM chart allows configuring the new CustomResourceStateMetrics feature:

* https://github.com/prometheus-community/helm-charts/pull/2167
* https://github.com/kubernetes/kube-state-metrics/pull/1710

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
