### PR TITLE
[kube-prometheus-stack] bump grafana 6.38.0 (9.1.4)

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 3.3.1
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.37.3
-digest: sha256:1db99e2752cc271323cf886c3ea14105f3aec0883ec67e944533f6246870d15c
-generated: "2022-09-11T15:48:48.5400618+03:00"
+  version: 6.38.0
+digest: sha256:1e01e98175d27e49834a47b0496d6e4b22d051da907e26eec2b8e7acb3189d6f
+generated: "2022-09-13T10:18:40.298886+02:00"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -22,7 +22,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 39.12.1
+version: 39.13.0
 appVersion: 0.58.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus
@@ -48,6 +48,6 @@ dependencies:
     repository: https://prometheus-community.github.io/helm-charts
     condition: nodeExporter.enabled
   - name: grafana
-    version: "6.37.*"
+    version: "6.38.*"
     repository: https://grafana.github.io/helm-charts
     condition: grafana.enabled


### PR DESCRIPTION
Updated grafana to helm version 6.38.0 and app version 9.1.4

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
