### PR TITLE
[kube-prometheus-stack] Bump grafana to 6.32.7

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 3.3.0
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.32.2
-digest: sha256:1ffce4c349bde42891b285563895b04166215d64fde69dc88635eeef2d9e084a
-generated: "2022-07-12T14:26:19.436991+02:00"
+  version: 6.32.7
+digest: sha256:d19a95a034fd1017dd78d79ab1bef5431932f9b2395fc0f30df4fa12dbc0845b
+generated: "2022-07-24T05:16:31.403735+04:00"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -22,7 +22,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 38.1.0
+version: 38.0.2
 appVersion: 0.57.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 38.0.0
+version: 38.1.0
 appVersion: 0.57.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR bumps grafana chart dependency. This new version includes **significant** bugfixes for anonymous authentication.

#### Which issue this PR fixes
- fixes #1806 (not sure if this issue tracks that specifically, but the symptoms of the issue match 100%).

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
