### PR TITLE
[kube-prometheus-stack] Add queryConfig to thanosRulerSpec

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -22,7 +22,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 40.3.1
+version: 40.4.0
 appVersion: 0.59.2
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/thanos-ruler/ruler.yaml
+++ b/charts/kube-prometheus-stack/templates/thanos-ruler/ruler.yaml
@@ -78,6 +78,10 @@ spec:
   queryEndpoints:
 {{ toYaml .Values.thanosRuler.thanosRulerSpec.queryEndpoints | indent 4 }}
 {{- end }}
+{{- if .Values.thanosRuler.thanosRulerSpec.queryConfig }}
+  queryConfig:
+{{ toYaml .Values.thanosRuler.thanosRulerSpec.queryConfig | indent 4 }}
+{{- end }}
 {{- if .Values.thanosRuler.thanosRulerSpec.resources }}
   resources:
 {{ toYaml .Values.thanosRuler.thanosRulerSpec.resources | indent 4 }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -3261,14 +3261,14 @@ thanosRuler:
     ## When used alongside with ObjectStorageConfig, ObjectStorageConfigFile takes precedence.
     objectStorageConfigFile: ""
 
-    ## QueryEndpoints defines Thanos querier endpoints from which to query metrics. 
+    ## QueryEndpoints defines Thanos querier endpoints from which to query metrics.
     ## Maps to the --query flag of thanos ruler.
     queryEndpoints: []
 
-    ## Define configuration for connecting to thanos query instances. If this is defined, the queryEndpoints field will be ignored. 
+    ## Define configuration for connecting to thanos query instances. If this is defined, the queryEndpoints field will be ignored.
     ## Maps to the query.config CLI argument. Only available with thanos v0.11.0 and higher.
     queryConfig: {}
-    
+
     ## Labels configure the external label pairs to ThanosRuler. A default replica
     ## label `thanos_ruler_replica` will be always added as a label with the value
     ## of the pod's name and it will be dropped in the alerts.

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -3261,6 +3261,14 @@ thanosRuler:
     ## When used alongside with ObjectStorageConfig, ObjectStorageConfigFile takes precedence.
     objectStorageConfigFile: ""
 
+    ## QueryEndpoints defines Thanos querier endpoints from which to query metrics. 
+    ## Maps to the --query flag of thanos ruler.
+    queryEndpoints: []
+
+    ## Define configuration for connecting to thanos query instances. If this is defined, the QueryEndpoints field will be ignored. 
+    ## Maps to the query.config CLI argument. Only available with thanos v0.11.0 and higher.
+    queryConfig: {}
+    
     ## Labels configure the external label pairs to ThanosRuler. A default replica
     ## label `thanos_ruler_replica` will be always added as a label with the value
     ## of the pod's name and it will be dropped in the alerts.

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -3265,7 +3265,7 @@ thanosRuler:
     ## Maps to the --query flag of thanos ruler.
     queryEndpoints: []
 
-    ## Define configuration for connecting to thanos query instances. If this is defined, the QueryEndpoints field will be ignored. 
+    ## Define configuration for connecting to thanos query instances. If this is defined, the queryEndpoints field will be ignored. 
     ## Maps to the query.config CLI argument. Only available with thanos v0.11.0 and higher.
     queryConfig: {}
     


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR allows detailed configuration of the Thanos Query endpoint for Thanos Ruler. Prometheus operator [already supports](https://docs.openshift.com/container-platform/4.8/rest_api/monitoring_apis/thanosruler-monitoring-coreos-com-v1.html) providing `queryConfig` parameter specified in [Thanos API](https://thanos.io/tip/components/rule.md/#query-api). The primary motivation is to connect Thanos Ruler to Thanos Query with TLS certificates configured so requests can be called against HTTPS protocol.

This PR also adds missing `queryEndpoints` parameter documentation to the `values.yaml` file.

#### Which issue this PR fixes

No issue created

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)

Signed-off-by: Jan Safarik <cowjen01@gmail.com>
