### PR TITLE
[prometheus-smartctl-exporter] Upgrade to smartctl-exporter v0.8.0

### DIFF
--- a/charts/prometheus-smartctl-exporter/Chart.yaml
+++ b/charts/prometheus-smartctl-exporter/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.7.0"
+appVersion: "v0.8.0"
 
 maintainers:
   - name: kfox1111

--- a/charts/prometheus-smartctl-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-smartctl-exporter/templates/daemonset.yaml
@@ -39,6 +39,7 @@ spec:
         name: main
         securityContext:
           privileged: true
+          runAsUser: 0
         ports:
         - name: http
           containerPort: 9633


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR updates the image of smartctl-importer to v0.8.0 which bundles its own `smartctl` binary, and doesn't need to mount the node's filesystem to use host binaries.

It does require running as root for the bundled `smartctl` to read SMART data from `/dev`.

* https://github.com/prometheus-community/smartctl_exporter/releases/tag/v0.8.0
* https://hub.docker.com/r/prometheuscommunity/smartctl-exporter/tags

#### Which issue this PR fixes

- Fixes #2521 

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
