### PR TITLE
[kube-state-metrics] add servicemonitor scrape limits

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 4.21.0
+version: 4.21.1
 appVersion: 2.6.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 4.21.1
+version: 4.22.0
 appVersion: 2.6.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/_helpers.tpl
+++ b/charts/kube-state-metrics/templates/_helpers.tpl
@@ -83,19 +83,19 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{/* Sets default scrape limits for servicemonitor */}}
 {{- define "servicemonitor.scrapeLimits" -}}
-{{- if .sampleLimit }}
-sampleLimit: {{ .sampleLimit }}
+{{- with .sampleLimit }}
+sampleLimit: {{ . }}
 {{- end }}
-{{- if .targetLimit }}
-targetLimit: {{ .targetLimit }}
+{{- with .targetLimit }}
+targetLimit: {{ . }}
 {{- end }}
-{{- if .labelLimit }}
-labelLimit: {{ .labelLimit }}
+{{- with .labelLimit }}
+labelLimit: {{ . }}
 {{- end }}
-{{- if .labelNameLengthLimit }}
-labelNameLengthLimit: {{ .labelNameLengthLimit }}
+{{- with .labelNameLengthLimit }}
+labelNameLengthLimit: {{ . }}
 {{- end }}
-{{- if .labelValueLengthLimit }}
-labelValueLengthLimit: {{ .labelValueLengthLimit }}
+{{- with .labelValueLengthLimit }}
+labelValueLengthLimit: {{ . }}
 {{- end }}
 {{- end -}}

--- a/charts/kube-state-metrics/templates/_helpers.tpl
+++ b/charts/kube-state-metrics/templates/_helpers.tpl
@@ -80,3 +80,22 @@ Selector labels
 app.kubernetes.io/name: {{ include "kube-state-metrics.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/* Sets default scrape limits for servicemonitor */}}
+{{- define "servicemonitor.scrapeLimits" -}}
+{{- if .sampleLimit }}
+sampleLimit: {{ .sampleLimit }}
+{{- end }}
+{{- if .targetLimit }}
+targetLimit: {{ .targetLimit }}
+{{- end }}
+{{- if .labelLimit }}
+labelLimit: {{ .labelLimit }}
+{{- end }}
+{{- if .labelNameLengthLimit }}
+labelNameLengthLimit: {{ .labelNameLengthLimit }}
+{{- end }}
+{{- if .labelValueLengthLimit }}
+labelValueLengthLimit: {{ .labelValueLengthLimit }}
+{{- end }}
+{{- end -}}

--- a/charts/kube-state-metrics/templates/servicemonitor.yaml
+++ b/charts/kube-state-metrics/templates/servicemonitor.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- end }}
 spec:
   jobLabel: {{ default "app.kubernetes.io/name" .Values.prometheus.monitor.jobLabel }}
-  {{ include "servicemonitor.scrapeLimits" .Values.prometheus.monitor | nindent 2 }}
+  {{ include "servicemonitor.scrapeLimits" .Values.prometheus.monitor | indent 2 }}
   selector:
     matchLabels:
     {{- if .Values.prometheus.monitor.selectorOverride -}}

--- a/charts/kube-state-metrics/templates/servicemonitor.yaml
+++ b/charts/kube-state-metrics/templates/servicemonitor.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- end }}
 spec:
   jobLabel: {{ default "app.kubernetes.io/name" .Values.prometheus.monitor.jobLabel }}
-{{ include "servicemonitor.scrapeLimits" .Values.prometheus.monitor | indent 2 }}
+  {{ include "servicemonitor.scrapeLimits" .Values.prometheus.monitor | nindent 2 }}
   selector:
     matchLabels:
     {{- if .Values.prometheus.monitor.selectorOverride -}}

--- a/charts/kube-state-metrics/templates/servicemonitor.yaml
+++ b/charts/kube-state-metrics/templates/servicemonitor.yaml
@@ -11,6 +11,7 @@ metadata:
   {{- end }}
 spec:
   jobLabel: {{ default "app.kubernetes.io/name" .Values.prometheus.monitor.jobLabel }}
+{{ include "servicemonitor.scrapeLimits" .Values.prometheus.monitor | indent 2 }}
   selector:
     matchLabels:
     {{- if .Values.prometheus.monitor.selectorOverride -}}

--- a/charts/kube-state-metrics/templates/servicemonitor.yaml
+++ b/charts/kube-state-metrics/templates/servicemonitor.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- end }}
 spec:
   jobLabel: {{ default "app.kubernetes.io/name" .Values.prometheus.monitor.jobLabel }}
-  {{ include "servicemonitor.scrapeLimits" .Values.prometheus.monitor | indent 2 }}
+  {{- include "servicemonitor.scrapeLimits" .Values.prometheus.monitor | nindent 2 }}
   selector:
     matchLabels:
     {{- if .Values.prometheus.monitor.selectorOverride -}}

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -79,6 +79,25 @@ prometheus:
     namespace: ""
     jobLabel: ""
     interval: ""
+    ## SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.
+    ##
+    sampleLimit: 0
+
+    ## TargetLimit defines a limit on the number of scraped targets that will be accepted.
+    ##
+    targetLimit: 0
+
+    ## Per-scrape limit on number of labels that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+    ##
+    labelLimit: 0
+
+    ## Per-scrape limit on length of labels name that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+    ##
+    labelNameLengthLimit: 0
+
+    ## Per-scrape limit on length of labels value that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+    ##
+    labelValueLengthLimit: 0
     scrapeTimeout: ""
     proxyUrl: ""
     selectorOverride: {}


### PR DESCRIPTION
Signed-off-by: Markus Blaschke <mblaschke82@gmail.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
adds support for servicemonitor/podmonitor scrape limits (eg. sampleLimit) to kube-prometheus-stack

#### Which issue this PR fixes


#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
