### PR TITLE
[prometheus-postgres-exporter] Align PSP deprecation with other charts

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.10.1"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 3.1.3
+version: 3.1.4
 home: https://github.com/prometheus-community/postgres_exporter
 sources:
 - https://github.com/prometheus-community/postgres_exporter

--- a/charts/prometheus-postgres-exporter/templates/podsecuritypolicy.yaml
+++ b/charts/prometheus-postgres-exporter/templates/podsecuritypolicy.yaml
@@ -1,9 +1,5 @@
-{{- if .Values.rbac.pspEnabled }}
-{{ if $.Capabilities.APIVersions.Has "policy/v1/PodSecurityPolicy" -}}
-apiVersion: policy/v1
-{{- else -}}
+{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: policy/v1beta1
-{{- end }}
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus-postgres-exporter.fullname" . }}


### PR DESCRIPTION
#### Which issue this PR fixes

Try to fix PodSecurityPolicy being removed after Kubernetes 1.25+.

#### Special notes for your reviewer
- This PR just simply removes PSP (same as disable PSP).
- PSP before 1.25+ only reaches `policy/v1beta1`
- `policy/v1` does `NOT` contain PodSecurityPolicy. Please don't mix with PodDisruptionBudget.

#### Checklist

- [x] DCO signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name

Signed-off-by: zanac1986 <zanhsieh@protonmail.com>