### PR TITLE
[prometheus] Allow addition of extra labels to prometheus configmap

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: prometheus
-appVersion: 2.39.2
+appVersion: 2.39.1
 version: 15.16.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.39.2
-version: 15.15.0
+version: 15.16.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.36.2
-version: 15.14.0
+version: 15.15.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/templates/server/cm.yaml
+++ b/charts/prometheus/templates/server/cm.yaml
@@ -5,6 +5,9 @@ kind: ConfigMap
 metadata:
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
+    {{- with .Values.server.extraConfigmapLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ template "prometheus.server.fullname" . }}
 {{ include "prometheus.namespace" . | indent 2 }}
 data:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -816,6 +816,9 @@ server:
   ##
   configMapOverrideName: ""
 
+  ## Extra labels for Prometheus server ConfigMap (ConfigMap that holds serverFiles)
+  extraConfigmapLabels: {}
+
   ingress:
     ## If true, Prometheus server Ingress will be created
     ##


### PR DESCRIPTION
#### What this PR does / why we need it

This PR allows addition of extra labels to Prometheus ConfigMap (ConfigMap that holds the prometheus configuration).

Main motivation is to solve Prometheus issue with loading of configuration from multiple files - https://github.com/prometheus/prometheus/issues/8543. 

I use a small sidecar that merges configuration from multiple ConfigMaps (https://github.com/Lirt/prometheus-config-merger/) - first ConfigMap is the one created from Prometheus helm chart and additional one is created by myself. The sidecar is watching for ConfigMaps with specific label and merges their content into a final configuration file that Prometheus uses (eg. `/etc/config/prometheus.yml`).

Since this helm chart doesn't support adding extra labels to the main Prometheus ConfigMap I would like to add support for it.

#### Which issue this PR fixes

No issue created

#### Special notes for your reviewer

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)

Signed-off-by: Ondrej Vasko <ondrej.vaskoo@gmail.com>