### PR TITLE
[prometheus-postgres-exporter] Allow user queries to merge with default queries

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.10.1"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 3.1.4
+version: 3.1.5
 home: https://github.com/prometheus-community/postgres_exporter
 sources:
 - https://github.com/prometheus-community/postgres_exporter

--- a/charts/prometheus-postgres-exporter/templates/configmap.yaml
+++ b/charts/prometheus-postgres-exporter/templates/configmap.yaml
@@ -11,5 +11,6 @@ metadata:
 data:
   allow-snippet-annotations: "false"
   config.yaml: |
-{{ printf .Values.config.queries | indent 4 }}
+    {{- tpl (mergeOverwrite (tpl .Values.config.queries . | fromYaml)
+    (tpl .Values.config.userQueries . | fromYaml) | toYaml) . | nindent 4 }}
 {{- end }}

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -426,6 +426,9 @@ config:
             usage: "HISTOGRAM"
             description: "Idle time of server processes"
 
+  # These are user-specified queries that are deep merged with the queries above
+  userQueries: ""
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Allows a Prometheus postgres exporter user to specify their own queries, and these will be merged with the default ones. This is a useful feature because it means users don't have to fully override default queries when they want to add a thing or two.

For instance, a test config that proves user-defined queries will override a default one and also a new one would be added to config.yaml would look like:

````
  userQueries: |-
    pg_database:
      query: "SELECT pg_database_size(pg_database.datname) as size_bytes FROM pg_database"
      master: true
      cache_seconds: 30
      metrics:
        - datname:
            usage: "LABEL"
            description: "Name of the database"
        - size_bytes:
            usage: "GAUGE"
            description: "Disk space used by the database"
    new_pg:
      query: "SELECT pg_database_size(pg_database.datname) as size_bytes FROM pg_database"
      master: true
      cache_seconds: 30
      metrics:
        - datname:
            usage: "LABEL"
            description: "Name of the database"
        - size_bytes:
            usage: "GAUGE"
            description: "Disk space used by the database"
````

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #2588 

#### Special notes for your reviewer


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
