### PR TITLE
[kube-prometheus-stack] Fix/yaml error tag yaml 2002 value

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 36.2.1
+version: 36.2.2
 appVersion: 0.57.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/crds/crd-alertmanagerconfigs.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-alertmanagerconfigs.yaml
@@ -70,7 +70,7 @@ spec:
                               if non-empty.
                             enum:
                             - '!='
-                            - =
+                            - '='
                             - =~
                             - '!~'
                             type: string
@@ -103,7 +103,7 @@ spec:
                               if non-empty.
                             enum:
                             - '!='
-                            - =
+                            - '='
                             - =~
                             - '!~'
                             type: string
@@ -4313,7 +4313,7 @@ spec:
                             if non-empty.
                           enum:
                           - '!='
-                          - =
+                          - '='
                           - =~
                           - '!~'
                           type: string


### PR DESCRIPTION
@andrewgkew
@bismarck
@gianrubio


#### What this PR does / why we need it:
This will fix a pyaml issue which causes the equal sign to throw a `could not determine a constructor for the tag 'tag:yaml.org,2002:value'` error.
