### PR TITLE
[prometheus-blackbox-exporter] Fix PSP deprecation after k8s 1.25+

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 7.1.0
+version: 7.1.1
 appVersion: 0.22.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/charts/prometheus-blackbox-exporter/templates/podsecuritypolicy.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/podsecuritypolicy.yaml
@@ -40,3 +40,4 @@ spec:
   - NET_RAW
   {{- end }}
 {{- end }}
+{{- end }}

--- a/charts/prometheus-blackbox-exporter/templates/podsecuritypolicy.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/podsecuritypolicy.yaml
@@ -39,3 +39,4 @@ spec:
   allowedCapabilities: 
   - NET_RAW
 {{- end }}
+{{- end }}

--- a/charts/prometheus-blackbox-exporter/templates/podsecuritypolicy.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/podsecuritypolicy.yaml
@@ -1,9 +1,6 @@
 {{- if .Values.pspEnabled }}
-{{ if $.Capabilities.APIVersions.Has "policy/v1/PodSecurityPolicy" -}}
-apiVersion: policy/v1
-{{- else -}}
+{{- if $.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
-{{- end }}
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus-blackbox-exporter.fullname" . }}-psp
@@ -41,5 +38,4 @@ spec:
   {{- if has "NET_RAW" .Values.securityContext.capabilities.add }}
   allowedCapabilities: 
   - NET_RAW
-  {{- end }}
 {{- end }}

--- a/charts/prometheus-blackbox-exporter/templates/podsecuritypolicy.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/podsecuritypolicy.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.pspEnabled }}
-{{- if $.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+{{- if and .Values.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -39,5 +38,4 @@ spec:
   allowedCapabilities: 
   - NET_RAW
   {{- end }}
-{{- end }}
 {{- end }}

--- a/charts/prometheus-blackbox-exporter/templates/podsecuritypolicy.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/podsecuritypolicy.yaml
@@ -38,5 +38,5 @@ spec:
   {{- if has "NET_RAW" .Values.securityContext.capabilities.add }}
   allowedCapabilities: 
   - NET_RAW
-{{- end }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
#### Which issue this PR fixes

Try to fix PodSecurityPolicy being removed after Kubernetes 1.25+.

#### Special notes for your reviewer
- This PR just simply removes PSP (same as disable PSP).
- PSP before 1.25+ only reaches `policy/v1beta1`
- `policy/v1` does `NOT` contain PodSecurityPolicy. Please don't mix with PodDisruptionBudget.

#### Checklist

- [x] DCO signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name

Signed-off-by: zanac1986 <zanhsieh@protonmail.com>