### PR TITLE
[prometheus] Allow custom HTTP headers in PushGateway Probes

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.36.2
-version: 15.13.1
+version: 15.14.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.36.2
-version: 15.13.0
+version: 15.13.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/templates/pushgateway/deploy.yaml
+++ b/charts/prometheus/templates/pushgateway/deploy.yaml
@@ -68,6 +68,10 @@ spec:
               path: /-/healthy
             {{- end }}
               port: 9091
+              {{- with .Values.pushgateway.probeHeaders }}
+              httpHeaders:
+{{- toYaml . | nindent 14 }}
+              {{- end }}
             initialDelaySeconds: 10
             timeoutSeconds: 10
           readinessProbe:
@@ -78,6 +82,10 @@ spec:
               path: /-/ready
             {{- end }}
               port: 9091
+              {{- with .Values.pushgateway.probeHeaders }}
+              httpHeaders:
+{{- toYaml . | nindent 14 }}
+              {{- end }}
             initialDelaySeconds: 10
             timeoutSeconds: 10
           resources:

--- a/charts/prometheus/templates/pushgateway/deploy.yaml
+++ b/charts/prometheus/templates/pushgateway/deploy.yaml
@@ -70,7 +70,7 @@ spec:
               port: 9091
               {{- with .Values.pushgateway.probeHeaders }}
               httpHeaders:
-{{- toYaml . | nindent 14 }}
+                {{- toYaml . | nindent 16 }}
               {{- end }}
             initialDelaySeconds: 10
             timeoutSeconds: 10
@@ -84,7 +84,7 @@ spec:
               port: 9091
               {{- with .Values.pushgateway.probeHeaders }}
               httpHeaders:
-{{- toYaml . | nindent 14 }}
+                {{- toYaml . | nindent 16 }}
               {{- end }}
             initialDelaySeconds: 10
             timeoutSeconds: 10

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -1354,6 +1354,13 @@ pushgateway:
   # strategy:
   #   type: Recreate
 
+  ## Custom HTTP headers for Liveness/Readiness/Startup Probe
+  ##
+  ## Useful for providing HTTP Basic Auth to healthchecks
+  probeHeaders: []
+    # - name: "Authorization"
+    #   value: "Bearer ABCDEabcde12345"
+
   persistentVolume:
     ## If true, pushgateway will create/use a Persistent Volume Claim
     ##


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Allows custom HTTP headers within the PushGateway HTTP Probes. This is because the PushGateway supports the use of basic authentication which also applies to the default probe endpoints. With basic auth enabled, probes will fail without being able to provide the Auth header.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
