### PR TITLE
[prometheus-pushgateway] Add topologySpreadConstraints

### DIFF
--- a/charts/prometheus-pushgateway/Chart.yaml
+++ b/charts/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.4.2"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 1.18.3
+version: 1.19.0
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/charts/prometheus-pushgateway/templates/_helpers.tpl
+++ b/charts/prometheus-pushgateway/templates/_helpers.tpl
@@ -129,6 +129,10 @@ Returns pod spec
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}
     {{- end }}
+    {{- if .Values.topologySpreadConstraints }}
+      affinity:
+{{ toYaml .Values.topologySpreadConstraints | indent 8 }}
+    {{- end }}
     {{- if .Values.securityContext }}
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}

--- a/charts/prometheus-pushgateway/values.yaml
+++ b/charts/prometheus-pushgateway/values.yaml
@@ -184,6 +184,10 @@ containerSecurityContext: {}
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}
 
+## Topology spread constraints for pods
+## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+topologySpreadConstraints: []
+
 # Enable this if you're using https://github.com/coreos/prometheus-operator
 serviceMonitor:
   enabled: false


### PR DESCRIPTION
#### What this PR does / why we need it

Add a new value `topologySpreadConstraints` to the values file for the Pushgateway, to set the topology spread constraints in the Deployment / StatefulSet.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
