### PR TITLE
[prometheus-node-exporter] Fix PSP deprecation after k8s 1.25+

### DIFF
--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - prometheus
   - exporter
 type: application
-version: 4.4.0
+version: 4.4.1
 appVersion: 1.3.1
 home: https://github.com/prometheus/node_exporter/
 sources:

--- a/charts/prometheus-node-exporter/templates/psp-clusterrole.yaml
+++ b/charts/prometheus-node-exporter/templates/psp-clusterrole.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.rbac.create }}
-{{- if .Values.rbac.pspEnabled }}
+{{- if and .Values.rbac.create .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -11,5 +10,4 @@ rules:
   verbs:     ['use']
   resourceNames:
   - {{ template "prometheus-node-exporter.fullname" . }}
-{{- end }}
 {{- end }}

--- a/charts/prometheus-node-exporter/templates/psp-clusterrolebinding.yaml
+++ b/charts/prometheus-node-exporter/templates/psp-clusterrolebinding.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.rbac.create }}
-{{- if .Values.rbac.pspEnabled }}
+{{- if and .Values.rbac.create .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -13,5 +12,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "prometheus-node-exporter.fullname" . }}
     namespace: {{ template "prometheus-node-exporter.namespace" . }}
-{{- end }}
 {{- end }}

--- a/charts/prometheus-node-exporter/templates/psp.yaml
+++ b/charts/prometheus-node-exporter/templates/psp.yaml
@@ -1,16 +1,14 @@
-{{- if .Values.rbac.create }}
-{{- if .Values.rbac.pspEnabled }}
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+{{- if and .Values.rbac.create .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus-node-exporter.fullname" . }}
   namespace: {{ template "prometheus-node-exporter.namespace" . }}
   labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}
-{{- if .Values.rbac.pspAnnotations }}
+  {{- with .Values.rbac.pspAnnotations }}
   annotations:
-{{ toYaml .Values.rbac.pspAnnotations | indent 4 }}
-{{- end}}
+    {{- toYaml . | nindent 4 }}
+  {{- end}}
 spec:
   privileged: false
   # Allow core volume types.
@@ -47,6 +45,4 @@ spec:
       - min: 0
         max: 65535
   readOnlyRootFilesystem: false
-{{- end }}
-{{- end }}
 {{- end }}


### PR DESCRIPTION
#### Which issue this PR fixes

Try to fix PodSecurityPolicy being removed after Kubernetes 1.25+.

#### Special notes for your reviewer
- This PR just simply removes PSP (same as disable PSP).
- PSP before 1.25+ only reaches `policy/v1beta1`
- `policy/v1` does `NOT` contain PodSecurityPolicy. Please don't mix with PodDisruptionBudget.

#### Checklist

- [x] DCO signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name

Signed-off-by: zanac1986 <zanhsieh@protonmail.com>