### PR TITLE
[prometheus-redis-exporter] support redis password file secret volume mount

### DIFF
--- a/charts/prometheus-redis-exporter/Chart.yaml
+++ b/charts/prometheus-redis-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.43.0
 description: Prometheus exporter for Redis metrics
 name: prometheus-redis-exporter
-version: 5.0.0
+version: 5.1.0
 home: https://github.com/oliver006/redis_exporter
 sources:
   - https://github.com/oliver006/redis_exporter

--- a/charts/prometheus-redis-exporter/templates/deployment.yaml
+++ b/charts/prometheus-redis-exporter/templates/deployment.yaml
@@ -113,7 +113,6 @@ spec:
           secret:
              secretName: {{ .Values.auth.redisPasswordFile.secret.name }}
         {{- end }}
-
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/prometheus-redis-exporter/templates/deployment.yaml
+++ b/charts/prometheus-redis-exporter/templates/deployment.yaml
@@ -54,6 +54,10 @@ spec:
               value: {{ .Values.redisAddress }}
             {{- end }}
           {{- if .Values.auth.enabled }}
+            {{- if and (.Values.auth.redisPasswordFile.secret.name) (.Values.auth.redisPasswordFile.secret.key) }}
+            - name: REDIS_PASSWORD_FILE
+              value: {{ .Values.auth.redisPasswordFile.mountPath }}/{{ .Values.auth.redisPasswordFile.secret.key }}
+            {{- else }}
             - name: REDIS_PASSWORD
             {{- if .Values.auth.secret.name }}
               valueFrom:
@@ -67,6 +71,7 @@ spec:
             - name: REDIS_USER
               value: {{ .Values.auth.redisUser }}
             {{- end }}
+            {{- end }}
           {{- end }}
 {{- if .Values.script }}
             - name: REDIS_EXPORTER_SCRIPT
@@ -75,11 +80,15 @@ spec:
 {{- if .Values.env }}
 {{ toYaml .Values.env | indent 12 }}
 {{- end }}
-{{- if .Values.script }}
           volumeMounts:
-              - mountPath: /script
-                name: script-mount
-{{- end }}
+            {{- if .Values.script }}
+            - mountPath: /script
+              name: script-mount
+            {{- end }}
+            {{- if and (.Values.auth.enabled) (.Values.auth.redisPasswordFile.secret.name) }}
+            - mountPath: {{ .Values.auth.redisPasswordFile.mountPath }}
+              name: redis-password-file-mount
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /
@@ -90,15 +99,21 @@ spec:
               port: exporter-port
           resources:
 {{ toYaml .Values.resources | indent 12 }}
-    {{- if .Values.script }}
       volumes:
+        {{- if .Values.script }}
         - name: script-mount
           configMap:
              name: {{ .Values.script.configmap }}
              items:
               - key: {{ .Values.script.keyname }}
                 path: script.lua
-    {{- end }}
+        {{- end }}
+        {{- if and (.Values.auth.enabled) (.Values.auth.redisPasswordFile.secret.name) }}
+        - name: redis-password-file-mount
+          secret:
+             secretName: {{ .Values.auth.redisPasswordFile.secret.name }}
+        {{- end }}
+
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/prometheus-redis-exporter/values.yaml
+++ b/charts/prometheus-redis-exporter/values.yaml
@@ -162,3 +162,14 @@ auth:
   redisPassword: ""
   # Redis user (version 6.X and above)
   redisUser: ""
+  # Redis password file (e.g., https://github.com/oliver006/redis_exporter/blob/v1.27.0/contrib/sample-pwd-file.json)
+  # secret (useful for multiple redis instances with different passwords). If secret name and key are set
+  # this will ignore the single password auth.secret.*
+  redisPasswordFile:
+    # The secret key will be mounted into this path as a file
+    # e.g., if secret key is pass.json, the env variable
+    # REDIS_PASSWORD_FILE will be set to /auth/pass.json
+    mountPath: /auth
+    secret:
+      name: ""
+      key: ""


### PR DESCRIPTION
Signed-off-by: sat-devopsnow <sat@opsverse.io>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Especially useful when one exporter is scraping multiple targets with different password by [taking advantage of the exporter's `redis.password-file | REDIS_PASSWORD_FILE` options](https://github.com/oliver006/redis_exporter/tree/v1.27.0#command-line-flags)... Details here and in the `Test Results` section:

The Redis exporter [supports metric scraping of multiple redis instances by exposing the `/scrape` endpoint](https://github.com/oliver006/redis_exporter/tree/v1.27.0#prometheus-configuration-to-scrape-multiple-redis-hosts). However, if auth is enabled on those instances (and if each of these instances have different passwords), the only workaround is to run multiple exporters - because only a single password can be passed to the exporter.

This PR utilizes the exporter's `redis.password-file | REDIS_PASSWORD_FILE` options - which allow a password file with multiple redis instances as keys with corresponding password as value: e.g.,https://github.com/oliver006/redis_exporter/blob/v1.27.0/contrib/sample-pwd-file.json

#### Which issue this PR fixes

N/A; addendum to #2199 

#### Special notes for your reviewer

* Please look at `Test Results` for the testing / in action
* As an aside: I feel `appVersion` in Chart.yaml is wrong (it should probably be pointing to the default redis-exporter version in values.yaml, which is 1.27.0) - but that's outside the purview of this specific PR

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)

#### Test Results

(1) Create two redis instances on test k8s (v1.21) cluster:

```
helm upgrade --install redis-1 --set global.redis.password=foo --set replica.replicaCount=0 bitnami/redis
helm upgrade --install redis-2 --set global.redis.password=bar --set replica.replicaCount=0 bitnami/redis
```

(2) Create a secret with the password file contents as the key value:

```
kubectl create secret generic redis-auth --from-literal=redis-password-file.json='{"redis://redis-1-master.default.svc.cluster.local:6379": "foo", "redis://redis-2-master.default.svc.cluster.local:6379": "bar"}'
```

(3) Updated values.yaml of redis exporter to enable the password file secret mount:

```
 ...
 auth:
   # Use password authentication
-  enabled: false
+  enabled: true
   # Use existing secret (ignores redisPassword)
   secret:
     name: ""
@@ -162,3 +162,14 @@ auth:
   redisPassword: ""
   # Redis user (version 6.X and above)
   redisUser: ""
+  # Redis password file (e.g., https://github.com/oliver006/redis_exporter/blob/v1.27.0/contrib/sample-pwd-file.json)
+  # secret (useful for multiple redis instances with different passwords). If secret name and key are set
+  # this will ignore the single password auth.secret.*
+  redisPasswordFile:
+    # The secret key will be mounted into this path as a file
+    # e.g., if secret key is pass.json, the env variable
+    # REDIS_PASSWORD_FILE will be set to /auth/pass.json
+    mountPath: /auth
+    secret:
+      name: "redis-auth"
+      key: "redis-password-file.json"
```

(4) Installed this exporter chart and port-forwarded the resulting service

```
helm install test-redexp .
...
kubectl port-forward svc/test-redexp-prometheus-redis-exporter 9121:9121
```

(5) Verified metrics for the 2 instances were coming in (using [the /scrape endpoint for multiple targets](https://github.com/oliver006/redis_exporter/tree/19f7b036bb46869858eec74d8d3fc2186d641399#prometheus-configuration-to-scrape-multiple-redis-hosts)):

```
$ curl -s -XGET http://localhost:9121/scrape?target=redis-1-master.default.svc.cluster.local:6379 | tail -n 1
redis_uptime_in_seconds 3772

$ curl -s -XGET http://localhost:9121/scrape?target=redis-2-master.default.svc.cluster.local:6379 | tail -n 1
redis_uptime_in_seconds 3685
```

(6) Updated the secret with a bad password for redis-2, restarted the exporter pod, and verified showed redis-2 as down:

```
$ curl -s -XGET http://localhost:9121/scrape?target=redis-1-master.default.svc.cluster.local:6379 | tail -n 1
redis_uptime_in_seconds 4841

$ curl -s -XGET http://localhost:9121/scrape?target=redis-2-master.default.svc.cluster.local:6379 | tail -n 1
redis_up 0
```
##### Additional tests

Per contributing guidelines, also ran `ct`:

```
$ ct lint --chart-dirs . --charts .
Linting charts...
Version increment checking disabled.

------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 prometheus-redis-exporter => (version: "5.1.0", path: ".")
------------------------------------------------------------------------------------------------------------------------

Linting chart 'prometheus-redis-exporter => (version: "5.1.0", path: ".")'
Validating /<redacted>/helm-charts/charts/prometheus-redis-exporter/Chart.yaml...
Validation success! 👍
Validating maintainers...
==> Linting .
[INFO] Chart.yaml: icon is recommended
[WARNING] templates/podsecuritypolicy.yaml: policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+

1 chart(s) linted, 0 chart(s) failed
------------------------------------------------------------------------------------------------------------------------
 ✔︎ prometheus-redis-exporter => (version: "5.1.0", path: ".")
------------------------------------------------------------------------------------------------------------------------
All charts linted successfully
```