### PR TITLE
[kube-prometheus-stack] Upgrade Grafana chart to 6.31.x (with Grafana version 9)

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 3.3.0
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.29.11
-digest: sha256:63805fe7ce9942b928b4c5d2d03c0fd0b73f6924e4126c66f658079bd7a8d435
-generated: "2022-06-20T10:09:14.407533489+02:00"
+  version: 6.31.0
+digest: sha256:f93a0e3d320f36dd95a3de335219d70d140ead8a0a853a37725cdf2f7c6ecc83
+generated: "2022-06-23T06:58:32.0817776+02:00"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 36.0.3
+version: 36.1.3
 appVersion: 0.57.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus
@@ -49,6 +49,6 @@ dependencies:
     repository: https://prometheus-community.github.io/helm-charts
     condition: nodeExporter.enabled
   - name: grafana
-    version: "6.29.*"
+    version: "6.31.*"
     repository: https://grafana.github.io/helm-charts
     condition: grafana.enabled


### PR DESCRIPTION
Signed-off-by: Gustav Tonér <gustav.toner@gmail.com>

#### What this PR does / why we need it:
This upgrades the Grafana chart to version 6.31.x which in turn uses the newly released Grafana version 9.

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
