### PR TITLE
[kube-prometheus-stack] Canceled grpc is now not considered an error

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 36.6.1
+version: 36.6.2
 appVersion: 0.57.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/etcd.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/etcd.yaml
@@ -77,7 +77,7 @@ spec:
 {{- end }}
         message: 'etcd cluster "{{`{{`}} $labels.job {{`}}`}}": {{`{{`}} $value {{`}}`}}% of requests for {{`{{`}} $labels.grpc_method {{`}}`}} failed on etcd instance {{`{{`}} $labels.instance {{`}}`}}.'
       expr: |-
-        100 * sum(rate(grpc_server_handled_total{job=~".*etcd.*", grpc_code!="OK"}[5m])) BY (job, instance, grpc_service, grpc_method)
+        100 * sum(rate(grpc_server_handled_total{job=~".*etcd.*", grpc_code!~"OK|Canceled"}[5m])) BY (job, instance, grpc_service, grpc_method)
           /
         sum(rate(grpc_server_handled_total{job=~".*etcd.*"}[5m])) BY (job, instance, grpc_service, grpc_method)
           > 1
@@ -96,7 +96,7 @@ spec:
 {{- end }}
         message: 'etcd cluster "{{`{{`}} $labels.job {{`}}`}}": {{`{{`}} $value {{`}}`}}% of requests for {{`{{`}} $labels.grpc_method {{`}}`}} failed on etcd instance {{`{{`}} $labels.instance {{`}}`}}.'
       expr: |-
-        100 * sum(rate(grpc_server_handled_total{job=~".*etcd.*", grpc_code!="OK"}[5m])) BY (job, instance, grpc_service, grpc_method)
+        100 * sum(rate(grpc_server_handled_total{job=~".*etcd.*", grpc_code!~"OK|Canceled"}[5m])) BY (job, instance, grpc_service, grpc_method)
           /
         sum(rate(grpc_server_handled_total{job=~".*etcd.*"}[5m])) BY (job, instance, grpc_service, grpc_method)
           > 5


### PR DESCRIPTION
"Canceled" grpc state means client-initiated cancellation of streaming
grpc call, e.g. Watch. This is a legitimate non-error case. Before this
change such codes were considered an error and generated false positive
alerts.

The related PR to etcd-io/website:
https://github.com/etcd-io/website/pull/556

There is a bunch or related issues since 2020:
https://github.com/search?q=etcdHighNumberOfFailedGRPCRequests&type=issues
I think the most common resolution was to just disable the rule.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
