### PR TITLE
[kube-prometheus-stack] SecurityContext for webhook job create/patch container

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -22,7 +22,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 39.9.0
+version: 39.9.1
 appVersion: 0.58.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -22,7 +22,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 39.9.1
+version: 39.11.0
 appVersion: 0.58.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-createSecret.yaml
@@ -42,6 +42,10 @@ spec:
             - --host={{ template "kube-prometheus-stack.operator.fullname" . }},{{ template "kube-prometheus-stack.operator.fullname" . }}.{{ template "kube-prometheus-stack.namespace" . }}.svc
             - --namespace={{ template "kube-prometheus-stack.namespace" . }}
             - --secret-name={{ template "kube-prometheus-stack.fullname" . }}-admission
+          {{- if .Values.controller.admissionWebhooks.createWebhookJob.securityContext }}
+          securityContext:
+{{ toYaml .Values.controller.admissionWebhooks.createWebhookJob.securityContext | nindent 12 }}
+          {{- end }}
           resources:
 {{ toYaml .Values.prometheusOperator.admissionWebhooks.patch.resources | indent 12 }}
       restartPolicy: OnFailure

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-createSecret.yaml
@@ -42,7 +42,7 @@ spec:
             - --host={{ template "kube-prometheus-stack.operator.fullname" . }},{{ template "kube-prometheus-stack.operator.fullname" . }}.{{ template "kube-prometheus-stack.namespace" . }}.svc
             - --namespace={{ template "kube-prometheus-stack.namespace" . }}
             - --secret-name={{ template "kube-prometheus-stack.fullname" . }}-admission
-          {{- with .Values.controller.admissionWebhooks.createWebhookJob }}
+          {{- with .Values.prometheusOperator.admissionWebhooks.createSecretJob }}
           securityContext:
           {{ toYaml .securityContext | nindent 12 }}
           {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-createSecret.yaml
@@ -42,9 +42,9 @@ spec:
             - --host={{ template "kube-prometheus-stack.operator.fullname" . }},{{ template "kube-prometheus-stack.operator.fullname" . }}.{{ template "kube-prometheus-stack.namespace" . }}.svc
             - --namespace={{ template "kube-prometheus-stack.namespace" . }}
             - --secret-name={{ template "kube-prometheus-stack.fullname" . }}-admission
-          {{- if .Values.controller.admissionWebhooks.createWebhookJob.securityContext }}
+          {{- with .Values.controller.admissionWebhooks.createWebhookJob.securityContext }}
           securityContext:
-{{ toYaml .Values.controller.admissionWebhooks.createWebhookJob.securityContext | nindent 12 }}
+          {{ toYaml . | nindent 12 }}
           {{- end }}
           resources:
 {{ toYaml .Values.prometheusOperator.admissionWebhooks.patch.resources | indent 12 }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-createSecret.yaml
@@ -42,9 +42,9 @@ spec:
             - --host={{ template "kube-prometheus-stack.operator.fullname" . }},{{ template "kube-prometheus-stack.operator.fullname" . }}.{{ template "kube-prometheus-stack.namespace" . }}.svc
             - --namespace={{ template "kube-prometheus-stack.namespace" . }}
             - --secret-name={{ template "kube-prometheus-stack.fullname" . }}-admission
-          {{- with .Values.controller.admissionWebhooks.createWebhookJob.securityContext }}
+          {{- with .Values.controller.admissionWebhooks.createWebhookJob }}
           securityContext:
-          {{ toYaml . | nindent 12 }}
+          {{ toYaml .securityContext | nindent 12 }}
           {{- end }}
           resources:
 {{ toYaml .Values.prometheusOperator.admissionWebhooks.patch.resources | indent 12 }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -43,6 +43,10 @@ spec:
             - --namespace={{ template "kube-prometheus-stack.namespace" . }}
             - --secret-name={{ template "kube-prometheus-stack.fullname" . }}-admission
             - --patch-failure-policy={{ .Values.prometheusOperator.admissionWebhooks.failurePolicy }}
+          {{- if .Values.controller.admissionWebhooks.patchWebhookJob.securityContext }}
+          securityContext:
+{{ toYaml .Values.controller.admissionWebhooks.patchWebhookJob.securityContext | nindent 12 }}
+          {{- end }}
           resources:
 {{ toYaml .Values.prometheusOperator.admissionWebhooks.patch.resources | indent 12 }}
       restartPolicy: OnFailure

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -43,7 +43,7 @@ spec:
             - --namespace={{ template "kube-prometheus-stack.namespace" . }}
             - --secret-name={{ template "kube-prometheus-stack.fullname" . }}-admission
             - --patch-failure-policy={{ .Values.prometheusOperator.admissionWebhooks.failurePolicy }}
-          {{- with .Values.controller.admissionWebhooks.patchWebhookJob }}
+          {{- with .Values.prometheusOperator.admissionWebhooks.patchWebhookJob }}
           securityContext:
           {{ toYaml .securityContext | nindent 12 }}
           {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -43,9 +43,9 @@ spec:
             - --namespace={{ template "kube-prometheus-stack.namespace" . }}
             - --secret-name={{ template "kube-prometheus-stack.fullname" . }}-admission
             - --patch-failure-policy={{ .Values.prometheusOperator.admissionWebhooks.failurePolicy }}
-          {{- with .Values.controller.admissionWebhooks.patchWebhookJob.securityContext }}
+          {{- with .Values.controller.admissionWebhooks.patchWebhookJob }}
           securityContext:
-          {{ toYaml . | nindent 12 }}
+          {{ toYaml .securityContext | nindent 12 }}
           {{- end }}
           resources:
 {{ toYaml .Values.prometheusOperator.admissionWebhooks.patch.resources | indent 12 }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -43,9 +43,9 @@ spec:
             - --namespace={{ template "kube-prometheus-stack.namespace" . }}
             - --secret-name={{ template "kube-prometheus-stack.fullname" . }}-admission
             - --patch-failure-policy={{ .Values.prometheusOperator.admissionWebhooks.failurePolicy }}
-          {{- if .Values.controller.admissionWebhooks.patchWebhookJob.securityContext }}
+          {{- with .Values.controller.admissionWebhooks.patchWebhookJob.securityContext }}
           securityContext:
-{{ toYaml .Values.controller.admissionWebhooks.patchWebhookJob.securityContext | nindent 12 }}
+          {{ toYaml . | nindent 12 }}
           {{- end }}
           resources:
 {{ toYaml .Values.prometheusOperator.admissionWebhooks.patch.resources | indent 12 }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1643,7 +1643,6 @@ prometheusOperator:
         tag: v1.2.0
         sha: ""
         pullPolicy: IfNotPresent
-
       resources: {}
       ## Provide a priority class name to the webhook patching job
       ##
@@ -1661,7 +1660,6 @@ prometheusOperator:
         runAsGroup: 2000
         runAsNonRoot: true
         runAsUser: 2000
-
 
     # Security context for create job container
     createSecretJob:

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1613,6 +1613,15 @@ prometheusOperator:
         tag: v1.2.0
         sha: ""
         pullPolicy: IfNotPresent
+
+      # Security context for create job container
+      createSecretJob:
+        securityContext: {}
+
+        # Security context for patch job container
+      patchWebhookJob:
+        securityContext: {}
+
       resources: {}
       ## Provide a priority class name to the webhook patching job
       ##

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -703,6 +703,14 @@ grafana:
   enabled: true
   namespaceOverride: ""
 
+  ## Image and version of grafana. If not provided (left commented out) default values from grafana charts will be used.
+  ##
+  # image:
+  #   repository: docker.io/grafana/grafana
+  #   tag: 9.0.6
+  #   sha: ""
+  #   pullPolicy: IfNotPresent
+
   ## ForceDeployDatasources Create datasource configmap even if grafana deployment has been disabled
   ##
   forceDeployDatasources: false
@@ -766,6 +774,13 @@ grafana:
     #   - grafana.example.com
 
   sidecar:
+    ## Image and version of sidecar. If not provided (left commented out) default values from grafana charts will be used.
+    ##
+    # image:
+    #   repository: quay.io/kiwigrid/k8s-sidecar
+    #   tag: 1.19.2
+    #   sha: ""
+
     dashboards:
       enabled: true
       label: grafana_dashboard
@@ -1471,6 +1486,14 @@ kubeStateMetrics:
 ## Configuration for kube-state-metrics subchart
 ##
 kube-state-metrics:
+  ##
+  ##
+  # image:
+  #  repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
+  #  tag: v2.5.0
+  #  sha: ""
+  #  pullPolicy: IfNotPresent
+
   namespaceOverride: ""
   rbac:
     create: true
@@ -1525,6 +1548,13 @@ nodeExporter:
 ## Configuration for prometheus-node-exporter subchart
 ##
 prometheus-node-exporter:
+  ## Image and version of prometheus-node-exporter. If not provided (left commented out) default values from grafana charts will be used.
+  ##
+  # image:
+  #   repository: quay.io/prometheus/node-exporter
+  #   tag: v1.3.1
+  #   pullPolicy: IfNotPresent
+
   namespaceOverride: ""
   podLabels:
     ## Add the 'node-exporter' label to be used by serviceMonitor to match standard common usage in rules and grafana dashboards

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1644,14 +1644,6 @@ prometheusOperator:
         sha: ""
         pullPolicy: IfNotPresent
 
-      # Security context for create job container
-      createSecretJob:
-        securityContext: {}
-
-        # Security context for patch job container
-      patchWebhookJob:
-        securityContext: {}
-
       resources: {}
       ## Provide a priority class name to the webhook patching job
       ##
@@ -1669,6 +1661,15 @@ prometheusOperator:
         runAsGroup: 2000
         runAsNonRoot: true
         runAsUser: 2000
+
+
+    # Security context for create job container
+    createSecretJob:
+      securityContext: {}
+
+      # Security context for patch job container
+    patchWebhookJob:
+      securityContext: {}
 
     # Use certmanager to generate webhook certs
     certManager:


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Stumbled in to this when working with kyverno and enforced strict policies.

Kyverno and using strict policy configuration, job create for `ingress-nginx-admission-create` fails with policies `require-drop-all`and `disallow-privilege-escalation`. 

Adding the ability to configure containers in webhooks create and patch from helm values.

> k describe job monitoring-kube-prometheus-admission-patch
```
resource Pod/my-namespace/monitoring-kube-prometheus-admission-patch-njdkq was blocked due to the following policies

disallow-capabilities-strict:
  require-drop-all: 'validation failure: Containers must drop `ALL` capabilities.'
disallow-privilege-escalation:
  privilege-escalation: 'validation error: Privilege escalation is disallowed. The
    fields spec.containers[*].securityContext.allowPrivilegeEscalation, spec.initContainers[*].securityContext.allowPrivilegeEscalation,
    and spec.ephemeralContainers[*].securityContext.allowPrivilegeEscalation must
    be set to `false`. Rule privilege-escalation failed at path /spec/containers/0/securityContext/'
```

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
