### PR TITLE
[kube-state-metrics] Fix PSP deprecation after k8s 1.25+

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 4.20.2
+version: 4.20.3
 appVersion: 2.6.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/podsecuritypolicy.yaml
+++ b/charts/kube-state-metrics/templates/podsecuritypolicy.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.podSecurityPolicy.enabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -36,4 +37,5 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
+{{- end }}
 {{- end }}

--- a/charts/kube-state-metrics/templates/podsecuritypolicy.yaml
+++ b/charts/kube-state-metrics/templates/podsecuritypolicy.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.podSecurityPolicy.enabled }}
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+{{- if and .Values.podSecurityPolicy.enabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -37,5 +36,4 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
-{{- end }}
 {{- end }}

--- a/charts/kube-state-metrics/templates/psp-clusterrole.yaml
+++ b/charts/kube-state-metrics/templates/psp-clusterrole.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.podSecurityPolicy.enabled .Values.rbac.create -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -16,4 +17,5 @@ rules:
   verbs:     ['use']
   resourceNames:
   - {{ template "kube-state-metrics.fullname" . }}
+{{- end }}
 {{- end }}

--- a/charts/kube-state-metrics/templates/psp-clusterrole.yaml
+++ b/charts/kube-state-metrics/templates/psp-clusterrole.yaml
@@ -1,5 +1,4 @@
-{{- if and .Values.podSecurityPolicy.enabled .Values.rbac.create -}}
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+{{- if and .Values.podSecurityPolicy.enabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -17,5 +16,4 @@ rules:
   verbs:     ['use']
   resourceNames:
   - {{ template "kube-state-metrics.fullname" . }}
-{{- end }}
 {{- end }}

--- a/charts/kube-state-metrics/templates/psp-clusterrolebinding.yaml
+++ b/charts/kube-state-metrics/templates/psp-clusterrolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.podSecurityPolicy.enabled .Values.rbac.create -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -13,4 +14,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "kube-state-metrics.serviceAccountName" . }}
     namespace: {{ template "kube-state-metrics.namespace" . }}
+{{- end }}
 {{- end }}

--- a/charts/kube-state-metrics/templates/psp-clusterrolebinding.yaml
+++ b/charts/kube-state-metrics/templates/psp-clusterrolebinding.yaml
@@ -1,5 +1,4 @@
-{{- if and .Values.podSecurityPolicy.enabled .Values.rbac.create -}}
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+{{- if and .Values.podSecurityPolicy.enabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -14,5 +13,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "kube-state-metrics.serviceAccountName" . }}
     namespace: {{ template "kube-state-metrics.namespace" . }}
-{{- end }}
 {{- end }}


### PR DESCRIPTION
#### Which issue this PR fixes

Try to fix PodSecurityPolicy being removed after Kubernetes 1.25+.

#### Special notes for your reviewer
- This PR just simply removes PSP (same as disable PSP).
- PSP before 1.25+ only reaches `policy/v1beta1`
- `policy/v1` does `NOT` contain PodSecurityPolicy. Please don't mix with PodDisruptionBudget.

#### Checklist

- [x] DCO signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name

Signed-off-by: zanac1986 <zanhsieh@protonmail.com>
