### PR TITLE
[prometheus-adapter] Fix PSP deprecation after k8s 1.25+

### DIFF
--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 3.4.0
+version: 3.4.1
 appVersion: v0.10.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/kubernetes-sigs/prometheus-adapter

--- a/charts/prometheus-adapter/templates/psp.yaml
+++ b/charts/prometheus-adapter/templates/psp.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.psp.create -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 ---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -63,4 +64,5 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "k8s-prometheus-adapter.serviceAccountName" . }}
   namespace: {{ include "k8s-prometheus-adapter.namespace" . | quote }}
+{{- end -}}
 {{- end -}}

--- a/charts/prometheus-adapter/templates/psp.yaml
+++ b/charts/prometheus-adapter/templates/psp.yaml
@@ -64,4 +64,3 @@ subjects:
   name: {{ template "k8s-prometheus-adapter.serviceAccountName" . }}
   namespace: {{ include "k8s-prometheus-adapter.namespace" . | quote }}
 {{- end -}}
-{{- end -}}

--- a/charts/prometheus-adapter/templates/psp.yaml
+++ b/charts/prometheus-adapter/templates/psp.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.psp.create -}}
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+{{- if and .Values.psp.create (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 ---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy


### PR DESCRIPTION
#### Which issue this PR fixes

Try to fix PodSecurityPolicy being removed after Kubernetes 1.25+.

#### Special notes for your reviewer
- This PR just simply removes PSP (same as disable PSP).
- PSP before 1.25+ only reaches `policy/v1beta1`
- `policy/v1` does `NOT` contain PodSecurityPolicy. Please don't mix with PodDisruptionBudget.

#### Checklist

- [x] DCO signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name

Signed-off-by: zanac1986 <zanhsieh@protonmail.com>