### PR TITLE
[kube-prometheus-stack] bump grafana to 6.43.0 (9.2.1)

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
-  version: 4.20.2
+  version: 4.20.3
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
-  version: 4.3.0
+  version: 4.3.1
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.40.4
-digest: sha256:ab846d47d33c02362c737fee5ca62926f7df9dcd3fb2ea0d91dd07b139960042
-generated: "2022-10-11T13:15:40.503744781+02:00"
+  version: 6.43.0
+digest: sha256:5aee2de0d0a09daa69c0cd58307e69470a93f67bbdf2218ae5e70de07c08790f
+generated: "2022-10-24T23:03:34.986785+02:00"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -22,7 +22,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 41.5.1
+version: 41.6.0
 appVersion: 0.60.1
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus
@@ -48,6 +48,6 @@ dependencies:
     repository: https://prometheus-community.github.io/helm-charts
     condition: nodeExporter.enabled
   - name: grafana
-    version: "6.40.*"
+    version: "6.43.*"
     repository: https://grafana.github.io/helm-charts
     condition: grafana.enabled


### PR DESCRIPTION
#### What this PR does / why we need it

Updated grafana to helm version 6.43.0 and app version 9.2.1

Changes: https://github.com/grafana/helm-charts/compare/grafana-6.40.4...grafana-6.43.0


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
