### PR TITLE
[kube-state-metrics] Bump kube-state-metrics version

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,8 +7,8 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 4.17.0
-appVersion: 2.5.0
+version: 4.18.0
+appVersion: 2.6.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:
 - https://github.com/kubernetes/kube-state-metrics/

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -2,7 +2,7 @@
 prometheusScrape: true
 image:
   repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
-  tag: v2.5.0
+  tag: v2.6.0
   sha: ""
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
#### What this PR does / why we need it

Bumps the version of the referenced kube-state-metrics image to the latest released version v2.6.0.

#### Which issue this PR fixes

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
