### PR TITLE
[prometheus-cloudwatch-exporter] Support networking.k8s.io/v1 in helpers file for k8s clusters > 1.21

### DIFF
--- a/charts/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/charts/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.15.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.21.0
+version: 0.21.1
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/charts/prometheus-cloudwatch-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-cloudwatch-exporter/templates/_helpers.tpl
@@ -68,7 +68,9 @@ Return the appropriate apiVersion for rbac.
 Return the appropriate apiVersion for ingress.
 */}}
 {{- define "ingress.apiVersion" -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- print "networking.k8s.io/v1" -}}
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 {{- print "networking.k8s.io/v1beta1" -}}
 {{- else -}}
 {{- print "extensions/v1beta1" -}}


### PR DESCRIPTION
Currently Cloudwatch exporter only supports `networking.k8s.io/v1beta1` for ingress objects, but this apiObject version was deprecated in 1.22. There should be an option to support` networking.k8s.io/v1`
