### PR TITLE
[prometheus-postgres-exporter] Use correct port in port-forward command

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.10.1"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 3.0.1
+version: 3.0.2
 home: https://github.com/prometheus-community/postgres_exporter
 sources:
 - https://github.com/prometheus-community/postgres_exporter

--- a/charts/prometheus-postgres-exporter/templates/NOTES.txt
+++ b/charts/prometheus-postgres-exporter/templates/NOTES.txt
@@ -11,5 +11,5 @@
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "prometheus-postgres-exporter.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:80
+  kubectl port-forward $POD_NAME 8080:9187
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes a minor documentation bug.

#### Which issue this PR fixes

Fixes #2187.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)

I assume that this change is too minor for a version bump?