### PR TITLE
[prometheus-pushgateway] - Add extra init containers for pushgateway helm chart

### DIFF
--- a/charts/prometheus-pushgateway/Chart.yaml
+++ b/charts/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.4.2"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 1.19.1
+version: 1.20.0
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/charts/prometheus-pushgateway/templates/_helpers.tpl
+++ b/charts/prometheus-pushgateway/templates/_helpers.tpl
@@ -78,8 +78,7 @@ Returns pod spec
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
     {{- end }}
       {{- if .Values.extraInitContainers }}
-      initContainers:
-{{ toYaml .Values.extraInitContainers | indent 8 }}      
+      initContainers:{{ toYaml .Values.extraInitContainers | nindent 8 }}      
       {{- end }}
       containers:
         {{- if .Values.extraContainers }}

--- a/charts/prometheus-pushgateway/templates/_helpers.tpl
+++ b/charts/prometheus-pushgateway/templates/_helpers.tpl
@@ -78,7 +78,8 @@ Returns pod spec
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
     {{- end }}
       {{- if .Values.extraInitContainers }}
-      initContainers:{{ toYaml .Values.extraInitContainers | nindent 8 }}      
+      initContainers:
+        {{ toYaml .Values.extraInitContainers | nindent 8 }}      
       {{- end }}
       containers:
         {{- if .Values.extraContainers }}

--- a/charts/prometheus-pushgateway/templates/_helpers.tpl
+++ b/charts/prometheus-pushgateway/templates/_helpers.tpl
@@ -77,6 +77,10 @@ Returns pod spec
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
     {{- end }}
+      {{- if .Values.extraInitContainers }}
+      initContainers:
+{{ toYaml .Values.extraInitContainers | indent 8 }}      
+      {{- end }}
       containers:
         {{- if .Values.extraContainers }}
 {{ toYaml .Values.extraContainers | indent 8 }}

--- a/charts/prometheus-pushgateway/values.yaml
+++ b/charts/prometheus-pushgateway/values.yaml
@@ -56,6 +56,10 @@ extraVars: []
 ##  - --persistence.interval=5m
 extraArgs: []
 
+## Additional InitContainers to initialize the pod
+##
+extraInitContainers: []
+
 # Optional additional containers (sidecar)
 extraContainers: []
   # - name: oAuth2-proxy


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
This PR adds the ability for specifying init containers for the pushgateway helm chart.  We intend to use this to allow creating a DNS record pointing at our podIP to allow external consumers to use pushgateway without needing the cost of a ingress loadbalancer
#### Which issue this PR fixes
N/A
#### Special notes for your reviewer
This change was basically lifted directly from prometheus-blackbox-exporter as it has that support.
Testing output of pod with init container specified
```
Name:         test-pushgateway-prometheus-pushgateway-7fb84dc66f-j2qsq
Namespace:    do2
Priority:     0
Node:         ip-10-31-229-39.ca-central-1.compute.internal/10.31.229.39
Start Time:   Thu, 22 Sep 2022 09:24:41 -0600
Labels:       app=prometheus-pushgateway
              chart=prometheus-pushgateway-1.18.4
              heritage=Helm
              pod-template-hash=7fb84dc66f
              release=test-pushgateway
Annotations:  kubernetes.io/psp: eks.privileged
Status:       Running
IP:           10.31.233.82
IPs:
  IP:           10.31.233.82
Controlled By:  ReplicaSet/test-pushgateway-prometheus-pushgateway-7fb84dc66f
Init Containers:
  hello:
    Container ID:  containerd://14587246ce46ee41bcdf04577fcf0e604a815fd036c06b4ceb63bbd140275382
    Image:         alpine:3
    Image ID:      docker.io/library/alpine@sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2ad
    Port:          <none>
    Host Port:     <none>
    Args:
      echo
      Done
    State:          Terminated
      Reason:       Completed
      Exit Code:    0
      Started:      Thu, 22 Sep 2022 09:24:42 -0600
      Finished:     Thu, 22 Sep 2022 09:24:42 -0600
    Ready:          True
    Restart Count:  0
    Environment:    <none>
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-ll7ps (ro)
Containers:
  pushgateway:
    Container ID:   containerd://d9d36ed1d4c73fb7a2eb8f9323c0ce5f2be8a2da390edf37df5e06b1f662e17f
    Image:          prom/pushgateway:v1.4.2
    Image ID:       docker.io/prom/pushgateway@sha256:a684e7c830a4b19e564a93bfc3bf713e85b04ab9dfcab5633c14cbba241f9231
    Port:           9091/TCP
    Host Port:      0/TCP
    State:          Running
      Started:      Thu, 22 Sep 2022 09:24:45 -0600
    Ready:          True
    Restart Count:  0
    Liveness:       http-get http://:9091/-/ready delay=10s timeout=10s period=10s #success=1 #failure=3
    Readiness:      http-get http://:9091/-/ready delay=10s timeout=10s period=10s #success=1 #failure=3
    Environment:    <none>
    Mounts:
      /data from storage-volume (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-ll7ps (ro)
Conditions:
  Type              Status
  Initialized       True
  Ready             True
  ContainersReady   True
  PodScheduled      True
Volumes:
  storage-volume:
    Type:       EmptyDir (a temporary directory that shares a pod's lifetime)
    Medium:
    SizeLimit:  <unset>
  kube-api-access-ll7ps:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
QoS Class:                   BestEffort
Node-Selectors:              <none>
Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type    Reason     Age   From               Message
  ----    ------     ----  ----               -------
  Normal  Scheduled  38s   default-scheduler  Successfully assigned do2/test-pushgateway-prometheus-pushgateway-7fb84dc66f-j2qsq to ip-10-31-229-39.ca-central-1.compute.internal
  Normal  Pulling    37s   kubelet            Pulling image "alpine:3"
  Normal  Pulled     37s   kubelet            Successfully pulled image "alpine:3" in 248.134657ms
  Normal  Created    37s   kubelet            Created container hello
  Normal  Started    37s   kubelet            Started container hello
  Normal  Pulling    36s   kubelet            Pulling image "prom/pushgateway:v1.4.2"
  Normal  Pulled     34s   kubelet            Successfully pulled image "prom/pushgateway:v1.4.2" in 1.794044824s
  Normal  Created    34s   kubelet            Created container pushgateway
  Normal  Started    34s   kubelet            Started container pushgateway
```
#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
