### PR TITLE
[kube-prometheus-stack] Add web property to AlertmanagerSpec

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 36.2.1
+version: 36.3.0
 appVersion: 0.57.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/alertmanager/alertmanager.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/alertmanager.yaml
@@ -68,6 +68,10 @@ spec:
 {{ else }}
   alertmanagerConfigNamespaceSelector: {}
 {{- end }}
+{{- if .Values.alertmanager.alertmanagerSpec.web }}
+  web:
+{{ toYaml .Values.alertmanager.alertmanagerSpec.web | indent 4 }}
+{{- end }}
 {{- if .Values.alertmanager.alertmanagerSpec.alertmanagerConfiguration }}
   alertmanagerConfiguration:
 {{ toYaml .Values.alertmanager.alertmanagerSpec.alertmanagerConfiguration | indent 4 }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -468,6 +468,10 @@ alertmanager:
     ##
     # configSecret:
 
+    ## WebTLSConfig defines the TLS parameters for HTTPS
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#alertmanagerwebspec
+    web: {}
+
     ## AlertmanagerConfigs to be selected to merge and configure Alertmanager with.
     ##
     alertmanagerConfigSelector: {}


### PR DESCRIPTION
For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.
@andrewgkew
@bismarck
@desaintmartin
@gianrubio
@gkarthiks
@GMartinez-Sisti
@scottrigby
@Xtigyro

#### What this PR does / why we need it:

Adds capability to configure Alertmanager TLS auth

#### Which issue this PR fixes
  - fixes #2240 

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
