### PR TITLE
[prometheus-couchdb-exporter] Fix PSP deprecation after k8s 1.25+

### DIFF
--- a/charts/prometheus-couchdb-exporter/Chart.yaml
+++ b/charts/prometheus-couchdb-exporter/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart to export the metrics from couchdb in Prometheus format.
 name: prometheus-couchdb-exporter
 home: https://github.com/gesellix/couchdb-prometheus-exporter
-version: 0.2.0
+version: 0.2.1
 keywords:
 - couchdb-exporter
 sources:

--- a/charts/prometheus-couchdb-exporter/templates/podsecuritypolicy.yaml
+++ b/charts/prometheus-couchdb-exporter/templates/podsecuritypolicy.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.rbac.pspEnabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -36,4 +37,5 @@ spec:
   fsGroup:
     rule: 'RunAsAny'
   readOnlyRootFilesystem: false
+{{- end }}
 {{- end }}

--- a/charts/prometheus-couchdb-exporter/templates/podsecuritypolicy.yaml
+++ b/charts/prometheus-couchdb-exporter/templates/podsecuritypolicy.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.rbac.pspEnabled }}
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -37,5 +36,4 @@ spec:
   fsGroup:
     rule: 'RunAsAny'
   readOnlyRootFilesystem: false
-{{- end }}
 {{- end }}


### PR DESCRIPTION
#### Which issue this PR fixes

Try to fix PodSecurityPolicy being removed after Kubernetes 1.25+.

#### Special notes for your reviewer
- This PR just simply removes PSP (same as disable PSP).
- PSP before 1.25+ only reaches `policy/v1beta1`
- `policy/v1` does `NOT` contain PodSecurityPolicy. Please don't mix with PodDisruptionBudget.

#### Checklist

- [x] DCO signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name

Signed-off-by: zanac1986 <zanhsieh@protonmail.com>