### PR TITLE
[prometheus-consul-exporter] Fix PSP deprecation after k8s 1.25+

### DIFF
--- a/charts/prometheus-consul-exporter/Chart.yaml
+++ b/charts/prometheus-consul-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.4.0"
 description: A Helm chart for the Prometheus Consul Exporter
 name: prometheus-consul-exporter
-version: 0.5.0
+version: 0.5.1
 keywords:
   - metrics
   - consul

--- a/charts/prometheus-consul-exporter/templates/podsecuritypolicy.yaml
+++ b/charts/prometheus-consul-exporter/templates/podsecuritypolicy.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.rbac.pspEnabled }}
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -39,5 +38,4 @@ spec:
   fsGroup:
     rule: 'RunAsAny'
   readOnlyRootFilesystem: false
-{{- end }}
 {{- end }}

--- a/charts/prometheus-consul-exporter/templates/podsecuritypolicy.yaml
+++ b/charts/prometheus-consul-exporter/templates/podsecuritypolicy.yaml
@@ -1,9 +1,6 @@
 {{- if .Values.rbac.pspEnabled }}
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
-{{ else }}
-apiVersion: extensions/v1beta1
-{{ end -}}
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus-consul-exporter.fullname" . }}
@@ -42,4 +39,5 @@ spec:
   fsGroup:
     rule: 'RunAsAny'
   readOnlyRootFilesystem: false
+{{- end }}
 {{- end }}


### PR DESCRIPTION
#### Which issue this PR fixes

Try to fix PodSecurityPolicy being removed after Kubernetes 1.25+.

#### Special notes for your reviewer
- This PR just simply removes PSP (same as disable PSP).
- PSP before 1.25+ only reaches `policy/v1beta1`
- `policy/v1` does `NOT` contain PodSecurityPolicy. Please don't mix with PodDisruptionBudget.

#### Checklist

- [x] DCO signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name

Signed-off-by: zanac1986 <zanhsieh@protonmail.com>