### PR TITLE
[kube-state-metrics] Allow namespaces to be defined as both string/list

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 4.20.1
+version: 4.20.2
 appVersion: 2.6.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/kube-state-metrics/templates/deployment.yaml
@@ -76,7 +76,7 @@ spec:
         {{- end }}
         {{- $namespaces := list }}
         {{- if .Values.namespaces }}
-        {{- range $ns := split "," .Values.namespaces }}
+        {{- range $ns := join "," .Values.namespaces | split "," }}
         {{- $namespaces = append $namespaces (tpl $ns $) }}
         {{- end }}
         {{- end }}

--- a/charts/kube-state-metrics/templates/role.yaml
+++ b/charts/kube-state-metrics/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- if and (eq .Values.rbac.create true) (not .Values.rbac.useExistingRole) -}}
-{{- range (ternary (split "," .Values.namespaces) (list "") (eq $.Values.rbac.useClusterRole false)) }}
+{{- range (ternary (join "," .Values.namespaces | split "," ) (list "") (eq $.Values.rbac.useClusterRole false)) }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if eq $.Values.rbac.useClusterRole false }}

--- a/charts/kube-state-metrics/templates/rolebinding.yaml
+++ b/charts/kube-state-metrics/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if and (eq  .Values.rbac.create true) (eq .Values.rbac.useClusterRole false) -}}
-{{- range (split "," $.Values.namespaces) }}
+{{- range (join "," $.Values.namespaces) | split "," }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -214,7 +214,7 @@ kubeconfig:
 # If releaseNamespace and namespaces are both set a merged list will be collected.
 releaseNamespace: false
 
-# Comma-separated list of namespaces to be enabled for collecting resources. By default all namespaces are collected.
+# Comma-separated list(string) or yaml list of namespaces to be enabled for collecting resources. By default all namespaces are collected.
 namespaces: ""
 
 # Comma-separated list of namespaces not to be enabled. If namespaces and namespaces-denylist are both set,


### PR DESCRIPTION
Allow namespaces to be defined as both string/list.
This was inspired by the fact that Prometheus-Operator requires [namespaces list](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml#L1664) and not string. By supporting this a kube-prometheus-stack user can use [yaml anchors ](https://helm.sh/docs/chart_template_guide/yaml_techniques/#yaml-anchors) in values.yaml in order to define the watched namespaces once and reuse in both deployments.