### PR TITLE
[prometheus-elasticsearch-exporter] Bump exporter to 1.5.0

### DIFF
--- a/charts/prometheus-elasticsearch-exporter/Chart.yaml
+++ b/charts/prometheus-elasticsearch-exporter/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: prometheus-elasticsearch-exporter
-version: 4.13.0
+version: 4.14.0
 kubeVersion: ">=1.10.0-0"
-appVersion: 1.3.0
+appVersion: 1.5.0
 home: https://github.com/prometheus-community/elasticsearch_exporter
 sources:
   - https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-elasticsearch-exporter

--- a/charts/prometheus-elasticsearch-exporter/values.yaml
+++ b/charts/prometheus-elasticsearch-exporter/values.yaml
@@ -14,7 +14,7 @@ restartPolicy: Always
 
 image:
   repository: quay.io/prometheuscommunity/elasticsearch-exporter
-  tag: v1.3.0
+  tag: v1.5.0
   pullPolicy: IfNotPresent
   pullSecret: ""
 


### PR DESCRIPTION
#### What this PR does / why we need it
Bump default version of the exporter to 1.5.0.

Breaking change if you upgrade from 1.3.0 or earlier. See [changelog](https://github.com/prometheus-community/elasticsearch_exporter/blob/master/CHANGELOG.md#150--2022-07-28)
Doesn't apply if you upgrade from 1.4.0

#### Special notes for your reviewer

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
