### PR TITLE
[prometheus-fastly-exporter] Fix PSP deprecation after k8s 1.25+

### DIFF
--- a/charts/prometheus-fastly-exporter/Chart.yaml
+++ b/charts/prometheus-fastly-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "7.2.4"
 description: A Helm chart for the Prometheus Fastly Exporter
 name: prometheus-fastly-exporter
-version: 0.1.0
+version: 0.1.1
 keywords:
   - metrics
   - fastly

--- a/charts/prometheus-fastly-exporter/templates/podsecuritypolicy.yaml
+++ b/charts/prometheus-fastly-exporter/templates/podsecuritypolicy.yaml
@@ -1,9 +1,5 @@
-{{- if .Values.rbac.pspEnabled }}
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
+{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: policy/v1beta1
-{{ else }}
-apiVersion: extensions/v1beta1
-{{ end -}}
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus-fastly-exporter.fullname" . }}


### PR DESCRIPTION
#### Which issue this PR fixes

Try to fix PodSecurityPolicy being removed after Kubernetes 1.25+.

#### Special notes for your reviewer
- This PR just simply removes PSP (same as disable PSP).
- PSP before 1.25+ only reaches `policy/v1beta1`
- `policy/v1` does `NOT` contain PodSecurityPolicy. Please don't mix with PodDisruptionBudget.

#### Checklist

- [x] DCO signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name

Signed-off-by: zanac1986 <zanhsieh@protonmail.com>