### PR TITLE
[alertmanager] add loadBalancerIP and loadBalancerSourceRanges

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 0.20.1
+version: 0.21.0
 appVersion: v0.23.0
 maintainers:
   - name: monotek

--- a/charts/alertmanager/templates/services.yaml
+++ b/charts/alertmanager/templates/services.yaml
@@ -10,6 +10,15 @@ metadata:
 {{- end }}
 spec:
   type: {{ .Values.service.type }}
+{{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+{{- end }}
+{{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- range $cidr := .Values.service.loadBalancerSourceRanges }}
+    - {{ $cidr }}
+  {{- end }}
+{{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -72,6 +72,8 @@ service:
   type: ClusterIP
   port: 9093
   clusterPort: 9094
+  loadBalancerIP: "" # Assign ext IP when Service type is LoadBalancer
+  loadBalancerSourceRanges: [] # Only allow access to loadBalancerIP from these IPs
   # if you want to force a specific nodePort. Must be use with service.type=NodePort
   # nodePort:
 

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -72,8 +72,8 @@ service:
   type: ClusterIP
   port: 9093
   clusterPort: 9094
-  loadBalancerIP: "" # Assign ext IP when Service type is LoadBalancer
-  loadBalancerSourceRanges: [] # Only allow access to loadBalancerIP from these IPs
+  loadBalancerIP: ""  # Assign ext IP when Service type is LoadBalancer
+  loadBalancerSourceRanges: []  # Only allow access to loadBalancerIP from these IPs
   # if you want to force a specific nodePort. Must be use with service.type=NodePort
   # nodePort:
 


### PR DESCRIPTION
What this PR does / why we need it:
Add loadBalancerIP and loadBalancerSourceRanges to Alertmanager Helm chart

Checklist:

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x]  Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. [alertmanager])
 
Signed-off-by: Kyle Nguyen <nvietthu@gmail.com>
