### PR TITLE
[kube-prometheus-stack] Add option to annotate CRD

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -22,7 +22,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 40.4.0
+version: 40.4.1
 appVersion: 0.59.2
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/crds/crd-alertmanagerconfigs.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-alertmanagerconfigs.yaml
@@ -5,9 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
-{{ if .Values.global.cdr.annotations }}
-{{ toYaml .Values.global.cdr.annotations | indent 4 }}
-{{ end }}
+{{- if .Values.global.crd.annotations }}
+{{ toYaml .Values.global.crd.annotations | indent 4 }}
+{{- end }}
   creationTimestamp: null
   name: alertmanagerconfigs.monitoring.coreos.com
 spec:

--- a/charts/kube-prometheus-stack/crds/crd-alertmanagerconfigs.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-alertmanagerconfigs.yaml
@@ -5,6 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+{{- if .Values.global.cdr.annotations }}
+{{ toYaml .Values.global.cdr.annotations | indent 4 }}
+{{- end }}
   creationTimestamp: null
   name: alertmanagerconfigs.monitoring.coreos.com
 spec:

--- a/charts/kube-prometheus-stack/crds/crd-alertmanagerconfigs.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-alertmanagerconfigs.yaml
@@ -5,9 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
-{{- if .Values.global.cdr.annotations }}
+{{ if .Values.global.cdr.annotations }}
 {{ toYaml .Values.global.cdr.annotations | indent 4 }}
-{{- end }}
+{{ end }}
   creationTimestamp: null
   name: alertmanagerconfigs.monitoring.coreos.com
 spec:

--- a/charts/kube-prometheus-stack/crds/crd-alertmanagers.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-alertmanagers.yaml
@@ -5,9 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
-{{- if .Values.global.cdr.annotations }}
+{{ if .Values.global.cdr.annotations }}
 {{ toYaml .Values.global.cdr.annotations | indent 4 }}
-{{- end }}
+{{ end }}
   creationTimestamp: null
   name: alertmanagers.monitoring.coreos.com
 spec:

--- a/charts/kube-prometheus-stack/crds/crd-alertmanagers.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-alertmanagers.yaml
@@ -5,6 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+{{- if .Values.global.cdr.annotations }}
+{{ toYaml .Values.global.cdr.annotations | indent 4 }}
+{{- end }}
   creationTimestamp: null
   name: alertmanagers.monitoring.coreos.com
 spec:

--- a/charts/kube-prometheus-stack/crds/crd-alertmanagers.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-alertmanagers.yaml
@@ -5,9 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
-{{ if .Values.global.cdr.annotations }}
-{{ toYaml .Values.global.cdr.annotations | indent 4 }}
-{{ end }}
+{{- if .Values.global.crd.annotations }}
+{{ toYaml .Values.global.crd.annotations | indent 4 }}
+{{- end }}
   creationTimestamp: null
   name: alertmanagers.monitoring.coreos.com
 spec:

--- a/charts/kube-prometheus-stack/crds/crd-podmonitors.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-podmonitors.yaml
@@ -5,9 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
-{{- if .Values.global.cdr.annotations }}
+{{ if .Values.global.cdr.annotations }}
 {{ toYaml .Values.global.cdr.annotations | indent 4 }}
-{{- end }}
+{{ end }}
   creationTimestamp: null
   name: podmonitors.monitoring.coreos.com
 spec:

--- a/charts/kube-prometheus-stack/crds/crd-podmonitors.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-podmonitors.yaml
@@ -5,6 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+{{- if .Values.global.cdr.annotations }}
+{{ toYaml .Values.global.cdr.annotations | indent 4 }}
+{{- end }}
   creationTimestamp: null
   name: podmonitors.monitoring.coreos.com
 spec:

--- a/charts/kube-prometheus-stack/crds/crd-podmonitors.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-podmonitors.yaml
@@ -5,9 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
-{{ if .Values.global.cdr.annotations }}
-{{ toYaml .Values.global.cdr.annotations | indent 4 }}
-{{ end }}
+{{- if .Values.global.crd.annotations }}
+{{ toYaml .Values.global.crd.annotations | indent 4 }}
+{{- end }}
   creationTimestamp: null
   name: podmonitors.monitoring.coreos.com
 spec:

--- a/charts/kube-prometheus-stack/crds/crd-probes.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-probes.yaml
@@ -5,9 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
-{{- if .Values.global.cdr.annotations }}
+{{ if .Values.global.cdr.annotations }}
 {{ toYaml .Values.global.cdr.annotations | indent 4 }}
-{{- end }}
+{{ end }}
   creationTimestamp: null
   name: probes.monitoring.coreos.com
 spec:

--- a/charts/kube-prometheus-stack/crds/crd-probes.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-probes.yaml
@@ -5,9 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
-{{ if .Values.global.cdr.annotations }}
-{{ toYaml .Values.global.cdr.annotations | indent 4 }}
-{{ end }}
+{{- if .Values.global.crd.annotations }}
+{{ toYaml .Values.global.crd.annotations | indent 4 }}
+{{- end }}
   creationTimestamp: null
   name: probes.monitoring.coreos.com
 spec:

--- a/charts/kube-prometheus-stack/crds/crd-probes.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-probes.yaml
@@ -5,6 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+{{- if .Values.global.cdr.annotations }}
+{{ toYaml .Values.global.cdr.annotations | indent 4 }}
+{{- end }}
   creationTimestamp: null
   name: probes.monitoring.coreos.com
 spec:

--- a/charts/kube-prometheus-stack/crds/crd-prometheuses.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-prometheuses.yaml
@@ -5,6 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+{{- if .Values.global.cdr.annotations }}
+{{ toYaml .Values.global.cdr.annotations | indent 4 }}
+{{- end }}
   creationTimestamp: null
   name: prometheuses.monitoring.coreos.com
 spec:

--- a/charts/kube-prometheus-stack/crds/crd-prometheuses.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-prometheuses.yaml
@@ -5,9 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
-{{ if .Values.global.cdr.annotations }}
-{{ toYaml .Values.global.cdr.annotations | indent 4 }}
-{{ end }}
+{{- if .Values.global.crd.annotations }}
+{{ toYaml .Values.global.crd.annotations | indent 4 }}
+{{- end }}
   creationTimestamp: null
   name: prometheuses.monitoring.coreos.com
 spec:

--- a/charts/kube-prometheus-stack/crds/crd-prometheuses.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-prometheuses.yaml
@@ -5,9 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
-{{- if .Values.global.cdr.annotations }}
+{{ if .Values.global.cdr.annotations }}
 {{ toYaml .Values.global.cdr.annotations | indent 4 }}
-{{- end }}
+{{ end }}
   creationTimestamp: null
   name: prometheuses.monitoring.coreos.com
 spec:

--- a/charts/kube-prometheus-stack/crds/crd-prometheusrules.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-prometheusrules.yaml
@@ -5,9 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
-{{ if .Values.global.cdr.annotations }}
-{{ toYaml .Values.global.cdr.annotations | indent 4 }}
-{{ end }}
+{{- if .Values.global.crd.annotations }}
+{{ toYaml .Values.global.crd.annotations | indent 4 }}
+{{- end }}
   creationTimestamp: null
   name: prometheusrules.monitoring.coreos.com
 spec:

--- a/charts/kube-prometheus-stack/crds/crd-prometheusrules.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-prometheusrules.yaml
@@ -5,6 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+{{- if .Values.global.cdr.annotations }}
+{{ toYaml .Values.global.cdr.annotations | indent 4 }}
+{{- end }}
   creationTimestamp: null
   name: prometheusrules.monitoring.coreos.com
 spec:

--- a/charts/kube-prometheus-stack/crds/crd-prometheusrules.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-prometheusrules.yaml
@@ -5,9 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
-{{- if .Values.global.cdr.annotations }}
+{{ if .Values.global.cdr.annotations }}
 {{ toYaml .Values.global.cdr.annotations | indent 4 }}
-{{- end }}
+{{ end }}
   creationTimestamp: null
   name: prometheusrules.monitoring.coreos.com
 spec:

--- a/charts/kube-prometheus-stack/crds/crd-servicemonitors.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-servicemonitors.yaml
@@ -5,9 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
-{{ if .Values.global.cdr.annotations }}
-{{ toYaml .Values.global.cdr.annotations | indent 4 }}
-{{ end }}
+{{- if .Values.global.crd.annotations }}
+{{ toYaml .Values.global.crd.annotations | indent 4 }}
+{{- end }}
   creationTimestamp: null
   name: servicemonitors.monitoring.coreos.com
 spec:

--- a/charts/kube-prometheus-stack/crds/crd-servicemonitors.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-servicemonitors.yaml
@@ -5,9 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
-{{- if .Values.global.cdr.annotations }}
+{{ if .Values.global.cdr.annotations }}
 {{ toYaml .Values.global.cdr.annotations | indent 4 }}
-{{- end }}
+{{ end }}
   creationTimestamp: null
   name: servicemonitors.monitoring.coreos.com
 spec:

--- a/charts/kube-prometheus-stack/crds/crd-servicemonitors.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-servicemonitors.yaml
@@ -5,6 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+{{- if .Values.global.cdr.annotations }}
+{{ toYaml .Values.global.cdr.annotations | indent 4 }}
+{{- end }}
   creationTimestamp: null
   name: servicemonitors.monitoring.coreos.com
 spec:

--- a/charts/kube-prometheus-stack/crds/crd-thanosrulers.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-thanosrulers.yaml
@@ -5,6 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+{{- if .Values.global.cdr.annotations }}
+{{ toYaml .Values.global.cdr.annotations | indent 4 }}
+{{- end }}
   creationTimestamp: null
   name: thanosrulers.monitoring.coreos.com
 spec:

--- a/charts/kube-prometheus-stack/crds/crd-thanosrulers.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-thanosrulers.yaml
@@ -5,9 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
-{{ if .Values.global.cdr.annotations }}
-{{ toYaml .Values.global.cdr.annotations | indent 4 }}
-{{ end }}
+{{- if .Values.global.crd.annotations }}
+{{ toYaml .Values.global.crd.annotations | indent 4 }}
+{{- end }}
   creationTimestamp: null
   name: thanosrulers.monitoring.coreos.com
 spec:

--- a/charts/kube-prometheus-stack/crds/crd-thanosrulers.yaml
+++ b/charts/kube-prometheus-stack/crds/crd-thanosrulers.yaml
@@ -5,9 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
-{{- if .Values.global.cdr.annotations }}
+{{ if .Values.global.cdr.annotations }}
 {{ toYaml .Values.global.cdr.annotations | indent 4 }}
-{{- end }}
+{{ end }}
   creationTimestamp: null
   name: thanosrulers.monitoring.coreos.com
 spec:

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -107,7 +107,7 @@ global:
   ## Annotate kubernetes Custom Resource Definitions
   ##
   crd:
-   annotations: {}
+    annotations: {}
   rbac:
     create: true
 

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -104,6 +104,10 @@ additionalPrometheusRulesMap: {}
 
 ##
 global:
+  ## Annotate kubernetes Custom Resource Definitions
+  ##
+  crd:
+   annotations: {}
   rbac:
     create: true
 


### PR DESCRIPTION
Signed-off-by: czomo <tomaszjdul@gmail.com>


#### What this PR does / why we need it
Introduced server-side apply on ArgoCD 2.5 require annotation to select resources required to change. see https://blog.argoproj.io/argo-cd-v2-5-release-candidate-e2121f2002ba

#### Which issue this PR fixes
Resolve : https://github.com/prometheus-community/helm-charts/issues/2425
Resolve:  fixes issues with out of sync of CRD running them without server-side in ArgoCD
Resolve: https://github.com/prometheus-operator/prometheus-operator/issues/4439#issuecomment-1030198014
#### Special notes for your reviewer
I consider moving crd of `global` path inside of values.yaml. tell me wdyt
#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
