### PR TITLE
[prometheus] handle PSP removed in k8s 1.25+

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.39.1
-version: 15.16.0
+version: 15.16.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/templates/_helpers.tpl
+++ b/charts/prometheus/templates/_helpers.tpl
@@ -177,12 +177,7 @@ Return the appropriate apiVersion for networkpolicy.
 {{- define "prometheus.networkPolicy.apiVersion" -}}
 {{- print "networking.k8s.io/v1" -}}
 {{- end -}}
-{{/*
-Return the appropriate apiVersion for podsecuritypolicy.
-*/}}
-{{- define "prometheus.podSecurityPolicy.apiVersion" -}}
-{{- print "policy/v1beta1" -}}
-{{- end -}}
+
 {{/*
 Return the appropriate apiVersion for poddisruptionbudget.
 */}}

--- a/charts/prometheus/templates/alertmanager/psp.yaml
+++ b/charts/prometheus/templates/alertmanager/psp.yaml
@@ -1,14 +1,15 @@
 {{- if and .Values.alertmanager.enabled .Values.rbac.create .Values.podSecurityPolicy.enabled }}
-apiVersion: {{ template "prometheus.podSecurityPolicy.apiVersion" . }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus.alertmanager.fullname" . }}
   labels:
     {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
+  {{- with .Values.alertmanager.podSecurityPolicy.annotations }}
   annotations:
-{{- if .Values.alertmanager.podSecurityPolicy.annotations }}
-{{ toYaml .Values.alertmanager.podSecurityPolicy.annotations | indent 4 }}
-{{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   privileged: false
   allowPrivilegeEscalation: false
@@ -43,4 +44,5 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: true
+{{- end }}
 {{- end }}

--- a/charts/prometheus/templates/node-exporter/psp.yaml
+++ b/charts/prometheus/templates/node-exporter/psp.yaml
@@ -1,14 +1,15 @@
 {{- if and .Values.nodeExporter.enabled .Values.rbac.create .Values.podSecurityPolicy.enabled }}
-apiVersion: {{ template "prometheus.podSecurityPolicy.apiVersion" . }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus.nodeExporter.fullname" . }}
   labels:
     {{- include "prometheus.nodeExporter.labels" . | nindent 4 }}
+  {{- with .Values.nodeExporter.podSecurityPolicy.annotations }}
   annotations:
-{{- if .Values.nodeExporter.podSecurityPolicy.annotations }}
-{{ toYaml .Values.nodeExporter.podSecurityPolicy.annotations | indent 4 }}
-{{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   privileged: false
   allowPrivilegeEscalation: false
@@ -52,4 +53,5 @@ spec:
   hostPorts:
     - min: 1
       max: 65535
+{{- end }}
 {{- end }}

--- a/charts/prometheus/templates/pushgateway/psp.yaml
+++ b/charts/prometheus/templates/pushgateway/psp.yaml
@@ -1,14 +1,15 @@
 {{- if and .Values.pushgateway.enabled .Values.rbac.create .Values.podSecurityPolicy.enabled }}
-apiVersion: {{ template "prometheus.podSecurityPolicy.apiVersion" . }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus.pushgateway.fullname" . }}
   labels:
     {{- include "prometheus.pushgateway.labels" . | nindent 4 }}
+  {{- with .Values.pushgateway.podSecurityPolicy.annotations }}
   annotations:
-{{- if .Values.pushgateway.podSecurityPolicy.annotations }}
-{{ toYaml .Values.pushgateway.podSecurityPolicy.annotations | indent 4 }}
-{{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   privileged: false
   allowPrivilegeEscalation: false
@@ -39,4 +40,5 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: true
+{{- end }}
 {{- end }}

--- a/charts/prometheus/templates/server/psp.yaml
+++ b/charts/prometheus/templates/server/psp.yaml
@@ -1,14 +1,15 @@
 {{- if and .Values.server.enabled .Values.rbac.create .Values.podSecurityPolicy.enabled }}
-apiVersion: {{ template "prometheus.podSecurityPolicy.apiVersion" . }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus.server.fullname" . }}
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
+  {{- with .Values.server.podSecurityPolicy.annotations }}
   annotations:
-{{- if .Values.server.podSecurityPolicy.annotations }}
-{{ toYaml .Values.server.podSecurityPolicy.annotations | indent 4 }}
-{{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   privileged: false
   allowPrivilegeEscalation: false
@@ -48,4 +49,5 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
+{{- end }}
 {{- end }}


### PR DESCRIPTION
#### Which issue this PR fixes

Try to fix PodSecurityPolicy being removed after Kubernetes 1.25+. See:
https://github.com/prometheus-community/helm-charts/issues/2556

#### Special notes for your reviewer
- This PR just simply removes PSP (same as disable PSP).
- PSP before 1.25+ only reaches `policy/v1beta1`
- `policy/v1' does `NOT` contain PodSecurityPolicy. Please don't mix with PodDisruptionBudget.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name

Signed-off-by: zanac1986 <zanhsieh@protonmail.com>