### PR TITLE
[kube-prometheus-stack] When the custom label repeatedly conflicts with the general label, the general label is used first. Generic labels should be used in preference here

### DIFF
--- a/charts/kube-prometheus-stack/templates/exporters/core-dns/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/core-dns/servicemonitor.yaml
@@ -6,10 +6,10 @@ metadata:
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}-coredns
+{{ include "kube-prometheus-stack.labels" . | indent 4 }}
   {{- with .Values.coreDns.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
-{{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
   jobLabel: jobLabel
   selector:

--- a/charts/kube-prometheus-stack/templates/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-api-server/servicemonitor.yaml
@@ -6,10 +6,10 @@ metadata:
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}-apiserver
+{{ include "kube-prometheus-stack.labels" . | indent 4 }}
   {{- with .Values.kubeApiServer.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
-{{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/servicemonitor.yaml
@@ -6,10 +6,10 @@ metadata:
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}-kube-controller-manager
+{{ include "kube-prometheus-stack.labels" . | indent 4 }}
   {{- with .Values.kubeControllerManager.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
-{{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
   jobLabel: jobLabel
   selector:

--- a/charts/kube-prometheus-stack/templates/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-dns/servicemonitor.yaml
@@ -6,10 +6,10 @@ metadata:
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}-kube-dns
+{{ include "kube-prometheus-stack.labels" . | indent 4 }} 
   {{- with .Values.kubeDns.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
-{{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
   jobLabel: jobLabel
   selector:

--- a/charts/kube-prometheus-stack/templates/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-etcd/servicemonitor.yaml
@@ -6,10 +6,10 @@ metadata:
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}-kube-etcd
+{{ include "kube-prometheus-stack.labels" . | indent 4 }}
   {{- with .Values.kubeEtcd.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
-{{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
   jobLabel: jobLabel
   selector:

--- a/charts/kube-prometheus-stack/templates/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-proxy/servicemonitor.yaml
@@ -6,10 +6,10 @@ metadata:
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}-kube-proxy
+{{ include "kube-prometheus-stack.labels" . | indent 4 }}
   {{- with .Values.kubeProxy.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
-{{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
   jobLabel: jobLabel
   selector:

--- a/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -6,10 +6,10 @@ metadata:
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}-kube-scheduler
+  {{ include "kube-prometheus-stack.labels" . | indent 4 }}
   {{- with .Values.kubeScheduler.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
-{{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
   jobLabel: jobLabel
   selector:

--- a/charts/kube-prometheus-stack/templates/exporters/kubelet/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kubelet/servicemonitor.yaml
@@ -6,10 +6,10 @@ metadata:
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}-kubelet
+{{- include "kube-prometheus-stack.labels" . | indent 4 }}
   {{- with .Values.kubelet.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
   endpoints:
   {{- if .Values.kubelet.serviceMonitor.https }}


### PR DESCRIPTION
…ts with the general label, the general label is used first. Generic labels should be used in preference here.

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
When the custom label repeatedly conflicts with the general label, the general label is used first. Generic labels should be used in preference here.
#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
