### PR TITLE
[prometheus-redis-exporter] Align PSP deprecation with other charts

### DIFF
--- a/charts/prometheus-redis-exporter/Chart.yaml
+++ b/charts/prometheus-redis-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.44.0
 description: Prometheus exporter for Redis metrics
 name: prometheus-redis-exporter
-version: 5.2.0
+version: 5.2.1
 home: https://github.com/oliver006/redis_exporter
 sources:
   - https://github.com/oliver006/redis_exporter

--- a/charts/prometheus-redis-exporter/templates/podsecuritypolicy.yaml
+++ b/charts/prometheus-redis-exporter/templates/podsecuritypolicy.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.rbac.pspEnabled }}
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -34,5 +33,4 @@ spec:
   fsGroup:
     rule: 'RunAsAny'
   readOnlyRootFilesystem: false
-{{- end }}
 {{- end }}


### PR DESCRIPTION
#### Which issue this PR fixes

Try to fix PodSecurityPolicy being removed after Kubernetes 1.25+.

#### Special notes for your reviewer
- This PR just simply removes PSP (same as disable PSP).
- PSP before 1.25+ only reaches `policy/v1beta1`
- `policy/v1` does `NOT` contain PodSecurityPolicy. Please don't mix with PodDisruptionBudget.

#### Checklist

- [x] DCO signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name

Signed-off-by: zanac1986 <zanhsieh@protonmail.com>