### PR TITLE
[prometheus]: Add possibility to disable securityContext for Prometheus and Alertmanager workloads

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.39.1
-version: 15.17.1
+version: 15.17.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.39.1
-version: 15.16.1
+version: 15.16.2
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.39.1
-version: 15.16.2
+version: 15.17.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/templates/alertmanager/deploy.yaml
+++ b/charts/prometheus/templates/alertmanager/deploy.yaml
@@ -47,9 +47,11 @@ spec:
         - name: {{ template "prometheus.name" . }}-{{ .Values.alertmanager.name }}
           image: "{{ .Values.alertmanager.image.repository }}:{{ .Values.alertmanager.image.tag }}"
           imagePullPolicy: "{{ .Values.alertmanager.image.pullPolicy }}"
-          {{- if .Values.alertmanager.containerSecurityContext.enabled }}
+          {{- if .Values.alertmanager.containerSecurityContextEnabled }}
+          {{- if .Values.alertmanager.containerSecurityContext }}
           securityContext:
-            {{- omit .Values.alertmanager.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+            {{- toYaml .Values.alertmanager.containerSecurityContext | nindent 12 }}
+          {{- end }}
           {{- end }}
           env:
             {{- range $key, $value := .Values.alertmanager.extraEnv }}
@@ -117,9 +119,11 @@ spec:
         - name: {{ template "prometheus.name" . }}-{{ .Values.alertmanager.name }}-{{ .Values.configmapReload.alertmanager.name }}
           image: "{{ .Values.configmapReload.alertmanager.image.repository }}:{{ .Values.configmapReload.alertmanager.image.tag }}"
           imagePullPolicy: "{{ .Values.configmapReload.alertmanager.image.pullPolicy }}"
-          {{- if .Values.configmapReload.alertmanager.containerSecurityContext.enabled }}
+          {{- if .Values.configmapReload.alertmanager.containerSecurityContextEnabled }}
+          {{- if .Values.configmapReload.alertmanager.containerSecurityContext }}
           securityContext:
-            {{- omit .Values.configmapReload.alertmanager.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+            {{- toYaml .Values.configmapReload.alertmanager.containerSecurityContext | nindent 12 }}
+          {{- end }}
           {{- end }}
           args:
             - --volume-dir=/etc/config

--- a/charts/prometheus/templates/alertmanager/deploy.yaml
+++ b/charts/prometheus/templates/alertmanager/deploy.yaml
@@ -47,10 +47,10 @@ spec:
         - name: {{ template "prometheus.name" . }}-{{ .Values.alertmanager.name }}
           image: "{{ .Values.alertmanager.image.repository }}:{{ .Values.alertmanager.image.tag }}"
           imagePullPolicy: "{{ .Values.alertmanager.image.pullPolicy }}"
-          {{- if .Values.alertmanager.containerSecurityContextEnabled }}
           {{- if .Values.alertmanager.containerSecurityContext }}
+          {{- with .Values.alertmanager.containerSecurityContext }}
           securityContext:
-            {{- toYaml .Values.alertmanager.containerSecurityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- end }}
           env:
@@ -119,10 +119,10 @@ spec:
         - name: {{ template "prometheus.name" . }}-{{ .Values.alertmanager.name }}-{{ .Values.configmapReload.alertmanager.name }}
           image: "{{ .Values.configmapReload.alertmanager.image.repository }}:{{ .Values.configmapReload.alertmanager.image.tag }}"
           imagePullPolicy: "{{ .Values.configmapReload.alertmanager.image.pullPolicy }}"
-          {{- if .Values.configmapReload.alertmanager.containerSecurityContextEnabled }}
           {{- if .Values.configmapReload.alertmanager.containerSecurityContext }}
+          {{- with .Values.configmapReload.alertmanager.containerSecurityContext }}
           securityContext:
-            {{- toYaml .Values.configmapReload.alertmanager.containerSecurityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- end }}
           args:

--- a/charts/prometheus/templates/alertmanager/deploy.yaml
+++ b/charts/prometheus/templates/alertmanager/deploy.yaml
@@ -47,8 +47,10 @@ spec:
         - name: {{ template "prometheus.name" . }}-{{ .Values.alertmanager.name }}
           image: "{{ .Values.alertmanager.image.repository }}:{{ .Values.alertmanager.image.tag }}"
           imagePullPolicy: "{{ .Values.alertmanager.image.pullPolicy }}"
+          {{- if .Values.alertmanager.containerSecurityContext.enabled }}
           securityContext:
-            {{- toYaml .Values.alertmanager.containerSecurityContext | nindent 12 }}
+            {{- omit .Values.alertmanager.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           env:
             {{- range $key, $value := .Values.alertmanager.extraEnv }}
             - name: {{ $key }}
@@ -115,8 +117,10 @@ spec:
         - name: {{ template "prometheus.name" . }}-{{ .Values.alertmanager.name }}-{{ .Values.configmapReload.alertmanager.name }}
           image: "{{ .Values.configmapReload.alertmanager.image.repository }}:{{ .Values.configmapReload.alertmanager.image.tag }}"
           imagePullPolicy: "{{ .Values.configmapReload.alertmanager.image.pullPolicy }}"
+          {{- if .Values.configmapReload.alertmanager.containerSecurityContext.enabled }}
           securityContext:
-            {{- toYaml .Values.configmapReload.alertmanager.containerSecurityContext | nindent 12 }}
+            {{- omit .Values.configmapReload.alertmanager.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           args:
             - --volume-dir=/etc/config
             - --webhook-url=http://127.0.0.1:9093{{ .Values.alertmanager.prefixURL }}/-/reload
@@ -155,9 +159,9 @@ spec:
       dnsConfig:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- if .Values.alertmanager.securityContext }}
+    {{- if .Values.alertmanager.securityContext.enabled }}
       securityContext:
-{{ toYaml .Values.alertmanager.securityContext | indent 8 }}
+{{ omit .Values.alertmanager.securityContext "enabled" | toYaml | indent 8 }}
     {{- end }}
     {{- if .Values.alertmanager.tolerations }}
       tolerations:

--- a/charts/prometheus/templates/alertmanager/deploy.yaml
+++ b/charts/prometheus/templates/alertmanager/deploy.yaml
@@ -159,9 +159,9 @@ spec:
       dnsConfig:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- if .Values.alertmanager.securityContext.enabled }}
+    {{- with .Values.alertmanager.securityContext }}
       securityContext:
-{{ omit .Values.alertmanager.securityContext "enabled" | toYaml | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- if .Values.alertmanager.tolerations }}
       tolerations:

--- a/charts/prometheus/templates/alertmanager/deploy.yaml
+++ b/charts/prometheus/templates/alertmanager/deploy.yaml
@@ -47,11 +47,9 @@ spec:
         - name: {{ template "prometheus.name" . }}-{{ .Values.alertmanager.name }}
           image: "{{ .Values.alertmanager.image.repository }}:{{ .Values.alertmanager.image.tag }}"
           imagePullPolicy: "{{ .Values.alertmanager.image.pullPolicy }}"
-          {{- if .Values.alertmanager.containerSecurityContext }}
           {{- with .Values.alertmanager.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
-          {{- end }}
           {{- end }}
           env:
             {{- range $key, $value := .Values.alertmanager.extraEnv }}
@@ -119,11 +117,9 @@ spec:
         - name: {{ template "prometheus.name" . }}-{{ .Values.alertmanager.name }}-{{ .Values.configmapReload.alertmanager.name }}
           image: "{{ .Values.configmapReload.alertmanager.image.repository }}:{{ .Values.configmapReload.alertmanager.image.tag }}"
           imagePullPolicy: "{{ .Values.configmapReload.alertmanager.image.pullPolicy }}"
-          {{- if .Values.configmapReload.alertmanager.containerSecurityContext }}
           {{- with .Values.configmapReload.alertmanager.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
-          {{- end }}
           {{- end }}
           args:
             - --volume-dir=/etc/config

--- a/charts/prometheus/templates/alertmanager/sts.yaml
+++ b/charts/prometheus/templates/alertmanager/sts.yaml
@@ -47,8 +47,10 @@ spec:
         - name: {{ template "prometheus.name" . }}-{{ .Values.alertmanager.name }}
           image: "{{ .Values.alertmanager.image.repository }}:{{ .Values.alertmanager.image.tag }}"
           imagePullPolicy: "{{ .Values.alertmanager.image.pullPolicy }}"
+          {{- if .Values.alertmanager.containerSecurityContext.enabled }}
           securityContext:
-            {{- toYaml .Values.alertmanager.containerSecurityContext | nindent 12 }}
+            {{- omit .Values.alertmanager.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           env:
             {{- range $key, $value := .Values.alertmanager.extraEnv }}
             - name: {{ $key }}
@@ -111,8 +113,10 @@ spec:
         - name: {{ template "prometheus.name" . }}-{{ .Values.alertmanager.name }}-{{ .Values.configmapReload.alertmanager.name }}
           image: "{{ .Values.configmapReload.alertmanager.image.repository }}:{{ .Values.configmapReload.alertmanager.image.tag }}"
           imagePullPolicy: "{{ .Values.configmapReload.alertmanager.image.pullPolicy }}"
+          {{- if .Values.configmapReload.alertmanager.containerSecurityContext.enabled }}
           securityContext:
-            {{- toYaml .Values.configmapReload.alertmanager.containerSecurityContext | nindent 12 }}
+            {{- omit .Values.configmapReload.alertmanager.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           args:
             - --volume-dir=/etc/config
             - --webhook-url=http://localhost:9093{{ .Values.alertmanager.prefixURL }}/-/reload
@@ -138,9 +142,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.alertmanager.nodeSelector | indent 8 }}
     {{- end }}
-    {{- if .Values.alertmanager.securityContext }}
+    {{- if .Values.alertmanager.securityContext.enabled }}
       securityContext:
-{{ toYaml .Values.alertmanager.securityContext | indent 8 }}
+{{ omit .Values.alertmanager.securityContext "enabled" | toYaml | indent 8 }}
     {{- end }}
     {{- if .Values.alertmanager.tolerations }}
       tolerations:

--- a/charts/prometheus/templates/alertmanager/sts.yaml
+++ b/charts/prometheus/templates/alertmanager/sts.yaml
@@ -47,11 +47,9 @@ spec:
         - name: {{ template "prometheus.name" . }}-{{ .Values.alertmanager.name }}
           image: "{{ .Values.alertmanager.image.repository }}:{{ .Values.alertmanager.image.tag }}"
           imagePullPolicy: "{{ .Values.alertmanager.image.pullPolicy }}"
-          {{- if .Values.alertmanager.containerSecurityContext }}
           {{- with .Values.alertmanager.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
-          {{- end }}
           {{- end }}
           env:
             {{- range $key, $value := .Values.alertmanager.extraEnv }}
@@ -115,11 +113,9 @@ spec:
         - name: {{ template "prometheus.name" . }}-{{ .Values.alertmanager.name }}-{{ .Values.configmapReload.alertmanager.name }}
           image: "{{ .Values.configmapReload.alertmanager.image.repository }}:{{ .Values.configmapReload.alertmanager.image.tag }}"
           imagePullPolicy: "{{ .Values.configmapReload.alertmanager.image.pullPolicy }}"
-          {{- if .Values.configmapReload.alertmanager.containerSecurityContext }}
           {{- with .Values.configmapReload.alertmanager.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
-          {{- end }}
           {{- end }}
           args:
             - --volume-dir=/etc/config

--- a/charts/prometheus/templates/alertmanager/sts.yaml
+++ b/charts/prometheus/templates/alertmanager/sts.yaml
@@ -142,9 +142,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.alertmanager.nodeSelector | indent 8 }}
     {{- end }}
-    {{- if .Values.alertmanager.securityContext.enabled }}
+    {{- with .Values.alertmanager.securityContext }}
       securityContext:
-{{ omit .Values.alertmanager.securityContext "enabled" | toYaml | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- if .Values.alertmanager.tolerations }}
       tolerations:

--- a/charts/prometheus/templates/alertmanager/sts.yaml
+++ b/charts/prometheus/templates/alertmanager/sts.yaml
@@ -47,10 +47,10 @@ spec:
         - name: {{ template "prometheus.name" . }}-{{ .Values.alertmanager.name }}
           image: "{{ .Values.alertmanager.image.repository }}:{{ .Values.alertmanager.image.tag }}"
           imagePullPolicy: "{{ .Values.alertmanager.image.pullPolicy }}"
-          {{- if .Values.alertmanager.containerSecurityContextEnabled }}
           {{- if .Values.alertmanager.containerSecurityContext }}
+          {{- with .Values.alertmanager.containerSecurityContext }}
           securityContext:
-            {{- toYaml .Values.alertmanager.containerSecurityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- end }}
           env:
@@ -115,10 +115,10 @@ spec:
         - name: {{ template "prometheus.name" . }}-{{ .Values.alertmanager.name }}-{{ .Values.configmapReload.alertmanager.name }}
           image: "{{ .Values.configmapReload.alertmanager.image.repository }}:{{ .Values.configmapReload.alertmanager.image.tag }}"
           imagePullPolicy: "{{ .Values.configmapReload.alertmanager.image.pullPolicy }}"
-          {{- if .Values.configmapReload.alertmanager.containerSecurityContextEnabled }}
           {{- if .Values.configmapReload.alertmanager.containerSecurityContext }}
+          {{- with .Values.configmapReload.alertmanager.containerSecurityContext }}
           securityContext:
-            {{- toYaml .Values.configmapReload.alertmanager.containerSecurityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- end }}
           args:

--- a/charts/prometheus/templates/alertmanager/sts.yaml
+++ b/charts/prometheus/templates/alertmanager/sts.yaml
@@ -47,9 +47,11 @@ spec:
         - name: {{ template "prometheus.name" . }}-{{ .Values.alertmanager.name }}
           image: "{{ .Values.alertmanager.image.repository }}:{{ .Values.alertmanager.image.tag }}"
           imagePullPolicy: "{{ .Values.alertmanager.image.pullPolicy }}"
-          {{- if .Values.alertmanager.containerSecurityContext.enabled }}
+          {{- if .Values.alertmanager.containerSecurityContextEnabled }}
+          {{- if .Values.alertmanager.containerSecurityContext }}
           securityContext:
-            {{- omit .Values.alertmanager.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+            {{- toYaml .Values.alertmanager.containerSecurityContext | nindent 12 }}
+          {{- end }}
           {{- end }}
           env:
             {{- range $key, $value := .Values.alertmanager.extraEnv }}
@@ -113,9 +115,11 @@ spec:
         - name: {{ template "prometheus.name" . }}-{{ .Values.alertmanager.name }}-{{ .Values.configmapReload.alertmanager.name }}
           image: "{{ .Values.configmapReload.alertmanager.image.repository }}:{{ .Values.configmapReload.alertmanager.image.tag }}"
           imagePullPolicy: "{{ .Values.configmapReload.alertmanager.image.pullPolicy }}"
-          {{- if .Values.configmapReload.alertmanager.containerSecurityContext.enabled }}
+          {{- if .Values.configmapReload.alertmanager.containerSecurityContextEnabled }}
+          {{- if .Values.configmapReload.alertmanager.containerSecurityContext }}
           securityContext:
-            {{- omit .Values.configmapReload.alertmanager.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+            {{- toYaml .Values.configmapReload.alertmanager.containerSecurityContext | nindent 12 }}
+          {{- end }}
           {{- end }}
           args:
             - --volume-dir=/etc/config

--- a/charts/prometheus/templates/server/deploy.yaml
+++ b/charts/prometheus/templates/server/deploy.yaml
@@ -252,9 +252,9 @@ spec:
       dnsConfig:
 {{ toYaml .Values.server.dnsConfig | indent 8 }}
     {{- end }}
-    {{- if .Values.server.securityContext.enabled }}
+    {{- with .Values.server.securityContext }}
       securityContext:
-{{ omit .Values.server.securityContext "enabled" | toYaml | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- if .Values.server.tolerations }}
       tolerations:

--- a/charts/prometheus/templates/server/deploy.yaml
+++ b/charts/prometheus/templates/server/deploy.yaml
@@ -56,10 +56,10 @@ spec:
         - name: {{ template "prometheus.name" . }}-{{ .Values.server.name }}-{{ .Values.configmapReload.prometheus.name }}
           image: "{{ .Values.configmapReload.prometheus.image.repository }}:{{ .Values.configmapReload.prometheus.image.tag }}"
           imagePullPolicy: "{{ .Values.configmapReload.prometheus.image.pullPolicy }}"
-          {{- if .Values.configmapReload.prometheus.containerSecurityContextEnabled }}
           {{- if .Values.configmapReload.prometheus.containerSecurityContext }}
+          {{- with .Values.configmapReload.prometheus.containerSecurityContext }}
           securityContext:
-            {{- toYaml .Values.configmapReload.prometheus.containerSecurityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- end }}
           args:
@@ -218,10 +218,10 @@ spec:
           {{- if .Values.server.extraVolumeMounts }}
             {{ toYaml .Values.server.extraVolumeMounts | nindent 12 }}
           {{- end }}
-          {{- if .Values.server.containerSecurityContextEnabled }}
           {{- if .Values.server.containerSecurityContext }}
+          {{- with .Values.server.containerSecurityContext }}
           securityContext:
-            {{- toYaml .Values.server.containerSecurityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- end }}
       {{- if .Values.server.sidecarContainers }}

--- a/charts/prometheus/templates/server/deploy.yaml
+++ b/charts/prometheus/templates/server/deploy.yaml
@@ -56,8 +56,10 @@ spec:
         - name: {{ template "prometheus.name" . }}-{{ .Values.server.name }}-{{ .Values.configmapReload.prometheus.name }}
           image: "{{ .Values.configmapReload.prometheus.image.repository }}:{{ .Values.configmapReload.prometheus.image.tag }}"
           imagePullPolicy: "{{ .Values.configmapReload.prometheus.image.pullPolicy }}"
+          {{- if .Values.configmapReload.prometheus.containerSecurityContext.enabled }}
           securityContext:
-            {{- toYaml .Values.configmapReload.prometheus.containerSecurityContext | nindent 12 }}
+            {{- omit .Values.configmapReload.prometheus.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           args:
             - --volume-dir=/etc/config
             - --webhook-url=http://127.0.0.1:9090{{ .Values.server.prefixURL }}/-/reload
@@ -214,9 +216,9 @@ spec:
           {{- if .Values.server.extraVolumeMounts }}
             {{ toYaml .Values.server.extraVolumeMounts | nindent 12 }}
           {{- end }}
-          {{- with .Values.server.containerSecurityContext }}
+          {{- if .Values.server.containerSecurityContext.enabled }}
           securityContext:
-            {{- toYaml . | nindent 12 }}
+            {{- omit .Values.server.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
       {{- if .Values.server.sidecarContainers }}
         {{- range $name, $spec :=  .Values.server.sidecarContainers }}
@@ -250,9 +252,9 @@ spec:
       dnsConfig:
 {{ toYaml .Values.server.dnsConfig | indent 8 }}
     {{- end }}
-    {{- if .Values.server.securityContext }}
+    {{- if .Values.server.securityContext.enabled }}
       securityContext:
-{{ toYaml .Values.server.securityContext | indent 8 }}
+{{ omit .Values.server.securityContext "enabled" | toYaml | indent 8 }}
     {{- end }}
     {{- if .Values.server.tolerations }}
       tolerations:

--- a/charts/prometheus/templates/server/deploy.yaml
+++ b/charts/prometheus/templates/server/deploy.yaml
@@ -56,9 +56,11 @@ spec:
         - name: {{ template "prometheus.name" . }}-{{ .Values.server.name }}-{{ .Values.configmapReload.prometheus.name }}
           image: "{{ .Values.configmapReload.prometheus.image.repository }}:{{ .Values.configmapReload.prometheus.image.tag }}"
           imagePullPolicy: "{{ .Values.configmapReload.prometheus.image.pullPolicy }}"
-          {{- if .Values.configmapReload.prometheus.containerSecurityContext.enabled }}
+          {{- if .Values.configmapReload.prometheus.containerSecurityContextEnabled }}
+          {{- if .Values.configmapReload.prometheus.containerSecurityContext }}
           securityContext:
-            {{- omit .Values.configmapReload.prometheus.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+            {{- toYaml .Values.configmapReload.prometheus.containerSecurityContext | nindent 12 }}
+          {{- end }}
           {{- end }}
           args:
             - --volume-dir=/etc/config
@@ -216,9 +218,11 @@ spec:
           {{- if .Values.server.extraVolumeMounts }}
             {{ toYaml .Values.server.extraVolumeMounts | nindent 12 }}
           {{- end }}
-          {{- if .Values.server.containerSecurityContext.enabled }}
+          {{- if .Values.server.containerSecurityContextEnabled }}
+          {{- if .Values.server.containerSecurityContext }}
           securityContext:
-            {{- omit .Values.server.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+            {{- toYaml .Values.server.containerSecurityContext | nindent 12 }}
+          {{- end }}
           {{- end }}
       {{- if .Values.server.sidecarContainers }}
         {{- range $name, $spec :=  .Values.server.sidecarContainers }}

--- a/charts/prometheus/templates/server/deploy.yaml
+++ b/charts/prometheus/templates/server/deploy.yaml
@@ -56,11 +56,9 @@ spec:
         - name: {{ template "prometheus.name" . }}-{{ .Values.server.name }}-{{ .Values.configmapReload.prometheus.name }}
           image: "{{ .Values.configmapReload.prometheus.image.repository }}:{{ .Values.configmapReload.prometheus.image.tag }}"
           imagePullPolicy: "{{ .Values.configmapReload.prometheus.image.pullPolicy }}"
-          {{- if .Values.configmapReload.prometheus.containerSecurityContext }}
           {{- with .Values.configmapReload.prometheus.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
-          {{- end }}
           {{- end }}
           args:
             - --volume-dir=/etc/config
@@ -218,11 +216,9 @@ spec:
           {{- if .Values.server.extraVolumeMounts }}
             {{ toYaml .Values.server.extraVolumeMounts | nindent 12 }}
           {{- end }}
-          {{- if .Values.server.containerSecurityContext }}
           {{- with .Values.server.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
-          {{- end }}
           {{- end }}
       {{- if .Values.server.sidecarContainers }}
         {{- range $name, $spec :=  .Values.server.sidecarContainers }}

--- a/charts/prometheus/templates/server/sts.yaml
+++ b/charts/prometheus/templates/server/sts.yaml
@@ -56,8 +56,10 @@ spec:
         - name: {{ template "prometheus.name" . }}-{{ .Values.server.name }}-{{ .Values.configmapReload.prometheus.name }}
           image: "{{ .Values.configmapReload.prometheus.image.repository }}:{{ .Values.configmapReload.prometheus.image.tag }}"
           imagePullPolicy: "{{ .Values.configmapReload.prometheus.image.pullPolicy }}"
+          {{- if .Values.configmapReload.prometheus.containerSecurityContext.enabled }}
           securityContext:
-            {{- toYaml .Values.configmapReload.prometheus.containerSecurityContext | nindent 12 }}
+            {{- omit .Values.configmapReload.prometheus.containerSecurityContext "enabled" | toYaml .Values.configmapReload.prometheus.containerSecurityContext | nindent 12 }}
+          {{- end }}
           args:
             - --volume-dir=/etc/config
             - --webhook-url=http://127.0.0.1:9090{{ .Values.server.prefixURL }}/-/reload
@@ -214,9 +216,9 @@ spec:
           {{- if .Values.server.extraVolumeMounts }}
           {{ toYaml .Values.server.extraVolumeMounts | nindent 12 }}
           {{- end }}
-          {{- with .Values.server.containerSecurityContext }}
+          {{- if .Values.server.containerSecurityContext.enabled }}
           securityContext:
-            {{- toYaml . | nindent 12 }}
+            {{- omit .Values.server.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
     {{- if .Values.server.sidecarContainers }}
       {{- range $name, $spec :=  .Values.server.sidecarContainers }}
@@ -248,9 +250,9 @@ spec:
       dnsConfig:
 {{ toYaml .Values.server.dnsConfig | indent 8 }}
     {{- end }}
-    {{- if .Values.server.securityContext }}
+    {{- if .Values.server.securityContext.enabled }}
       securityContext:
-{{ toYaml .Values.server.securityContext | indent 8 }}
+{{- omit .Values.server.securityContext "enabled" | toYaml | indent 8 }}
     {{- end }}
     {{- if .Values.server.tolerations }}
       tolerations:

--- a/charts/prometheus/templates/server/sts.yaml
+++ b/charts/prometheus/templates/server/sts.yaml
@@ -56,10 +56,10 @@ spec:
         - name: {{ template "prometheus.name" . }}-{{ .Values.server.name }}-{{ .Values.configmapReload.prometheus.name }}
           image: "{{ .Values.configmapReload.prometheus.image.repository }}:{{ .Values.configmapReload.prometheus.image.tag }}"
           imagePullPolicy: "{{ .Values.configmapReload.prometheus.image.pullPolicy }}"
-          {{- if .Values.server.configmapReload.prometheus.containerSecurityContextEnabled }}
           {{- if .Values.configmapReload.prometheus.containerSecurityContext }}
+          {{- with .Values.configmapReload.prometheus.containerSecurityContext }}
           securityContext:
-            {{- toYaml .Values.configmapReload.prometheus.containerSecurityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- end }}
           args:
@@ -218,10 +218,10 @@ spec:
           {{- if .Values.server.extraVolumeMounts }}
           {{ toYaml .Values.server.extraVolumeMounts | nindent 12 }}
           {{- end }}
-          {{- if .Values.server.containerSecurityContextEnabled }}
           {{- if .Values.server.containerSecurityContext }}
+          {{- with .Values.server.containerSecurityContext }}
           securityContext:
-            {{- toYaml .Values.server.containerSecurityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- end }}
     {{- if .Values.server.sidecarContainers }}

--- a/charts/prometheus/templates/server/sts.yaml
+++ b/charts/prometheus/templates/server/sts.yaml
@@ -252,9 +252,9 @@ spec:
       dnsConfig:
 {{ toYaml .Values.server.dnsConfig | indent 8 }}
     {{- end }}
-    {{- if .Values.server.securityContext.enabled }}
+    {{- with .Values.server.securityContext }}
       securityContext:
-{{- omit .Values.server.securityContext "enabled" | toYaml | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- if .Values.server.tolerations }}
       tolerations:

--- a/charts/prometheus/templates/server/sts.yaml
+++ b/charts/prometheus/templates/server/sts.yaml
@@ -56,9 +56,11 @@ spec:
         - name: {{ template "prometheus.name" . }}-{{ .Values.server.name }}-{{ .Values.configmapReload.prometheus.name }}
           image: "{{ .Values.configmapReload.prometheus.image.repository }}:{{ .Values.configmapReload.prometheus.image.tag }}"
           imagePullPolicy: "{{ .Values.configmapReload.prometheus.image.pullPolicy }}"
-          {{- if .Values.configmapReload.prometheus.containerSecurityContext.enabled }}
+          {{- if .Values.server.configmapReload.prometheus.containerSecurityContextEnabled }}
+          {{- if .Values.configmapReload.prometheus.containerSecurityContext }}
           securityContext:
-            {{- omit .Values.configmapReload.prometheus.containerSecurityContext "enabled" | toYaml .Values.configmapReload.prometheus.containerSecurityContext | nindent 12 }}
+            {{- toYaml .Values.configmapReload.prometheus.containerSecurityContext | nindent 12 }}
+          {{- end }}
           {{- end }}
           args:
             - --volume-dir=/etc/config
@@ -216,9 +218,11 @@ spec:
           {{- if .Values.server.extraVolumeMounts }}
           {{ toYaml .Values.server.extraVolumeMounts | nindent 12 }}
           {{- end }}
-          {{- if .Values.server.containerSecurityContext.enabled }}
+          {{- if .Values.server.containerSecurityContextEnabled }}
+          {{- if .Values.server.containerSecurityContext }}
           securityContext:
-            {{- omit .Values.server.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+            {{- toYaml .Values.server.containerSecurityContext | nindent 12 }}
+          {{- end }}
           {{- end }}
     {{- if .Values.server.sidecarContainers }}
       {{- range $name, $spec :=  .Values.server.sidecarContainers }}

--- a/charts/prometheus/templates/server/sts.yaml
+++ b/charts/prometheus/templates/server/sts.yaml
@@ -56,11 +56,9 @@ spec:
         - name: {{ template "prometheus.name" . }}-{{ .Values.server.name }}-{{ .Values.configmapReload.prometheus.name }}
           image: "{{ .Values.configmapReload.prometheus.image.repository }}:{{ .Values.configmapReload.prometheus.image.tag }}"
           imagePullPolicy: "{{ .Values.configmapReload.prometheus.image.pullPolicy }}"
-          {{- if .Values.configmapReload.prometheus.containerSecurityContext }}
           {{- with .Values.configmapReload.prometheus.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
-          {{- end }}
           {{- end }}
           args:
             - --volume-dir=/etc/config

--- a/charts/prometheus/templates/server/sts.yaml
+++ b/charts/prometheus/templates/server/sts.yaml
@@ -218,11 +218,9 @@ spec:
           {{- if .Values.server.extraVolumeMounts }}
           {{ toYaml .Values.server.extraVolumeMounts | nindent 12 }}
           {{- end }}
-          {{- if .Values.server.containerSecurityContext }}
           {{- with .Values.server.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
-          {{- end }}
           {{- end }}
     {{- if .Values.server.sidecarContainers }}
       {{- range $name, $spec :=  .Values.server.sidecarContainers }}

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -355,7 +355,6 @@ alertmanager:
     fsGroup: 65534
 
   ## Security context to be added to alertmanager container
-  containerSecurityContextEnabled: true
   containerSecurityContext: {}
 
   service:
@@ -423,7 +422,6 @@ configmapReload:
       #   readOnly: true
 
     ## Security context to be added to configmap-reload container
-    containerSecurityContextEnabled: true
     containerSecurityContext: {}
 
     ## configmap-reload resource requests and limits
@@ -466,7 +464,6 @@ configmapReload:
       #   readOnly: true
 
     ## Security context to be added to configmap-reload container
-    containerSecurityContextEnabled: true
     containerSecurityContext: {}
 
     ## configmap-reload resource requests and limits
@@ -1114,7 +1111,6 @@ server:
     fsGroup: 65534
 
   ## Security context to be added to server container
-  containerSecurityContextEnabled: true
   containerSecurityContext: {}
 
   service:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -83,8 +83,7 @@ alertmanager:
 
   ## Additional alertmanager Secret mounts
   # Defines additional mounts with secrets. Secrets must be manually created in the namespace.
-  extraSecretMounts:
-    []
+  extraSecretMounts: []
     # - name: secret-files
     #   mountPath: /etc/secrets
     #   subPath: ""
@@ -92,8 +91,7 @@ alertmanager:
     #   readOnly: true
 
   ## Additional alertmanager Configmap mounts
-  extraConfigmapMounts:
-    []
+  extraConfigmapMounts: []
     # - name: template-files
     #   mountPath: /etc/config/templates.d
     #   configMap: alertmanager-template-files
@@ -169,8 +167,7 @@ alertmanager:
   ## Node tolerations for alertmanager scheduling to nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   ##
-  tolerations:
-    []
+  tolerations: []
     # - key: "key"
     #   operator: "Equal|Exists"
     #   value: "value"
@@ -270,8 +267,7 @@ alertmanager:
 
   ## Annotations to be added to alertmanager pods
   ##
-  podAnnotations:
-    {}
+  podAnnotations: {}
     ## Tell prometheus to use a specific set of alertmanager pods
     ## instead of all alertmanager pods found in the same namespace
     ## Useful if you deploy multiple releases within the same namespace
@@ -286,8 +282,7 @@ alertmanager:
   ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
   ##
   podSecurityPolicy:
-    annotations:
-      {}
+    annotations: {}
       ## Specify pod annotations
       ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
       ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
@@ -330,8 +325,7 @@ alertmanager:
   ## alertmanager resource requests and limits
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
-  resources:
-    {}
+  resources: {}
     # limits:
     #   cpu: 10m
     #   memory: 32Mi
@@ -340,8 +334,7 @@ alertmanager:
     #   memory: 32Mi
 
   # Custom DNS configuration to be added to alertmanager pods
-  dnsConfig:
-    {}
+  dnsConfig: {}
     # nameservers:
     #   - 1.2.3.4
     # searches:
@@ -362,7 +355,8 @@ alertmanager:
     fsGroup: 65534
 
   ## Security context to be added to alertmanager container
-  containerSecurityContext: {}
+  containerSecurityContext:
+    enabled: false
 
   service:
     annotations: {}
@@ -418,10 +412,10 @@ configmapReload:
     ##
     extraVolumeDirs: []
 
+
     ## Additional configmap-reload mounts
     ##
-    extraConfigmapMounts:
-      []
+    extraConfigmapMounts: []
       # - name: prometheus-alerts
       #   mountPath: /etc/alerts.d
       #   subPath: ""
@@ -429,7 +423,8 @@ configmapReload:
       #   readOnly: true
 
     ## Security context to be added to configmap-reload container
-    containerSecurityContext: {}
+    containerSecurityContext:
+      enabled: false
 
     ## configmap-reload resource requests and limits
     ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -460,10 +455,10 @@ configmapReload:
     ##
     extraVolumeDirs: []
 
+
     ## Additional configmap-reload mounts
     ##
-    extraConfigmapMounts:
-      []
+    extraConfigmapMounts: []
       # - name: prometheus-alerts
       #   mountPath: /etc/alerts.d
       #   subPath: ""
@@ -471,7 +466,8 @@ configmapReload:
       #   readOnly: true
 
     ## Security context to be added to configmap-reload container
-    containerSecurityContext: {}
+    containerSecurityContext:
+      enabled: false
 
     ## configmap-reload resource requests and limits
     ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -520,8 +516,7 @@ nodeExporter:
   ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
   ##
   podSecurityPolicy:
-    annotations:
-      {}
+    annotations: {}
       ## Specify pod annotations
       ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
       ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
@@ -550,16 +545,14 @@ nodeExporter:
 
   ## Additional node-exporter hostPath mounts
   ##
-  extraHostPathMounts:
-    []
+  extraHostPathMounts: []
     # - name: textfile-dir
     #   mountPath: /srv/txt_collector
     #   hostPath: /var/lib/node-exporter
     #   readOnly: true
     #   mountPropagation: HostToContainer
 
-  extraConfigmapMounts:
-    []
+  extraConfigmapMounts: []
     # - name: certs-configmap
     #   mountPath: /prometheus
     #   configMap: certs-configmap
@@ -568,8 +561,7 @@ nodeExporter:
   ## Node tolerations for node-exporter scheduling to nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   ##
-  tolerations:
-    []
+  tolerations: []
     # - key: "key"
     #   operator: "Equal|Exists"
     #   value: "value"
@@ -599,8 +591,7 @@ nodeExporter:
   ## node-exporter resource limits & requests
   ## Ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ##
-  resources:
-    {}
+  resources: {}
     # limits:
     #   cpu: 200m
     #   memory: 50Mi
@@ -611,8 +602,7 @@ nodeExporter:
     securityContext:
       allowPrivilegeEscalation: false
   # Custom DNS configuration to be added to node-exporter pods
-  dnsConfig:
-    {}
+  dnsConfig: {}
     # nameservers:
     #   - 1.2.3.4
     # searches:
@@ -779,8 +769,7 @@ server:
   ## Custom HTTP headers for Liveness/Readiness/Startup Probe
   ##
   ## Useful for providing HTTP Basic Auth to healthchecks
-  probeHeaders:
-    []
+  probeHeaders: []
     # - name: "Authorization"
     #   value: "Bearer ABCDEabcde12345"
 
@@ -802,16 +791,14 @@ server:
 
   ## Additional Prometheus server hostPath mounts
   ##
-  extraHostPathMounts:
-    []
+  extraHostPathMounts: []
     # - name: certs-dir
     #   mountPath: /etc/kubernetes/certs
     #   subPath: ""
     #   hostPath: /etc/kubernetes/certs
     #   readOnly: true
 
-  extraConfigmapMounts:
-    []
+  extraConfigmapMounts: []
     # - name: certs-configmap
     #   mountPath: /prometheus
     #   subPath: ""
@@ -820,8 +807,7 @@ server:
 
   ## Additional Prometheus server Secret mounts
   # Defines additional mounts with secrets. Secrets must be manually created in the namespace.
-  extraSecretMounts:
-    []
+  extraSecretMounts: []
     # - name: secret-files
     #   mountPath: /etc/secrets
     #   subPath: ""
@@ -896,8 +882,7 @@ server:
   ## Node tolerations for server scheduling to nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   ##
-  tolerations:
-    []
+  tolerations: []
     # - key: "key"
     #   operator: "Equal|Exists"
     #   value: "value"
@@ -1001,8 +986,7 @@ server:
 
   ## Annotations to be added to Prometheus server pods
   ##
-  podAnnotations:
-    {}
+  podAnnotations: {}
     # iam.amazonaws.com/role: prometheus
 
   ## Labels to be added to Prometheus server pods
@@ -1017,8 +1001,7 @@ server:
   ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
   ##
   podSecurityPolicy:
-    annotations:
-      {}
+    annotations: {}
       ## Specify pod annotations
       ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
       ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
@@ -1082,8 +1065,7 @@ server:
   ## Prometheus server resource requests and limits
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
-  resources:
-    {}
+  resources: {}
     # limits:
     #   cpu: 500m
     #   memory: 512Mi
@@ -1112,8 +1094,7 @@ server:
     # - containerName: 'prometheus-server'
 
   # Custom DNS configuration to be added to prometheus server pods
-  dnsConfig:
-    {}
+  dnsConfig: {}
     # nameservers:
     #   - 1.2.3.4
     # searches:
@@ -1133,7 +1114,8 @@ server:
     fsGroup: 65534
 
   ## Security context to be added to server container
-  containerSecurityContext: {}
+  containerSecurityContext:
+    enabled: false
 
   service:
     ## If false, no Service will be created for the Prometheus server
@@ -1274,8 +1256,7 @@ pushgateway:
   ## Node tolerations for pushgateway scheduling to nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   ##
-  tolerations:
-    []
+  tolerations: []
     # - key: "key"
     #   operator: "Equal|Exists"
     #   value: "value"
@@ -1298,8 +1279,7 @@ pushgateway:
   ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
   ##
   podSecurityPolicy:
-    annotations:
-      {}
+    annotations: {}
       ## Specify pod annotations
       ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
       ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
@@ -1325,8 +1305,7 @@ pushgateway:
   ## pushgateway resource requests and limits
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
-  resources:
-    {}
+  resources: {}
     # limits:
     #   cpu: 10m
     #   memory: 32Mi
@@ -1344,8 +1323,7 @@ pushgateway:
     # - containerName: 'prometheus-pushgateway'
 
   # Custom DNS configuration to be added to push-gateway pods
-  dnsConfig:
-    {}
+  dnsConfig: {}
     # nameservers:
     #   - 1.2.3.4
     # searches:
@@ -1388,8 +1366,7 @@ pushgateway:
   ## Custom HTTP headers for Liveness/Readiness/Startup Probe
   ##
   ## Useful for providing HTTP Basic Auth to healthchecks
-  probeHeaders:
-    []
+  probeHeaders: []
     # - name: "Authorization"
     #   value: "Bearer ABCDEabcde12345"
 
@@ -1453,7 +1430,7 @@ pushgateway:
 alertmanagerFiles:
   alertmanager.yml:
     global: {}
-    # slack_api_url: ''
+      # slack_api_url: ''
 
     receivers:
       - name: default-receiver
@@ -1473,6 +1450,7 @@ ruleFiles: {}
 ## Prometheus server ConfigMap entries
 ##
 serverFiles:
+
   ## Alerts configuration
   ## Ref: https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
   alerting_rules.yml: {}
@@ -1500,7 +1478,7 @@ serverFiles:
     rule_files:
       - /etc/config/recording_rules.yml
       - /etc/config/alerting_rules.yml
-      ## Below two files are DEPRECATED will be removed from this default values file
+    ## Below two files are DEPRECATED will be removed from this default values file
       - /etc/config/rules
       - /etc/config/alerts
 
@@ -1508,7 +1486,7 @@ serverFiles:
       - job_name: prometheus
         static_configs:
           - targets:
-              - localhost:9090
+            - localhost:9090
 
       # A scrape configuration for running Prometheus on a Kubernetes cluster.
       # This uses separate scrape configs for cluster components (i.e. API server, node)
@@ -1524,7 +1502,7 @@ serverFiles:
       # the endpoints associated with the default/kubernetes service using the
       # default named port `https`. This works for single API server deployments as
       # well as HA API server deployments.
-      - job_name: "kubernetes-apiservers"
+      - job_name: 'kubernetes-apiservers'
 
         kubernetes_sd_configs:
           - role: endpoints
@@ -1554,16 +1532,11 @@ serverFiles:
         # will add targets for each API server which Kubernetes adds an endpoint to
         # the default/kubernetes service.
         relabel_configs:
-          - source_labels:
-              [
-                __meta_kubernetes_namespace,
-                __meta_kubernetes_service_name,
-                __meta_kubernetes_endpoint_port_name,
-              ]
+          - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
             action: keep
             regex: default;kubernetes;https
 
-      - job_name: "kubernetes-nodes"
+      - job_name: 'kubernetes-nodes'
 
         # Default to scraping over https. If required, just disable this or change to
         # `http`.
@@ -1599,7 +1572,8 @@ serverFiles:
             target_label: __metrics_path__
             replacement: /api/v1/nodes/$1/proxy/metrics
 
-      - job_name: "kubernetes-nodes-cadvisor"
+
+      - job_name: 'kubernetes-nodes-cadvisor'
 
         # Default to scraping over https. If required, just disable this or change to
         # `http`.
@@ -1654,36 +1628,28 @@ serverFiles:
       # service then set this appropriately.
       # * `prometheus.io/param_<parameter>`: If the metrics endpoint uses parameters
       # then you can set any parameter
-      - job_name: "kubernetes-service-endpoints"
+      - job_name: 'kubernetes-service-endpoints'
         honor_labels: true
 
         kubernetes_sd_configs:
           - role: endpoints
 
         relabel_configs:
-          - source_labels:
-              [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
             action: keep
             regex: true
-          - source_labels:
-              [__meta_kubernetes_service_annotation_prometheus_io_scrape_slow]
+          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape_slow]
             action: drop
             regex: true
-          - source_labels:
-              [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
             action: replace
             target_label: __scheme__
             regex: (https?)
-          - source_labels:
-              [__meta_kubernetes_service_annotation_prometheus_io_path]
+          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
             action: replace
             target_label: __metrics_path__
             regex: (.+)
-          - source_labels:
-              [
-                __address__,
-                __meta_kubernetes_service_annotation_prometheus_io_port,
-              ]
+          - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
             action: replace
             target_label: __address__
             regex: (.+?)(?::\d+)?;(\d+)
@@ -1717,7 +1683,7 @@ serverFiles:
       # service then set this appropriately.
       # * `prometheus.io/param_<parameter>`: If the metrics endpoint uses parameters
       # then you can set any parameter
-      - job_name: "kubernetes-service-endpoints-slow"
+      - job_name: 'kubernetes-service-endpoints-slow'
         honor_labels: true
 
         scrape_interval: 5m
@@ -1727,25 +1693,18 @@ serverFiles:
           - role: endpoints
 
         relabel_configs:
-          - source_labels:
-              [__meta_kubernetes_service_annotation_prometheus_io_scrape_slow]
+          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape_slow]
             action: keep
             regex: true
-          - source_labels:
-              [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
             action: replace
             target_label: __scheme__
             regex: (https?)
-          - source_labels:
-              [__meta_kubernetes_service_annotation_prometheus_io_path]
+          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
             action: replace
             target_label: __metrics_path__
             regex: (.+)
-          - source_labels:
-              [
-                __address__,
-                __meta_kubernetes_service_annotation_prometheus_io_port,
-              ]
+          - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
             action: replace
             target_label: __address__
             regex: (.+?)(?::\d+)?;(\d+)
@@ -1765,15 +1724,14 @@ serverFiles:
             action: replace
             target_label: node
 
-      - job_name: "prometheus-pushgateway"
+      - job_name: 'prometheus-pushgateway'
         honor_labels: true
 
         kubernetes_sd_configs:
           - role: service
 
         relabel_configs:
-          - source_labels:
-              [__meta_kubernetes_service_annotation_prometheus_io_probe]
+          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_probe]
             action: keep
             regex: pushgateway
 
@@ -1783,7 +1741,7 @@ serverFiles:
       # via the following annotations:
       #
       # * `prometheus.io/probe`: Only probe services that have a value of `true`
-      - job_name: "kubernetes-services"
+      - job_name: 'kubernetes-services'
         honor_labels: true
 
         metrics_path: /probe
@@ -1794,8 +1752,7 @@ serverFiles:
           - role: service
 
         relabel_configs:
-          - source_labels:
-              [__meta_kubernetes_service_annotation_prometheus_io_probe]
+          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_probe]
             action: keep
             regex: true
           - source_labels: [__address__]
@@ -1822,23 +1779,20 @@ serverFiles:
       # to set this to `https` & most likely set the `tls_config` of the scrape config.
       # * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
       # * `prometheus.io/port`: Scrape the pod on the indicated port instead of the default of `9102`.
-      - job_name: "kubernetes-pods"
+      - job_name: 'kubernetes-pods'
         honor_labels: true
 
         kubernetes_sd_configs:
           - role: pod
 
         relabel_configs:
-          - source_labels:
-              [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
             action: keep
             regex: true
-          - source_labels:
-              [__meta_kubernetes_pod_annotation_prometheus_io_scrape_slow]
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape_slow]
             action: drop
             regex: true
-          - source_labels:
-              [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
             action: replace
             regex: (https?)
             target_label: __scheme__
@@ -1846,8 +1800,7 @@ serverFiles:
             action: replace
             target_label: __metrics_path__
             regex: (.+)
-          - source_labels:
-              [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
             action: replace
             regex: (.+?)(?::\d+)?;(\d+)
             replacement: $1:$2
@@ -1878,7 +1831,7 @@ serverFiles:
       # to set this to `https` & most likely set the `tls_config` of the scrape config.
       # * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
       # * `prometheus.io/port`: Scrape the pod on the indicated port instead of the default of `9102`.
-      - job_name: "kubernetes-pods-slow"
+      - job_name: 'kubernetes-pods-slow'
         honor_labels: true
 
         scrape_interval: 5m
@@ -1888,12 +1841,10 @@ serverFiles:
           - role: pod
 
         relabel_configs:
-          - source_labels:
-              [__meta_kubernetes_pod_annotation_prometheus_io_scrape_slow]
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape_slow]
             action: keep
             regex: true
-          - source_labels:
-              [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
             action: replace
             regex: (https?)
             target_label: __scheme__
@@ -1901,8 +1852,7 @@ serverFiles:
             action: replace
             target_label: __metrics_path__
             regex: (.+)
-          - source_labels:
-              [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
             action: replace
             regex: (.+?)(?::\d+)?;(\d+)
             replacement: $1:$2
@@ -1958,8 +1908,7 @@ networkPolicy:
 forceNamespace: null
 
 # Extra manifests to deploy as an array
-extraManifests:
-  []
+extraManifests: []
   # - apiVersion: v1
   #   kind: ConfigMap
   #   metadata:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -83,7 +83,8 @@ alertmanager:
 
   ## Additional alertmanager Secret mounts
   # Defines additional mounts with secrets. Secrets must be manually created in the namespace.
-  extraSecretMounts: []
+  extraSecretMounts:
+    []
     # - name: secret-files
     #   mountPath: /etc/secrets
     #   subPath: ""
@@ -91,7 +92,8 @@ alertmanager:
     #   readOnly: true
 
   ## Additional alertmanager Configmap mounts
-  extraConfigmapMounts: []
+  extraConfigmapMounts:
+    []
     # - name: template-files
     #   mountPath: /etc/config/templates.d
     #   configMap: alertmanager-template-files
@@ -167,7 +169,8 @@ alertmanager:
   ## Node tolerations for alertmanager scheduling to nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   ##
-  tolerations: []
+  tolerations:
+    []
     # - key: "key"
     #   operator: "Equal|Exists"
     #   value: "value"
@@ -267,7 +270,8 @@ alertmanager:
 
   ## Annotations to be added to alertmanager pods
   ##
-  podAnnotations: {}
+  podAnnotations:
+    {}
     ## Tell prometheus to use a specific set of alertmanager pods
     ## instead of all alertmanager pods found in the same namespace
     ## Useful if you deploy multiple releases within the same namespace
@@ -282,7 +286,8 @@ alertmanager:
   ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
   ##
   podSecurityPolicy:
-    annotations: {}
+    annotations:
+      {}
       ## Specify pod annotations
       ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
       ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
@@ -325,7 +330,8 @@ alertmanager:
   ## alertmanager resource requests and limits
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 10m
     #   memory: 32Mi
@@ -334,7 +340,8 @@ alertmanager:
     #   memory: 32Mi
 
   # Custom DNS configuration to be added to alertmanager pods
-  dnsConfig: {}
+  dnsConfig:
+    {}
     # nameservers:
     #   - 1.2.3.4
     # searches:
@@ -348,6 +355,7 @@ alertmanager:
   ## Security context to be added to alertmanager pods
   ##
   securityContext:
+    enabled: true
     runAsUser: 65534
     runAsNonRoot: true
     runAsGroup: 65534
@@ -410,10 +418,10 @@ configmapReload:
     ##
     extraVolumeDirs: []
 
-
     ## Additional configmap-reload mounts
     ##
-    extraConfigmapMounts: []
+    extraConfigmapMounts:
+      []
       # - name: prometheus-alerts
       #   mountPath: /etc/alerts.d
       #   subPath: ""
@@ -452,10 +460,10 @@ configmapReload:
     ##
     extraVolumeDirs: []
 
-
     ## Additional configmap-reload mounts
     ##
-    extraConfigmapMounts: []
+    extraConfigmapMounts:
+      []
       # - name: prometheus-alerts
       #   mountPath: /etc/alerts.d
       #   subPath: ""
@@ -512,7 +520,8 @@ nodeExporter:
   ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
   ##
   podSecurityPolicy:
-    annotations: {}
+    annotations:
+      {}
       ## Specify pod annotations
       ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
       ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
@@ -541,14 +550,16 @@ nodeExporter:
 
   ## Additional node-exporter hostPath mounts
   ##
-  extraHostPathMounts: []
+  extraHostPathMounts:
+    []
     # - name: textfile-dir
     #   mountPath: /srv/txt_collector
     #   hostPath: /var/lib/node-exporter
     #   readOnly: true
     #   mountPropagation: HostToContainer
 
-  extraConfigmapMounts: []
+  extraConfigmapMounts:
+    []
     # - name: certs-configmap
     #   mountPath: /prometheus
     #   configMap: certs-configmap
@@ -557,7 +568,8 @@ nodeExporter:
   ## Node tolerations for node-exporter scheduling to nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   ##
-  tolerations: []
+  tolerations:
+    []
     # - key: "key"
     #   operator: "Equal|Exists"
     #   value: "value"
@@ -587,7 +599,8 @@ nodeExporter:
   ## node-exporter resource limits & requests
   ## Ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ##
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 200m
     #   memory: 50Mi
@@ -598,7 +611,8 @@ nodeExporter:
     securityContext:
       allowPrivilegeEscalation: false
   # Custom DNS configuration to be added to node-exporter pods
-  dnsConfig: {}
+  dnsConfig:
+    {}
     # nameservers:
     #   - 1.2.3.4
     # searches:
@@ -765,7 +779,8 @@ server:
   ## Custom HTTP headers for Liveness/Readiness/Startup Probe
   ##
   ## Useful for providing HTTP Basic Auth to healthchecks
-  probeHeaders: []
+  probeHeaders:
+    []
     # - name: "Authorization"
     #   value: "Bearer ABCDEabcde12345"
 
@@ -787,14 +802,16 @@ server:
 
   ## Additional Prometheus server hostPath mounts
   ##
-  extraHostPathMounts: []
+  extraHostPathMounts:
+    []
     # - name: certs-dir
     #   mountPath: /etc/kubernetes/certs
     #   subPath: ""
     #   hostPath: /etc/kubernetes/certs
     #   readOnly: true
 
-  extraConfigmapMounts: []
+  extraConfigmapMounts:
+    []
     # - name: certs-configmap
     #   mountPath: /prometheus
     #   subPath: ""
@@ -803,7 +820,8 @@ server:
 
   ## Additional Prometheus server Secret mounts
   # Defines additional mounts with secrets. Secrets must be manually created in the namespace.
-  extraSecretMounts: []
+  extraSecretMounts:
+    []
     # - name: secret-files
     #   mountPath: /etc/secrets
     #   subPath: ""
@@ -878,7 +896,8 @@ server:
   ## Node tolerations for server scheduling to nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   ##
-  tolerations: []
+  tolerations:
+    []
     # - key: "key"
     #   operator: "Equal|Exists"
     #   value: "value"
@@ -982,7 +1001,8 @@ server:
 
   ## Annotations to be added to Prometheus server pods
   ##
-  podAnnotations: {}
+  podAnnotations:
+    {}
     # iam.amazonaws.com/role: prometheus
 
   ## Labels to be added to Prometheus server pods
@@ -997,7 +1017,8 @@ server:
   ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
   ##
   podSecurityPolicy:
-    annotations: {}
+    annotations:
+      {}
       ## Specify pod annotations
       ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
       ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
@@ -1061,7 +1082,8 @@ server:
   ## Prometheus server resource requests and limits
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 500m
     #   memory: 512Mi
@@ -1090,7 +1112,8 @@ server:
     # - containerName: 'prometheus-server'
 
   # Custom DNS configuration to be added to prometheus server pods
-  dnsConfig: {}
+  dnsConfig:
+    {}
     # nameservers:
     #   - 1.2.3.4
     # searches:
@@ -1103,6 +1126,7 @@ server:
   ## Security context to be added to server pods
   ##
   securityContext:
+    enabled: true
     runAsUser: 65534
     runAsNonRoot: true
     runAsGroup: 65534
@@ -1250,7 +1274,8 @@ pushgateway:
   ## Node tolerations for pushgateway scheduling to nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   ##
-  tolerations: []
+  tolerations:
+    []
     # - key: "key"
     #   operator: "Equal|Exists"
     #   value: "value"
@@ -1273,7 +1298,8 @@ pushgateway:
   ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
   ##
   podSecurityPolicy:
-    annotations: {}
+    annotations:
+      {}
       ## Specify pod annotations
       ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
       ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
@@ -1299,7 +1325,8 @@ pushgateway:
   ## pushgateway resource requests and limits
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 10m
     #   memory: 32Mi
@@ -1317,7 +1344,8 @@ pushgateway:
     # - containerName: 'prometheus-pushgateway'
 
   # Custom DNS configuration to be added to push-gateway pods
-  dnsConfig: {}
+  dnsConfig:
+    {}
     # nameservers:
     #   - 1.2.3.4
     # searches:
@@ -1360,7 +1388,8 @@ pushgateway:
   ## Custom HTTP headers for Liveness/Readiness/Startup Probe
   ##
   ## Useful for providing HTTP Basic Auth to healthchecks
-  probeHeaders: []
+  probeHeaders:
+    []
     # - name: "Authorization"
     #   value: "Bearer ABCDEabcde12345"
 
@@ -1424,7 +1453,7 @@ pushgateway:
 alertmanagerFiles:
   alertmanager.yml:
     global: {}
-      # slack_api_url: ''
+    # slack_api_url: ''
 
     receivers:
       - name: default-receiver
@@ -1444,7 +1473,6 @@ ruleFiles: {}
 ## Prometheus server ConfigMap entries
 ##
 serverFiles:
-
   ## Alerts configuration
   ## Ref: https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
   alerting_rules.yml: {}
@@ -1472,7 +1500,7 @@ serverFiles:
     rule_files:
       - /etc/config/recording_rules.yml
       - /etc/config/alerting_rules.yml
-    ## Below two files are DEPRECATED will be removed from this default values file
+      ## Below two files are DEPRECATED will be removed from this default values file
       - /etc/config/rules
       - /etc/config/alerts
 
@@ -1480,7 +1508,7 @@ serverFiles:
       - job_name: prometheus
         static_configs:
           - targets:
-            - localhost:9090
+              - localhost:9090
 
       # A scrape configuration for running Prometheus on a Kubernetes cluster.
       # This uses separate scrape configs for cluster components (i.e. API server, node)
@@ -1496,7 +1524,7 @@ serverFiles:
       # the endpoints associated with the default/kubernetes service using the
       # default named port `https`. This works for single API server deployments as
       # well as HA API server deployments.
-      - job_name: 'kubernetes-apiservers'
+      - job_name: "kubernetes-apiservers"
 
         kubernetes_sd_configs:
           - role: endpoints
@@ -1526,11 +1554,16 @@ serverFiles:
         # will add targets for each API server which Kubernetes adds an endpoint to
         # the default/kubernetes service.
         relabel_configs:
-          - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+          - source_labels:
+              [
+                __meta_kubernetes_namespace,
+                __meta_kubernetes_service_name,
+                __meta_kubernetes_endpoint_port_name,
+              ]
             action: keep
             regex: default;kubernetes;https
 
-      - job_name: 'kubernetes-nodes'
+      - job_name: "kubernetes-nodes"
 
         # Default to scraping over https. If required, just disable this or change to
         # `http`.
@@ -1566,8 +1599,7 @@ serverFiles:
             target_label: __metrics_path__
             replacement: /api/v1/nodes/$1/proxy/metrics
 
-
-      - job_name: 'kubernetes-nodes-cadvisor'
+      - job_name: "kubernetes-nodes-cadvisor"
 
         # Default to scraping over https. If required, just disable this or change to
         # `http`.
@@ -1622,28 +1654,36 @@ serverFiles:
       # service then set this appropriately.
       # * `prometheus.io/param_<parameter>`: If the metrics endpoint uses parameters
       # then you can set any parameter
-      - job_name: 'kubernetes-service-endpoints'
+      - job_name: "kubernetes-service-endpoints"
         honor_labels: true
 
         kubernetes_sd_configs:
           - role: endpoints
 
         relabel_configs:
-          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+          - source_labels:
+              [__meta_kubernetes_service_annotation_prometheus_io_scrape]
             action: keep
             regex: true
-          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape_slow]
+          - source_labels:
+              [__meta_kubernetes_service_annotation_prometheus_io_scrape_slow]
             action: drop
             regex: true
-          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+          - source_labels:
+              [__meta_kubernetes_service_annotation_prometheus_io_scheme]
             action: replace
             target_label: __scheme__
             regex: (https?)
-          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+          - source_labels:
+              [__meta_kubernetes_service_annotation_prometheus_io_path]
             action: replace
             target_label: __metrics_path__
             regex: (.+)
-          - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+          - source_labels:
+              [
+                __address__,
+                __meta_kubernetes_service_annotation_prometheus_io_port,
+              ]
             action: replace
             target_label: __address__
             regex: (.+?)(?::\d+)?;(\d+)
@@ -1677,7 +1717,7 @@ serverFiles:
       # service then set this appropriately.
       # * `prometheus.io/param_<parameter>`: If the metrics endpoint uses parameters
       # then you can set any parameter
-      - job_name: 'kubernetes-service-endpoints-slow'
+      - job_name: "kubernetes-service-endpoints-slow"
         honor_labels: true
 
         scrape_interval: 5m
@@ -1687,18 +1727,25 @@ serverFiles:
           - role: endpoints
 
         relabel_configs:
-          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape_slow]
+          - source_labels:
+              [__meta_kubernetes_service_annotation_prometheus_io_scrape_slow]
             action: keep
             regex: true
-          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+          - source_labels:
+              [__meta_kubernetes_service_annotation_prometheus_io_scheme]
             action: replace
             target_label: __scheme__
             regex: (https?)
-          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+          - source_labels:
+              [__meta_kubernetes_service_annotation_prometheus_io_path]
             action: replace
             target_label: __metrics_path__
             regex: (.+)
-          - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+          - source_labels:
+              [
+                __address__,
+                __meta_kubernetes_service_annotation_prometheus_io_port,
+              ]
             action: replace
             target_label: __address__
             regex: (.+?)(?::\d+)?;(\d+)
@@ -1718,14 +1765,15 @@ serverFiles:
             action: replace
             target_label: node
 
-      - job_name: 'prometheus-pushgateway'
+      - job_name: "prometheus-pushgateway"
         honor_labels: true
 
         kubernetes_sd_configs:
           - role: service
 
         relabel_configs:
-          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_probe]
+          - source_labels:
+              [__meta_kubernetes_service_annotation_prometheus_io_probe]
             action: keep
             regex: pushgateway
 
@@ -1735,7 +1783,7 @@ serverFiles:
       # via the following annotations:
       #
       # * `prometheus.io/probe`: Only probe services that have a value of `true`
-      - job_name: 'kubernetes-services'
+      - job_name: "kubernetes-services"
         honor_labels: true
 
         metrics_path: /probe
@@ -1746,7 +1794,8 @@ serverFiles:
           - role: service
 
         relabel_configs:
-          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_probe]
+          - source_labels:
+              [__meta_kubernetes_service_annotation_prometheus_io_probe]
             action: keep
             regex: true
           - source_labels: [__address__]
@@ -1773,20 +1822,23 @@ serverFiles:
       # to set this to `https` & most likely set the `tls_config` of the scrape config.
       # * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
       # * `prometheus.io/port`: Scrape the pod on the indicated port instead of the default of `9102`.
-      - job_name: 'kubernetes-pods'
+      - job_name: "kubernetes-pods"
         honor_labels: true
 
         kubernetes_sd_configs:
           - role: pod
 
         relabel_configs:
-          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+          - source_labels:
+              [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
             action: keep
             regex: true
-          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape_slow]
+          - source_labels:
+              [__meta_kubernetes_pod_annotation_prometheus_io_scrape_slow]
             action: drop
             regex: true
-          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
+          - source_labels:
+              [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
             action: replace
             regex: (https?)
             target_label: __scheme__
@@ -1794,7 +1846,8 @@ serverFiles:
             action: replace
             target_label: __metrics_path__
             regex: (.+)
-          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+          - source_labels:
+              [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
             action: replace
             regex: (.+?)(?::\d+)?;(\d+)
             replacement: $1:$2
@@ -1825,7 +1878,7 @@ serverFiles:
       # to set this to `https` & most likely set the `tls_config` of the scrape config.
       # * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
       # * `prometheus.io/port`: Scrape the pod on the indicated port instead of the default of `9102`.
-      - job_name: 'kubernetes-pods-slow'
+      - job_name: "kubernetes-pods-slow"
         honor_labels: true
 
         scrape_interval: 5m
@@ -1835,10 +1888,12 @@ serverFiles:
           - role: pod
 
         relabel_configs:
-          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape_slow]
+          - source_labels:
+              [__meta_kubernetes_pod_annotation_prometheus_io_scrape_slow]
             action: keep
             regex: true
-          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
+          - source_labels:
+              [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
             action: replace
             regex: (https?)
             target_label: __scheme__
@@ -1846,7 +1901,8 @@ serverFiles:
             action: replace
             target_label: __metrics_path__
             regex: (.+)
-          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+          - source_labels:
+              [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
             action: replace
             regex: (.+?)(?::\d+)?;(\d+)
             replacement: $1:$2
@@ -1902,7 +1958,8 @@ networkPolicy:
 forceNamespace: null
 
 # Extra manifests to deploy as an array
-extraManifests: []
+extraManifests:
+  []
   # - apiVersion: v1
   #   kind: ConfigMap
   #   metadata:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -355,8 +355,8 @@ alertmanager:
     fsGroup: 65534
 
   ## Security context to be added to alertmanager container
-  containerSecurityContext:
-    enabled: false
+  containerSecurityContextEnabled: true
+  containerSecurityContext: {}
 
   service:
     annotations: {}
@@ -423,8 +423,8 @@ configmapReload:
       #   readOnly: true
 
     ## Security context to be added to configmap-reload container
-    containerSecurityContext:
-      enabled: false
+    containerSecurityContextEnabled: true
+    containerSecurityContext: {}
 
     ## configmap-reload resource requests and limits
     ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -466,8 +466,8 @@ configmapReload:
       #   readOnly: true
 
     ## Security context to be added to configmap-reload container
-    containerSecurityContext:
-      enabled: false
+    containerSecurityContextEnabled: true
+    containerSecurityContext: {}
 
     ## configmap-reload resource requests and limits
     ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -1114,8 +1114,8 @@ server:
     fsGroup: 65534
 
   ## Security context to be added to server container
-  containerSecurityContext:
-    enabled: false
+  containerSecurityContextEnabled: true
+  containerSecurityContext: {}
 
   service:
     ## If false, no Service will be created for the Prometheus server

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -348,13 +348,13 @@ alertmanager:
   ## Security context to be added to alertmanager pods
   ##
   securityContext:
-    enabled: true
     runAsUser: 65534
     runAsNonRoot: true
     runAsGroup: 65534
     fsGroup: 65534
 
   ## Security context to be added to alertmanager container
+  ##
   containerSecurityContext: {}
 
   service:
@@ -1101,16 +1101,17 @@ server:
     #   - name: ndots
     #     value: "2"
   #   - name: edns0
+
   ## Security context to be added to server pods
   ##
   securityContext:
-    enabled: true
     runAsUser: 65534
     runAsNonRoot: true
     runAsGroup: 65534
     fsGroup: 65534
 
   ## Security context to be added to server container
+  ##
   containerSecurityContext: {}
 
   service:


### PR DESCRIPTION
Add possibility to disable securityContext for Prometheus and Alertmanager workloads

Signed-off-by: Roman Slipchenko <romanslipchenko@gmail.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it:

* Add the possibility to disable security context for Prometheus and Alertmanager workloads for smooth deployment to OpenShift.
If securityContext is omitted, OpenShift SCC Admission controller can inject needed securityContext on chart deploy time.
More details - https://docs.openshift.com/container-platform/4.11/authentication/managing-security-context-constraints.html


#### Which issue this PR fixes

None

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
