### PR TITLE
[prometheus-cloudwatch-exporter] Add extraEnv to values file to specify extra env vars being added to the deployment

### DIFF
--- a/charts/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/charts/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.15.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.20.0
+version: 0.20.1
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/charts/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/charts/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.15.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.20.1
+version: 0.21.0
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/charts/prometheus-cloudwatch-exporter/templates/deployment.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/deployment.yaml
@@ -44,8 +44,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-        {{- if .Values.extraEnv }}
-        {{- .Values.extraEnv  | toYaml | nindent 12 }}
+        {{- with .Values.extraEnv }}
+        {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- if not .Values.aws.role }}
         {{- if .Values.aws.secret.name }}

--- a/charts/prometheus-cloudwatch-exporter/templates/deployment.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/deployment.yaml
@@ -39,9 +39,16 @@ spec:
     {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+        {{- if .Values.extraEnv }}
+        {{- .Values.extraEnv  | toYaml | nindent 12 }}
+        {{- end }}
         {{- if not .Values.aws.role }}
         {{- if .Values.aws.secret.name }}
-          env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
@@ -60,7 +67,6 @@ spec:
                   name: {{ .Values.aws.secret.name }}
           {{- end }}
         {{- else if and .Values.aws.aws_secret_access_key .Values.aws.aws_access_key_id }}
-          env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
@@ -73,7 +79,6 @@ spec:
                   name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
         {{- end }}
         {{- else if .Values.aws.stsRegional.enabled }}
-          env:
             - name: AWS_STS_REGIONAL_ENDPOINTS
               value: regional
         {{- end }}

--- a/charts/prometheus-cloudwatch-exporter/values.yaml
+++ b/charts/prometheus-cloudwatch-exporter/values.yaml
@@ -38,6 +38,11 @@ pod:
   labels: {}
   annotations: {}
 
+# Extra environment variables
+extraEnv:
+  # - name: foo
+  #   value: baa
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR adds `extraEnv` as an option in the values.yaml which can be used to add extra environment variables to the deployment. To simplify the `env` logic I've added `POD_IP` as an env var that will always be present.

The reason it's needed is that I want the option to set an environment variable `AWS_SHARED_CREDENTIALS_FILE` to instruct where the aws credentials file exists on disk, so that I can use the vault injector to mount the creds to a specific directory.

#### Which issue this PR fixes

#### Special notes for your reviewer

I'm happy to modify the logic if required, please let me know

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
