### PR TITLE
[prometheus-json-exporter] - Allow passing module name for targets

### DIFF
--- a/charts/prometheus-json-exporter/Chart.yaml
+++ b/charts/prometheus-json-exporter/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/prometheus-json-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-json-exporter/templates/servicemonitor.yaml
@@ -25,6 +25,10 @@ spec:
     params:
       target:
       - {{ .url }}
+      {{- if .module }}
+      module:
+      - {{ .module }}
+      {{- end }}
     metricRelabelings:
       - sourceLabels: [instance]
         targetLabel: instance

--- a/charts/prometheus-json-exporter/values.yaml
+++ b/charts/prometheus-json-exporter/values.yaml
@@ -68,6 +68,7 @@ serviceMonitor:
 #      interval: 60s                    # Scraping interval. Overrides value set in `defaults`
 #      scrapeTimeout: 60s               # Scrape timeout. Overrides value set in `defaults`
 #      additionalMetricsRelabels: {}    # Map of metric labels and values to add
+#      module: example_module           # Name of the module to pick up from `config.yaml` for scraping this target. Optional. Default is  `default` provided by the exporter itself.
 
 ingress:
   enabled: false


### PR DESCRIPTION
Signed-off-by: Faisal K. <khalique.faisal@gmail.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
The [json-exporter](https://github.com/prometheus-community/json_exporter) provides the option of [passing name of the module](https://github.com/prometheus-community/json_exporter/blob/v0.5.0/cmd/main.go#L90) which should be picked up from [config.yml](https://github.com/prometheus-community/json_exporter/blob/master/examples/config.yml) for scraping metrics from the associated target.
However, [service monitor](https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus-json-exporter/templates/servicemonitor.yaml#L25) template for [json-exporter](https://github.com/prometheus-community/json_exporter) [helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-json-exporter) does not provide such an option to be passed.
This change allows the name of the module to be passed (optionally) along with the target name and URL.


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
