### PR TITLE
[prometheus-mongodb-exporter] fixing default mongodb uri

### DIFF
--- a/charts/prometheus-mongodb-exporter/Chart.yaml
+++ b/charts/prometheus-mongodb-exporter/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 name: prometheus-mongodb-exporter
 sources:
 - https://github.com/percona/mongodb_exporter
-version: 3.1.0
+version: 3.1.1

--- a/charts/prometheus-mongodb-exporter/values.yaml
+++ b/charts/prometheus-mongodb-exporter/values.yaml
@@ -22,7 +22,7 @@ livenessProbe:
 
 # [mongodb[+srv]://][user:pass@]host1[:port1][,host2[:port2],...][/database][?options]
 mongodb:
-  uri: "mongodb://mongodb:27017"
+  uri: "mongodb://monogdb:27017"
 
 # Name of an externally managed secret (in the same namespace) containing the connection uri as key `mongodb-uri`.
 # If this is provided, the value mongodb.uri is ignored.

--- a/charts/prometheus-mongodb-exporter/values.yaml
+++ b/charts/prometheus-mongodb-exporter/values.yaml
@@ -22,7 +22,7 @@ livenessProbe:
 
 # [mongodb[+srv]://][user:pass@]host1[:port1][,host2[:port2],...][/database][?options]
 mongodb:
-  uri: "mongodb://monogdb:27017"
+  uri: "mongodb://mongodb:27017"
 
 # Name of an externally managed secret (in the same namespace) containing the connection uri as key `mongodb-uri`.
 # If this is provided, the value mongodb.uri is ignored.


### PR DESCRIPTION
#### What this PR does / why we need it
Fixing a typo in the MongoDB URI in values.yaml file

#### Which issue this PR fixes
Now the exporter can find MongoDB service running on the cluster

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
