### PR TITLE
[prometheus-postgres-exporter] Use policy/v1 PodSecurityPolicy when available

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.10.1"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 3.0.2
+version: 3.0.3
 home: https://github.com/prometheus-community/postgres_exporter
 sources:
 - https://github.com/prometheus-community/postgres_exporter

--- a/charts/prometheus-postgres-exporter/templates/podsecuritypolicy.yaml
+++ b/charts/prometheus-postgres-exporter/templates/podsecuritypolicy.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.rbac.pspEnabled }}
+{{ if $.Capabilities.APIVersions.Has "policy/v1/PodSecurityPolicy" -}}
+apiVersion: policy/v1
+{{- else -}}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus-postgres-exporter.fullname" . }}


### PR DESCRIPTION
Signed-off-by: Othmane El Warrak <othmane.el.warrak@ibm.com>
@gianrubio @zanhsieh 
#### What this PR does / why we need it:
The policy/v1beta1 pod security policy is deprecated starting v1.21 and will be removed starting v1.25. this PR aims to use policy/v1 when possible or policy/v1beta1 otherwise. 

#### Which issue this PR fixes
  - fixes #2207 
  - closes #2207 

#### Special notes for your reviewer:
This PR is based on https://github.com/prometheus-community/helm-charts/pull/2201

#### Checklist
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
