### PR TITLE
[prometheus-statsd-exporter] add PodMonitoring for Google Managed Prometheus

### DIFF
--- a/charts/prometheus-statsd-exporter/Chart.yaml
+++ b/charts/prometheus-statsd-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus-statsd-exporter
 description: A Helm chart for prometheus stats-exporter
-version: 0.6.2
+version: 0.6.3
 appVersion: 0.22.7
 home: https://github.com/prometheus/statsd_exporter
 sources:

--- a/charts/prometheus-statsd-exporter/templates/podmonitor.yaml
+++ b/charts/prometheus-statsd-exporter/templates/podmonitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.podMonitor.enabled }}
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: {{ template "prometheus-statsd-exporter.fullname" . }}-metrics
+  namespace: {{ default .Release.Namespace .Values.podMonitor.namespace | quote }}
+  labels: {{- include "prometheus-statsd-exporter.labels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
+    {{- range $key, $value := .Values.podMonitor.additionalLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "prometheus-statsd-exporter.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: {{ .Values.podMonitor.endpoint }}
+      interval: {{ .Values.podMonitor.interval }}
+{{- end }}

--- a/charts/prometheus-statsd-exporter/values.yaml
+++ b/charts/prometheus-statsd-exporter/values.yaml
@@ -76,6 +76,15 @@ serviceMonitor:
   # More info https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
   relabelings: []
 
+podMonitor:
+  # If enabled, It creates Google Managed Prometheus scraping config
+  enabled: false
+  interval: 30s
+  # Set a custom namespace where to deploy PodMonitoring resource
+  namespace: ""
+  # This is the default endpoint of the metrics
+  endpoint: /metrics
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
Signed-off-by: Chuyen Pham <pkchuyen@users.noreply.github.com>

#### What this PR does / why we need it
It creates PodMonitoring resource which allows Google Managed Prometheus creating the scraping config and collect statsd metrics.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
