### PR TITLE
[prometheus-kube-stack] disabled restrictive cAdvisorMetricRelabelings rules by default

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 37.2.0
+version: 37.3.0
 appVersion: 0.57.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -982,14 +982,17 @@ kubelet:
       - sourceLabels: [__name__]
         action: drop
         regex: 'container_spec.*'
-      # Drop cgroup metrics with no pod.
-      - sourceLabels: [id, pod]
-        action: drop
-        regex: '.+;'
-      # Drop cgroup metrics with no container.
-      - sourceLabels: [id, container]
-        action: drop
-        regex: '.+;'
+      # Theses rules will drop all metrics with no pods and/or no containers labels.
+      # This will make queries likes `container_cpu_usage_seconds_total{id="/"}` to fail out of the box.
+      #
+      # # Drop cgroup metrics with no pod.
+      # - sourceLabels: [id, pod]
+      #   action: drop
+      #   regex: '.+;'
+      # # Drop cgroup metrics with no container.
+      # - sourceLabels: [id, container]
+      #   action: drop
+      #   regex: '.+;'
     # - sourceLabels: [__name__, image]
     #   separator: ;
     #   regex: container_([a-z_]+);


### PR DESCRIPTION
Signed-off-by: David <davidcalvertfr@gmail.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

I think two of the new rules introduced in 37.0.0 by @SuperQ are a bit too restrictive to be enabled by default.

Rules concerned :

      # Drop cgroup metrics with no pod.
      - sourceLabels: [id, pod]
        action: drop
        regex: '.+;'
      # Drop cgroup metrics with no container.
      - sourceLabels: [id, container]
        action: drop
        regex: '.+;'
Theses 2 rules drop every metrics without a pod and/or a container.
This will make some basic queries like container_cpu_usage_seconds_total{id="/"} to stop working out of the box.
I would at least comment theses two to limit the number of impacted users.



#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes https://github.com/prometheus-community/helm-charts/issues/2279

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
