### PR TITLE
[prometheus-pushgateway] update notes.txt notify port

### DIFF
--- a/charts/prometheus-pushgateway/Chart.yaml
+++ b/charts/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.4.2"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 1.18.2
+version: 1.18.3
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/charts/prometheus-pushgateway/templates/NOTES.txt
+++ b/charts/prometheus-pushgateway/templates/NOTES.txt
@@ -14,6 +14,6 @@
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "prometheus-pushgateway.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:80
+  echo "Visit http://127.0.0.1:9091 to use your application"
+  kubectl port-forward $POD_NAME 9091:80
 {{- end }}

--- a/charts/prometheus-pushgateway/templates/NOTES.txt
+++ b/charts/prometheus-pushgateway/templates/NOTES.txt
@@ -15,5 +15,5 @@
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "prometheus-pushgateway.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:9091 to use your application"
-  kubectl port-forward $POD_NAME 9091:80
+  kubectl port-forward $POD_NAME 9091
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it

prometheus-pushgateway pod port is 9091, but install notify is 8080. i update to real port 9091.

#### Which issue this PR fixes


#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
