### PR TITLE
[prometheus-json-exporter] fix: Multiple targets are now created as differently named ServiceMonitors

### DIFF
--- a/charts/prometheus-json-exporter/Chart.yaml
+++ b/charts/prometheus-json-exporter/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/prometheus-json-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-json-exporter/templates/servicemonitor.yaml
@@ -4,7 +4,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ template "prometheus-json-exporter.fullname" $ }}
+  name: {{ template "prometheus-json-exporter.fullname" $ }}-{{ .name }}
   {{- if $.Values.serviceMonitor.namespace }}
   namespace: {{ $.Values.serviceMonitor.namespace }}
   {{- end }}


### PR DESCRIPTION

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

The chart now creates multiple, differently named, ServiceMonitors to allow for multiple targets to be scraped.

#### Which issue this PR fixes

Multiple targets did not create differently named ServiceMonitors resulting in the following error when defining more than one target:
`Error: servicemonitors.monitoring.coreos.com "json-exporter-prometheus-json-exporter" already exists`

#### Special notes for your reviewer:

_None_

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
