### PR TITLE
[prometheus-node-exporter] custom servicemonitor apiversion

### DIFF
--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - prometheus
   - exporter
 type: application
-version: 4.2.1
+version: 4.3.0
 appVersion: 1.3.1
 home: https://github.com/prometheus/node_exporter/
 sources:

--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - prometheus
   - exporter
 type: application
-version: 4.0.0
+version: 4.1.0
 appVersion: 1.3.1
 home: https://github.com/prometheus/node_exporter/
 sources:

--- a/charts/prometheus-node-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-node-exporter/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.prometheus.monitor.enabled }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: {{ .Values.prometheus.monitor.apiVersion | default "monitoring.coreos.com/v1" }}
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-node-exporter.fullname" . }}

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -51,6 +51,8 @@ prometheus:
     metricRelabelings: []
     interval: ""
     scrapeTimeout: 10s
+    ## prometheus.monitor.apiVersion ApiVersion for the serviceMonitor Resource(defaults to "monitoring.coreos.com/v1")
+    apiVersion: ""
 
 ## Customize the updateStrategy if set
 updateStrategy:


### PR DESCRIPTION
Signed-off-by: lusson <lusson@foxmail.com>

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Add values prometheus.monitor.apiVersion to modify serviceMonitor api.
To meet the needs of modifying the apiversion of serviceMonitor to access the monitoring platforms of some cloud manufacturers.

#### Which issue this PR fixes

no

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
