### PR TITLE
[prometheus] Update Prometheus to v2.39.1

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.39.1
-version: 15.14.0
+version: 15.15.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: prometheus
-appVersion: 2.36.2
+appVersion: 2.39.1
 version: 15.14.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -682,7 +682,7 @@ server:
   ##
   image:
     repository: quay.io/prometheus/prometheus
-    tag: v2.36.2
+    tag: v2.39.1
     pullPolicy: IfNotPresent
 
   ## prometheus server priorityClassName


### PR DESCRIPTION
Signed-off-by: arukiidou <arukiidou@yahoo.co.jp>

### What this PR does / why we need it
This Pull Request updated Prometheus versions deployed in kube-prometheus-stack chart from v2.36.2 to v2.39.1.
This is helpful to benefit from this releases memory improvements.

see: https://github.com/prometheus/prometheus/releases
relates: #2524

### Which issue this PR fixes
(optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged)

None.

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
