### PR TITLE
[prometheus-stackdriver-exporter] Fix spec.serviceAccountName

### DIFF
--- a/charts/prometheus-stackdriver-exporter/Chart.yaml
+++ b/charts/prometheus-stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: prometheus-stackdriver-exporter
-version: 4.0.0
+version: 4.1.0
 appVersion: 0.12.0
 home: https://www.stackdriver.com/
 sources:

--- a/charts/prometheus-stackdriver-exporter/Chart.yaml
+++ b/charts/prometheus-stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: prometheus-stackdriver-exporter
-version: 4.1.0
+version: 4.0.1
 appVersion: 0.12.0
 home: https://www.stackdriver.com/
 sources:

--- a/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
-      serviceAccount: {{ template "stackdriver-exporter.serviceAccountName" . }}
+      serviceAccountName: {{ template "stackdriver-exporter.serviceAccountName" . }}
       restartPolicy: {{ .Values.restartPolicy }}
       volumes:
       {{- if .Values.stackdriver.serviceAccountSecret }}

--- a/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
@@ -37,6 +37,7 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+      serviceAccount: {{ template "stackdriver-exporter.serviceAccountName" . }}
       serviceAccountName: {{ template "stackdriver-exporter.serviceAccountName" . }}
       restartPolicy: {{ .Values.restartPolicy }}
       volumes:


### PR DESCRIPTION
Signed-off-by: Tuan Anh Nguyen <tuananh.nguyen-ext@commercetools.de>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
With the serviceAccountName spec missing, helm won't be able to apply the change to deployment when we change the service account name.

Step to reproduce the bug
- Install prometheus-stackdriver-exporter using helm with default setting
  - `helm get manifest` shows `serviceAccount: default`
  - `kubectl get deployment` shows `serviceAccount: default` and `serviceAccountName: default`
- Change serviceAccount.create to true and upgrade the current release. 
  - `helm get manifest` shows  `serviceAccount: ` with new value (generated from release name)
  - `kubectl get deployment` still shows `serviceAccount: default` and `serviceAccountName: default`
 
The correct spec is `serviceAccountName` following https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/

And we still need to keep spec.serviceAccount due to https://github.com/kubernetes/kubernetes/issues/72519

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
