### PR TITLE
[prometheus-blackbox-exporter] Add selfMonitor support

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 7.0.1
+version: 7.1.0
 appVersion: 0.22.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/charts/prometheus-blackbox-exporter/templates/selfservicemonitor.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/selfservicemonitor.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.serviceMonitor.selfMonitor }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "prometheus-blackbox-exporter.fullname" $ }}
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" $ }}
+  labels:
+    {{- include "prometheus-blackbox-exporter.labels" $ | nindent 4 }}
+    {{- if or $.Values.serviceMonitor.selfMonitorDefaults.labels .labels }}
+    {{- toYaml (.labels | default $.Values.serviceMonitor.selfMonitorDefaults.labels) | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+  - path: /metrics
+    interval: {{ .interval | default $.Values.serviceMonitor.selfMonitorDefaults.interval }}
+    scrapeTimeout: {{ .scrapeTimeout | default $.Values.serviceMonitor.selfMonitorDefaults.scrapeTimeout }}
+    scheme: http
+    relabelings:
+{{- if concat (.additionalRelabeling | default list) $.Values.serviceMonitor.selfMonitorDefaults.additionalRelabeling }}
+{{ toYaml (concat (.additionalRelabeling | default list) $.Values.serviceMonitor.selfMonitorDefaults.additionalRelabeling) | indent 6 }}
+{{- end }}
+  jobLabel: "{{ $.Release.Name }}"
+  selector:
+    matchLabels:
+      {{- include "prometheus-blackbox-exporter.selectorLabels" $ | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ template "prometheus-blackbox-exporter.namespace" $ }}
+{{- end}}

--- a/charts/prometheus-blackbox-exporter/templates/selfservicemonitor.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/selfservicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceMonitor.selfMonitor }}
+{{- if .Values.serviceMonitor.selfMonitor.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -7,18 +7,18 @@ metadata:
   namespace: {{ template "prometheus-blackbox-exporter.namespace" $ }}
   labels:
     {{- include "prometheus-blackbox-exporter.labels" $ | nindent 4 }}
-    {{- if or $.Values.serviceMonitor.selfMonitorDefaults.labels .labels }}
-    {{- toYaml (.labels | default $.Values.serviceMonitor.selfMonitorDefaults.labels) | nindent 4 }}
+    {{- if or $.Values.serviceMonitor.selfMonitor.labels .labels }}
+    {{- toYaml (.labels | default $.Values.serviceMonitor.selfMonitor.labels) | nindent 4 }}
     {{- end }}
 spec:
   endpoints:
   - path: /metrics
-    interval: {{ .interval | default $.Values.serviceMonitor.selfMonitorDefaults.interval }}
-    scrapeTimeout: {{ .scrapeTimeout | default $.Values.serviceMonitor.selfMonitorDefaults.scrapeTimeout }}
+    interval: {{ .interval | default $.Values.serviceMonitor.selfMonitor.interval }}
+    scrapeTimeout: {{ .scrapeTimeout | default $.Values.serviceMonitor.selfMonitor.scrapeTimeout }}
     scheme: http
     relabelings:
-{{- if concat (.additionalRelabeling | default list) $.Values.serviceMonitor.selfMonitorDefaults.additionalRelabeling }}
-{{ toYaml (concat (.additionalRelabeling | default list) $.Values.serviceMonitor.selfMonitorDefaults.additionalRelabeling) | indent 6 }}
+{{- if concat (.additionalRelabeling | default list) $.Values.serviceMonitor.selfMonitor.additionalRelabeling }}
+{{ toYaml (concat (.additionalRelabeling | default list) $.Values.serviceMonitor.selfMonitor.additionalRelabeling) | indent 6 }}
 {{- end }}
   jobLabel: "{{ $.Release.Name }}"
   selector:

--- a/charts/prometheus-blackbox-exporter/templates/selfservicemonitor.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/selfservicemonitor.yaml
@@ -27,4 +27,4 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ template "prometheus-blackbox-exporter.namespace" $ }}
-{{- end}}
+{{- end }}

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -213,7 +213,7 @@ extraArgs: []
 replicas: 1
 
 serviceMonitor:
-  ## If true, a ServiceMonitor CRD is created for a prometheus operator 
+  ## If true, a ServiceMonitor CRD is created for a prometheus operator
   ## https://github.com/coreos/prometheus-operator for blackbox-exporter itself
   ##
   selfMonitor:
@@ -224,7 +224,7 @@ serviceMonitor:
     interval: 30s
     scrapeTimeout: 30s
 
-  ## If true, a ServiceMonitor CRD is created for a prometheus operator 
+  ## If true, a ServiceMonitor CRD is created for a prometheus operator
   ## https://github.com/coreos/prometheus-operator for each target
   ##
   enabled: false

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -213,8 +213,21 @@ extraArgs: []
 replicas: 1
 
 serviceMonitor:
-  ## If true, a ServiceMonitor CRD is created for a prometheus operator
-  ## https://github.com/coreos/prometheus-operator
+  ## If true, a ServiceMonitor CRD is created for a prometheus operator 
+  ## https://github.com/coreos/prometheus-operator for blackbox-exporter itself
+  ##
+  selfMonitor: false
+
+  # Default values that will be used for ServiceMonitor
+  selfMonitorDefaults:
+    additionalMetricsRelabels: {}
+    additionalRelabeling: []
+    labels: {}
+    interval: 30s
+    scrapeTimeout: 30s
+
+  ## If true, a ServiceMonitor CRD is created for a prometheus operator 
+  ## https://github.com/coreos/prometheus-operator for each target
   ##
   enabled: false
 

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -216,10 +216,8 @@ serviceMonitor:
   ## If true, a ServiceMonitor CRD is created for a prometheus operator 
   ## https://github.com/coreos/prometheus-operator for blackbox-exporter itself
   ##
-  selfMonitor: false
-
-  # Default values that will be used for ServiceMonitor
-  selfMonitorDefaults:
+  selfMonitor:
+    enabled: false
     additionalMetricsRelabels: {}
     additionalRelabeling: []
     labels: {}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

#### Which issue this PR fixes

Now if you deploy blackbox-exporter via this chart it will not create ServiceMonitor for itself, only for targets. This PR provides the ability to do it by overriding variables and enabling selfMonitor, similar to what kube-prometheus-stack chart does for alert-manager for example https://github.com/prometheus-community/helm-charts/blob/63a64f62d19f2c505a5139e91dc544ad1891273e/charts/kube-prometheus-stack/values.yaml#L405-L409 The problem was originally raised in #1936

#### Special notes for your reviewer
Not sure about value structure and formatting, open to suggestions
#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
