### PR TITLE
[prometheus-statsd-exporter] Add extraEnv and extraArgs

### DIFF
--- a/charts/prometheus-statsd-exporter/Chart.yaml
+++ b/charts/prometheus-statsd-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus-statsd-exporter
 description: A Helm chart for prometheus stats-exporter
-version: 0.4.2
+version: 0.4.3
 appVersion: 0.22.1
 home: https://github.com/prometheus/statsd_exporter
 sources:

--- a/charts/prometheus-statsd-exporter/Chart.yaml
+++ b/charts/prometheus-statsd-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: prometheus-statsd-exporter
 description: A Helm chart for prometheus stats-exporter
-version: 0.4.3
-appVersion: 0.22.1
+version: 0.5.0
+appVersion: 0.22.7
 home: https://github.com/prometheus/statsd_exporter
 sources:
   - https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus-statsd-exporter

--- a/charts/prometheus-statsd-exporter/templates/deployment.yaml
+++ b/charts/prometheus-statsd-exporter/templates/deployment.yaml
@@ -32,6 +32,13 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- with .Values.extraEnv }}
+          env:
+            {{- range $key, $value := . }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
@@ -53,7 +60,10 @@ spec:
             - --statsd.event-flush-interval={{ .Values.statsd.eventFlushInterval }}
             {{- if or .Values.statsd.mappingConfigMapName .Values.statsd.mappingConfig }}
             - --statsd.mapping-config=/etc/prometheus-statsd-exporter/statsd-mapping.conf
-          {{- end }}
+            {{- end }}
+            {{- if .Values.extraArgs }}
+              {{- toYaml .Values.extraArgs | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/prometheus-statsd-exporter/templates/tests/test-connection.yaml
+++ b/charts/prometheus-statsd-exporter/templates/tests/test-connection.yaml
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "prometheus-statsd-exporter.fullname" . }}:{{ .Values.service.port }}']
+      args: ['{{ include "prometheus-statsd-exporter.fullname" . }}:{{ .Values.service.port }}/metrics']
   restartPolicy: Never

--- a/charts/prometheus-statsd-exporter/templates/tests/test-connection.yaml
+++ b/charts/prometheus-statsd-exporter/templates/tests/test-connection.yaml
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "prometheus-statsd-exporter.fullname" . }}:{{ .Values.service.port }}/metrics']
+      args: ['{{ include "prometheus-statsd-exporter.fullname" . }}.{{ Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/metrics']
   restartPolicy: Never

--- a/charts/prometheus-statsd-exporter/templates/tests/test-connection.yaml
+++ b/charts/prometheus-statsd-exporter/templates/tests/test-connection.yaml
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "prometheus-statsd-exporter.fullname" . }}.{{ Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/metrics']
+      args: ['{{ include "prometheus-statsd-exporter.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/metrics']
   restartPolicy: Never

--- a/charts/prometheus-statsd-exporter/values.yaml
+++ b/charts/prometheus-statsd-exporter/values.yaml
@@ -9,7 +9,7 @@ image:
   repository: prom/statsd-exporter
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: v0.22.1
+  tag: v0.22.7
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/prometheus-statsd-exporter/values.yaml
+++ b/charts/prometheus-statsd-exporter/values.yaml
@@ -16,12 +16,9 @@ nameOverride: ""
 fullnameOverride: ""
 
 # Additional container environment variables
-# For instance to add a http_proxy
-#
-# extraEnv:
+extraEnv: {}
 #   HTTP_PROXY: "http://superproxy.com:3128"
 #   NO_PROXY: "localhost,127.0.0.1"
-extraEnv: {}
 
 # Additional arguments in the statsd_exporter command line
 extraArgs: []

--- a/charts/prometheus-statsd-exporter/values.yaml
+++ b/charts/prometheus-statsd-exporter/values.yaml
@@ -15,6 +15,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# Additional container environment variables
+# For instance to add a http_proxy
+#
+# extraEnv:
+#   HTTP_PROXY: "http://superproxy.com:3128"
+#   NO_PROXY: "localhost,127.0.0.1"
+extraEnv: {}
+
+# Additional arguments in the statsd_exporter command line
+extraArgs: []
+  # - --history.limit=1000
 
 statsd:
   # The UDP port on which to receive statsd metric lines.


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds the following parameters in `values.yaml`:
* `extraEnv`: additional container environment variables
* `extraArgs`: additional arguments in the statsd_exporter command line

These new parameters are already present in other prometheus exporter charts (e.g. https://github.com/prometheus-community/helm-charts/blob/f7368412de885085b61082cf44a2a37d6ec2aea3/charts/prometheus-blackbox-exporter/values.yaml#L21, and https://github.com/prometheus-community/helm-charts/blob/f7368412de885085b61082cf44a2a37d6ec2aea3/charts/prometheus-blackbox-exporter/values.yaml#L204).

In our case, we need this feature to change the logging format to `json`.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
