### PR TITLE
[kube-prometheus-stack] Fix variable WalCompression

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -22,7 +22,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 39.13.0
+version: 39.13.1
 appVersion: 0.58.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -112,8 +112,10 @@ spec:
 {{- if .Values.prometheus.prometheusSpec.retentionSize }}
   retentionSize: {{ .Values.prometheus.prometheusSpec.retentionSize | quote }}
 {{- end }}
-{{- if .Values.prometheus.prometheusSpec.walCompression }}
-  walCompression: {{ .Values.prometheus.prometheusSpec.walCompression }}
+{{- if eq .Values.prometheus.prometheusSpec.walCompression false }}
+  walCompression: false
+{{ else }}
+  walCompression: true
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.routePrefix }}
   routePrefix: {{ .Values.prometheus.prometheusSpec.routePrefix | quote  }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -2538,7 +2538,7 @@ prometheus:
 
     ## Enable compression of the write-ahead log using Snappy.
     ##
-    walCompression: false
+    walCompression: true
 
     ## If true, the Operator won't process any Prometheus configuration changes
     ##


### PR DESCRIPTION
Signed-off-by: Zemtsov Vladimir <vl.zemtsov@gmail.com>

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
`walCompression` - bool variable
In helm construction:
```
{{- if .Values.prometheus.prometheusSpec.walCompression }}
  walCompression: {{ .Values.prometheus.prometheusSpec.walCompression }}
{{- end }}
```
If walCompression = true, in CRD Prometheus added:
```
walCompression: true
```
if walCompression = false, IF in helm don't add walCompression field to CRD, and Prometheus used default - TRUE

Doesn't matter what you set to `walCompression` variable in helm, WalCompression always be enable in Prometheus.

I fix it.


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
