### PR TITLE
kube-state-metrics add leases to collectors

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 4.20.3
+version: 4.21.0
 appVersion: 2.6.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/role.yaml
+++ b/charts/kube-state-metrics/templates/role.yaml
@@ -69,6 +69,12 @@ rules:
   - jobs
   verbs: ["list", "watch"]
 {{ end -}}
+{{ if has "leases" $.Values.collectors }}
+- apiGroups: ["coordination.k8s.io"]
+  resources:
+  - leases
+  verbs: ["list", "watch"]
+{{ end -}}
 {{ if has "limitranges" $.Values.collectors }}
 - apiGroups: [""]
   resources:

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -184,6 +184,7 @@ collectors:
   - horizontalpodautoscalers
   - ingresses
   - jobs
+  - leases
   - limitranges
   - mutatingwebhookconfigurations
   - namespaces


### PR DESCRIPTION
Signed-off-by: Craig Skinfill <craig.skinfill@gmail.com>

#### What this PR does / why we need it
Adds `leases` to the collectors for kube-state-metrics

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
