### PR TITLE
[prometheus] Automatically set "dnsPolicy" to "ClusterFirstWithHostNet" when using "hostNetwork"

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.36.2
-version: 15.12.0
+version: 15.12.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/templates/server/deploy.yaml
+++ b/charts/prometheus/templates/server/deploy.yaml
@@ -230,8 +230,10 @@ spec:
           {{- end }}
         {{- end }}
       {{- end }}
-      hostNetwork: {{ .Values.server.hostNetwork }}
-    {{- if .Values.server.dnsPolicy }}
+    {{- if .Values.server.hostNetwork }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+    {{- else }}
       dnsPolicy: {{ .Values.server.dnsPolicy }}
     {{- end }}
     {{- if .Values.imagePullSecrets }}

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -1069,7 +1069,7 @@ server:
   ##
   hostNetwork: false
 
-  # When hostNetwork is enabled, you probably want to set this to ClusterFirstWithHostNet
+  # When hostNetwork is enabled, this will set to ClusterFirstWithHostNet automatically
   dnsPolicy: ClusterFirst
 
   # Use hostPort


### PR DESCRIPTION
#### What this PR does / why we need it

Automatically set "dnsPolicy" to "ClusterFirstWithHostNet" when using "hostNetwork"



Signed-off-by: Pratik Raj <rajpratik71@gmail.com>

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
