### PR TITLE
[prometheus-elasticsearch-exporter] Fix PSP deprecation after k8s 1.25+

### DIFF
--- a/charts/prometheus-elasticsearch-exporter/Chart.yaml
+++ b/charts/prometheus-elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: prometheus-elasticsearch-exporter
-version: 4.15.0
+version: 4.15.1
 kubeVersion: ">=1.10.0-0"
 appVersion: 1.5.0
 home: https://github.com/prometheus-community/elasticsearch_exporter

--- a/charts/prometheus-elasticsearch-exporter/templates/podsecuritypolicies.yaml
+++ b/charts/prometheus-elasticsearch-exporter/templates/podsecuritypolicies.yaml
@@ -1,9 +1,6 @@
 {{- if .Values.podSecurityPolicies.enabled -}}
-{{- if .Capabilities.APIVersions.Has "policy/v1/PodSecurityPolicy" }}
-apiVersion: policy/v1
-{{- else }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
-{{- end }}
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "elasticsearch-exporter.fullname" . }}
@@ -40,4 +37,5 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: true
+{{- end }}
 {{- end }}

--- a/charts/prometheus-elasticsearch-exporter/templates/podsecuritypolicies.yaml
+++ b/charts/prometheus-elasticsearch-exporter/templates/podsecuritypolicies.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.podSecurityPolicies.enabled -}}
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+{{- if and .Values.podSecurityPolicies.enabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -37,5 +36,4 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: true
-{{- end }}
 {{- end }}


### PR DESCRIPTION
#### Which issue this PR fixes

Try to fix PodSecurityPolicy being removed after Kubernetes 1.25+.

#### Special notes for your reviewer
- This PR just simply removes PSP (same as disable PSP).
- PSP before 1.25+ only reaches `policy/v1beta1`
- `policy/v1` does `NOT` contain PodSecurityPolicy. Please don't mix with PodDisruptionBudget.

#### Checklist

- [x] DCO signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name

Signed-off-by: zanac1986 <zanhsieh@protonmail.com>