### PR TITLE
[kube-state-metrics] Add selfMonitor.telemetryNodePort field to values

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 4.10.0
+version: 4.11.0
 appVersion: 2.5.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/service.yaml
+++ b/charts/kube-state-metrics/templates/service.yaml
@@ -27,6 +27,9 @@ spec:
     protocol: TCP
     port: {{ .Values.selfMonitor.telemetryPort | default 8081 }}
     targetPort: {{ .Values.selfMonitor.telemetryPort | default 8081 }}
+  {{- if .Values.selfMonitor.telemetryNodePort }}
+    nodePort: {{ .Values.selfMonitor.telemetryNodePort }}
+  {{- end }}
   {{ end }}
 {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: "{{ .Values.service.loadBalancerIP }}"

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -229,7 +229,9 @@ kubeTargetVersionOverride: ""
 
 # Enable self metrics configuration for service and Service Monitor
 # Default values for telemetry configuration can be overridden
+# If you set telemetryNodePort, you must also set service.type to NodePort
 selfMonitor:
   enabled: false
   # telemetryHost: 0.0.0.0
   # telemetryPort: 8081
+  # telemetryNodePort: 0


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
Adds a `selfMonitor.telemetryNodePort` field to values.yaml so that a NodePort for the telemetry endpoint can be specified when `service.type` is set to `NodePort`.

#### Special notes for your reviewer:
Tagging @tariq1890 @mrueg @dotdc as per the PR template comment.

There is a slight incongruence here in that if `selfMonitor.telemetryNodePort` is specified but `service.type` is not set to `NodePort`, the deployment will fail. Options to fix, if desired:
* put the telemetry endpoint fields under `service`
* create separate Services for telemetry and core metrics
* set the Service type to `NodePort` if either `service.nodePort` or `selfMonitor.telemetryNodePort` are specified

(In the existing chart, the deployment will also fail if `services.nodePort` is non-zero while `services.type` is not `NodePort` - but that's a bit less surprising since the dependent fields are all under the `services` top-level key.)

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
