### PR TITLE
[prometheus-smartctl-exporter] Fix quoting issue in new arguments

### DIFF
--- a/charts/prometheus-smartctl-exporter/Chart.yaml
+++ b/charts/prometheus-smartctl-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/prometheus-smartctl-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-smartctl-exporter/templates/daemonset.yaml
@@ -40,8 +40,8 @@ spec:
 {{ range $config.devices }}
         - '--smartctl.device={{ . }}'
 {{ end }}
-        - '--web.listen-address="{{ $config.bind_to }}"'
-        - '--web.telemetry-path="{{ $config.url_path }}"'
+        - '--web.listen-address={{ $config.bind_to }}'
+        - '--web.telemetry-path={{ $config.url_path }}'
         name: main
         securityContext:
           privileged: true


### PR DESCRIPTION
#### What this PR does / why we need it
Quoting is incorrect in 0.9.0

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
