### PR TITLE
[prometheus-node-exporter] Add sidecarHostVolumeMounts

### DIFF
--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - prometheus
   - exporter
 type: application
-version: 4.0.0
+version: 4.1.0
 appVersion: 1.3.1
 home: https://github.com/prometheus/node_exporter/
 sources:

--- a/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -146,7 +146,7 @@ spec:
             {{- end }}
 {{- if .Values.sidecars }}
 {{ toYaml .Values.sidecars | indent 8 }}
-          {{- if or (.Values.sidecarVolumeMount)(.Values.sidecarHostVolumeMounts)}}
+          {{- if or .Values.sidecarVolumeMount .Values.sidecarHostVolumeMounts }}
           volumeMounts:
             {{- range $_, $mount := .Values.sidecarVolumeMount }}
             - name: {{ $mount.name }}

--- a/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -146,12 +146,20 @@ spec:
             {{- end }}
 {{- if .Values.sidecars }}
 {{ toYaml .Values.sidecars | indent 8 }}
-          {{- if .Values.sidecarVolumeMount }}
+          {{- if or (.Values.sidecarVolumeMount)(.Values.sidecarHostVolumeMounts)}}
           volumeMounts:
             {{- range $_, $mount := .Values.sidecarVolumeMount }}
             - name: {{ $mount.name }}
               mountPath: {{ $mount.mountPath }}
               readOnly: {{ $mount.readOnly }}
+            {{- end }}
+            {{- range $_, $mount := .Values.sidecarHostVolumeMounts }}
+            - name: {{ $mount.name }}
+              mountPath: {{ $mount.mountPath }}
+              readOnly: {{ $mount.readOnly }}
+            {{- if $mount.mountPropagation }}
+              mountPropagation: {{ $mount.mountPropagation }}
+            {{- end }}
             {{- end }}
           {{- end }}
 {{- end }}
@@ -201,6 +209,13 @@ spec:
         - name: {{ $mount.name }}
           emptyDir:
             medium: Memory
+        {{- end }}
+        {{- end }}
+        {{- if .Values.sidecarHostVolumeMounts }}
+        {{- range $_, $mount := .Values.sidecarHostVolumeMounts }}
+        - name: {{ $mount.name }}
+          hostPath:
+            path: {{ $mount.hostPath }}
         {{- end }}
         {{- end }}
         {{- if .Values.configmaps }}

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -171,7 +171,7 @@ extraArgs: []
 #   - --collector.diskstats.ignored-devices=^(ram|loop|fd|(h|s|v)d[a-z]|nvme\\d+n\\d+p)\\d+$
 #   - --collector.textfile.directory=/run/prometheus
 
-## Additional mounts from the host
+## Additional mounts from the host to node-exporter container
 ##
 extraHostVolumeMounts: []
 #  - name: <mountName>
@@ -204,6 +204,15 @@ sidecarVolumeMount: []
 ##  - name: collector-textfiles
 ##    mountPath: /run/prometheus
 ##    readOnly: false
+
+## Additional mounts from the host to sidecar containers
+##
+sidecarHostVolumeMounts: []
+#  - name: <mountName>
+#    hostPath: <hostPath>
+#    mountPath: <mountPath>
+#    readOnly: true|false
+#    mountPropagation: None|HostToContainer|Bidirectional
 
 ## Additional InitContainers to initialize the pod
 ##


### PR DESCRIPTION
Signed-off-by: Kevin Huang <git@kevin.huang.to>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

To export the disk's SMART status using a sidecar attached to node-exporter, we would like to mount the /dev from the node to the sidecar in read-only.

To do so, we add a `sidecarHostVolumeMounts` value, that works similarly to `extraHostVolumeMounts`.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
