### PR TITLE
[prometheus-cloudwatch-exporter] Pass metrics configuration from separate file

### DIFF
--- a/charts/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/charts/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.15.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.21.0
+version: 0.21.1
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/charts/prometheus-cloudwatch-exporter/configuration/metrics.yml
+++ b/charts/prometheus-cloudwatch-exporter/configuration/metrics.yml
@@ -1,0 +1,88 @@
+#For More examples:-  https://github.com/prometheus/cloudwatch_exporter/tree/master/examples
+region: eu-central-1
+metrics:
+#RDS Metrics
+- aws_dimensions:
+  - DBInstanceIdentifier
+  aws_metric_name: DatabaseConnections
+  aws_namespace: AWS/RDS
+  aws_statistics:
+  - Maximum
+- aws_dimensions:
+  - DBInstanceIdentifier
+  aws_metric_name: FreeableMemory
+  aws_namespace: AWS/RDS
+  aws_statistics:
+  - Average
+- aws_dimensions:
+  - DBInstanceIdentifier
+  aws_metric_name: CPUUtilization
+  aws_namespace: AWS/RDS
+  aws_statistics:
+  - Average
+- aws_dimensions:
+  - DBInstanceIdentifier
+  aws_metric_name: ReadIOPS
+  aws_namespace: AWS/RDS
+  aws_statistics:
+  - Sum
+- aws_dimensions:
+  - DBInstanceIdentifier
+  aws_metric_name: WriteIOPS
+  aws_namespace: AWS/RDS
+  aws_statistics:
+  - Sum
+- aws_dimensions:
+  - DBInstanceIdentifier
+  aws_metric_name: ReadLatency
+  aws_namespace: AWS/RDS
+  aws_statistics:
+  - Average
+- aws_dimensions:
+  - DBInstanceIdentifier
+  aws_metric_name: WriteLatency
+  aws_namespace: AWS/RDS
+  aws_statistics:
+  - Average
+- aws_dimensions:
+  - DBInstanceIdentifier
+  aws_metric_name: ReadThroughput
+  aws_namespace: AWS/RDS
+  aws_statistics:
+  - Average
+- aws_dimensions:
+  - DBInstanceIdentifier
+  aws_metric_name: WriteThroughput
+  aws_namespace: AWS/RDS
+  aws_statistics:
+  - Average
+- aws_dimensions:
+  - DBInstanceIdentifier
+  aws_metric_name: CPUCreditUsage
+  aws_namespace: AWS/RDS
+  aws_statistics:
+  - Average
+- aws_dimensions:
+  - DBInstanceIdentifier
+  aws_metric_name: CPUCreditBalance
+  aws_namespace: AWS/RDS
+  aws_statistics:
+  - Average
+- aws_dimensions:
+  - DBInstanceIdentifier
+  aws_metric_name: DiskQueueDepth
+  aws_namespace: AWS/RDS
+  aws_statistics:
+  - Average
+- aws_dimensions:
+  - DBInstanceIdentifier
+  aws_metric_name: NetworkTransmitThroughput
+  aws_namespace: AWS/RDS
+  aws_statistics:
+  - Average
+- aws_dimensions:
+  - DBInstanceIdentifier
+  aws_metric_name: NetworkReceiveThroughput
+  aws_namespace: AWS/RDS
+  aws_statistics:
+  - Average

--- a/charts/prometheus-cloudwatch-exporter/templates/configmap.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/configmap.yaml
@@ -10,4 +10,4 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   config.yml: |
-    {{ tpl .Values.config . | nindent 4 }}
+{{ .Files.Get "configuration/metrics.yml" | indent 4 }}

--- a/charts/prometheus-cloudwatch-exporter/values.yaml
+++ b/charts/prometheus-cloudwatch-exporter/values.yaml
@@ -93,38 +93,6 @@ rbac:
   # Specifies whether RBAC resources should be created
   create: true
 
-# Configuration is rendered with `tpl` function, therefore you can use any Helm variables and/or templates here
-config: |-
-  # This is the default configuration for prometheus-cloudwatch-exporter
-  region: eu-west-1
-  period_seconds: 240
-  metrics:
-  - aws_namespace: AWS/ELB
-    aws_metric_name: HealthyHostCount
-    aws_dimensions: [AvailabilityZone, LoadBalancerName]
-    aws_statistics: [Average]
-
-  - aws_namespace: AWS/ELB
-    aws_metric_name: UnHealthyHostCount
-    aws_dimensions: [AvailabilityZone, LoadBalancerName]
-    aws_statistics: [Average]
-
-  - aws_namespace: AWS/ELB
-    aws_metric_name: RequestCount
-    aws_dimensions: [AvailabilityZone, LoadBalancerName]
-    aws_statistics: [Sum]
-
-  - aws_namespace: AWS/ELB
-    aws_metric_name: Latency
-    aws_dimensions: [AvailabilityZone, LoadBalancerName]
-    aws_statistics: [Average]
-
-  - aws_namespace: AWS/ELB
-    aws_metric_name: SurgeQueueLength
-    aws_dimensions: [AvailabilityZone, LoadBalancerName]
-    aws_statistics: [Maximum, Sum]
-
-
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Currently, we have to pass Metrics configuration to configmap by defining in values.yaml file. This PR will help to call the metrics from a separate file to keep the values.yaml file clean and error-free. Therefore we can add  all the metrics define in 
https://github.com/prometheus/cloudwatch_exporter/tree/master/examples without growing the values.yaml file.

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
