### PR TITLE
[prometheus-rabbitmq-exporter] Add imagePullSecrets feature flag

### DIFF
--- a/charts/prometheus-rabbitmq-exporter/Chart.yaml
+++ b/charts/prometheus-rabbitmq-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Rabbitmq metrics exporter for prometheus
 name: prometheus-rabbitmq-exporter
-version: 1.2.1
+version: 1.3.0
 appVersion: v0.29.0
 home: https://github.com/kbudde/rabbitmq_exporter
 sources:

--- a/charts/prometheus-rabbitmq-exporter/Chart.yaml
+++ b/charts/prometheus-rabbitmq-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Rabbitmq metrics exporter for prometheus
 name: prometheus-rabbitmq-exporter
-version: 1.2.0
+version: 1.2.1
 appVersion: v0.29.0
 home: https://github.com/kbudde/rabbitmq_exporter
 sources:

--- a/charts/prometheus-rabbitmq-exporter/templates/deployment.yaml
+++ b/charts/prometheus-rabbitmq-exporter/templates/deployment.yaml
@@ -27,6 +27,12 @@ spec:
       annotations:
 {{ toYaml .Values.annotations | indent 8 }}
     spec:
+    {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+    {{- end }}
       serviceAccountName: {{ template "prometheus-rabbitmq-exporter.serviceAccountName" . }}
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/prometheus-rabbitmq-exporter/values.yaml
+++ b/charts/prometheus-rabbitmq-exporter/values.yaml
@@ -6,6 +6,8 @@ image:
   repository: kbudde/rabbitmq-exporter
   tag: v0.29.0
   pullPolicy: IfNotPresent
+  pullSecrets: []
+
 service:
   type: ClusterIP
   externalPort: 9419


### PR DESCRIPTION
Signed-off-by: Jordan Brown <jordan.brown@workday.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

Currently, there is no way to pass a imagePullSecrets flag to the rabbitmq-exporter. This PR adds the feature flag necessary for this functionality. 

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
