### PR TITLE
[prometheus-node-exporter] ServiceMonitor selectorOverride fix

### DIFF
--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - prometheus
   - exporter
 type: application
-version: 4.4.1
+version: 4.4.2
 appVersion: 1.3.1
 home: https://github.com/prometheus/node_exporter/
 sources:

--- a/charts/prometheus-node-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-node-exporter/templates/servicemonitor.yaml
@@ -13,7 +13,9 @@ spec:
   selector:
     matchLabels:
     {{- if .Values.prometheus.monitor.selectorOverride }}
-      {{ toYaml .Values.prometheus.monitor.selectorOverride | indent 6 }}
+      {{- with .Values.prometheus.monitor.selectorOverride }}
+      {{- toYaml . | nindent 6 }}
+      {{- end -}}
     {{ else }}
       {{ include "prometheus-node-exporter.selectorLabels" . | indent 6 }}
     {{- end }}

--- a/charts/prometheus-node-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-node-exporter/templates/servicemonitor.yaml
@@ -12,12 +12,10 @@ spec:
   jobLabel: {{ default "app.kubernetes.io/name" .Values.prometheus.monitor.jobLabel }}
   selector:
     matchLabels:
-    {{- if .Values.prometheus.monitor.selectorOverride }}
-      {{- with .Values.prometheus.monitor.selectorOverride }}
-      {{- toYaml . | nindent 6 }}
-      {{- end -}}
-    {{ else }}
-      {{ include "prometheus-node-exporter.selectorLabels" . | indent 6 }}
+    {{- with .Values.prometheus.monitor.selectorOverride }}
+    {{- toYaml . | nindent 6 }}
+    {{- else }}
+    {{ include "prometheus-node-exporter.selectorLabels" . | indent 6 }}
     {{- end }}
   endpoints:
     - port: {{ .Values.service.portName }}


### PR DESCRIPTION
Signed-off-by: João Estrela <jestrela@barracuda.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR fixes not being able to use values such as:

```yaml
prometheus:
  monitor:
    enabled: true
    selectorOverride:
      myNewLabel: myNewLabelValue
      myNewLabelTwo: myNewLabelValueTwo
```

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
