### PR TITLE
[kube-state-metrics] Update deployment.yaml, fix selfMonitor port

### DIFF
--- a/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/kube-state-metrics/templates/deployment.yaml
@@ -92,7 +92,9 @@ spec:
         {{- if .Values.selfMonitor.telemetryHost }}
         - --telemetry-host={{ .Values.selfMonitor.telemetryHost }}
         {{- end }}
+        {{- if .Values.selfMonitor.telemetryPort }}
         - --telemetry-port={{ .Values.selfMonitor.telemetryPort | default 8081 }}
+        {{- end }}
         {{- if or (.Values.kubeconfig.enabled) (.Values.volumeMounts) }}
         volumeMounts:
         {{- if .Values.kubeconfig.enabled }}


### PR DESCRIPTION
Signed-off-by: Zhaojun Li <zhaojun.li@hotmail.com>

#### What this PR does / why we need it

fix selfMonitor port

#### Special notes for your reviewer

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
