### PR TITLE
[prometheus] fix double securityContext for server-container in prometheus-deployment

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.36.2
-version: 15.12.0
+version: 15.12.2
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/templates/server/deploy.yaml
+++ b/charts/prometheus/templates/server/deploy.yaml
@@ -88,8 +88,6 @@ spec:
         - name: {{ template "prometheus.name" . }}-{{ .Values.server.name }}
           image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
           imagePullPolicy: "{{ .Values.server.image.pullPolicy }}"
-          securityContext:
-            {{- toYaml .Values.server.containerSecurityContext | nindent 12 }}
           {{- if .Values.server.env }}
           env:
 {{ toYaml .Values.server.env | indent 12}}

--- a/charts/prometheus/templates/server/deploy.yaml
+++ b/charts/prometheus/templates/server/deploy.yaml
@@ -214,9 +214,9 @@ spec:
           {{- if .Values.server.extraVolumeMounts }}
             {{ toYaml .Values.server.extraVolumeMounts | nindent 12 }}
           {{- end }}
-          {{- if .Values.server.containerSecurityContext }}
+          {{- with .Values.server.containerSecurityContext }}
           securityContext:
-            {{- toYaml .Values.server.containerSecurityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
       {{- if .Values.server.sidecarContainers }}
         {{- range $name, $spec :=  .Values.server.sidecarContainers }}

--- a/charts/prometheus/templates/server/sts.yaml
+++ b/charts/prometheus/templates/server/sts.yaml
@@ -192,9 +192,9 @@ spec:
           {{- if .Values.server.extraVolumeMounts }}
           {{ toYaml .Values.server.extraVolumeMounts | nindent 12 }}
           {{- end }}
-          {{- if .Values.server.containerSecurityContext }}
+          {{- with .Values.server.containerSecurityContext }}
           securityContext:
-            {{- toYaml .Values.server.containerSecurityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
     {{- if .Values.server.sidecarContainers }}
       {{- range $name, $spec :=  .Values.server.sidecarContainers }}

--- a/charts/prometheus/templates/server/sts.yaml
+++ b/charts/prometheus/templates/server/sts.yaml
@@ -88,8 +88,6 @@ spec:
         - name: {{ template "prometheus.name" . }}-{{ .Values.server.name }}
           image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
           imagePullPolicy: "{{ .Values.server.image.pullPolicy }}"
-          securityContext:
-            {{- toYaml .Values.server.containerSecurityContext | nindent 12 }}
           {{- if .Values.server.env }}
           env:
 {{ toYaml .Values.server.env | indent 12}}
@@ -193,6 +191,10 @@ spec:
           {{- end }}
           {{- if .Values.server.extraVolumeMounts }}
           {{ toYaml .Values.server.extraVolumeMounts | nindent 12 }}
+          {{- end }}
+          {{- if .Values.server.containerSecurityContext }}
+          securityContext:
+            {{- toYaml .Values.server.containerSecurityContext | nindent 12 }}
           {{- end }}
     {{- if .Values.server.sidecarContainers }}
       {{- range $name, $spec :=  .Values.server.sidecarContainers }}


### PR DESCRIPTION
If you set `server.containerSecurityContext` (when `kind: Deployment`) helm-install fails with the following error

```
error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:
        line 95: mapping key "securityContext" already defined at line 49
```

Apparently by some changes earlier this year `securityContext` gets set twice for the server-container.

This PR removes one of them and also aligns a similar section in `kind: StatefulSet` to look the same as in the deployment.