### PR TITLE
[kube-prometheus-stack] PodSecurityPolicy being removed from Kubernetes

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -22,7 +22,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 41.4.0
+version: 41.4.1
 appVersion: 0.60.1
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/alertmanager/psp-role.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/psp-role.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.alertmanager.enabled .Values.global.rbac.create .Values.global.rbac.pspEnabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -18,4 +19,5 @@ rules:
   verbs:     ['use']
   resourceNames:
   - {{ template "kube-prometheus-stack.fullname" . }}-alertmanager
+{{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/alertmanager/psp-rolebinding.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/psp-rolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.alertmanager.enabled .Values.global.rbac.create .Values.global.rbac.pspEnabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -15,4 +16,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "kube-prometheus-stack.alertmanager.serviceAccountName" . }}
     namespace: {{ template "kube-prometheus-stack.namespace" . }}
+{{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/alertmanager/psp.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/psp.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.alertmanager.enabled .Values.global.rbac.create .Values.global.rbac.pspEnabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -43,4 +44,4 @@ spec:
         max: 65535
   readOnlyRootFilesystem: false
 {{- end }}
-
+{{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/psp-clusterrole.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/psp-clusterrole.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.prometheusOperator.enabled .Values.global.rbac.create .Values.global.rbac.pspEnabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -17,4 +18,5 @@ rules:
   verbs:     ['use']
   resourceNames:
   - {{ template "kube-prometheus-stack.fullname" . }}-operator
+{{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/psp-clusterrolebinding.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/psp-clusterrolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.prometheusOperator.enabled .Values.global.rbac.create .Values.global.rbac.pspEnabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -14,4 +15,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "kube-prometheus-stack.operator.serviceAccountName" . }}
     namespace: {{ template "kube-prometheus-stack.namespace" . }}
+{{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/psp.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/psp.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.prometheusOperator.enabled .Values.global.rbac.create .Values.global.rbac.pspEnabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -42,4 +43,5 @@ spec:
       - min: 0
         max: 65535
   readOnlyRootFilesystem: false
+{{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/psp-clusterrole.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/psp-clusterrole.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.prometheus.enabled .Values.global.rbac.create .Values.global.rbac.pspEnabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -17,4 +18,5 @@ rules:
   verbs:     ['use']
   resourceNames:
   - {{ template "kube-prometheus-stack.fullname" . }}-prometheus
+{{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/psp-clusterrolebinding.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/psp-clusterrolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.prometheus.enabled .Values.global.rbac.create .Values.global.rbac.pspEnabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -15,4 +16,4 @@ subjects:
     name: {{ template "kube-prometheus-stack.prometheus.serviceAccountName" . }}
     namespace: {{ template "kube-prometheus-stack.namespace" . }}
 {{- end }}
-
+{{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/psp.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/psp.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.prometheus.enabled .Values.global.rbac.create .Values.global.rbac.pspEnabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -52,5 +53,6 @@ spec:
 {{- if .Values.prometheus.podSecurityPolicy.allowedHostPaths }}
   allowedHostPaths:
 {{ toYaml .Values.prometheus.podSecurityPolicy.allowedHostPaths | indent 4 }}
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
#### Which issue this PR fixes

Try to fix PodSecurityPolicy being removed after Kubernetes 1.25+. See:
https://github.com/prometheus-community/helm-charts/issues/2556

#### Special notes for your reviewer
- This PR just simply removes PSP (same as disable PSP).
- PSP before 1.25+ only reaches `policy/v1beta1`
- `policy/v1' does `NOT` contain PodSecurityPolicy. Please don't mix with PodDisruptionBudget.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name

Signed-off-by: zanac1986 <zanhsieh@protonmail.com>