### PR TITLE
[prometheus] major refactor

### DIFF
--- a/charts/prometheus-kafka-exporter/Chart.yaml
+++ b/charts/prometheus-kafka-exporter/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: "v1.4.2"
+appVersion: "v1.6.0"
 description: A Helm chart to export the metrics from Kafka in Prometheus format using the kafka-exporter from https://github.com/danielqsj/kafka_exporter
 name: prometheus-kafka-exporter
 home: https://github.com/danielqsj/kafka_exporter
-version: 1.6.1
+version: 1.7.0
 sources:
   - https://gkarthiks.github.io/helm-charts/charts/prometheus-kafka-exporter
 keywords:

--- a/charts/prometheus-kafka-exporter/templates/deployment.yaml
+++ b/charts/prometheus-kafka-exporter/templates/deployment.yaml
@@ -98,7 +98,7 @@ spec:
                   key: password
           {{- end }}
           name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: exporter-port

--- a/charts/prometheus-kafka-exporter/values.yaml
+++ b/charts/prometheus-kafka-exporter/values.yaml
@@ -1,6 +1,7 @@
 image:
   repository: danielqsj/kafka-exporter
-  tag: v1.4.2
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
   pullPolicy: IfNotPresent
 
 replicaCount: 1

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.39.1
-version: 15.17.0
+version: 15.18.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/templates/_helpers.tpl
+++ b/charts/prometheus/templates/_helpers.tpl
@@ -17,52 +17,59 @@ Create chart name and version as used by the chart label.
 Create unified labels for prometheus components
 */}}
 {{- define "prometheus.common.matchLabels" -}}
-app: {{ template "prometheus.name" . }}
-release: {{ .Release.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/part-of: {{ template "prometheus.name" . }}
 {{- end -}}
 
 {{- define "prometheus.common.metaLabels" -}}
-chart: {{ template "prometheus.chart" . }}
-heritage: {{ .Release.Service }}
+helm.sh/chart: {{ template "prometheus.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
 {{- end -}}
 
 {{- define "prometheus.alertmanager.labels" -}}
+app.kubernetes.io/name: {{ .Values.alertmanager.name | quote }}
 {{ include "prometheus.alertmanager.matchLabels" . }}
 {{ include "prometheus.common.metaLabels" . }}
 {{- end -}}
 
 {{- define "prometheus.alertmanager.matchLabels" -}}
-component: {{ .Values.alertmanager.name | quote }}
+app.kubernetes.io/component: {{ .Values.alertmanager.name | quote }}
 {{ include "prometheus.common.matchLabels" . }}
 {{- end -}}
 
 {{- define "prometheus.nodeExporter.labels" -}}
+app.kubernetes.io/name: {{ .Values.nodeExporter.name | quote }}
 {{ include "prometheus.nodeExporter.matchLabels" . }}
 {{ include "prometheus.common.metaLabels" . }}
 {{- end -}}
 
 {{- define "prometheus.nodeExporter.matchLabels" -}}
-component: {{ .Values.nodeExporter.name | quote }}
+app.kubernetes.io/component: {{ .Values.nodeExporter.name | quote }}
 {{ include "prometheus.common.matchLabels" . }}
 {{- end -}}
 
 {{- define "prometheus.pushgateway.labels" -}}
+app.kubernetes.io/name: {{ .Values.pushgateway.name | quote }}
 {{ include "prometheus.pushgateway.matchLabels" . }}
 {{ include "prometheus.common.metaLabels" . }}
 {{- end -}}
 
 {{- define "prometheus.pushgateway.matchLabels" -}}
-component: {{ .Values.pushgateway.name | quote }}
+app.kubernetes.io/component: {{ .Values.pushgateway.name | quote }}
 {{ include "prometheus.common.matchLabels" . }}
 {{- end -}}
 
 {{- define "prometheus.server.labels" -}}
+app.kubernetes.io/name: {{ .Values.server.name | quote }}
 {{ include "prometheus.server.matchLabels" . }}
 {{ include "prometheus.common.metaLabels" . }}
 {{- end -}}
 
 {{- define "prometheus.server.matchLabels" -}}
-component: {{ .Values.server.name | quote }}
+app.kubernetes.io/component: {{ .Values.server.name | quote }}
 {{ include "prometheus.common.matchLabels" . }}
 {{- end -}}
 

--- a/charts/prometheus/templates/_helpers.tpl
+++ b/charts/prometheus/templates/_helpers.tpl
@@ -135,6 +135,21 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
+
+{{/*
+Define enableServiceLinks
+*/}}
+{{- define "prometheus.server.enableServiceLinks" -}}
+{{- if semverCompare ">=1.13-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if or (.Values.server.enableServiceLinks) (eq (.Values.server.enableServiceLinks | toString) "<nil>") -}}
+{{- printf "enableServiceLinks: true" -}}
+{{- else -}}
+{{- printf "enableServiceLinks: false" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+
 {{/*
 Create a fully qualified pushgateway name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
@@ -285,3 +300,4 @@ Define the prometheus.namespace template if set with forceNamespace or .Release.
 {{ printf "namespace: %s" .Release.Namespace }}
 {{- end -}}
 {{- end -}}
+

--- a/charts/prometheus/templates/alertmanager/clusterrole.yaml
+++ b/charts/prometheus/templates/alertmanager/clusterrole.yaml
@@ -1,12 +1,16 @@
-{{- if and .Values.alertmanager.enabled .Values.rbac.create .Values.alertmanager.useClusterRole (not .Values.alertmanager.useExistingRole) -}}
-apiVersion: {{ template "rbac.apiVersion" . }}
+{{- if and .Values.alertmanager.enabled
+           .Values.rbac.create
+           .Values.alertmanager.useClusterRole
+           (not .Values.alertmanager.useExistingRole) -}}
+apiVersion: {{ template "rbac.apiVersion" $ }}
 kind: ClusterRole
 metadata:
   labels:
-    {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
-  name: {{ template "prometheus.alertmanager.fullname" . }}
+    {{- include "prometheus.alertmanager.labels" $ | nindent 4 }}
+  name: {{ template "prometheus.alertmanager.fullname" $ }}
 rules:
-{{- if .Values.podSecurityPolicy.enabled }}
+  {{- if and .Values.podSecurityPolicy.enabled
+             (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
   - apiGroups:
     - extensions
     resources:
@@ -14,8 +18,8 @@ rules:
     verbs:
     - use
     resourceNames:
-    - {{ template "prometheus.alertmanager.fullname" . }}
-{{- else }}
+    - {{ template "prometheus.alertmanager.fullname" $ }}
+  {{- else }}
   []
-{{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/prometheus/templates/alertmanager/clusterrole.yaml
+++ b/charts/prometheus/templates/alertmanager/clusterrole.yaml
@@ -12,13 +12,13 @@ rules:
   {{- if and .Values.podSecurityPolicy.enabled
              (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
   - apiGroups:
-    - extensions
+      - extensions
     resources:
-    - podsecuritypolicies
+      - podsecuritypolicies
     verbs:
-    - use
+      - use
     resourceNames:
-    - {{ template "prometheus.alertmanager.fullname" $ }}
+      - {{ template "prometheus.alertmanager.fullname" $ }}
   {{- else }}
   []
   {{- end }}

--- a/charts/prometheus/templates/alertmanager/clusterrole.yaml
+++ b/charts/prometheus/templates/alertmanager/clusterrole.yaml
@@ -1,7 +1,4 @@
-{{- if and .Values.alertmanager.enabled
-           .Values.rbac.create
-           .Values.alertmanager.useClusterRole
-           (not .Values.alertmanager.useExistingRole) -}}
+{{- if and .Values.alertmanager.enabled .Values.rbac.create .Values.alertmanager.useClusterRole (not .Values.alertmanager.useExistingRole) -}}
 apiVersion: {{ template "rbac.apiVersion" $ }}
 kind: ClusterRole
 metadata:
@@ -9,8 +6,7 @@ metadata:
     {{- include "prometheus.alertmanager.labels" $ | nindent 4 }}
   name: {{ template "prometheus.alertmanager.fullname" $ }}
 rules:
-  {{- if and .Values.podSecurityPolicy.enabled
-             (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
+  {{- if and .Values.podSecurityPolicy.enabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
   - apiGroups:
       - extensions
     resources:

--- a/charts/prometheus/templates/alertmanager/clusterrolebinding.yaml
+++ b/charts/prometheus/templates/alertmanager/clusterrolebinding.yaml
@@ -1,20 +1,22 @@
-{{- if and .Values.alertmanager.enabled .Values.rbac.create .Values.alertmanager.useClusterRole -}}
-apiVersion: {{ template "rbac.apiVersion" . }}
+{{- if and .Values.alertmanager.enabled
+           .Values.rbac.create
+           .Values.alertmanager.useClusterRole -}}
+apiVersion: {{ template "rbac.apiVersion" $ }}
 kind: ClusterRoleBinding
 metadata:
   labels:
-    {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
-  name: {{ template "prometheus.alertmanager.fullname" . }}
+    {{- include "prometheus.alertmanager.labels" $ | nindent 4 }}
+  name: {{ template "prometheus.alertmanager.fullname" $ }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "prometheus.serviceAccountName.alertmanager" . }}
-{{ include "prometheus.namespace" . | indent 4 }}
+    name: {{ template "prometheus.serviceAccountName.alertmanager" $ }}
+    {{- include "prometheus.namespace" $ | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-{{- if (not .Values.alertmanager.useExistingRole) }}
-  name: {{ template "prometheus.alertmanager.fullname" . }}
-{{- else }}
+  {{- if .Values.alertmanager.useExistingRole }}
   name: {{ .Values.alertmanager.useExistingRole }}
-{{- end }}
+  {{- else }}
+  name: {{ template "prometheus.alertmanager.fullname" $ }}
+  {{- end }}
 {{- end }}

--- a/charts/prometheus/templates/alertmanager/clusterrolebinding.yaml
+++ b/charts/prometheus/templates/alertmanager/clusterrolebinding.yaml
@@ -1,6 +1,4 @@
-{{- if and .Values.alertmanager.enabled
-           .Values.rbac.create
-           .Values.alertmanager.useClusterRole -}}
+{{- if and .Values.alertmanager.enabled .Values.rbac.create .Values.alertmanager.useClusterRole -}}
 apiVersion: {{ template "rbac.apiVersion" $ }}
 kind: ClusterRoleBinding
 metadata:

--- a/charts/prometheus/templates/alertmanager/cm.yaml
+++ b/charts/prometheus/templates/alertmanager/cm.yaml
@@ -1,6 +1,4 @@
-{{- if and .Values.alertmanager.enabled 
-           (empty .Values.alertmanager.configMapOverrideName)
-           (empty .Values.alertmanager.configFromSecret) -}}
+{{- if and .Values.alertmanager.enabled (empty .Values.alertmanager.configMapOverrideName) (empty .Values.alertmanager.configFromSecret) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/prometheus/templates/alertmanager/cm.yaml
+++ b/charts/prometheus/templates/alertmanager/cm.yaml
@@ -1,20 +1,23 @@
-{{- if and .Values.alertmanager.enabled (and (empty .Values.alertmanager.configMapOverrideName) (empty .Values.alertmanager.configFromSecret)) -}}
+{{- if and .Values.alertmanager.enabled 
+           (empty .Values.alertmanager.configMapOverrideName)
+           (empty .Values.alertmanager.configFromSecret) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
-  name: {{ template "prometheus.alertmanager.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+    {{- include "prometheus.alertmanager.labels" $ | nindent 4 }}
+  name: {{ template "prometheus.alertmanager.fullname" $ }}
+  {{- include "prometheus.namespace" $ | nindent 2 }}
 data:
   allow-snippet-annotations: "false"
 {{- $root := . -}}
 {{- range $key, $value := .Values.alertmanagerFiles }}
   {{- if $key | regexMatch ".*\\.ya?ml$" }}
   {{ $key }}: |
-{{ toYaml $value | default "{}" | indent 4 }}
+    {{- toYaml $value | default "{}" | nindent 4 }}
   {{- else }}
-  {{ $key }}: {{ toYaml $value | indent 4 }}
+  {{ $key }}:
+    {{- toYaml $value | nindent 4 }}
   {{- end }}
 {{- end -}}
 {{- end -}}

--- a/charts/prometheus/templates/alertmanager/deploy.yaml
+++ b/charts/prometheus/templates/alertmanager/deploy.yaml
@@ -1,58 +1,63 @@
-{{- if and .Values.alertmanager.enabled (not .Values.alertmanager.statefulSet.enabled) -}}
-apiVersion: {{ template "prometheus.deployment.apiVersion" . }}
+{{- $cmReloadAlert := $.Values.configmapReload.alertmanager -}}
+
+{{- with .Values.alertmanager }}
+{{- if and .enabled (not .statefulSet.enabled) -}}
+apiVersion: {{ template "prometheus.deployment.apiVersion" $ }}
 kind: Deployment
 metadata:
-{{- if .Values.alertmanager.deploymentAnnotations }}
+  {{- with .deploymentAnnotations }}
   annotations:
-    {{ toYaml .Values.alertmanager.deploymentAnnotations | nindent 4 }}
-{{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
-    {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
-  name: {{ template "prometheus.alertmanager.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+    {{- include "prometheus.alertmanager.labels" $ | nindent 4 }}
+  name: {{ template "prometheus.alertmanager.fullname" $ }}
+  {{- include "prometheus.namespace" $ | nindent 2 }}
 spec:
   selector:
     matchLabels:
-      {{- include "prometheus.alertmanager.matchLabels" . | nindent 6 }}
-  replicas: {{ .Values.alertmanager.replicaCount }}
-  {{- if .Values.alertmanager.strategy }}
+      {{- include "prometheus.alertmanager.matchLabels" $ | nindent 6 }}
+  replicas: {{ .replicaCount }}
+  {{- with .strategy }}
   strategy:
-{{ toYaml .Values.alertmanager.strategy | trim | indent 4 }}
-    {{ if eq .Values.alertmanager.strategy.type "Recreate" }}rollingUpdate: null{{ end }}
-{{- end }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- if eq .type "Recreate" }}
+    rollingUpdate: null
+    {{- end }}
+  {{- end }}
   template:
     metadata:
-    {{- if .Values.alertmanager.podAnnotations }}
+      {{- with .podAnnotations }}
       annotations:
-        {{ toYaml .Values.alertmanager.podAnnotations | nindent 8 }}
-    {{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
-        {{- include "prometheus.alertmanager.labels" . | nindent 8 }}
-        {{- if .Values.alertmanager.podLabels}}
-        {{ toYaml .Values.alertmanager.podLabels | nindent 8 }}
+        {{- include "prometheus.alertmanager.labels" $ | nindent 8 }}
+        {{- with .podLabels}}
+        {{- toYaml . | nindent 8 }}
         {{- end}}
     spec:
-{{- if .Values.alertmanager.schedulerName }}
-      schedulerName: "{{ .Values.alertmanager.schedulerName }}"
-{{- end }}
-      serviceAccountName: {{ template "prometheus.serviceAccountName.alertmanager" . }}
-      {{- if .Values.alertmanager.extraInitContainers }}
-      initContainers:
-{{ toYaml .Values.alertmanager.extraInitContainers | indent 8 }}
+      {{- with .priorityClassName }}
+      priorityClassName: "{{ . }}"
       {{- end }}
-{{- if .Values.alertmanager.priorityClassName }}
-      priorityClassName: "{{ .Values.alertmanager.priorityClassName }}"
-{{- end }}
+      {{- with .schedulerName }}
+      schedulerName: "{{ . }}"
+      {{- end }}
+      serviceAccountName: {{ template "prometheus.serviceAccountName.alertmanager" $ }}
+      {{- with .extraInitContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
-        - name: {{ template "prometheus.name" . }}-{{ .Values.alertmanager.name }}
-          image: "{{ .Values.alertmanager.image.repository }}:{{ .Values.alertmanager.image.tag }}"
-          imagePullPolicy: "{{ .Values.alertmanager.image.pullPolicy }}"
-          {{- with .Values.alertmanager.containerSecurityContext }}
+        - name: {{ template "prometheus.name" $ }}-{{ .name }}
+          image: "{{ .image.repository }}:{{ .image.tag }}"
+          imagePullPolicy: "{{ .image.pullPolicy }}"
+          {{- with .containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-            {{- range $key, $value := .Values.alertmanager.extraEnv }}
+            {{- range $key, $value := .extraEnv }}
             - name: {{ $key }}
               value: {{ $value }}
             {{- end }}
@@ -62,152 +67,157 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
           args:
-            - --config.file=/etc/config/{{ .Values.alertmanager.configFileName }}
-            - --storage.path={{ .Values.alertmanager.persistentVolume.mountPath }}
-          {{- if .Values.alertmanager.service.enableMeshPeer }}
+            - --config.file=/etc/config/{{ .configFileName }}
+            - --storage.path={{ .persistentVolume.mountPath }}
+            {{- if .service.enableMeshPeer }}
             - --cluster.listen-address=0.0.0.0:6783
             - --cluster.advertise-address=[$(POD_IP)]:6783
-          {{- else }}
+            {{- else }}
             - --cluster.listen-address=
-          {{- end }}
-          {{- range $key, $value := .Values.alertmanager.extraArgs }}
+            {{- end }}
+            {{- range $key, $value := .extraArgs }}
             - --{{ $key }}={{ $value }}
-          {{- end }}
-          {{- if .Values.alertmanager.baseURL }}
-            - --web.external-url={{ .Values.alertmanager.baseURL }}
-          {{- end }}
-          {{- range .Values.alertmanager.clusterPeers }}
+            {{- end }}
+            {{- with .baseURL }}
+            - --web.external-url={{ . }}
+            {{- end }}
+            {{- range .clusterPeers }}
             - --cluster.peer={{ . }}
-          {{- end }}
+            {{- end }}
 
           ports:
             - containerPort: 9093
           readinessProbe:
             httpGet:
-              path: {{ .Values.alertmanager.prefixURL }}/-/ready
+              path: {{ .prefixURL }}/-/ready
               port: 9093
-              {{- with .Values.alertmanager.probeHeaders }}
+              {{- with .probeHeaders }}
               httpHeaders:
-{{- toYaml . | nindent 14 }}
+                {{- toYaml . | nindent 16 }}
               {{- end }}
             initialDelaySeconds: 30
             timeoutSeconds: 30
+          {{- with .resources }}
           resources:
-{{ toYaml .Values.alertmanager.resources | indent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config
             - name: storage-volume
-              mountPath: "{{ .Values.alertmanager.persistentVolume.mountPath }}"
-              subPath: "{{ .Values.alertmanager.persistentVolume.subPath }}"
-          {{- range .Values.alertmanager.extraSecretMounts }}
+              mountPath: "{{ .persistentVolume.mountPath }}"
+              subPath: "{{ .persistentVolume.subPath }}"
+            {{- range .extraSecretMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
-          {{- end }}
-          {{- range .Values.alertmanager.extraConfigmapMounts }}
+            {{- end }}
+            {{- range .extraConfigmapMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
-          {{- end }}
+            {{- end }}
 
-        {{- if .Values.configmapReload.alertmanager.enabled }}
-        - name: {{ template "prometheus.name" . }}-{{ .Values.alertmanager.name }}-{{ .Values.configmapReload.alertmanager.name }}
-          image: "{{ .Values.configmapReload.alertmanager.image.repository }}:{{ .Values.configmapReload.alertmanager.image.tag }}"
-          imagePullPolicy: "{{ .Values.configmapReload.alertmanager.image.pullPolicy }}"
-          {{- with .Values.configmapReload.alertmanager.containerSecurityContext }}
+        {{- if $cmReloadAlert.enabled }}
+        - name: {{ template "prometheus.name" $ }}-{{ .name }}-{{ $cmReloadAlert.name }}
+          image: "{{ $cmReloadAlert.image.repository }}:{{ $cmReloadAlert.image.tag }}"
+          imagePullPolicy: "{{ $cmReloadAlert.image.pullPolicy }}"
+          {{- with $cmReloadAlert.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           args:
             - --volume-dir=/etc/config
-            - --webhook-url=http://127.0.0.1:9093{{ .Values.alertmanager.prefixURL }}/-/reload
-          {{- range $key, $value := .Values.configmapReload.alertmanager.extraArgs }}
+            - --webhook-url=http://127.0.0.1:9093{{ .prefixURL }}/-/reload
+          {{- range $key, $value := $cmReloadAlert.extraArgs }}
             - --{{ $key }}={{ $value }}
           {{- end }}
-          {{- range .Values.configmapReload.alertmanager.extraVolumeDirs }}
+          {{- range $cmReloadAlert.extraVolumeDirs }}
             - --volume-dir={{ . }}
           {{- end }}
-          {{- if .Values.configmapReload.alertmanager.containerPort }}
+          {{- with $cmReloadAlert.containerPort }}
           ports:
-            - containerPort: {{ .Values.configmapReload.alertmanager.containerPort }}
+            - containerPort: {{ . }}
           {{- end }}
+          {{- with $cmReloadAlert.resources }}
           resources:
-{{ toYaml .Values.configmapReload.alertmanager.resources | indent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config
               readOnly: true
-            {{- range .Values.configmapReload.alertmanager.extraConfigmapMounts }}
-            - name: {{ $.Values.configmapReload.alertmanager.name }}-{{ .name }}
+            {{- range $cmReloadAlert.extraConfigmapMounts }}
+            - name: {{ $cmReloadAlert.name }}-{{ .name }}
               mountPath: {{ .mountPath }}
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
             {{- end }}
         {{- end }}
-    {{- if .Values.imagePullSecrets }}
+      {{- with $.Values.imagePullSecrets }}
       imagePullSecrets:
-{{ toYaml .Values.imagePullSecrets | indent 8 }}
-    {{- end }}
-    {{- if .Values.alertmanager.nodeSelector }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.alertmanager.nodeSelector | indent 8 }}
-    {{- end }}
-    {{- with .Values.alertmanager.dnsConfig }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .dnsConfig }}
       dnsConfig:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.alertmanager.securityContext }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .securityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- if .Values.alertmanager.tolerations }}
+      {{- end }}
+      {{- with .tolerations }}
       tolerations:
-{{ toYaml .Values.alertmanager.tolerations | indent 8 }}
-    {{- end }}
-    {{- if .Values.alertmanager.affinity }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .affinity }}
       affinity:
-{{ toYaml .Values.alertmanager.affinity | indent 8 }}
-    {{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: config-volume
-          {{- if empty .Values.alertmanager.configFromSecret }}
-          configMap:
-            name: {{ if .Values.alertmanager.configMapOverrideName }}{{ .Release.Name }}-{{ .Values.alertmanager.configMapOverrideName }}{{- else }}{{ template "prometheus.alertmanager.fullname" . }}{{- end }}
-          {{- else }}
+          {{- with .configFromSecret }}
           secret:
-            secretName: {{ .Values.alertmanager.configFromSecret }}
+            secretName: {{ .configFromSecret }}
+          {{- else }}
+          configMap:
+            name: {{ if .configMapOverrideName }}{{ $.Release.Name }}-{{ .configMapOverrideName }}{{- else }}{{ template "prometheus.alertmanager.fullname" $ }}{{- end }}
           {{- end }}
-      {{- range .Values.alertmanager.extraSecretMounts }}
+        {{- range .extraConfigmapMounts }}
+        - name: {{ .name }}
+          configMap:
+            name: {{ .configMap }}
+        {{- end }}
+        {{- range .extraSecretMounts }}
         - name: {{ .name }}
           secret:
             secretName: {{ .secretName }}
             {{- with .optional }}
             optional: {{ . }}
             {{- end }}
-      {{- end }}
-      {{- range .Values.alertmanager.extraConfigmapMounts }}
-        - name: {{ .name }}
+        {{- end }}
+        {{- range $cmReloadAlert.extraConfigmapMounts }}
+        - name: {{ $cmReloadAlert.name }}-{{ .name }}
           configMap:
             name: {{ .configMap }}
-      {{- end }}
-      {{- range .Values.configmapReload.alertmanager.extraConfigmapMounts }}
-        - name: {{ $.Values.configmapReload.alertmanager.name }}-{{ .name }}
-          configMap:
-            name: {{ .configMap }}
-      {{- end }}
+        {{- end }}
         - name: storage-volume
-        {{- if .Values.alertmanager.persistentVolume.enabled }}
+        {{- if .persistentVolume.enabled }}
           persistentVolumeClaim:
-            claimName: {{ if .Values.alertmanager.persistentVolume.existingClaim }}{{ .Values.alertmanager.persistentVolume.existingClaim }}{{- else }}{{ template "prometheus.alertmanager.fullname" . }}{{- end }}
+            claimName: {{ if .persistentVolume.existingClaim }}{{ .persistentVolume.existingClaim }}{{- else }}{{ template "prometheus.alertmanager.fullname" $ }}{{- end }}
         {{- else }}
           emptyDir:
-          {{- if .Values.alertmanager.emptyDir.sizeLimit }}
-            sizeLimit: {{ .Values.alertmanager.emptyDir.sizeLimit }}
+          {{- with .emptyDir.sizeLimit }}
+            sizeLimit: {{ . }}
           {{- else }}
             {}
           {{- end -}}
         {{- end -}}
+{{- end }}
 {{- end }}

--- a/charts/prometheus/templates/alertmanager/headless-svc.yaml
+++ b/charts/prometheus/templates/alertmanager/headless-svc.yaml
@@ -1,31 +1,33 @@
 {{- if and .Values.alertmanager.enabled .Values.alertmanager.statefulSet.enabled -}}
+{{- with .Values.alertmanager.statefulSet.headless }}
 apiVersion: v1
 kind: Service
 metadata:
-{{- if .Values.alertmanager.statefulSet.headless.annotations }}
+  {{- with .annotations }}
   annotations:
-{{ toYaml .Values.alertmanager.statefulSet.headless.annotations | indent 4 }}
-{{- end }}
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
   labels:
-    {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
-{{- if .Values.alertmanager.statefulSet.headless.labels }}
-{{ toYaml .Values.alertmanager.statefulSet.headless.labels | indent 4 }}
-{{- end }}
-  name: {{ template "prometheus.alertmanager.fullname" . }}-headless
-{{ include "prometheus.namespace" . | indent 2 }}
+    {{- include "prometheus.alertmanager.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ template "prometheus.alertmanager.fullname" $ }}-headless
+  {{- include "prometheus.namespace" $ | indent 2 }}
 spec:
   clusterIP: None
   ports:
     - name: http
-      port: {{ .Values.alertmanager.statefulSet.headless.servicePort }}
+      port: {{ .servicePort }}
       protocol: TCP
       targetPort: 9093
-{{- if .Values.alertmanager.statefulSet.headless.enableMeshPeer }}
+    {{- if .enableMeshPeer }}
     - name: meshpeer
       port: 6783
       protocol: TCP
       targetPort: 6783
-{{- end }}
+    {{- end }}
   selector:
-    {{- include "prometheus.alertmanager.matchLabels" . | nindent 4 }}
+    {{- include "prometheus.alertmanager.matchLabels" $ | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/prometheus/templates/alertmanager/ingress.yaml
+++ b/charts/prometheus/templates/alertmanager/ingress.yaml
@@ -1,27 +1,27 @@
 {{- if and .Values.alertmanager.enabled .Values.alertmanager.ingress.enabled -}}
-{{- $ingressApiIsStable := eq (include "ingress.isStable" .) "true" -}}
-{{- $ingressSupportsIngressClassName := eq (include "ingress.supportsIngressClassName" .) "true" -}}
-{{- $ingressSupportsPathType := eq (include "ingress.supportsPathType" .) "true" -}}
+{{- $ingressApiIsStable := eq (include "ingress.isStable" $ ) "true" -}}
+{{- $ingressSupportsIngressClassName := eq (include "ingress.supportsIngressClassName" $ ) "true" -}}
+{{- $ingressSupportsPathType := eq (include "ingress.supportsPathType" $ ) "true" -}}
 {{- $releaseName := .Release.Name -}}
-{{- $serviceName := include "prometheus.alertmanager.fullname" . }}
+{{- $serviceName := include "prometheus.alertmanager.fullname" $ }}
 {{- $servicePort := .Values.alertmanager.service.servicePort -}}
 {{- $ingressPath := .Values.alertmanager.ingress.path -}}
 {{- $ingressPathType := .Values.alertmanager.ingress.pathType -}}
 {{- $extraPaths := .Values.alertmanager.ingress.extraPaths -}}
-apiVersion: {{ template "ingress.apiVersion" . }}
+apiVersion: {{ template "ingress.apiVersion" $ }}
 kind: Ingress
 metadata:
-{{- if .Values.alertmanager.ingress.annotations }}
+  {{- with .Values.alertmanager.ingress.annotations }}
   annotations:
-{{ toYaml .Values.alertmanager.ingress.annotations | indent 4 }}
-{{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
-    {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
-{{- range $key, $value := .Values.alertmanager.ingress.extraLabels }}
+    {{- include "prometheus.alertmanager.labels" $ | nindent 4 }}
+    {{- range $key, $value := .Values.alertmanager.ingress.extraLabels }}
     {{ $key }}: {{ $value }}
-{{- end }}
-  name: {{ template "prometheus.alertmanager.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+    {{- end }}
+  name: {{ template "prometheus.alertmanager.fullname" $ }}
+  {{- include "prometheus.namespace" $ | nindent 2 }}
 spec:
   {{- if and $ingressSupportsIngressClassName .Values.alertmanager.ingress.ingressClassName }}
   ingressClassName: {{ .Values.alertmanager.ingress.ingressClassName }}
@@ -32,12 +32,12 @@ spec:
     - host: {{ first $url }}
       http:
         paths:
-{{ if $extraPaths }}
-{{ toYaml $extraPaths | indent 10 }}
-{{- end }}
+          {{- with $extraPaths }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
           - path: {{ $ingressPath }}
-            {{- if $ingressSupportsPathType }}
-            pathType: {{ $ingressPathType }}
+            {{- with $ingressSupportsPathType }}
+            pathType: {{ . }}
             {{- end }}
             backend:
               {{- if $ingressApiIsStable }}
@@ -50,8 +50,8 @@ spec:
               servicePort: {{ $servicePort }}
               {{- end }}
   {{- end -}}
-{{- if .Values.alertmanager.ingress.tls }}
+  {{- with .Values.alertmanager.ingress.tls }}
   tls:
-{{ toYaml .Values.alertmanager.ingress.tls | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end -}}
 {{- end -}}

--- a/charts/prometheus/templates/alertmanager/netpol.yaml
+++ b/charts/prometheus/templates/alertmanager/netpol.yaml
@@ -1,20 +1,21 @@
-{{- if and .Values.alertmanager.enabled .Values.networkPolicy.enabled -}}
-apiVersion: {{ template "prometheus.networkPolicy.apiVersion" . }}
+{{- if and .Values.alertmanager.enabled
+           .Values.networkPolicy.enabled -}}
+apiVersion: {{ template "prometheus.networkPolicy.apiVersion" $ }}
 kind: NetworkPolicy
 metadata:
-  name: {{ template "prometheus.alertmanager.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+  name: {{ template "prometheus.alertmanager.fullname" $ }}
+  {{- include "prometheus.namespace" $ | nindent 2 }}
   labels:
-    {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
+    {{- include "prometheus.alertmanager.labels" $ | nindent 4 }}
 spec:
   podSelector:
     matchLabels:
-      {{- include "prometheus.alertmanager.matchLabels" . | nindent 6 }}
+      {{- include "prometheus.alertmanager.matchLabels" $ | nindent 6 }}
   ingress:
     - from:
       - podSelector:
           matchLabels:
-            {{- include "prometheus.server.matchLabels" . | nindent 12 }}
+            {{- include "prometheus.server.matchLabels" $ | nindent 12 }}
     - ports:
       - port: 9093
 {{- end -}}

--- a/charts/prometheus/templates/alertmanager/netpol.yaml
+++ b/charts/prometheus/templates/alertmanager/netpol.yaml
@@ -1,5 +1,4 @@
-{{- if and .Values.alertmanager.enabled
-           .Values.networkPolicy.enabled -}}
+{{- if and .Values.alertmanager.enabled .Values.networkPolicy.enabled -}}
 apiVersion: {{ template "prometheus.networkPolicy.apiVersion" $ }}
 kind: NetworkPolicy
 metadata:

--- a/charts/prometheus/templates/alertmanager/pdb.yaml
+++ b/charts/prometheus/templates/alertmanager/pdb.yaml
@@ -1,14 +1,14 @@
 {{- if .Values.alertmanager.podDisruptionBudget.enabled }}
-apiVersion: {{ template "prometheus.podDisruptionBudget.apiVersion" . }}
+apiVersion: {{ template "prometheus.podDisruptionBudget.apiVersion" $ }}
 kind: PodDisruptionBudget
 metadata:
-  name: {{ template "prometheus.alertmanager.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+  name: {{ template "prometheus.alertmanager.fullname" $ }}
+  {{- include "prometheus.namespace" $ | nindent 2 }}
   labels:
-    {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
+    {{- include "prometheus.alertmanager.labels" $ | nindent 4 }}
 spec:
   maxUnavailable: {{ .Values.alertmanager.podDisruptionBudget.maxUnavailable }}
   selector:
     matchLabels:
-      {{- include "prometheus.alertmanager.labels" . | nindent 6 }}
+      {{- include "prometheus.alertmanager.labels" $ | nindent 6 }}
 {{- end }}

--- a/charts/prometheus/templates/alertmanager/psp.yaml
+++ b/charts/prometheus/templates/alertmanager/psp.yaml
@@ -1,11 +1,12 @@
-{{- if and .Values.alertmanager.enabled .Values.rbac.create .Values.podSecurityPolicy.enabled }}
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+{{- if and .Values.alertmanager.enabled
+           .Values.rbac.create .Values.podSecurityPolicy.enabled
+           .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ template "prometheus.alertmanager.fullname" . }}
+  name: {{ template "prometheus.alertmanager.fullname" $ }}
   labels:
-    {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
+    {{- include "prometheus.alertmanager.labels" $ | nindent 4 }}
   {{- with .Values.alertmanager.podSecurityPolicy.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -44,5 +45,4 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: true
-{{- end }}
 {{- end }}

--- a/charts/prometheus/templates/alertmanager/psp.yaml
+++ b/charts/prometheus/templates/alertmanager/psp.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.alertmanager.enabled
            .Values.rbac.create .Values.podSecurityPolicy.enabled
-           .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+           (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/prometheus/templates/alertmanager/psp.yaml
+++ b/charts/prometheus/templates/alertmanager/psp.yaml
@@ -1,6 +1,4 @@
-{{- if and .Values.alertmanager.enabled
-           .Values.rbac.create .Values.podSecurityPolicy.enabled
-           (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
+{{- if and .Values.alertmanager.enabled .Values.rbac.create .Values.podSecurityPolicy.enabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/prometheus/templates/alertmanager/pvc.yaml
+++ b/charts/prometheus/templates/alertmanager/pvc.yaml
@@ -1,7 +1,4 @@
-{{- if and .Values.alertmanager.enabled
-           .Values.alertmanager.persistentVolume.enabled
-           (not .Values.alertmanager.statefulSet.enabled)
-           .Values.alertmanager.persistentVolume.existingClaim -}}
+{{- if and .Values.alertmanager.enabled .Values.alertmanager.persistentVolume.enabled (not .Values.alertmanager.statefulSet.enabled) .Values.alertmanager.persistentVolume.existingClaim -}}
 {{- with .Values.alertmanager.persistentVolume }}
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/charts/prometheus/templates/alertmanager/pvc.yaml
+++ b/charts/prometheus/templates/alertmanager/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.alertmanager.enabled .Values.alertmanager.persistentVolume.enabled (not .Values.alertmanager.statefulSet.enabled) .Values.alertmanager.persistentVolume.existingClaim -}}
+{{- if and (not .Values.alertmanager.statefulSet.enabled) .Values.alertmanager.enabled .Values.alertmanager.persistentVolume.enabled (not .Values.alertmanager.persistentVolume.existingClaim) -}}
 {{- with .Values.alertmanager.persistentVolume }}
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/charts/prometheus/templates/alertmanager/pvc.yaml
+++ b/charts/prometheus/templates/alertmanager/pvc.yaml
@@ -1,40 +1,41 @@
-{{- if not .Values.alertmanager.statefulSet.enabled -}}
-{{- if and .Values.alertmanager.enabled .Values.alertmanager.persistentVolume.enabled -}}
-{{- if not .Values.alertmanager.persistentVolume.existingClaim -}}
+{{- if and .Values.alertmanager.enabled
+           .Values.alertmanager.persistentVolume.enabled
+           (not .Values.alertmanager.statefulSet.enabled)
+           .Values.alertmanager.persistentVolume.existingClaim -}}
+{{- with .Values.alertmanager.persistentVolume }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  {{- if .Values.alertmanager.persistentVolume.annotations }}
+  {{- with .annotations }}
   annotations:
-{{ toYaml .Values.alertmanager.persistentVolume.annotations | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
-  name: {{ template "prometheus.alertmanager.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+    {{- include "prometheus.alertmanager.labels" $ | nindent 4 }}
+  name: {{ template "prometheus.alertmanager.fullname" $ }}
+  {{- include "prometheus.namespace" $ | nindent 2 }}
 spec:
   accessModes:
-{{ toYaml .Values.alertmanager.persistentVolume.accessModes | indent 4 }}
-{{- if .Values.alertmanager.persistentVolume.storageClass }}
-{{- if (eq "-" .Values.alertmanager.persistentVolume.storageClass) }}
+    {{- toYaml .accessModes | nindent 4 }}
+  {{- if .storageClass }}
+  {{- if (eq "-" .storageClass) }}
   storageClassName: ""
-{{- else }}
-  storageClassName: "{{ .Values.alertmanager.persistentVolume.storageClass }}"
-{{- end }}
-{{- end }}
-{{- if .Values.alertmanager.persistentVolume.volumeBindingMode }}
-  volumeBindingMode: "{{ .Values.alertmanager.persistentVolume.volumeBindingMode }}"
-{{- end }}
+  {{- else }}
+  storageClassName: "{{ .storageClass }}"
+  {{- end }}
+  {{- end }}
+  {{- with .volumeBindingMode }}
+  volumeBindingMode: "{{ . }}"
+  {{- end }}
   resources:
     requests:
-      storage: "{{ .Values.alertmanager.persistentVolume.size }}"
-{{- if .Values.alertmanager.persistentVolume.selector }}
+      storage: "{{ .size }}"
+  {{- with .selector }}
   selector:
-  {{- toYaml .Values.alertmanager.persistentVolume.selector | nindent 4 }}
-{{- end -}}
-{{- if .Values.alertmanager.persistentVolume.volumeName }}
-  volumeName: "{{ .Values.alertmanager.persistentVolume.volumeName }}"
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .volumeName }}
+  volumeName: "{{ . }}"
+  {{- end -}}
 {{- end }}
-{{- end -}}
-{{- end -}}
 {{- end -}}

--- a/charts/prometheus/templates/alertmanager/role.yaml
+++ b/charts/prometheus/templates/alertmanager/role.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.alertmanager.enabled .Values.rbac.create (eq .Values.alertmanager.useClusterRole false) (not .Values.alertmanager.useExistingRole) -}}
 {{- range $.Values.alertmanager.namespaces }}
-apiVersion: {{ template "rbac.apiVersion" . }}
+apiVersion: {{ template "rbac.apiVersion" $ }}
 kind: Role
 metadata:
   labels:
@@ -10,13 +10,13 @@ metadata:
 rules:
 {{- if $.Values.podSecurityPolicy.enabled }}
   - apiGroups:
-    - extensions
+      - extensions
     resources:
-    - podsecuritypolicies
+      - podsecuritypolicies
     verbs:
-    - use
+      - use
     resourceNames:
-    - {{ template "prometheus.alertmanager.fullname" $ }}
+      - {{ template "prometheus.alertmanager.fullname" $ }}
 {{- else }}
   []
 {{- end }}

--- a/charts/prometheus/templates/alertmanager/role.yaml
+++ b/charts/prometheus/templates/alertmanager/role.yaml
@@ -8,8 +8,7 @@ metadata:
   name: {{ template "prometheus.alertmanager.fullname" $ }}
   namespace: {{ . }}
 rules:
-  {{- if and $.Values.podSecurityPolicy.enabled 
-             (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
+  {{- if and $.Values.podSecurityPolicy.enabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
   - apiGroups:
       - extensions
     resources:

--- a/charts/prometheus/templates/alertmanager/role.yaml
+++ b/charts/prometheus/templates/alertmanager/role.yaml
@@ -8,7 +8,8 @@ metadata:
   name: {{ template "prometheus.alertmanager.fullname" $ }}
   namespace: {{ . }}
 rules:
-{{- if $.Values.podSecurityPolicy.enabled }}
+  {{- if and $.Values.podSecurityPolicy.enabled 
+             (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
   - apiGroups:
       - extensions
     resources:
@@ -17,8 +18,8 @@ rules:
       - use
     resourceNames:
       - {{ template "prometheus.alertmanager.fullname" $ }}
-{{- else }}
+  {{- else }}
   []
-{{- end }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/prometheus/templates/alertmanager/rolebinding.yaml
+++ b/charts/prometheus/templates/alertmanager/rolebinding.yaml
@@ -1,6 +1,4 @@
-{{- if and .Values.alertmanager.enabled
-           .Values.rbac.create
-           (not .Values.alertmanager.useClusterRole) -}}
+{{- if and .Values.alertmanager.enabled .Values.rbac.create (not .Values.alertmanager.useClusterRole) -}}
 {{ range $.Values.alertmanager.namespaces -}}
 apiVersion: {{ template "rbac.apiVersion" $ }}
 kind: RoleBinding

--- a/charts/prometheus/templates/alertmanager/rolebinding.yaml
+++ b/charts/prometheus/templates/alertmanager/rolebinding.yaml
@@ -1,6 +1,8 @@
-{{- if and .Values.alertmanager.enabled .Values.rbac.create (eq .Values.alertmanager.useClusterRole false) -}}
-{{ range $.Values.alertmanager.namespaces }}
-apiVersion: {{ template "rbac.apiVersion" . }}
+{{- if and .Values.alertmanager.enabled
+           .Values.rbac.create
+           (not .Values.alertmanager.useClusterRole) -}}
+{{ range $.Values.alertmanager.namespaces -}}
+apiVersion: {{ template "rbac.apiVersion" $ }}
 kind: RoleBinding
 metadata:
   labels:
@@ -10,14 +12,14 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "prometheus.serviceAccountName.alertmanager" $ }}
-{{ include "prometheus.namespace" $ | indent 4 }}
+    {{- include "prometheus.namespace" $ | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-{{- if (not $.Values.alertmanager.useExistingRole) }}
-  name: {{ template "prometheus.alertmanager.fullname" $ }}
-{{- else }}
+  {{- if $.Values.alertmanager.useExistingRole }}
   name: {{ $.Values.alertmanager.useExistingRole }}
-{{- end }}
+  {{- else }}
+  name: {{ template "prometheus.alertmanager.fullname" $ }}
+  {{- end }}
 {{- end }}
 {{ end }}

--- a/charts/prometheus/templates/alertmanager/service.yaml
+++ b/charts/prometheus/templates/alertmanager/service.yaml
@@ -1,53 +1,55 @@
 {{- if .Values.alertmanager.enabled -}}
+{{- with .Values.alertmanager.service }}
 apiVersion: v1
 kind: Service
 metadata:
-{{- if .Values.alertmanager.service.annotations }}
+  {{- with .annotations }}
   annotations:
-{{ toYaml .Values.alertmanager.service.annotations | indent 4 }}
-{{- end }}
-  labels:
-    {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
-{{- if .Values.alertmanager.service.labels }}
-{{ toYaml .Values.alertmanager.service.labels | indent 4 }}
-{{- end }}
-  name: {{ template "prometheus.alertmanager.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
-spec:
-{{- if .Values.alertmanager.service.clusterIP }}
-  clusterIP: {{ .Values.alertmanager.service.clusterIP }}
-{{- end }}
-{{- if .Values.alertmanager.service.externalIPs }}
-  externalIPs:
-{{ toYaml .Values.alertmanager.service.externalIPs | indent 4 }}
-{{- end }}
-{{- if .Values.alertmanager.service.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.alertmanager.service.loadBalancerIP }}
-{{- end }}
-{{- if .Values.alertmanager.service.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges:
-  {{- range $cidr := .Values.alertmanager.service.loadBalancerSourceRanges }}
-    - {{ $cidr }}
+    {{ toYaml . | nindent 4 }}
   {{- end }}
-{{- end }}
+  labels:
+    {{- include "prometheus.alertmanager.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ template "prometheus.alertmanager.fullname" $ }}
+  {{- include "prometheus.namespace" $ | nindent 2 }}
+spec:
+  {{- with .clusterIP }}
+  clusterIP: {{ . }}
+  {{- end }}
+  {{- with .externalIPs }}
+  externalIPs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .loadBalancerIP }}
+  loadBalancerIP: {{ . }}
+  {{- end }}
+  {{- with .loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- range $cidr := . }}
+    - {{ $cidr }}
+    {{- end }}
+  {{- end }}
   ports:
     - name: http
-      port: {{ .Values.alertmanager.service.servicePort }}
+      port: {{ .servicePort }}
       protocol: TCP
       targetPort: 9093
-    {{- if .Values.alertmanager.service.nodePort }}
-      nodePort: {{ .Values.alertmanager.service.nodePort }}
-    {{- end }}
-{{- if .Values.alertmanager.service.enableMeshPeer }}
+      {{- with .nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
+    {{- if .enableMeshPeer }}
     - name: meshpeer
       port: 6783
       protocol: TCP
       targetPort: 6783
-{{- end }}
+    {{- end }}
   selector:
-    {{- include "prometheus.alertmanager.matchLabels" . | nindent 4 }}
-{{- if .Values.alertmanager.service.sessionAffinity }}
-  sessionAffinity: {{ .Values.alertmanager.service.sessionAffinity }}
+    {{- include "prometheus.alertmanager.matchLabels" $ | nindent 4 }}
+  {{- with .sessionAffinity }}
+  sessionAffinity: {{ . }}
+  {{- end }}
+  type: "{{ .type }}"
 {{- end }}
-  type: "{{ .Values.alertmanager.service.type }}"
 {{- end }}

--- a/charts/prometheus/templates/alertmanager/serviceaccount.yaml
+++ b/charts/prometheus/templates/alertmanager/serviceaccount.yaml
@@ -3,9 +3,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
-  name: {{ template "prometheus.serviceAccountName.alertmanager" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+    {{- include "prometheus.alertmanager.labels" $ | nindent 4 }}
+  name: {{ template "prometheus.serviceAccountName.alertmanager" $ }}
+  {{- include "prometheus.namespace" $ | nindent 2 }}
+  {{- with .Values.serviceAccounts.alertmanager.annotations }}
   annotations:
-{{ toYaml .Values.serviceAccounts.alertmanager.annotations | indent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end -}}

--- a/charts/prometheus/templates/alertmanager/sts.yaml
+++ b/charts/prometheus/templates/alertmanager/sts.yaml
@@ -1,58 +1,61 @@
-{{- if and .Values.alertmanager.enabled .Values.alertmanager.statefulSet.enabled -}}
+{{- $cmReloadAlertmngr := $.Values.configmapReload.alertmanager -}}
+
+{{- with .Values.alertmanager }}
+{{- if and .enabled .statefulSet.enabled -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-{{- if .Values.alertmanager.statefulSet.annotations }}
+  {{- with .statefulSet.annotations }}
   annotations:
-    {{ toYaml .Values.alertmanager.statefulSet.annotations | nindent 4 }}
-{{- end }}
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
   labels:
-    {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
-    {{- if .Values.alertmanager.statefulSet.labels}}
-    {{ toYaml .Values.alertmanager.statefulSet.labels | nindent 4 }}
-    {{- end}}
-  name: {{ template "prometheus.alertmanager.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+    {{- include "prometheus.alertmanager.labels" $ | nindent 4 }}
+    {{- with .statefulSet.labels}}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ template "prometheus.alertmanager.fullname" $ }}
+  {{- include "prometheus.namespace" $ | indent 2 }}
 spec:
-  serviceName: {{ template "prometheus.alertmanager.fullname" . }}-headless
+  serviceName: {{ template "prometheus.alertmanager.fullname" $ }}-headless
   selector:
     matchLabels:
-      {{- include "prometheus.alertmanager.matchLabels" . | nindent 6 }}
-  replicas: {{ .Values.alertmanager.replicaCount }}
-  podManagementPolicy: {{ .Values.alertmanager.statefulSet.podManagementPolicy }}
+      {{- include "prometheus.alertmanager.matchLabels" $ | nindent 6 }}
+  replicas: {{ .replicaCount }}
+  podManagementPolicy: {{ .statefulSet.podManagementPolicy }}
   template:
     metadata:
-    {{- if .Values.alertmanager.podAnnotations }}
+      {{- with .podAnnotations }}
       annotations:
-        {{ toYaml .Values.alertmanager.podAnnotations | nindent 8 }}
-    {{- end }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       labels:
-        {{- include "prometheus.alertmanager.labels" . | nindent 8 }}
-        {{- if .Values.alertmanager.podLabels}}
-        {{ toYaml .Values.alertmanager.podLabels | nindent 8 }}
+        {{- include "prometheus.alertmanager.labels" $ | nindent 8 }}
+        {{- with .podLabels}}
+        {{- toYaml . | nindent 8 }}
         {{- end}}
     spec:
-{{- if .Values.alertmanager.affinity }}
+      {{- with .affinity }}
       affinity:
-{{ toYaml .Values.alertmanager.affinity | indent 8 }}
-{{- end }}
-{{- if .Values.alertmanager.schedulerName }}
-      schedulerName: "{{ .Values.alertmanager.schedulerName }}"
-{{- end }}
-      serviceAccountName: {{ template "prometheus.serviceAccountName.alertmanager" . }}
-{{- if .Values.alertmanager.priorityClassName }}
-      priorityClassName: "{{ .Values.alertmanager.priorityClassName }}"
-{{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .schedulerName }}
+      schedulerName: "{{ . }}"
+      {{- end }}
+      serviceAccountName: {{ template "prometheus.serviceAccountName.alertmanager" $ }}
+      {{- with .priorityClassName }}
+      priorityClassName: "{{ . }}"
+      {{- end }}
       containers:
-        - name: {{ template "prometheus.name" . }}-{{ .Values.alertmanager.name }}
-          image: "{{ .Values.alertmanager.image.repository }}:{{ .Values.alertmanager.image.tag }}"
-          imagePullPolicy: "{{ .Values.alertmanager.image.pullPolicy }}"
-          {{- with .Values.alertmanager.containerSecurityContext }}
+        - name: {{ template "prometheus.name" $ }}-{{ .name }}
+          image: "{{ .image.repository }}:{{ .image.tag }}"
+          imagePullPolicy: "{{ .image.pullPolicy }}"
+          {{- with .containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-            {{- range $key, $value := .Values.alertmanager.extraEnv }}
+            {{- range $key, $value := .extraEnv }}
             - name: {{ $key }}
               value: {{ $value }}
             {{- end }}
@@ -63,138 +66,143 @@ spec:
                   fieldPath: status.podIP
           args:
             - --config.file=/etc/config/alertmanager.yml
-            - --storage.path={{ .Values.alertmanager.persistentVolume.mountPath }}
-          {{- if .Values.alertmanager.statefulSet.headless.enableMeshPeer }}
+            - --storage.path={{ .persistentVolume.mountPath }}
+            {{- if .statefulSet.headless.enableMeshPeer }}
             - --cluster.advertise-address=[$(POD_IP)]:6783
             - --cluster.listen-address=0.0.0.0:6783
-          {{- range $n := until (.Values.alertmanager.replicaCount | int) }}
+            {{- range $n := until (.replicaCount | int) }}
             - --cluster.peer={{ template "prometheus.alertmanager.fullname" $ }}-{{ $n }}.{{ template "prometheus.alertmanager.fullname" $ }}-headless:6783
-          {{- end }}
-          {{- else }}
+            {{- end }}
+            {{- else }}
             - --cluster.listen-address=
-          {{- end }}
-          {{- range $key, $value := .Values.alertmanager.extraArgs }}
+            {{- end }}
+            {{- range $key, $value := .extraArgs }}
             - --{{ $key }}={{ $value }}
-          {{- end }}
-          {{- if .Values.alertmanager.baseURL }}
-            - --web.external-url={{ .Values.alertmanager.baseURL }}
-          {{- end }}
+            {{- end }}
+            {{- with .baseURL }}
+            - --web.external-url={{ . }}
+            {{- end }}
 
           ports:
             - containerPort: 9093
-          {{- if .Values.alertmanager.statefulSet.headless.enableMeshPeer }}
+            {{- if .statefulSet.headless.enableMeshPeer }}
             - containerPort: 6783
-          {{- end }}
+            {{- end }}
           readinessProbe:
             httpGet:
-              path: {{ .Values.alertmanager.prefixURL }}/#/status
+              path: {{ .prefixURL }}/#/status
               port: 9093
-              {{- with .Values.alertmanager.probeHeaders }}
+              {{- with .probeHeaders }}
               httpHeaders:
-{{- toYaml . | nindent 14 }}
+                {{- toYaml . | nindent 16 }}
               {{- end }}
             initialDelaySeconds: 30
             timeoutSeconds: 30
+          {{- with .resources }}
           resources:
-{{ toYaml .Values.alertmanager.resources | indent 12 }}
+            {{- toYaml . | indent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config
             - name: storage-volume
-              mountPath: "{{ .Values.alertmanager.persistentVolume.mountPath }}"
-              subPath: "{{ .Values.alertmanager.persistentVolume.subPath }}"
-          {{- range .Values.alertmanager.extraSecretMounts }}
+              mountPath: "{{ .persistentVolume.mountPath }}"
+              subPath: "{{ .persistentVolume.subPath }}"
+            {{- range .extraSecretMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
-          {{- end }}
-        {{- if .Values.configmapReload.alertmanager.enabled }}
-        - name: {{ template "prometheus.name" . }}-{{ .Values.alertmanager.name }}-{{ .Values.configmapReload.alertmanager.name }}
-          image: "{{ .Values.configmapReload.alertmanager.image.repository }}:{{ .Values.configmapReload.alertmanager.image.tag }}"
-          imagePullPolicy: "{{ .Values.configmapReload.alertmanager.image.pullPolicy }}"
-          {{- with .Values.configmapReload.alertmanager.containerSecurityContext }}
+            {{- end }}
+        {{- if $cmReloadAlertmngr.enabled }}
+        - name: {{ template "prometheus.name" $ }}-{{ .name }}-{{ $cmReloadAlertmngr.name }}
+          image: "{{ $cmReloadAlertmngr.image.repository }}:{{ $cmReloadAlertmngr.image.tag }}"
+          imagePullPolicy: "{{ $cmReloadAlertmngr.image.pullPolicy }}"
+          {{- with $cmReloadAlertmngr.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           args:
             - --volume-dir=/etc/config
-            - --webhook-url=http://localhost:9093{{ .Values.alertmanager.prefixURL }}/-/reload
-          {{- range $key, $value := .Values.configmapReload.alertmanager.extraArgs }}
+            - --webhook-url=http://localhost:9093{{ .prefixURL }}/-/reload
+            {{- range $key, $value := $cmReloadAlertmngr.extraArgs }}
             - --{{ $key }}={{ $value }}
-          {{- end }}
-          {{- if .Values.configmapReload.alertmanager.port }}
+            {{- end }}
+          {{- with $cmReloadAlertmngr.port }}
           ports:
-            - containerPort: {{ .Values.configmapReload.alertmanager.port }}
+            - containerPort: {{ . }}
           {{- end }}
+          {{- with $cmReloadAlertmngr.resources }}
           resources:
-{{ toYaml .Values.configmapReload.alertmanager.resources | indent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config
               readOnly: true
         {{- end }}
-    {{- if .Values.imagePullSecrets }}
+      {{- with $.Values.imagePullSecrets }}
       imagePullSecrets:
-{{ toYaml .Values.imagePullSecrets | indent 8 }}
-    {{- end }}
-    {{- if .Values.alertmanager.nodeSelector }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.alertmanager.nodeSelector | indent 8 }}
-    {{- end }}
-    {{- with .Values.alertmanager.securityContext }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .securityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- if .Values.alertmanager.tolerations }}
+      {{- end }}
+      {{- with .tolerations }}
       tolerations:
-{{ toYaml .Values.alertmanager.tolerations | indent 8 }}
-    {{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: config-volume
-          {{- if empty .Values.alertmanager.configFromSecret }}
-          configMap:
-            name: {{ if .Values.alertmanager.configMapOverrideName }}{{ .Release.Name }}-{{ .Values.alertmanager.configMapOverrideName }}{{- else }}{{ template "prometheus.alertmanager.fullname" . }}{{- end }}
-          {{- else }}
+          {{- with .configFromSecret }}
           secret:
-            secretName: {{ .Values.alertmanager.configFromSecret }}
+            secretName: {{ .configFromSecret }}
+          {{- else }}
+          configMap:
+            name: {{ if .configMapOverrideName }}{{ $.Release.Name }}-{{ .configMapOverrideName }}{{- else }}{{ template "prometheus.alertmanager.fullname" $ }}{{- end }}
           {{- end }}
-      {{- range .Values.alertmanager.extraSecretMounts }}
+        {{- range .extraSecretMounts }}
         - name: {{ .name }}
           secret:
             secretName: {{ .secretName }}
             {{- with .optional }}
             optional: {{ . }}
             {{- end }}
-      {{- end }}
-{{- if .Values.alertmanager.persistentVolume.enabled }}
+        {{- end }}
+  {{- if .persistentVolume.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: storage-volume
-        {{- if .Values.alertmanager.persistentVolume.annotations }}
+        {{- with .persistentVolume.annotations }}
         annotations:
-{{ toYaml .Values.alertmanager.persistentVolume.annotations | indent 10 }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
       spec:
         accessModes:
-{{ toYaml .Values.alertmanager.persistentVolume.accessModes | indent 10 }}
+          {{- toYaml .persistentVolume.accessModes | nindent 10 }}
         resources:
           requests:
-            storage: "{{ .Values.alertmanager.persistentVolume.size }}"
-      {{- if .Values.server.persistentVolume.storageClass }}
-      {{- if (eq "-" .Values.server.persistentVolume.storageClass) }}
+            storage: "{{ .persistentVolume.size }}"
+        {{- if .persistentVolume.storageClass }}
+        {{- if (eq "-" .persistentVolume.storageClass) }}
         storageClassName: ""
-      {{- else }}
-        storageClassName: "{{ .Values.alertmanager.persistentVolume.storageClass }}"
-      {{- end }}
-      {{- end }}
-{{- else }}
+        {{- else }}
+        storageClassName: "{{ .persistentVolume.storageClass }}"
+        {{- end }}
+        {{- end }}
+  {{- else }}
         - name: storage-volume
           emptyDir:
-          {{- if .Values.alertmanager.emptyDir.sizeLimit }}
-            sizeLimit: {{ .Values.alertmanager.emptyDir.sizeLimit }}
+          {{- with .emptyDir.sizeLimit }}
+            sizeLimit: {{ . }}
           {{- else }}
             {}
           {{- end -}}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/prometheus/templates/node-exporter/daemonset.yaml
+++ b/charts/prometheus/templates/node-exporter/daemonset.yaml
@@ -1,77 +1,80 @@
-{{- if .Values.nodeExporter.enabled -}}
-apiVersion: {{ template "prometheus.daemonset.apiVersion" . }}
+{{- with .Values.nodeExporter }}
+{{- if .enabled -}}
+apiVersion: {{ template "prometheus.daemonset.apiVersion" $ }}
 kind: DaemonSet
 metadata:
-{{- if .Values.nodeExporter.deploymentAnnotations }}
+  {{- with .deploymentAnnotations }}
   annotations:
-{{ toYaml .Values.nodeExporter.deploymentAnnotations | indent 4 }}
-{{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
-    {{- include "prometheus.nodeExporter.labels" . | nindent 4 }}
-  name: {{ template "prometheus.nodeExporter.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+    {{- include "prometheus.nodeExporter.labels" $ | nindent 4 }}
+  name: {{ template "prometheus.nodeExporter.fullname" $ }}
+  {{- include "prometheus.namespace" $ | nindent 2 }}
 spec:
   selector:
     matchLabels:
-      {{- include "prometheus.nodeExporter.matchLabels" . | nindent 6 }}
-  {{- if .Values.nodeExporter.updateStrategy }}
+      {{- include "prometheus.nodeExporter.matchLabels" $ | nindent 6 }}
+  {{- with .updateStrategy }}
   updateStrategy:
-{{ toYaml .Values.nodeExporter.updateStrategy | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   template:
     metadata:
-    {{- if .Values.nodeExporter.podAnnotations }}
+      {{- with .podAnnotations }}
       annotations:
-{{ toYaml .Values.nodeExporter.podAnnotations | indent 8 }}
-    {{- end }}
-      labels:
-        {{- include "prometheus.nodeExporter.labels" . | nindent 8 }}
-{{- if .Values.nodeExporter.pod.labels }}
-{{ toYaml .Values.nodeExporter.pod.labels | indent 8 }}
-{{- end }}
-    spec:
-      serviceAccountName: {{ template "prometheus.serviceAccountName.nodeExporter" . }}
-      {{- if .Values.nodeExporter.extraInitContainers }}
-      initContainers:
-{{ toYaml .Values.nodeExporter.extraInitContainers | indent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
-{{- if .Values.nodeExporter.priorityClassName }}
-      priorityClassName: "{{ .Values.nodeExporter.priorityClassName }}"
-{{- end }}
+      labels:
+        {{- include "prometheus.nodeExporter.labels" $ | nindent 8 }}
+        {{- with .podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ template "prometheus.serviceAccountName.nodeExporter" $ }}
+      {{- with .extraInitContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .priorityClassName }}
+      priorityClassName: "{{ . }}"
+      {{- end }}
       containers:
-        - name: {{ template "prometheus.name" . }}-{{ .Values.nodeExporter.name }}
-          image: "{{ .Values.nodeExporter.image.repository }}:{{ .Values.nodeExporter.image.tag }}"
-          imagePullPolicy: "{{ .Values.nodeExporter.image.pullPolicy }}"
+        - name: {{ template "prometheus.name" $ }}-{{ .name }}
+          image: "{{ .image.repository }}:{{ .image.tag }}"
+          imagePullPolicy: "{{ .image.pullPolicy }}"
           args:
             - --path.procfs=/host/proc
             - --path.sysfs=/host/sys
-          {{- if .Values.nodeExporter.hostRootfs }}
+            {{- if .hostRootfs }}
             - --path.rootfs=/host/root
-          {{- end }}
-          {{- if .Values.nodeExporter.hostNetwork }}
-            - --web.listen-address=:{{ .Values.nodeExporter.service.hostPort }}
-          {{- end }}
-          {{- range $key, $value := .Values.nodeExporter.extraArgs }}
-          {{- if $value }}
+            {{- end }}
+            {{- if .hostNetwork }}
+            - --web.listen-address=:{{ .service.hostPort }}
+            {{- end }}
+            {{- range $key, $value := .extraArgs }}
+            {{- if $value }}
             - --{{ $key }}={{ $value }}
-          {{- else }}
+            {{- else }}
             - --{{ $key }}
-          {{- end }}
-          {{- end }}
+            {{- end }}
+            {{- end }}
           ports:
             - name: metrics
-              {{- if .Values.nodeExporter.hostNetwork }}
-              containerPort: {{ .Values.nodeExporter.service.hostPort }}
+              {{- if .hostNetwork }}
+              containerPort: {{ .service.hostPort }}
               {{- else }}
               containerPort: 9100
               {{- end }}
-              hostPort: {{ .Values.nodeExporter.service.hostPort }}
+              hostPort: {{ .service.hostPort }}
+          {{- with .resources }}
           resources:
-{{ toYaml .Values.nodeExporter.resources | indent 12 }}
-          {{- if .Values.nodeExporter.container.securityContext }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .container.securityContext }}
           securityContext:
-{{ toYaml .Values.nodeExporter.container.securityContext | indent 12 }}
-          {{- end }}          
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: proc
               mountPath: /host/proc
@@ -79,51 +82,51 @@ spec:
             - name: sys
               mountPath: /host/sys
               readOnly: true
-          {{- if .Values.nodeExporter.hostRootfs }}
+            {{- if .hostRootfs }}
             - name: root
               mountPath: /host/root
               mountPropagation: HostToContainer
               readOnly: true
-          {{- end }}
-          {{- range .Values.nodeExporter.extraHostPathMounts }}
-            - name: {{ .name }}
-              mountPath: {{ .mountPath }}
-              readOnly: {{ .readOnly }}
-            {{- if .mountPropagation }}
-              mountPropagation: {{ .mountPropagation }}
             {{- end }}
-          {{- end }}
-          {{- range .Values.nodeExporter.extraConfigmapMounts }}
+            {{- range .extraHostPathMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
               readOnly: {{ .readOnly }}
-          {{- end }}
-    {{- if .Values.imagePullSecrets }}
+              {{- with .mountPropagation }}
+              mountPropagation: {{ . }}
+              {{- end }}
+            {{- end }}
+            {{- range .extraConfigmapMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              readOnly: {{ .readOnly }}
+            {{- end }}
+      {{- with $.Values.imagePullSecrets }}
       imagePullSecrets:
-{{ toYaml .Values.imagePullSecrets | indent 8 }}
-    {{- end }}
-    {{- if .Values.nodeExporter.hostNetwork }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .hostNetwork }}
       hostNetwork: true
-    {{- end }}
-    {{- if .Values.nodeExporter.hostPID }}
+      {{- end }}
+      {{- if .hostPID }}
       hostPID: true
-    {{- end }}
-    {{- if .Values.nodeExporter.tolerations }}
+      {{- end }}
+      {{- with .tolerations }}
       tolerations:
-{{ toYaml .Values.nodeExporter.tolerations | indent 8 }}
-    {{- end }}
-    {{- if .Values.nodeExporter.nodeSelector }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.nodeExporter.nodeSelector | indent 8 }}
-    {{- end }}
-    {{- with .Values.nodeExporter.dnsConfig }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .dnsConfig }}
       dnsConfig:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- if .Values.nodeExporter.securityContext }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .securityContext }}
       securityContext:
-{{ toYaml .Values.nodeExporter.securityContext | indent 8 }}
-    {{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: proc
           hostPath:
@@ -131,20 +134,20 @@ spec:
         - name: sys
           hostPath:
             path: /sys
-      {{- if .Values.nodeExporter.hostRootfs }}
+        {{- if .hostRootfs }}
         - name: root
           hostPath:
             path: /
-      {{- end }}
-      {{- range .Values.nodeExporter.extraHostPathMounts }}
+        {{- end }}
+        {{- range .extraHostPathMounts }}
         - name: {{ .name }}
           hostPath:
             path: {{ .hostPath }}
-      {{- end }}
-      {{- range .Values.nodeExporter.extraConfigmapMounts }}
+        {{- end }}
+        {{- range .extraConfigmapMounts }}
         - name: {{ .name }}
           configMap:
             name: {{ .configMap }}
-      {{- end }}
-
+        {{- end }}
 {{- end -}}
+{{- end }}

--- a/charts/prometheus/templates/node-exporter/psp.yaml
+++ b/charts/prometheus/templates/node-exporter/psp.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.nodeExporter.enabled
            .Values.rbac.create .Values.podSecurityPolicy.enabled
-          .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+           (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/prometheus/templates/node-exporter/psp.yaml
+++ b/charts/prometheus/templates/node-exporter/psp.yaml
@@ -1,6 +1,4 @@
-{{- if and .Values.nodeExporter.enabled
-           .Values.rbac.create .Values.podSecurityPolicy.enabled
-           (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
+{{- if and .Values.nodeExporter.enabled .Values.rbac.create .Values.podSecurityPolicy.enabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/prometheus/templates/node-exporter/psp.yaml
+++ b/charts/prometheus/templates/node-exporter/psp.yaml
@@ -1,11 +1,12 @@
-{{- if and .Values.nodeExporter.enabled .Values.rbac.create .Values.podSecurityPolicy.enabled }}
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+{{- if and .Values.nodeExporter.enabled
+           .Values.rbac.create .Values.podSecurityPolicy.enabled
+          .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ template "prometheus.nodeExporter.fullname" . }}
+  name: {{ template "prometheus.nodeExporter.fullname" $ }}
   labels:
-    {{- include "prometheus.nodeExporter.labels" . | nindent 4 }}
+    {{- include "prometheus.nodeExporter.labels" $ | nindent 4 }}
   {{- with .Values.nodeExporter.podSecurityPolicy.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -26,10 +27,10 @@ spec:
       readOnly: true
     - pathPrefix: /
       readOnly: true
-  {{- range .Values.nodeExporter.extraHostPathMounts }}
+    {{- range .Values.nodeExporter.extraHostPathMounts }}
     - pathPrefix: {{ .hostPath }}
       readOnly: {{ .readOnly }}
-  {{- end }}
+    {{- end }}
   hostNetwork: {{ .Values.nodeExporter.hostNetwork }}
   hostPID: {{ .Values.nodeExporter.hostPID }}
   hostIPC: false
@@ -53,5 +54,4 @@ spec:
   hostPorts:
     - min: 1
       max: 65535
-{{- end }}
 {{- end }}

--- a/charts/prometheus/templates/node-exporter/role.yaml
+++ b/charts/prometheus/templates/node-exporter/role.yaml
@@ -8,10 +8,18 @@ metadata:
   name: {{ template "prometheus.nodeExporter.fullname" $ }}
   {{- include "prometheus.namespace" $ | nindent 2 }}
 rules:
-- apiGroups: ['extensions']
-  resources: ['podsecuritypolicies']
-  verbs:     ['use']
-  resourceNames:
-    - {{ template "prometheus.nodeExporter.fullname" $ }}
+  {{- if and .Values.podSecurityPolicy.enabled
+             (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
+  - apiGroups: 
+      - extensions
+    resources: 
+      - podsecuritypolicies
+    verbs:
+      - use
+    resourceNames:
+      - {{ template "prometheus.nodeExporter.fullname" $ }}
+  {{- else }}
+  []
+  {{- end}}
 {{- end }}
 {{- end }}

--- a/charts/prometheus/templates/node-exporter/role.yaml
+++ b/charts/prometheus/templates/node-exporter/role.yaml
@@ -1,17 +1,17 @@
 {{- if and .Values.nodeExporter.enabled .Values.rbac.create }}
 {{- if or (default .Values.nodeExporter.podSecurityPolicy.enabled false) (.Values.podSecurityPolicy.enabled) }}
-apiVersion: {{ template "rbac.apiVersion" . }}
+apiVersion: {{ template "rbac.apiVersion" $ }}
 kind: Role
 metadata:
-  name: {{ template "prometheus.nodeExporter.fullname" . }}
   labels:
-    {{- include "prometheus.nodeExporter.labels" . | nindent 4 }}
-{{ include "prometheus.namespace" . | indent 2 }}
+    {{- include "prometheus.nodeExporter.labels" $ | nindent 4 }}
+  name: {{ template "prometheus.nodeExporter.fullname" $ }}
+  {{- include "prometheus.namespace" $ | nindent 2 }}
 rules:
 - apiGroups: ['extensions']
   resources: ['podsecuritypolicies']
   verbs:     ['use']
   resourceNames:
-  - {{ template "prometheus.nodeExporter.fullname" . }}
+    - {{ template "prometheus.nodeExporter.fullname" $ }}
 {{- end }}
 {{- end }}

--- a/charts/prometheus/templates/node-exporter/rolebinding.yaml
+++ b/charts/prometheus/templates/node-exporter/rolebinding.yaml
@@ -1,19 +1,19 @@
-{{- if and .Values.nodeExporter.enabled .Values.rbac.create }}
-{{- if .Values.podSecurityPolicy.enabled }}
-apiVersion: {{ template "rbac.apiVersion" . }}
+{{- if and .Values.nodeExporter.enabled
+           .Values.rbac.create
+           .Values.podSecurityPolicy.enabled }}
+apiVersion: {{ template "rbac.apiVersion" $ }}
 kind: RoleBinding
 metadata:
-  name: {{ template "prometheus.nodeExporter.fullname" . }}
+  name: {{ template "prometheus.nodeExporter.fullname" $ }}
   labels:
-    {{- include "prometheus.nodeExporter.labels" . | nindent 4 }}
-{{ include "prometheus.namespace" . | indent 2 }}
+    {{- include "prometheus.nodeExporter.labels" $ | nindent 4 }}
+  {{- include "prometheus.namespace" $ | nindent 2 }}
 roleRef:
   kind: Role
-  name: {{ template "prometheus.nodeExporter.fullname" . }}
+  name: {{ template "prometheus.nodeExporter.fullname" $ }}
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: {{ template "prometheus.serviceAccountName.nodeExporter" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
-{{- end }}
+  name: {{ template "prometheus.serviceAccountName.nodeExporter" $ }}
+  {{- include "prometheus.namespace" $ | nindent 2 }}
 {{- end }}

--- a/charts/prometheus/templates/node-exporter/rolebinding.yaml
+++ b/charts/prometheus/templates/node-exporter/rolebinding.yaml
@@ -1,6 +1,4 @@
-{{- if and .Values.nodeExporter.enabled
-           .Values.rbac.create
-           .Values.podSecurityPolicy.enabled }}
+{{- if and .Values.nodeExporter.enabled .Values.rbac.create .Values.podSecurityPolicy.enabled }}
 apiVersion: {{ template "rbac.apiVersion" $ }}
 kind: RoleBinding
 metadata:

--- a/charts/prometheus/templates/node-exporter/serviceaccount.yaml
+++ b/charts/prometheus/templates/node-exporter/serviceaccount.yaml
@@ -3,9 +3,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    {{- include "prometheus.nodeExporter.labels" . | nindent 4 }}
-  name: {{ template "prometheus.serviceAccountName.nodeExporter" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+    {{- include "prometheus.nodeExporter.labels" $ | nindent 4 }}
+  name: {{ template "prometheus.serviceAccountName.nodeExporter" $ }}
+  {{- include "prometheus.namespace" $ | nindent 2 }}
+  {{- with .Values.serviceAccounts.nodeExporter.annotations }}
   annotations:
-{{ toYaml .Values.serviceAccounts.nodeExporter.annotations | indent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end -}}

--- a/charts/prometheus/templates/node-exporter/svc.yaml
+++ b/charts/prometheus/templates/node-exporter/svc.yaml
@@ -1,47 +1,49 @@
 {{- if .Values.nodeExporter.enabled -}}
+{{- with .Values.nodeExporter.service }}
 apiVersion: v1
 kind: Service
 metadata:
-{{- if .Values.nodeExporter.service.annotations }}
+  {{- with .annotations }}
   annotations:
-{{ toYaml .Values.nodeExporter.service.annotations | indent 4 }}
-{{- end }}
-  labels:
-    {{- include "prometheus.nodeExporter.labels" . | nindent 4 }}
-{{- if .Values.nodeExporter.service.labels }}
-{{ toYaml .Values.nodeExporter.service.labels | indent 4 }}
-{{- end }}
-  name: {{ template "prometheus.nodeExporter.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
-spec:
-{{- if .Values.nodeExporter.service.clusterIP }}
-  clusterIP: {{ .Values.nodeExporter.service.clusterIP }}
-{{- end }}
-{{- if .Values.nodeExporter.service.externalIPs }}
-  externalIPs:
-{{ toYaml .Values.nodeExporter.service.externalIPs | indent 4 }}
-{{- end }}
-{{- if .Values.nodeExporter.service.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.nodeExporter.service.loadBalancerIP }}
-{{- end }}
-{{- if .Values.nodeExporter.service.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges:
-  {{- range $cidr := .Values.nodeExporter.service.loadBalancerSourceRanges }}
-    - {{ $cidr }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- end }}
+  labels:
+    {{- include "prometheus.nodeExporter.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ template "prometheus.nodeExporter.fullname" $ }}
+  {{- include "prometheus.namespace" $ | nindent 2 }}
+spec:
+  {{- with .clusterIP }}
+  clusterIP: {{ . }}
+  {{- end }}
+  {{- with .externalIPs }}
+  externalIPs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .loadBalancerIP }}
+  loadBalancerIP: {{ . }}
+  {{- end }}
+  {{- with .loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- range $cidr := . }}
+    - {{ $cidr }}
+    {{- end }}
+  {{- end }}
   ports:
     - name: metrics
-    {{- if .Values.nodeExporter.hostNetwork }}
-      port: {{ .Values.nodeExporter.service.hostPort }}
+      {{- if $.Values.nodeExporter.hostNetwork }}
+      port: {{ .hostPort }}
       protocol: TCP
-      targetPort: {{ .Values.nodeExporter.service.hostPort }}
-    {{- else }}
-      port: {{ .Values.nodeExporter.service.servicePort }}
+      targetPort: {{ .hostPort }}
+      {{- else }}
+      port: {{ .servicePort }}
       protocol: TCP
       targetPort: 9100
-    {{- end }}
+      {{- end }}
   selector:
-    {{- include "prometheus.nodeExporter.matchLabels" . | nindent 4 }}
-  type: "{{ .Values.nodeExporter.service.type }}"
+    {{- include "prometheus.nodeExporter.matchLabels" $ | nindent 4 }}
+  type: "{{ .type }}"
+{{- end }}
 {{- end -}}

--- a/charts/prometheus/templates/pushgateway/clusterrole.yaml
+++ b/charts/prometheus/templates/pushgateway/clusterrole.yaml
@@ -9,13 +9,13 @@ rules:
   {{- if and .Values.podSecurityPolicy.enabled
              (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
   - apiGroups:
-    - extensions
+      - extensions
     resources:
-    - podsecuritypolicies
+      - podsecuritypolicies
     verbs:
-    - use
+      - use
     resourceNames:
-    - {{ template "prometheus.pushgateway.fullname" $ }}
+      - {{ template "prometheus.pushgateway.fullname" $ }}
   {{- else }}
   []
   {{- end }}

--- a/charts/prometheus/templates/pushgateway/clusterrole.yaml
+++ b/charts/prometheus/templates/pushgateway/clusterrole.yaml
@@ -1,12 +1,13 @@
 {{- if and .Values.pushgateway.enabled .Values.rbac.create -}}
-apiVersion: {{ template "rbac.apiVersion" . }}
+apiVersion: {{ template "rbac.apiVersion" $ }}
 kind: ClusterRole
 metadata:
   labels:
-    {{- include "prometheus.pushgateway.labels" . | nindent 4 }}
-  name: {{ template "prometheus.pushgateway.fullname" . }}
+    {{- include "prometheus.pushgateway.labels" $ | nindent 4 }}
+  name: {{ template "prometheus.pushgateway.fullname" $ }}
 rules:
-{{- if .Values.podSecurityPolicy.enabled }}
+  {{- if and .Values.podSecurityPolicy.enabled
+             (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
   - apiGroups:
     - extensions
     resources:
@@ -14,8 +15,8 @@ rules:
     verbs:
     - use
     resourceNames:
-    - {{ template "prometheus.pushgateway.fullname" . }}
-{{- else }}
+    - {{ template "prometheus.pushgateway.fullname" $ }}
+  {{- else }}
   []
-{{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/prometheus/templates/pushgateway/clusterrolebinding.yaml
+++ b/charts/prometheus/templates/pushgateway/clusterrolebinding.yaml
@@ -1,16 +1,16 @@
 {{- if and .Values.pushgateway.enabled .Values.rbac.create -}}
-apiVersion: {{ template "rbac.apiVersion" . }}
+apiVersion: {{ template "rbac.apiVersion" $ }}
 kind: ClusterRoleBinding
 metadata:
   labels:
-    {{- include "prometheus.pushgateway.labels" . | nindent 4 }}
-  name: {{ template "prometheus.pushgateway.fullname" . }}
+    {{- include "prometheus.pushgateway.labels" $ | nindent 4 }}
+  name: {{ template "prometheus.pushgateway.fullname" $ }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "prometheus.serviceAccountName.pushgateway" . }}
-{{ include "prometheus.namespace" . | indent 4 }}
+    name: {{ template "prometheus.serviceAccountName.pushgateway" $ }}
+    {{- include "prometheus.namespace" $ | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "prometheus.pushgateway.fullname" . }}
+  name: {{ template "prometheus.pushgateway.fullname" $ }}
 {{- end }}

--- a/charts/prometheus/templates/pushgateway/deploy.yaml
+++ b/charts/prometheus/templates/pushgateway/deploy.yaml
@@ -1,74 +1,79 @@
-{{- if .Values.pushgateway.enabled -}}
-apiVersion: {{ template "prometheus.deployment.apiVersion" . }}
+{{- with .Values.pushgateway }}
+{{- if .enabled -}}
+apiVersion: {{ template "prometheus.deployment.apiVersion" $ }}
 kind: Deployment
 metadata:
-{{- if .Values.pushgateway.deploymentAnnotations }}
+  {{- with .deploymentAnnotations }}
   annotations:
-    {{ toYaml .Values.pushgateway.deploymentAnnotations | nindent 4 }}
-{{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
-    {{- include "prometheus.pushgateway.labels" . | nindent 4 }}
-  name: {{ template "prometheus.pushgateway.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+    {{- include "prometheus.pushgateway.labels" $ | nindent 4 }}
+  name: {{ template "prometheus.pushgateway.fullname" $ }}
+  {{- include "prometheus.namespace" $ | nindent 2 }}
 spec:
   selector:
-    {{- if .Values.schedulerName }}
-    schedulerName: "{{ .Values.schedulerName }}"
+    {{- with $.Values.schedulerName }}
+    schedulerName: "{{ . }}"
     {{- end }}
     matchLabels:
-      {{- include "prometheus.pushgateway.matchLabels" . | nindent 6 }}
-  replicas: {{ .Values.pushgateway.replicaCount }}
-  {{- if .Values.pushgateway.strategy }}
+      {{- include "prometheus.pushgateway.matchLabels" $ | nindent 6 }}
+  replicas: {{ .replicaCount }}
+  {{- with .strategy }}
   strategy:
-{{ toYaml .Values.pushgateway.strategy | trim | indent 4 }}
-    {{ if eq .Values.pushgateway.strategy.type "Recreate" }}rollingUpdate: null{{ end }}
-{{- end }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- if eq .type "Recreate" }}
+    rollingUpdate: null
+    {{- end }}
+  {{- end }}
   template:
     metadata:
-    {{- if .Values.pushgateway.podAnnotations }}
+      {{- with .podAnnotations }}
       annotations:
-        {{ toYaml .Values.pushgateway.podAnnotations | nindent 8 }}
-    {{- end }}
-      labels:
-        {{- include "prometheus.pushgateway.labels" . | nindent 8 }}
-        {{- if .Values.pushgateway.podLabels }}
-        {{ toYaml .Values.pushgateway.podLabels | nindent 8 }}
-        {{- end }}
-    spec:
-      serviceAccountName: {{ template "prometheus.serviceAccountName.pushgateway" . }}
-      {{- if .Values.pushgateway.extraInitContainers }}
-      initContainers:
-{{ toYaml .Values.pushgateway.extraInitContainers | indent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
-{{- if .Values.pushgateway.priorityClassName }}
-      priorityClassName: "{{ .Values.pushgateway.priorityClassName }}"
-{{- end }}
+      labels:
+        {{- include "prometheus.pushgateway.labels" $ | nindent 8 }}
+        {{- with .podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end}}
+    spec:
+      serviceAccountName: {{ template "prometheus.serviceAccountName.pushgateway" $ }}
+      {{- with .extraInitContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .priorityClassName }}
+      priorityClassName: "{{ . }}"
+      {{- end }}
       containers:
-        - name: {{ template "prometheus.name" . }}-{{ .Values.pushgateway.name }}
-          image: "{{ .Values.pushgateway.image.repository }}:{{ .Values.pushgateway.image.tag }}"
-          imagePullPolicy: "{{ .Values.pushgateway.image.pullPolicy }}"
+        - name: {{ template "prometheus.name" $ }}-{{ .name }}
+          image: "{{ .image.repository }}:{{ .image.tag }}"
+          imagePullPolicy: "{{ .image.pullPolicy }}"
+          {{- with .containerSecurityContext }}
           securityContext:
-            {{- toYaml .Values.pushgateway.containerSecurityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           args:
-          {{- range $key, $value := .Values.pushgateway.extraArgs }}
-          {{- $stringvalue := toString $value }}
-          {{- if eq $stringvalue "true" }}
+            {{- range $key, $value := .extraArgs }}
+            {{- $stringvalue := toString $value }}
+            {{- if eq $stringvalue "true" }}
             - --{{ $key }}
-          {{- else }}
+            {{- else }}
             - --{{ $key }}={{ $value }}
-          {{- end }}
-          {{- end }}
+            {{- end }}
+            {{- end }}
           ports:
             - containerPort: 9091
           livenessProbe:
             httpGet:
-            {{- if (index .Values "pushgateway" "extraArgs" "web.route-prefix") }}
-              path: /{{ index .Values "pushgateway" "extraArgs" "web.route-prefix" }}/-/healthy
-            {{- else }}
+              {{- if (index $.Values "pushgateway" "extraArgs" "web.route-prefix") }}
+              path: /{{ index $.Values "pushgateway" "extraArgs" "web.route-prefix" }}/-/healthy
+              {{- else }}
               path: /-/healthy
-            {{- end }}
+              {{- end }}
               port: 9091
-              {{- with .Values.pushgateway.probeHeaders }}
+              {{- with .probeHeaders }}
               httpHeaders:
                 {{- toYaml . | nindent 16 }}
               {{- end }}
@@ -76,54 +81,64 @@ spec:
             timeoutSeconds: 10
           readinessProbe:
             httpGet:
-            {{- if (index .Values "pushgateway" "extraArgs" "web.route-prefix") }}
-              path: /{{ index .Values "pushgateway" "extraArgs" "web.route-prefix" }}/-/ready
-            {{- else }}
+              {{- if (index $.Values "pushgateway" "extraArgs" "web.route-prefix") }}
+              path: /{{ index $.Values "pushgateway" "extraArgs" "web.route-prefix" }}/-/ready
+              {{- else }}
               path: /-/ready
-            {{- end }}
+              {{- end }}
               port: 9091
-              {{- with .Values.pushgateway.probeHeaders }}
+              {{- with .probeHeaders }}
               httpHeaders:
                 {{- toYaml . | nindent 16 }}
               {{- end }}
             initialDelaySeconds: 10
             timeoutSeconds: 10
+          {{- with .resources }}
           resources:
-{{ toYaml .Values.pushgateway.resources | indent 12 }}
-          {{- if .Values.pushgateway.persistentVolume.enabled }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .persistentVolume.enabled }}
           volumeMounts:
             - name: storage-volume
-              mountPath: "{{ .Values.pushgateway.persistentVolume.mountPath }}"
-              subPath: "{{ .Values.pushgateway.persistentVolume.subPath }}"
+              mountPath: "{{ .persistentVolume.mountPath }}"
+              subPath: "{{ .persistentVolume.subPath }}"
           {{- end }}
-    {{- if .Values.imagePullSecrets }}
+      {{- with $.Values.imagePullSecrets }}
       imagePullSecrets:
-{{ toYaml .Values.imagePullSecrets | indent 8 }}
-    {{- end }}
-    {{- if .Values.pushgateway.nodeSelector }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.pushgateway.nodeSelector | indent 8 }}
-    {{- end }}
-    {{- with .Values.pushgateway.dnsConfig }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .dnsConfig }}
       dnsConfig:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- if .Values.pushgateway.securityContext }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .securityContext }}
       securityContext:
-{{ toYaml .Values.pushgateway.securityContext | indent 8 }}
-    {{- end }}
-    {{- if .Values.pushgateway.tolerations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .tolerations }}
       tolerations:
-{{ toYaml .Values.pushgateway.tolerations | indent 8 }}
-    {{- end }}
-    {{- if .Values.pushgateway.affinity }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .affinity }}
       affinity:
-{{ toYaml .Values.pushgateway.affinity | indent 8 }}
-    {{- end }}
-      {{- if .Values.pushgateway.persistentVolume.enabled }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: storage-volume
+        {{- if .persistentVolume.enabled }}
           persistentVolumeClaim:
-            claimName: {{ if .Values.pushgateway.persistentVolume.existingClaim }}{{ .Values.pushgateway.persistentVolume.existingClaim }}{{- else }}{{ template "prometheus.pushgateway.fullname" . }}{{- end }}
-      {{- end -}}
+            claimName: {{ if .persistentVolume.existingClaim }}{{ .persistentVolume.existingClaim }}{{- else }}{{ template "prometheus.server.fullname" $ }}{{- end }}
+        {{- else }}
+          emptyDir:
+          {{- with .emptyDir.sizeLimit }}
+            sizeLimit: {{ . }}
+          {{- else }}
+            {}
+          {{- end -}}
+        {{- end -}}
+{{- end -}}
 {{- end }}

--- a/charts/prometheus/templates/pushgateway/ingress.yaml
+++ b/charts/prometheus/templates/pushgateway/ingress.yaml
@@ -1,40 +1,40 @@
 {{- if and .Values.pushgateway.enabled .Values.pushgateway.ingress.enabled -}}
 {{- $ingressApiIsStable := eq (include "ingress.isStable" .) "true" -}}
-{{- $ingressSupportsIngressClassName := eq (include "ingress.supportsIngressClassName" .) "true" -}}
-{{- $ingressSupportsPathType := eq (include "ingress.supportsPathType" .) "true" -}}
+{{- $ingressSupportsIngressClassName := eq (include "ingress.supportsIngressClassName" $) "true" -}}
+{{- $ingressSupportsPathType := eq (include "ingress.supportsPathType" $) "true" -}}
 {{- $releaseName := .Release.Name -}}
-{{- $serviceName := include "prometheus.pushgateway.fullname" . }}
+{{- $serviceName := include "prometheus.pushgateway.fullname" $ }}
 {{- $servicePort := .Values.pushgateway.service.servicePort -}}
 {{- $ingressPath := .Values.pushgateway.ingress.path -}}
 {{- $ingressPathType := .Values.pushgateway.ingress.pathType -}}
 {{- $extraPaths := .Values.pushgateway.ingress.extraPaths -}}
-apiVersion: {{ template "ingress.apiVersion" . }}
+apiVersion: {{ template "ingress.apiVersion" $ }}
 kind: Ingress
 metadata:
-{{- if .Values.pushgateway.ingress.annotations }}
+  {{- with .Values.pushgateway.ingress.annotations }}
   annotations:
-{{ toYaml .Values.pushgateway.ingress.annotations | indent 4}}
-{{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
-    {{- include "prometheus.pushgateway.labels" . | nindent 4 }}
-  name: {{ template "prometheus.pushgateway.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+    {{- include "prometheus.pushgateway.labels" $ | nindent 4 }}
+  name: {{ template "prometheus.pushgateway.fullname" $ }}
+  {{- include "prometheus.namespace" $ | nindent 2 }}
 spec:
   {{- if and $ingressSupportsIngressClassName .Values.pushgateway.ingress.ingressClassName }}
   ingressClassName: {{ .Values.pushgateway.ingress.ingressClassName }}
   {{- end }}
   rules:
-  {{- range .Values.pushgateway.ingress.hosts }}
+    {{- range .Values.pushgateway.ingress.hosts }}
     {{- $url := splitList "/" . }}
     - host: {{ first $url }}
       http:
         paths:
-{{ if $extraPaths }}
-{{ toYaml $extraPaths | indent 10 }}
-{{- end }}
+          {{- with $extraPaths }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
           - path: {{ $ingressPath }}
-            {{- if $ingressSupportsPathType }}
-            pathType: {{ $ingressPathType }}
+            {{- with $ingressSupportsPathType }}
+            pathType: {{ . }}
             {{- end }}
             backend:
               {{- if $ingressApiIsStable }}
@@ -46,9 +46,9 @@ spec:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
               {{- end }}
-  {{- end -}}
-{{- if .Values.pushgateway.ingress.tls }}
+    {{- end -}}
+  {{- with .Values.pushgateway.ingress.tls }}
   tls:
-{{ toYaml .Values.pushgateway.ingress.tls | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end -}}
 {{- end -}}

--- a/charts/prometheus/templates/pushgateway/netpol.yaml
+++ b/charts/prometheus/templates/pushgateway/netpol.yaml
@@ -1,20 +1,21 @@
-{{- if and .Values.pushgateway.enabled .Values.networkPolicy.enabled -}}
-apiVersion: {{ template "prometheus.networkPolicy.apiVersion" . }}
+{{- if and .Values.pushgateway.enabled
+           .Values.networkPolicy.enabled -}}
+apiVersion: {{ template "prometheus.networkPolicy.apiVersion" $ }}
 kind: NetworkPolicy
 metadata:
-  name: {{ template "prometheus.pushgateway.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+  name: {{ template "prometheus.pushgateway.fullname" $ }}
+  {{- include "prometheus.namespace" $ | nindent 2 }}
   labels:
-    {{- include "prometheus.pushgateway.labels" . | nindent 4 }}
+    {{- include "prometheus.pushgateway.labels" $ | nindent 4 }}
 spec:
   podSelector:
     matchLabels:
-      {{- include "prometheus.pushgateway.matchLabels" . | nindent 6 }}
+      {{- include "prometheus.pushgateway.matchLabels" $ | nindent 6 }}
   ingress:
     - from:
       - podSelector:
           matchLabels:
-            {{- include "prometheus.server.matchLabels" . | nindent 12 }}
+            {{- include "prometheus.server.matchLabels" $ | nindent 12 }}
     - ports:
       - port: 9091
 {{- end -}}

--- a/charts/prometheus/templates/pushgateway/pdb.yaml
+++ b/charts/prometheus/templates/pushgateway/pdb.yaml
@@ -1,14 +1,14 @@
 {{- if .Values.pushgateway.podDisruptionBudget.enabled }}
-apiVersion: {{ template "prometheus.podDisruptionBudget.apiVersion" . }}
+apiVersion: {{ template "prometheus.podDisruptionBudget.apiVersion" $ }}
 kind: PodDisruptionBudget
 metadata:
-  name: {{ template "prometheus.pushgateway.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+  name: {{ template "prometheus.pushgateway.fullname" $ }}
+  {{- include "prometheus.namespace" $ | nindent 2 }}
   labels:
-    {{- include "prometheus.pushgateway.labels" . | nindent 4 }}
+    {{- include "prometheus.pushgateway.labels" $ | nindent 4 }}
 spec:
   maxUnavailable: {{ .Values.pushgateway.podDisruptionBudget.maxUnavailable }}
   selector:
     matchLabels:
-      {{- include "prometheus.pushgateway.labels" . | nindent 6 }}
+      {{- include "prometheus.pushgateway.labels" $ | nindent 6 }}
 {{- end }}

--- a/charts/prometheus/templates/pushgateway/psp.yaml
+++ b/charts/prometheus/templates/pushgateway/psp.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.pushgateway.enabled
            .Values.rbac.create .Values.podSecurityPolicy.enabled
-           .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+           (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/prometheus/templates/pushgateway/psp.yaml
+++ b/charts/prometheus/templates/pushgateway/psp.yaml
@@ -1,6 +1,4 @@
-{{- if and .Values.pushgateway.enabled
-           .Values.rbac.create .Values.podSecurityPolicy.enabled
-           (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
+{{- if and .Values.pushgateway.enabled .Values.rbac.create .Values.podSecurityPolicy.enabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/prometheus/templates/pushgateway/psp.yaml
+++ b/charts/prometheus/templates/pushgateway/psp.yaml
@@ -1,11 +1,12 @@
-{{- if and .Values.pushgateway.enabled .Values.rbac.create .Values.podSecurityPolicy.enabled }}
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+{{- if and .Values.pushgateway.enabled
+           .Values.rbac.create .Values.podSecurityPolicy.enabled
+           .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ template "prometheus.pushgateway.fullname" . }}
+  name: {{ template "prometheus.pushgateway.fullname" $ }}
   labels:
-    {{- include "prometheus.pushgateway.labels" . | nindent 4 }}
+    {{- include "prometheus.pushgateway.labels" $ | nindent 4 }}
   {{- with .Values.pushgateway.podSecurityPolicy.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -40,5 +41,4 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: true
-{{- end }}
 {{- end }}

--- a/charts/prometheus/templates/pushgateway/pvc.yaml
+++ b/charts/prometheus/templates/pushgateway/pvc.yaml
@@ -1,5 +1,4 @@
-{{- if and .Values.pushgateway.persistentVolume.enabled 
-           (not .Values.pushgateway.persistentVolume.existingClaim) -}}
+{{- if and .Values.pushgateway.persistentVolume.enabled (not .Values.pushgateway.persistentVolume.existingClaim) -}}
 {{- with .Values.pushgateway.persistentVolume }}
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/charts/prometheus/templates/pushgateway/pvc.yaml
+++ b/charts/prometheus/templates/pushgateway/pvc.yaml
@@ -1,34 +1,35 @@
-{{- if .Values.pushgateway.persistentVolume.enabled -}}
-{{- if not .Values.pushgateway.persistentVolume.existingClaim -}}
+{{- if and .Values.pushgateway.persistentVolume.enabled 
+           (not .Values.pushgateway.persistentVolume.existingClaim) -}}
+{{- with .Values.pushgateway.persistentVolume }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  {{- if .Values.pushgateway.persistentVolume.annotations }}
+  {{- with .annotations }}
   annotations:
-{{ toYaml .Values.pushgateway.persistentVolume.annotations | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    {{- include "prometheus.pushgateway.labels" . | nindent 4 }}
-  name: {{ template "prometheus.pushgateway.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+    {{- include "prometheus.pushgateway.labels" $ | nindent 4 }}
+  name: {{ template "prometheus.pushgateway.fullname" $ }}
+  {{- include "prometheus.namespace" $ | nindent 2 }}
 spec:
   accessModes:
-{{ toYaml .Values.pushgateway.persistentVolume.accessModes | indent 4 }}
-{{- if .Values.pushgateway.persistentVolume.storageClass }}
-{{- if (eq "-" .Values.pushgateway.persistentVolume.storageClass) }}
+    {{- toYaml .accessModes | nindent 4 }}
+  {{- if .storageClass }}
+  {{- if (eq "-" .storageClass) }}
   storageClassName: ""
-{{- else }}
-  storageClassName: "{{ .Values.pushgateway.persistentVolume.storageClass }}"
-{{- end }}
-{{- end }}
-{{- if .Values.pushgateway.persistentVolume.volumeBindingMode }}
-  volumeBindingMode: "{{ .Values.pushgateway.persistentVolume.volumeBindingMode }}"
-{{- end }}
+  {{- else }}
+  storageClassName: "{{ .storageClass }}"
+  {{- end }}
+  {{- end }}
+  {{- with .volumeBindingMode }}
+  volumeBindingMode: "{{ . }}"
+  {{- end }}
   resources:
     requests:
-      storage: "{{ .Values.pushgateway.persistentVolume.size }}"
-{{- if .Values.pushgateway.persistentVolume.volumeName }}
-  volumeName: "{{ .Values.pushgateway.persistentVolume.volumeName }}"
+      storage: "{{ .size }}"
+  {{- with .volumeName }}
+  volumeName: "{{ . }}"
+  {{- end }}
 {{- end }}
-{{- end -}}
 {{- end -}}

--- a/charts/prometheus/templates/pushgateway/service.yaml
+++ b/charts/prometheus/templates/pushgateway/service.yaml
@@ -1,44 +1,46 @@
 {{- if .Values.pushgateway.enabled -}}
+{{- with .Values.pushgateway.service }}
 apiVersion: v1
 kind: Service
 metadata:
-{{- if .Values.pushgateway.service.annotations }}
+  {{- with .annotations }}
   annotations:
-{{ toYaml .Values.pushgateway.service.annotations | indent 4}}
-{{- end }}
-  labels:
-    {{- include "prometheus.pushgateway.labels" . | nindent 4 }}
-{{- if .Values.pushgateway.service.labels }}
-{{ toYaml .Values.pushgateway.service.labels | indent 4}}
-{{- end }}
-  name: {{ template "prometheus.pushgateway.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
-spec:
-{{- if .Values.pushgateway.service.clusterIP }}
-  clusterIP: {{ .Values.pushgateway.service.clusterIP }}
-{{- end }}
-{{- if .Values.pushgateway.service.externalIPs }}
-  externalIPs:
-{{ toYaml .Values.pushgateway.service.externalIPs | indent 4 }}
-{{- end }}
-{{- if .Values.pushgateway.service.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.pushgateway.service.loadBalancerIP }}
-{{- end }}
-{{- if .Values.pushgateway.service.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges:
-  {{- range $cidr := .Values.pushgateway.service.loadBalancerSourceRanges }}
-    - {{ $cidr }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- end }}
+  labels:
+    {{- include "prometheus.pushgateway.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ template "prometheus.pushgateway.fullname" $ }}
+  {{- include "prometheus.namespace" $ | nindent 2 }}
+spec:
+  {{- with .clusterIP }}
+  clusterIP: {{ . }}
+  {{- end }}
+  {{- with .externalIPs }}
+  externalIPs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .loadBalancerIP }}
+  loadBalancerIP: {{ . }}
+  {{- end }}
+  {{- with .loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- range $cidr := . }}
+    - {{ $cidr }}
+    {{- end }}
+  {{- end }}
   ports:
     - name: http
-      port: {{ .Values.pushgateway.service.servicePort }}
+      port: {{ .servicePort }}
       protocol: TCP
       targetPort: 9091
-    {{- if .Values.pushgateway.service.nodePort }}
-      nodePort: {{ .Values.pushgateway.service.nodePort }}
-    {{- end }}
+      {{- with .nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
   selector:
-    {{- include "prometheus.pushgateway.matchLabels" . | nindent 4 }}
-  type: "{{ .Values.pushgateway.service.type }}"
+    {{- include "prometheus.pushgateway.matchLabels" $ | nindent 4 }}
+  type: "{{ .type }}"
+{{- end }}
 {{- end }}

--- a/charts/prometheus/templates/pushgateway/serviceaccount.yaml
+++ b/charts/prometheus/templates/pushgateway/serviceaccount.yaml
@@ -3,9 +3,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    {{- include "prometheus.pushgateway.labels" . | nindent 4 }}
-  name: {{ template "prometheus.serviceAccountName.pushgateway" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+    {{- include "prometheus.pushgateway.labels" $ | nindent 4 }}
+  name: {{ template "prometheus.serviceAccountName.pushgateway" $ }}
+  {{- include "prometheus.namespace" $ | nindent 2 }}
+  {{- with .Values.serviceAccounts.pushgateway.annotations }}
   annotations:
-{{ toYaml .Values.serviceAccounts.pushgateway.annotations | indent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end -}}

--- a/charts/prometheus/templates/pushgateway/vpa.yaml
+++ b/charts/prometheus/templates/pushgateway/vpa.yaml
@@ -1,20 +1,22 @@
-{{- if .Values.pushgateway.enabled -}}
-{{- if .Values.pushgateway.verticalAutoscaler.enabled -}}
+{{- if and .Values.pushgateway.enabled .Values.pushgateway.verticalAutoscaler.enabled -}}
+{{- with .Values.pushgateway.verticalAutoscaler }}
 apiVersion: autoscaling.k8s.io/v1beta2
 kind: VerticalPodAutoscaler
 metadata:
   labels:
-    {{- include "prometheus.pushgateway.labels" . | nindent 4 }}
-  name: {{ template "prometheus.pushgateway.fullname" . }}-vpa
-{{ include "prometheus.namespace" . | indent 2 }}
+    {{- include "prometheus.pushgateway.labels" $ | nindent 4 }}
+  name: {{ template "prometheus.pushgateway.fullname" $ }}-vpa
+  {{- include "prometheus.namespace" $ | nindent 2 }}
 spec:
   targetRef:
     apiVersion: "apps/v1"
     kind: Deployment
-    name: {{ template "prometheus.pushgateway.fullname" . }}
+    name: {{ template "prometheus.pushgateway.fullname" $ }}
   updatePolicy:
-    updateMode: {{ .Values.pushgateway.verticalAutoscaler.updateMode | default "Off" | quote }}
+    updateMode: {{ .updateMode | default "Off" | quote }}
+  {{- with .containerPolicies }}
   resourcePolicy:
-    containerPolicies: {{ .Values.pushgateway.verticalAutoscaler.containerPolicies | default list | toYaml | trim | nindent 4 }}
-{{- end -}} {{/* if .Values.pushgateway.verticalAutoscaler.enabled */}}
-{{- end -}} {{/* .Values.pushgateway.enabled */}}
+    containerPolicies: {{ . | default list | toYaml | trim | nindent 4 }}
+  {{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/prometheus/templates/server/clusterrole.yaml
+++ b/charts/prometheus/templates/server/clusterrole.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "prometheus.server.labels" . | nindent 4 }}
   name: {{ template "prometheus.server.fullname" . }}
 rules:
-{{- if .Values.podSecurityPolicy.enabled }}
+  {{- if .Values.podSecurityPolicy.enabled }}
   - apiGroups:
     - extensions
     resources:
@@ -15,7 +15,7 @@ rules:
     - use
     resourceNames:
     - {{ template "prometheus.server.fullname" . }}
-{{- end }}
+  {{- end }}
   - apiGroups:
       - ""
     resources:

--- a/charts/prometheus/templates/server/clusterrole.yaml
+++ b/charts/prometheus/templates/server/clusterrole.yaml
@@ -1,12 +1,15 @@
-{{- if and .Values.server.enabled .Values.rbac.create (empty .Values.server.useExistingClusterRoleName) -}}
-apiVersion: {{ template "rbac.apiVersion" . }}
+{{- if and .Values.server.enabled
+           .Values.rbac.create
+           (empty .Values.server.useExistingClusterRoleName) -}}
+apiVersion: {{ template "rbac.apiVersion" $ }}
 kind: ClusterRole
 metadata:
   labels:
-    {{- include "prometheus.server.labels" . | nindent 4 }}
-  name: {{ template "prometheus.server.fullname" . }}
+    {{- include "prometheus.server.labels" $ | nindent 4 }}
+  name: {{ template "prometheus.server.fullname" $ }}
 rules:
-  {{- if .Values.podSecurityPolicy.enabled }}
+  {{- if and .Values.podSecurityPolicy.enabled
+             (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
   - apiGroups:
     - extensions
     resources:
@@ -14,7 +17,7 @@ rules:
     verbs:
     - use
     resourceNames:
-    - {{ template "prometheus.server.fullname" . }}
+    - {{ template "prometheus.server.fullname" $ }}
   {{- end }}
   - apiGroups:
       - ""

--- a/charts/prometheus/templates/server/clusterrole.yaml
+++ b/charts/prometheus/templates/server/clusterrole.yaml
@@ -11,13 +11,13 @@ rules:
   {{- if and .Values.podSecurityPolicy.enabled
              (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
   - apiGroups:
-    - extensions
+      - extensions
     resources:
-    - podsecuritypolicies
+      - podsecuritypolicies
     verbs:
-    - use
+      - use
     resourceNames:
-    - {{ template "prometheus.server.fullname" $ }}
+      - {{ template "prometheus.server.fullname" $ }}
   {{- end }}
   - apiGroups:
       - ""

--- a/charts/prometheus/templates/server/clusterrole.yaml
+++ b/charts/prometheus/templates/server/clusterrole.yaml
@@ -1,6 +1,4 @@
-{{- if and .Values.server.enabled
-           .Values.rbac.create
-           (empty .Values.server.useExistingClusterRoleName) -}}
+{{- if and .Values.server.enabled .Values.rbac.create (empty .Values.server.useExistingClusterRoleName) -}}
 apiVersion: {{ template "rbac.apiVersion" $ }}
 kind: ClusterRole
 metadata:
@@ -8,8 +6,7 @@ metadata:
     {{- include "prometheus.server.labels" $ | nindent 4 }}
   name: {{ template "prometheus.server.fullname" $ }}
 rules:
-  {{- if and .Values.podSecurityPolicy.enabled
-             (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
+  {{- if and .Values.podSecurityPolicy.enabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
   - apiGroups:
       - extensions
     resources:

--- a/charts/prometheus/templates/server/clusterrolebinding.yaml
+++ b/charts/prometheus/templates/server/clusterrolebinding.yaml
@@ -1,16 +1,19 @@
-{{- if and .Values.server.enabled .Values.rbac.create (empty .Values.server.namespaces) (empty .Values.server.useExistingClusterRoleName) -}}
-apiVersion: {{ template "rbac.apiVersion" . }}
+{{- if and .Values.server.enabled
+           .Values.rbac.create
+           (empty .Values.server.namespaces)
+           (empty .Values.server.useExistingClusterRoleName) -}}
+apiVersion: {{ template "rbac.apiVersion" $ }}
 kind: ClusterRoleBinding
 metadata:
   labels:
-    {{- include "prometheus.server.labels" . | nindent 4 }}
-  name: {{ template "prometheus.server.fullname" . }}
+    {{- include "prometheus.server.labels" $ | nindent 4 }}
+  name: {{ template "prometheus.server.fullname" $ }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "prometheus.serviceAccountName.server" . }}
-    {{- include "prometheus.namespace" . | nindent 4 }}
+    name: {{ template "prometheus.serviceAccountName.server" $ }}
+    {{- include "prometheus.namespace" $ | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "prometheus.server.fullname" . }}
+  name: {{ template "prometheus.server.fullname" $ }}
 {{- end }}

--- a/charts/prometheus/templates/server/clusterrolebinding.yaml
+++ b/charts/prometheus/templates/server/clusterrolebinding.yaml
@@ -1,7 +1,4 @@
-{{- if and .Values.server.enabled
-           .Values.rbac.create
-           (empty .Values.server.namespaces)
-           (empty .Values.server.useExistingClusterRoleName) -}}
+{{- if and .Values.server.enabled .Values.rbac.create (empty .Values.server.namespaces) (empty .Values.server.useExistingClusterRoleName) -}}
 apiVersion: {{ template "rbac.apiVersion" $ }}
 kind: ClusterRoleBinding
 metadata:

--- a/charts/prometheus/templates/server/clusterrolebinding.yaml
+++ b/charts/prometheus/templates/server/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "prometheus.serviceAccountName.server" . }}
-{{ include "prometheus.namespace" . | indent 4 }}
+    {{- include "prometheus.namespace" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/prometheus/templates/server/cm.yaml
+++ b/charts/prometheus/templates/server/cm.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
   name: {{ template "prometheus.server.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+  {{- include "prometheus.namespace" . | nindent 2 }}
 data:
   allow-snippet-annotations: "false"
 {{- $root := . -}}
@@ -54,9 +54,9 @@ data:
 {{ $root.Values.alertRelabelConfigs | toYaml  | trimSuffix "\n" | indent 6 }}
 {{- end }}
       alertmanagers:
-{{- if $root.Values.server.alertmanagers }}
-{{ toYaml $root.Values.server.alertmanagers | indent 8 }}
-{{- else }}
+      {{- if $root.Values.server.alertmanagers }}
+        {{- toYaml $root.Values.server.alertmanagers | nindent 8 }}
+      {{- else }}
       - kubernetes_sd_configs:
           - role: pod
         tls_config:
@@ -81,7 +81,7 @@ data:
         - source_labels: [__meta_kubernetes_pod_container_port_number]
           regex: "9093"
           action: keep
-{{- end -}}
+      {{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/prometheus/templates/server/cm.yaml
+++ b/charts/prometheus/templates/server/cm.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.server.enabled -}}
-{{- if (empty .Values.server.configMapOverrideName) -}}
+{{- if and .Values.server.enabled (empty .Values.server.configMapOverrideName) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -20,50 +19,50 @@ data:
   {{ $key }}: |
 {{- if eq $key "prometheus.yml" }}
     global:
-{{ $root.Values.server.global | toYaml | trimSuffix "\n" | indent 6 }}
-{{- if $root.Values.server.remoteWrite }}
+      {{- $root.Values.server.global | toYaml | trimSuffix "\n" | nindent 6 }}
+    {{- with $root.Values.server.remoteWrite }}
     remote_write:
-{{ $root.Values.server.remoteWrite | toYaml | indent 4 }}
-{{- end }}
-{{- if $root.Values.server.remoteRead }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with $root.Values.server.remoteRead }}
     remote_read:
-{{ $root.Values.server.remoteRead | toYaml | indent 4 }}
-{{- end }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}
 {{- if eq $key "alerts" }}
-{{- if and (not (empty $value)) (empty $value.groups) }}
+  {{- if and (not (empty $value)) (empty $value.groups) }}
     groups:
-{{- range $ruleKey, $ruleValue := $value }}
+    {{- range $ruleKey, $ruleValue := $value }}
     - name: {{ $ruleKey -}}.rules
       rules:
-{{ $ruleValue | toYaml | trimSuffix "\n" | indent 6 }}
-{{- end }}
+      {{- toYaml $ruleValue | trimSuffix "\n" | nindent 6 }}
+    {{- end }}
+  {{- else }}
+    {{- toYaml $value | nindent 4 }}
+  {{- end }}
 {{- else }}
-{{ toYaml $value | indent 4 }}
-{{- end }}
-{{- else }}
-{{ toYaml $value | default "{}" | indent 4 }}
+    {{- toYaml $value | default "{}" | nindent 4 }}
 {{- end }}
 {{- if eq $key "prometheus.yml" -}}
 {{- if $root.Values.extraScrapeConfigs }}
-{{ tpl $root.Values.extraScrapeConfigs $root | indent 4 }}
+    {{- tpl $root.Values.extraScrapeConfigs $root | nindent 4 }}
 {{- end -}}
-{{- if or ($root.Values.alertmanager.enabled) ($root.Values.server.alertmanagers) }}
+{{- if or $root.Values.alertmanager.enabled $root.Values.server.alertmanagers }}
     alerting:
-{{- if $root.Values.alertRelabelConfigs }}
-{{ $root.Values.alertRelabelConfigs | toYaml  | trimSuffix "\n" | indent 6 }}
-{{- end }}
+      {{- with $root.Values.alertRelabelConfigs }}
+      {{- toYaml . | trimSuffix "\n" | nindent 6 }}
+      {{- end }}
       alertmanagers:
-      {{- if $root.Values.server.alertmanagers }}
-        {{- toYaml $root.Values.server.alertmanagers | nindent 8 }}
+      {{- with $root.Values.server.alertmanagers }}
+        {{- toYaml . | nindent 8 }}
       {{- else }}
       - kubernetes_sd_configs:
           - role: pod
         tls_config:
           ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
         bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-        {{- if $root.Values.alertmanager.prefixURL }}
-        path_prefix: {{ $root.Values.alertmanager.prefixURL }}
+        {{- with $root.Values.alertmanager.prefixURL }}
+        path_prefix: {{ . }}
         {{- end }}
         relabel_configs:
         - source_labels: [__meta_kubernetes_namespace]
@@ -82,7 +81,6 @@ data:
           regex: "9093"
           action: keep
       {{- end -}}
-{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/prometheus/templates/server/deploy.yaml
+++ b/charts/prometheus/templates/server/deploy.yaml
@@ -33,7 +33,7 @@ spec:
       {{- end }}
       labels:
         {{- include "prometheus.server.labels" $ | nindent 8 }}
-        {{- with .podLabels}}
+        {{- with .podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end}}
     spec:
@@ -269,12 +269,12 @@ spec:
       terminationGracePeriodSeconds: {{ .terminationGracePeriodSeconds }}
       volumes:
         - name: config-volume
-          {{- if empty .configFromSecret }}
-          configMap:
-            name: {{ if .configMapOverrideName }}{{ $.Release.Name }}-{{ .configMapOverrideName }}{{- else }}{{ template "prometheus.server.fullname" $ }}{{- end }}
-          {{- else }}
+          {{- if .configFromSecret }}
           secret:
             secretName: {{ .configFromSecret }}
+          {{- else }}
+          configMap:
+            name: {{ if .configMapOverrideName }}{{ $.Release.Name }}-{{ .configMapOverrideName }}{{- else }}{{ template "prometheus.server.fullname" $ }}{{- end }}
           {{- end }}
         {{- range .extraHostPathMounts }}
         - name: {{ .name }}
@@ -316,8 +316,8 @@ spec:
             claimName: {{ if .persistentVolume.existingClaim }}{{ .persistentVolume.existingClaim }}{{- else }}{{ template "prometheus.server.fullname" $ }}{{- end }}
         {{- else }}
           emptyDir:
-          {{- if .emptyDir.sizeLimit }}
-            sizeLimit: {{ .emptyDir.sizeLimit }}
+          {{- with .emptyDir.sizeLimit }}
+            sizeLimit: {{ . }}
           {{- else }}
             {}
           {{- end -}}

--- a/charts/prometheus/templates/server/deploy.yaml
+++ b/charts/prometheus/templates/server/deploy.yaml
@@ -35,7 +35,7 @@ spec:
         {{- include "prometheus.server.labels" $ | nindent 8 }}
         {{- with .podLabels }}
         {{- toYaml . | nindent 8 }}
-        {{- end}}
+        {{- end }}
     spec:
       {{- with .priorityClassName }}
       priorityClassName: "{{ . }}"

--- a/charts/prometheus/templates/server/deploy.yaml
+++ b/charts/prometheus/templates/server/deploy.yaml
@@ -1,79 +1,77 @@
-{{- if .Values.server.enabled -}}
-{{- if not .Values.server.statefulSet.enabled -}}
-apiVersion: {{ template "prometheus.deployment.apiVersion" . }}
+{{- $cmReloadProm := $.Values.configmapReload.prometheus -}}
+
+{{- with .Values.server }}
+{{- if and .enabled (not .statefulSet.enabled) -}}
+apiVersion: {{ template "prometheus.deployment.apiVersion" $ }}
 kind: Deployment
 metadata:
-  {{- with .Values.server.deploymentAnnotations }}
+  {{- with .deploymentAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    {{- include "prometheus.server.labels" . | nindent 4 }}
-  name: {{ template "prometheus.server.fullname" . }}
-  {{- include "prometheus.namespace" . | nindent 2 }}
+    {{- include "prometheus.server.labels" $ | nindent 4 }}
+  name: {{ template "prometheus.server.fullname" $ }}
+  {{- include "prometheus.namespace" $ | nindent 2 }}
 spec:
   selector:
     matchLabels:
-      {{- include "prometheus.server.matchLabels" . | nindent 6 }}
-  replicas: {{ .Values.server.replicaCount }}
-  {{- with .Values.server.strategy }}
+      {{- include "prometheus.server.matchLabels" $ | nindent 6 }}
+  replicas: {{ .replicaCount }}
+  {{- with .strategy }}
   strategy:
     {{- toYaml . | trim | nindent 4 }}
-    {{ if eq .type "Recreate" }}rollingUpdate: null{{ end }}
+    {{- if eq .type "Recreate" }}
+    rollingUpdate: null
+    {{- end }}
   {{- end }}
   template:
     metadata:
-      {{- with .Values.server.podAnnotations }}
+      {{- with .podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "prometheus.server.labels" . | nindent 8 }}
-        {{- with .Values.server.podLabels}}
+        {{- include "prometheus.server.labels" $ | nindent 8 }}
+        {{- with .podLabels}}
         {{- toYaml . | nindent 8 }}
         {{- end}}
     spec:
-      {{- with .Values.server.priorityClassName }}
+      {{- with .priorityClassName }}
       priorityClassName: "{{ . }}"
       {{- end }}
-      {{- with .Values.server.schedulerName }}
+      {{- with .schedulerName }}
       schedulerName: "{{ . }}"
       {{- end }}
-      {{- if semverCompare ">=1.13-0" .Capabilities.KubeVersion.GitVersion }}
-      {{- if or (.Values.server.enableServiceLinks) (eq (.Values.server.enableServiceLinks | toString) "<nil>") }}
-      enableServiceLinks: true
-      {{- else }}
-      enableServiceLinks: false
-      {{- end }}
-      {{- end }}
-      serviceAccountName: {{ template "prometheus.serviceAccountName.server" . }}
-      {{- with .Values.server.extraInitContainers }}
+      {{- include "prometheus.server.enableServiceLinks" $ | nindent 6 }}
+      serviceAccountName: {{ template "prometheus.serviceAccountName.server" $ }}
+      {{- with .extraInitContainers }}
       initContainers:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-        {{- if .Values.configmapReload.prometheus.enabled }}
-        - name: {{ template "prometheus.name" . }}-{{ .Values.server.name }}-{{ .Values.configmapReload.prometheus.name }}
-          image: "{{ .Values.configmapReload.prometheus.image.repository }}:{{ .Values.configmapReload.prometheus.image.tag }}"
-          imagePullPolicy: "{{ .Values.configmapReload.prometheus.image.pullPolicy }}"
-          {{- with .Values.configmapReload.prometheus.containerSecurityContext }}
+        {{- if $cmReloadProm.enabled }}
+        - name: {{ template "prometheus.name" $ }}-{{ .name }}-{{ $cmReloadProm.name }}
+          image: "{{ $cmReloadProm.image.repository }}:{{ $cmReloadProm.image.tag }}"
+          imagePullPolicy: "{{ $cmReloadProm.image.pullPolicy }}"
+          {{- with $cmReloadProm.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           args:
             - --volume-dir=/etc/config
-            - --webhook-url=http://127.0.0.1:9090{{ .Values.server.prefixURL }}/-/reload
-          {{- range $key, $value := .Values.configmapReload.prometheus.extraArgs }}
+            - --webhook-url=http://127.0.0.1:9090{{ .prefixURL }}/-/reload
+          {{- range $key, $value := $cmReloadProm.extraArgs }}
             - --{{ $key }}={{ $value }}
           {{- end }}
-          {{- range .Values.configmapReload.prometheus.extraVolumeDirs }}
+          {{- range $cmReloadProm.extraVolumeDirs }}
             - --volume-dir={{ . }}
           {{- end }}
-          {{- with .Values.configmapReload.prometheus.containerPort }}
+          {{- with $cmReloadProm.containerPort }}
           ports:
             - containerPort: {{ . }}
           {{- end }}
-          {{- with .Values.configmapReload.prometheus.resources }}
+          {{- with $cmReloadProm.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -81,61 +79,61 @@ spec:
             - name: config-volume
               mountPath: /etc/config
               readOnly: true
-            {{- range .Values.configmapReload.prometheus.extraConfigmapMounts }}
-            - name: {{ $.Values.configmapReload.prometheus.name }}-{{ .name }}
+            {{- range $cmReloadProm.extraConfigmapMounts }}
+            - name: {{ $cmReloadProm.name }}-{{ .name }}
               mountPath: {{ .mountPath }}
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
             {{- end }}
         {{- end }}
 
-        - name: {{ template "prometheus.name" . }}-{{ .Values.server.name }}
-          image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
-          imagePullPolicy: "{{ .Values.server.image.pullPolicy }}"
-          {{- with .Values.server.env }}
+        - name: {{ template "prometheus.name" $ }}-{{ .name }}
+          image: "{{ .image.repository }}:{{ .image.tag }}"
+          imagePullPolicy: "{{ .image.pullPolicy }}"
+          {{- with .env }}
           env:
             {{- toYaml . | nindent 12}}
           {{- end }}
           args:
-            {{- with .Values.server.defaultFlagsOverride }}
+            {{- with .defaultFlagsOverride }}
             {{- toYaml . | nindent 12}}
             {{- else }}
-            {{- with .Values.server.retention }}
+            {{- with .retention }}
             - --storage.tsdb.retention.time={{ . }}
             {{- end }}
-            - --config.file={{ .Values.server.configPath }}
-            {{- with .Values.server.storagePath }}
+            - --config.file={{ .configPath }}
+            {{- with .storagePath }}
             - --storage.tsdb.path={{ . }}
             {{- else }}
-            - --storage.tsdb.path={{ .Values.server.persistentVolume.mountPath }}
+            - --storage.tsdb.path={{ .persistentVolume.mountPath }}
             {{- end }}
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
-            {{- range .Values.server.extraFlags }}
+            {{- range .extraFlags }}
             - --{{ . }}
             {{- end }}
-            {{- range $key, $value := .Values.server.extraArgs }}
+            {{- range $key, $value := .extraArgs }}
             - --{{ $key }}={{ $value }}
             {{- end }}
-            {{- with .Values.server.prefixURL }}
+            {{- with .prefixURL }}
             - --web.route-prefix={{ . }}
             {{- end }}
-            {{- with .Values.server.baseURL }}
+            {{- with .baseURL }}
             - --web.external-url={{ . }}
             {{- end }}
             {{- end }}
           ports:
             - containerPort: 9090
-              {{- with .Values.server.hostPort }}
+              {{- with .hostPort }}
               hostPort: {{ . }}
               {{- end }}
           readinessProbe:
-            {{- if not .Values.server.tcpSocketProbeEnabled }}
+            {{- if not .tcpSocketProbeEnabled }}
             httpGet:
-              path: {{ .Values.server.prefixURL }}/-/ready
+              path: {{ .prefixURL }}/-/ready
               port: 9090
-              scheme: {{ .Values.server.probeScheme }}
-              {{- with .Values.server.probeHeaders }}
+              scheme: {{ .probeScheme }}
+              {{- with .probeHeaders }}
               httpHeaders:
                 {{- toYaml . | nindent 16 }}
               {{- end }}
@@ -143,18 +141,18 @@ spec:
             tcpSocket:
               port: 9090
             {{- end }}
-            initialDelaySeconds: {{ .Values.server.readinessProbeInitialDelay }}
-            periodSeconds: {{ .Values.server.readinessProbePeriodSeconds }}
-            timeoutSeconds: {{ .Values.server.readinessProbeTimeout }}
-            failureThreshold: {{ .Values.server.readinessProbeFailureThreshold }}
-            successThreshold: {{ .Values.server.readinessProbeSuccessThreshold }}
+            initialDelaySeconds: {{ .readinessProbeInitialDelay }}
+            periodSeconds: {{ .readinessProbePeriodSeconds }}
+            timeoutSeconds: {{ .readinessProbeTimeout }}
+            failureThreshold: {{ .readinessProbeFailureThreshold }}
+            successThreshold: {{ .readinessProbeSuccessThreshold }}
           livenessProbe:
-            {{- if not .Values.server.tcpSocketProbeEnabled }}
+            {{- if not .tcpSocketProbeEnabled }}
             httpGet:
-              path: {{ .Values.server.prefixURL }}/-/healthy
+              path: {{ .prefixURL }}/-/healthy
               port: 9090
-              scheme: {{ .Values.server.probeScheme }}
-              {{- with .Values.server.probeHeaders }}
+              scheme: {{ .probeScheme }}
+              {{- with .probeHeaders }}
               httpHeaders:
                 {{- toYaml . | nindent 16 }}
               {{- end }}
@@ -162,21 +160,21 @@ spec:
             tcpSocket:
               port: 9090
             {{- end }}
-            initialDelaySeconds: {{ .Values.server.livenessProbeInitialDelay }}
-            periodSeconds: {{ .Values.server.livenessProbePeriodSeconds }}
-            timeoutSeconds: {{ .Values.server.livenessProbeTimeout }}
-            failureThreshold: {{ .Values.server.livenessProbeFailureThreshold }}
-            successThreshold: {{ .Values.server.livenessProbeSuccessThreshold }}
-          {{- if .Values.server.startupProbe.enabled }}
+            initialDelaySeconds: {{ .livenessProbeInitialDelay }}
+            periodSeconds: {{ .livenessProbePeriodSeconds }}
+            timeoutSeconds: {{ .livenessProbeTimeout }}
+            failureThreshold: {{ .livenessProbeFailureThreshold }}
+            successThreshold: {{ .livenessProbeSuccessThreshold }}
+          {{- if .startupProbe.enabled }}
           startupProbe:
-            {{- if not .Values.server.tcpSocketProbeEnabled }}
+            {{- if not .tcpSocketProbeEnabled }}
             httpGet:
-              path: {{ .Values.server.prefixURL }}/-/healthy
+              path: {{ .prefixURL }}/-/healthy
               port: 9090
-              scheme: {{ .Values.server.probeScheme }}
-              {{- if .Values.server.probeHeaders }}
+              scheme: {{ .probeScheme }}
+              {{- if .probeHeaders }}
               httpHeaders:
-              {{- range .Values.server.probeHeaders}}
+              {{- range .probeHeaders}}
               - name: {{ .name }}
                 value: {{ .value }}
               {{- end }}
@@ -185,11 +183,11 @@ spec:
             tcpSocket:
               port: 9090
             {{- end }}
-            failureThreshold: {{ .Values.server.startupProbe.failureThreshold }}
-            periodSeconds: {{ .Values.server.startupProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.server.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .startupProbe.failureThreshold }}
+            periodSeconds: {{ .startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .startupProbe.timeoutSeconds }}
           {{- end }}
-          {{- with .Values.server.resources }}
+          {{- with .resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -197,35 +195,35 @@ spec:
             - name: config-volume
               mountPath: /etc/config
             - name: storage-volume
-              mountPath: {{ .Values.server.persistentVolume.mountPath }}
-              subPath: "{{ .Values.server.persistentVolume.subPath }}"
-            {{- range .Values.server.extraHostPathMounts }}
+              mountPath: {{ .persistentVolume.mountPath }}
+              subPath: "{{ .persistentVolume.subPath }}"
+            {{- range .extraHostPathMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
             {{- end }}
-            {{- range .Values.server.extraConfigmapMounts }}
+            {{- range .extraConfigmapMounts }}
             - name: {{ $.Values.server.name }}-{{ .name }}
               mountPath: {{ .mountPath }}
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
             {{- end }}
-            {{- range .Values.server.extraSecretMounts }}
+            {{- range .extraSecretMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
             {{- end }}
-            {{- with .Values.server.extraVolumeMounts }}
+            {{- with .extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- with .Values.server.containerSecurityContext }}
+          {{- with .containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-        {{- if .Values.server.sidecarContainers }}
-        {{- range $name, $spec :=  .Values.server.sidecarContainers }}
+        {{- if .sidecarContainers }}
+        {{- range $name, $spec :=  .sidecarContainers }}
         - name: {{ $name }}
           {{- if kindIs "string" $spec }}
             {{- tpl $spec $ | nindent 10 }}
@@ -234,66 +232,66 @@ spec:
           {{- end }}
         {{- end }}
         {{- end }}
-      {{- if .Values.server.hostNetwork }}
+      {{- if .hostNetwork }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       {{- else }}
-      dnsPolicy: {{ .Values.server.dnsPolicy }}
+      dnsPolicy: {{ .dnsPolicy }}
       {{- end }}
-      {{- with .Values.imagePullSecrets }}
+      {{- with $.Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.server.nodeSelector }}
+      {{- with .nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.server.hostAliases }}
+      {{- with .hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.server.dnsConfig }}
+      {{- with .dnsConfig }}
       dnsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.server.securityContext }}
+      {{- with .securityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.server.tolerations }}
+      {{- with .tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.server.affinity }}
+      {{- with .affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      terminationGracePeriodSeconds: {{ .Values.server.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .terminationGracePeriodSeconds }}
       volumes:
         - name: config-volume
-          {{- if empty .Values.server.configFromSecret }}
+          {{- if empty .configFromSecret }}
           configMap:
-            name: {{ if .Values.server.configMapOverrideName }}{{ .Release.Name }}-{{ .Values.server.configMapOverrideName }}{{- else }}{{ template "prometheus.server.fullname" . }}{{- end }}
+            name: {{ if .configMapOverrideName }}{{ $.Release.Name }}-{{ .configMapOverrideName }}{{- else }}{{ template "prometheus.server.fullname" $ }}{{- end }}
           {{- else }}
           secret:
-            secretName: {{ .Values.server.configFromSecret }}
+            secretName: {{ .configFromSecret }}
           {{- end }}
-        {{- range .Values.server.extraHostPathMounts }}
+        {{- range .extraHostPathMounts }}
         - name: {{ .name }}
           hostPath:
             path: {{ .hostPath }}
         {{- end }}
-        {{- range .Values.configmapReload.prometheus.extraConfigmapMounts }}
-        - name: {{ $.Values.configmapReload.prometheus.name }}-{{ .name }}
+        {{- range $cmReloadProm.extraConfigmapMounts }}
+        - name: {{ $cmReloadProm.name }}-{{ .name }}
           configMap:
             name: {{ .configMap }}
         {{- end }}
-        {{- range .Values.server.extraConfigmapMounts }}
+        {{- range .extraConfigmapMounts }}
         - name: {{ $.Values.server.name }}-{{ .name }}
           configMap:
             name: {{ .configMap }}
         {{- end }}
-        {{- range .Values.server.extraSecretMounts }}
+        {{- range .extraSecretMounts }}
         - name: {{ .name }}
           secret:
             secretName: {{ .secretName }}
@@ -301,7 +299,7 @@ spec:
             optional: {{ . }}
             {{- end }}
         {{- end }}
-        {{- range .Values.configmapReload.prometheus.extraConfigmapMounts }}
+        {{- range $cmReloadProm.extraConfigmapMounts }}
         - name: {{ .name }}
           configMap:
             name: {{ .configMap }}
@@ -309,17 +307,17 @@ spec:
             optional: {{ . }}
             {{- end }}
         {{- end }}
-        {{- with .Values.server.extraVolumes }}
+        {{- with .extraVolumes }}
         {{- toYaml . | nindent 8}}
         {{- end }}
         - name: storage-volume
-        {{- if .Values.server.persistentVolume.enabled }}
+        {{- if .persistentVolume.enabled }}
           persistentVolumeClaim:
-            claimName: {{ if .Values.server.persistentVolume.existingClaim }}{{ .Values.server.persistentVolume.existingClaim }}{{- else }}{{ template "prometheus.server.fullname" . }}{{- end }}
+            claimName: {{ if .persistentVolume.existingClaim }}{{ .persistentVolume.existingClaim }}{{- else }}{{ template "prometheus.server.fullname" $ }}{{- end }}
         {{- else }}
           emptyDir:
-          {{- if .Values.server.emptyDir.sizeLimit }}
-            sizeLimit: {{ .Values.server.emptyDir.sizeLimit }}
+          {{- if .emptyDir.sizeLimit }}
+            sizeLimit: {{ .emptyDir.sizeLimit }}
           {{- else }}
             {}
           {{- end -}}

--- a/charts/prometheus/templates/server/deploy.yaml
+++ b/charts/prometheus/templates/server/deploy.yaml
@@ -3,53 +3,53 @@
 apiVersion: {{ template "prometheus.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
-{{- if .Values.server.deploymentAnnotations }}
+  {{- with .Values.server.deploymentAnnotations }}
   annotations:
-    {{ toYaml .Values.server.deploymentAnnotations | nindent 4 }}
-{{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
   name: {{ template "prometheus.server.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+  {{- include "prometheus.namespace" . | nindent 2 }}
 spec:
   selector:
     matchLabels:
       {{- include "prometheus.server.matchLabels" . | nindent 6 }}
   replicas: {{ .Values.server.replicaCount }}
-  {{- if .Values.server.strategy }}
+  {{- with .Values.server.strategy }}
   strategy:
-{{ toYaml .Values.server.strategy | trim | indent 4 }}
-    {{ if eq .Values.server.strategy.type "Recreate" }}rollingUpdate: null{{ end }}
-{{- end }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{ if eq .type "Recreate" }}rollingUpdate: null{{ end }}
+  {{- end }}
   template:
     metadata:
-    {{- if .Values.server.podAnnotations }}
+      {{- with .Values.server.podAnnotations }}
       annotations:
-        {{ toYaml .Values.server.podAnnotations | nindent 8 }}
-    {{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         {{- include "prometheus.server.labels" . | nindent 8 }}
-        {{- if .Values.server.podLabels}}
-        {{ toYaml .Values.server.podLabels | nindent 8 }}
+        {{- with .Values.server.podLabels}}
+        {{- toYaml . | nindent 8 }}
         {{- end}}
     spec:
-{{- if .Values.server.priorityClassName }}
-      priorityClassName: "{{ .Values.server.priorityClassName }}"
-{{- end }}
-{{- if .Values.server.schedulerName }}
-      schedulerName: "{{ .Values.server.schedulerName }}"
-{{- end }}
-{{- if semverCompare ">=1.13-0" .Capabilities.KubeVersion.GitVersion }}
+      {{- with .Values.server.priorityClassName }}
+      priorityClassName: "{{ . }}"
+      {{- end }}
+      {{- with .Values.server.schedulerName }}
+      schedulerName: "{{ . }}"
+      {{- end }}
+      {{- if semverCompare ">=1.13-0" .Capabilities.KubeVersion.GitVersion }}
       {{- if or (.Values.server.enableServiceLinks) (eq (.Values.server.enableServiceLinks | toString) "<nil>") }}
       enableServiceLinks: true
       {{- else }}
       enableServiceLinks: false
       {{- end }}
-{{- end }}
+      {{- end }}
       serviceAccountName: {{ template "prometheus.serviceAccountName.server" . }}
-      {{- if .Values.server.extraInitContainers }}
+      {{- with .Values.server.extraInitContainers }}
       initContainers:
-{{ toYaml .Values.server.extraInitContainers | indent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         {{- if .Values.configmapReload.prometheus.enabled }}
@@ -69,64 +69,66 @@ spec:
           {{- range .Values.configmapReload.prometheus.extraVolumeDirs }}
             - --volume-dir={{ . }}
           {{- end }}
-          {{- if .Values.configmapReload.prometheus.containerPort }}
+          {{- with .Values.configmapReload.prometheus.containerPort }}
           ports:
-            - containerPort: {{ .Values.configmapReload.prometheus.containerPort }}
+            - containerPort: {{ . }}
           {{- end }}
+          {{- with .Values.configmapReload.prometheus.resources }}
           resources:
-{{ toYaml .Values.configmapReload.prometheus.resources | indent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config
               readOnly: true
-          {{- range .Values.configmapReload.prometheus.extraConfigmapMounts }}
+            {{- range .Values.configmapReload.prometheus.extraConfigmapMounts }}
             - name: {{ $.Values.configmapReload.prometheus.name }}-{{ .name }}
               mountPath: {{ .mountPath }}
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
-          {{- end }}
+            {{- end }}
         {{- end }}
 
         - name: {{ template "prometheus.name" . }}-{{ .Values.server.name }}
           image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
           imagePullPolicy: "{{ .Values.server.image.pullPolicy }}"
-          {{- if .Values.server.env }}
+          {{- with .Values.server.env }}
           env:
-{{ toYaml .Values.server.env | indent 12}}
+            {{- toYaml . | nindent 12}}
           {{- end }}
           args:
-        {{- if .Values.server.defaultFlagsOverride }}
-        {{ toYaml .Values.server.defaultFlagsOverride | nindent 12}}
-        {{- else }}
-          {{- if .Values.server.retention }}
-            - --storage.tsdb.retention.time={{ .Values.server.retention }}
-          {{- end }}
+            {{- with .Values.server.defaultFlagsOverride }}
+            {{- toYaml . | nindent 12}}
+            {{- else }}
+            {{- with .Values.server.retention }}
+            - --storage.tsdb.retention.time={{ . }}
+            {{- end }}
             - --config.file={{ .Values.server.configPath }}
-            {{- if .Values.server.storagePath }}
-            - --storage.tsdb.path={{ .Values.server.storagePath }}
+            {{- with .Values.server.storagePath }}
+            - --storage.tsdb.path={{ . }}
             {{- else }}
             - --storage.tsdb.path={{ .Values.server.persistentVolume.mountPath }}
             {{- end }}
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
-          {{- range .Values.server.extraFlags }}
+            {{- range .Values.server.extraFlags }}
             - --{{ . }}
-          {{- end }}
-          {{- range $key, $value := .Values.server.extraArgs }}
+            {{- end }}
+            {{- range $key, $value := .Values.server.extraArgs }}
             - --{{ $key }}={{ $value }}
-          {{- end }}
-          {{- if .Values.server.prefixURL }}
-            - --web.route-prefix={{ .Values.server.prefixURL }}
-          {{- end }}
-          {{- if .Values.server.baseURL }}
-            - --web.external-url={{ .Values.server.baseURL }}
-          {{- end }}
-        {{- end }}
+            {{- end }}
+            {{- with .Values.server.prefixURL }}
+            - --web.route-prefix={{ . }}
+            {{- end }}
+            {{- with .Values.server.baseURL }}
+            - --web.external-url={{ . }}
+            {{- end }}
+            {{- end }}
           ports:
             - containerPort: 9090
-          {{- if .Values.server.hostPort }}
-              hostPort: {{ .Values.server.hostPort }}
-          {{- end }}
+              {{- with .Values.server.hostPort }}
+              hostPort: {{ . }}
+              {{- end }}
           readinessProbe:
             {{- if not .Values.server.tcpSocketProbeEnabled }}
             httpGet:
@@ -135,7 +137,7 @@ spec:
               scheme: {{ .Values.server.probeScheme }}
               {{- with .Values.server.probeHeaders }}
               httpHeaders:
-{{- toYaml . | nindent 14 }}
+                {{- toYaml . | nindent 16 }}
               {{- end }}
             {{- else }}
             tcpSocket:
@@ -154,7 +156,7 @@ spec:
               scheme: {{ .Values.server.probeScheme }}
               {{- with .Values.server.probeHeaders }}
               httpHeaders:
-{{- toYaml . | nindent 14 }}
+                {{- toYaml . | nindent 16 }}
               {{- end }}
             {{- else }}
             tcpSocket:
@@ -187,40 +189,42 @@ spec:
             periodSeconds: {{ .Values.server.startupProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.server.startupProbe.timeoutSeconds }}
           {{- end }}
+          {{- with .Values.server.resources }}
           resources:
-{{ toYaml .Values.server.resources | indent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config
             - name: storage-volume
               mountPath: {{ .Values.server.persistentVolume.mountPath }}
               subPath: "{{ .Values.server.persistentVolume.subPath }}"
-          {{- range .Values.server.extraHostPathMounts }}
+            {{- range .Values.server.extraHostPathMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
-          {{- end }}
-          {{- range .Values.server.extraConfigmapMounts }}
+            {{- end }}
+            {{- range .Values.server.extraConfigmapMounts }}
             - name: {{ $.Values.server.name }}-{{ .name }}
               mountPath: {{ .mountPath }}
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
-          {{- end }}
-          {{- range .Values.server.extraSecretMounts }}
+            {{- end }}
+            {{- range .Values.server.extraSecretMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
-          {{- end }}
-          {{- if .Values.server.extraVolumeMounts }}
-            {{ toYaml .Values.server.extraVolumeMounts | nindent 12 }}
-          {{- end }}
+            {{- end }}
+            {{- with .Values.server.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.server.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- if .Values.server.sidecarContainers }}
+        {{- if .Values.server.sidecarContainers }}
         {{- range $name, $spec :=  .Values.server.sidecarContainers }}
         - name: {{ $name }}
           {{- if kindIs "string" $spec }}
@@ -229,85 +233,85 @@ spec:
             {{- toYaml $spec | nindent 10 }}
           {{- end }}
         {{- end }}
-      {{- end }}
-    {{- if .Values.server.hostNetwork }}
+        {{- end }}
+      {{- if .Values.server.hostNetwork }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
-    {{- else }}
+      {{- else }}
       dnsPolicy: {{ .Values.server.dnsPolicy }}
-    {{- end }}
-    {{- if .Values.imagePullSecrets }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-{{ toYaml .Values.imagePullSecrets | indent 8 }}
-    {{- end }}
-    {{- if .Values.server.nodeSelector }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.server.nodeSelector | indent 8 }}
-    {{- end }}
-    {{- if .Values.server.hostAliases }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.hostAliases }}
       hostAliases:
-{{ toYaml .Values.server.hostAliases | indent 8 }}
-    {{- end }}
-    {{- if .Values.server.dnsConfig }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.dnsConfig }}
       dnsConfig:
-{{ toYaml .Values.server.dnsConfig | indent 8 }}
-    {{- end }}
-    {{- with .Values.server.securityContext }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.securityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- if .Values.server.tolerations }}
+      {{- end }}
+      {{- with .Values.server.tolerations }}
       tolerations:
-{{ toYaml .Values.server.tolerations | indent 8 }}
-    {{- end }}
-    {{- if .Values.server.affinity }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.affinity }}
       affinity:
-{{ toYaml .Values.server.affinity | indent 8 }}
-    {{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.server.terminationGracePeriodSeconds }}
       volumes:
         - name: config-volume
-        {{- if empty .Values.server.configFromSecret }}
+          {{- if empty .Values.server.configFromSecret }}
           configMap:
             name: {{ if .Values.server.configMapOverrideName }}{{ .Release.Name }}-{{ .Values.server.configMapOverrideName }}{{- else }}{{ template "prometheus.server.fullname" . }}{{- end }}
-        {{- else }}
+          {{- else }}
           secret:
             secretName: {{ .Values.server.configFromSecret }}
-        {{- end }}
-      {{- range .Values.server.extraHostPathMounts }}
+          {{- end }}
+        {{- range .Values.server.extraHostPathMounts }}
         - name: {{ .name }}
           hostPath:
             path: {{ .hostPath }}
-      {{- end }}
-      {{- range .Values.configmapReload.prometheus.extraConfigmapMounts }}
+        {{- end }}
+        {{- range .Values.configmapReload.prometheus.extraConfigmapMounts }}
         - name: {{ $.Values.configmapReload.prometheus.name }}-{{ .name }}
           configMap:
             name: {{ .configMap }}
-      {{- end }}
-      {{- range .Values.server.extraConfigmapMounts }}
+        {{- end }}
+        {{- range .Values.server.extraConfigmapMounts }}
         - name: {{ $.Values.server.name }}-{{ .name }}
           configMap:
             name: {{ .configMap }}
-      {{- end }}
-      {{- range .Values.server.extraSecretMounts }}
+        {{- end }}
+        {{- range .Values.server.extraSecretMounts }}
         - name: {{ .name }}
           secret:
             secretName: {{ .secretName }}
             {{- with .optional }}
             optional: {{ . }}
             {{- end }}
-      {{- end }}
-      {{- range .Values.configmapReload.prometheus.extraConfigmapMounts }}
+        {{- end }}
+        {{- range .Values.configmapReload.prometheus.extraConfigmapMounts }}
         - name: {{ .name }}
           configMap:
             name: {{ .configMap }}
             {{- with .optional }}
             optional: {{ . }}
             {{- end }}
-      {{- end }}
-{{- if .Values.server.extraVolumes }}
-{{ toYaml .Values.server.extraVolumes | indent 8}}
-{{- end }}
+        {{- end }}
+        {{- with .Values.server.extraVolumes }}
+        {{- toYaml . | nindent 8}}
+        {{- end }}
         - name: storage-volume
         {{- if .Values.server.persistentVolume.enabled }}
           persistentVolumeClaim:

--- a/charts/prometheus/templates/server/headless-svc.yaml
+++ b/charts/prometheus/templates/server/headless-svc.yaml
@@ -1,37 +1,37 @@
-{{- if .Values.server.enabled -}}
-{{- if .Values.server.statefulSet.enabled -}}
+{{- if and .Values.server.enabled .Values.server.statefulSet.enabled -}}
+{{- with .Values.server.statefulSet.headless}}
 apiVersion: v1
 kind: Service
 metadata:
-{{- if .Values.server.statefulSet.headless.annotations }}
+  {{- with .annotations }}
   annotations:
-{{ toYaml .Values.server.statefulSet.headless.annotations | indent 4 }}
-{{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
-    {{- include "prometheus.server.labels" . | nindent 4 }}
-{{- if .Values.server.statefulSet.headless.labels }}
-{{ toYaml .Values.server.statefulSet.headless.labels | indent 4 }}
-{{- end }}
-  name: {{ template "prometheus.server.fullname" . }}-headless
-{{ include "prometheus.namespace" . | indent 2 }}
+    {{- include "prometheus.server.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ template "prometheus.server.fullname" $ }}-headless
+  {{- include "prometheus.namespace" $ | nindent 2 }}
 spec:
   clusterIP: None
   ports:
     - name: http
-      port: {{ .Values.server.statefulSet.headless.servicePort }}
+      port: {{ .servicePort }}
       protocol: TCP
       targetPort: 9090
-    {{- if .Values.server.statefulSet.headless.gRPC.enabled }}
+    {{- if .gRPC.enabled }}
     - name: grpc
-      port: {{ .Values.server.statefulSet.headless.gRPC.servicePort }}
+      port: {{ .gRPC.servicePort }}
       protocol: TCP
       targetPort: 10901
-    {{- if .Values.server.statefulSet.headless.gRPC.nodePort }}
-      nodePort: {{ .Values.server.statefulSet.headless.gRPC.nodePort }}
-    {{- end }}
+      {{- with .gRPC.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
     {{- end }}
 
   selector:
-    {{- include "prometheus.server.matchLabels" . | nindent 4 }}
+    {{- include "prometheus.server.matchLabels" $ | nindent 4 }}
 {{- end -}}
 {{- end -}}

--- a/charts/prometheus/templates/server/ingress.yaml
+++ b/charts/prometheus/templates/server/ingress.yaml
@@ -28,14 +28,14 @@ spec:
   ingressClassName: {{ .Values.server.ingress.ingressClassName }}
   {{- end }}
   rules:
-  {{- range .Values.server.ingress.hosts }}
+    {{- range .Values.server.ingress.hosts }}
     {{- $url := splitList "/" . }}
     - host: {{ first $url }}
       http:
         paths:
-{{ if $extraPaths }}
-{{ toYaml $extraPaths | indent 10 }}
-{{- end }}
+          {{- if $extraPaths }}
+          {{- toYaml $extraPaths | nindent 10 }}
+          {{- end }}
           - path: {{ $ingressPath }}
             {{- if $ingressSupportsPathType }}
             pathType: {{ $ingressPathType }}
@@ -51,9 +51,9 @@ spec:
               servicePort: {{ $servicePort }}
               {{- end }}
   {{- end -}}
-{{- if .Values.server.ingress.tls }}
+  {{- with .Values.server.ingress.tls }}
   tls:
-{{ toYaml .Values.server.ingress.tls | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/prometheus/templates/server/ingress.yaml
+++ b/charts/prometheus/templates/server/ingress.yaml
@@ -12,17 +12,17 @@
 apiVersion: {{ template "ingress.apiVersion" . }}
 kind: Ingress
 metadata:
-{{- if .Values.server.ingress.annotations }}
+  {{- with .Values.server.ingress.annotations }}
   annotations:
-{{ toYaml .Values.server.ingress.annotations | indent 4 }}
-{{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
-{{- range $key, $value := .Values.server.ingress.extraLabels }}
+    {{- range $key, $value := .Values.server.ingress.extraLabels }}
     {{ $key }}: {{ $value }}
-{{- end }}
+    {{- end }}
   name: {{ template "prometheus.server.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+  {{- include "prometheus.namespace" . | nindent 2 }}
 spec:
   {{- if and $ingressSupportsIngressClassName .Values.server.ingress.ingressClassName }}
   ingressClassName: {{ .Values.server.ingress.ingressClassName }}
@@ -33,12 +33,12 @@ spec:
     - host: {{ first $url }}
       http:
         paths:
-          {{- if $extraPaths }}
-          {{- toYaml $extraPaths | nindent 10 }}
+          {{- with $extraPaths }}
+          {{- toYaml . | nindent 10 }}
           {{- end }}
           - path: {{ $ingressPath }}
-            {{- if $ingressSupportsPathType }}
-            pathType: {{ $ingressPathType }}
+            {{- with $ingressSupportsPathType }}
+            pathType: {{ . }}
             {{- end }}
             backend:
               {{- if $ingressApiIsStable }}

--- a/charts/prometheus/templates/server/ingress.yaml
+++ b/charts/prometheus/templates/server/ingress.yaml
@@ -1,15 +1,14 @@
-{{- if .Values.server.enabled -}}
-{{- if .Values.server.ingress.enabled -}}
-{{- $ingressApiIsStable := eq (include "ingress.isStable" .) "true" -}}
-{{- $ingressSupportsIngressClassName := eq (include "ingress.supportsIngressClassName" .) "true" -}}
-{{- $ingressSupportsPathType := eq (include "ingress.supportsPathType" .) "true" -}}
+{{- if and .Values.server.enabled .Values.server.ingress.enabled -}}
+{{- $ingressApiIsStable := eq (include "ingress.isStable" $) "true" -}}
+{{- $ingressSupportsIngressClassName := eq (include "ingress.supportsIngressClassName" $) "true" -}}
+{{- $ingressSupportsPathType := eq (include "ingress.supportsPathType" $) "true" -}}
 {{- $releaseName := .Release.Name -}}
-{{- $serviceName := include "prometheus.server.fullname" . }}
+{{- $serviceName := include "prometheus.server.fullname" $ }}
 {{- $servicePort := .Values.server.service.servicePort -}}
 {{- $ingressPath := .Values.server.ingress.path -}}
 {{- $ingressPathType := .Values.server.ingress.pathType -}}
 {{- $extraPaths := .Values.server.ingress.extraPaths -}}
-apiVersion: {{ template "ingress.apiVersion" . }}
+apiVersion: {{ template "ingress.apiVersion" $ }}
 kind: Ingress
 metadata:
   {{- with .Values.server.ingress.annotations }}
@@ -17,12 +16,12 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    {{- include "prometheus.server.labels" . | nindent 4 }}
+    {{- include "prometheus.server.labels" $ | nindent 4 }}
     {{- range $key, $value := .Values.server.ingress.extraLabels }}
     {{ $key }}: {{ $value }}
     {{- end }}
-  name: {{ template "prometheus.server.fullname" . }}
-  {{- include "prometheus.namespace" . | nindent 2 }}
+  name: {{ template "prometheus.server.fullname" $ }}
+  {{- include "prometheus.namespace" $ | nindent 2 }}
 spec:
   {{- if and $ingressSupportsIngressClassName .Values.server.ingress.ingressClassName }}
   ingressClassName: {{ .Values.server.ingress.ingressClassName }}
@@ -50,10 +49,9 @@ spec:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
               {{- end }}
-  {{- end -}}
+    {{- end -}}
   {{- with .Values.server.ingress.tls }}
   tls:
     {{- toYaml . | nindent 4 }}
   {{- end -}}
-{{- end -}}
 {{- end -}}

--- a/charts/prometheus/templates/server/netpol.yaml
+++ b/charts/prometheus/templates/server/netpol.yaml
@@ -1,5 +1,4 @@
-{{- if and .Values.server.enabled
-           .Values.networkPolicy.enabled }}
+{{- if and .Values.server.enabled .Values.networkPolicy.enabled }}
 apiVersion: {{ template "prometheus.networkPolicy.apiVersion" $ }}
 kind: NetworkPolicy
 metadata:

--- a/charts/prometheus/templates/server/netpol.yaml
+++ b/charts/prometheus/templates/server/netpol.yaml
@@ -1,18 +1,17 @@
-{{- if .Values.server.enabled -}}
-{{- if .Values.networkPolicy.enabled }}
-apiVersion: {{ template "prometheus.networkPolicy.apiVersion" . }}
+{{- if and .Values.server.enabled
+           .Values.networkPolicy.enabled }}
+apiVersion: {{ template "prometheus.networkPolicy.apiVersion" $ }}
 kind: NetworkPolicy
 metadata:
-  name: {{ template "prometheus.server.fullname" . }}
-  {{- include "prometheus.namespace" . | nindent 2 }}
+  name: {{ template "prometheus.server.fullname" $ }}
+  {{- include "prometheus.namespace" $ | nindent 2 }}
   labels:
-    {{- include "prometheus.server.labels" . | nindent 4 }}
+    {{- include "prometheus.server.labels" $ | nindent 4 }}
 spec:
   podSelector:
     matchLabels:
-      {{- include "prometheus.server.matchLabels" . | nindent 6 }}
+      {{- include "prometheus.server.matchLabels" $ | nindent 6 }}
   ingress:
     - ports:
       - port: 9090
-{{- end }}
 {{- end }}

--- a/charts/prometheus/templates/server/netpol.yaml
+++ b/charts/prometheus/templates/server/netpol.yaml
@@ -4,7 +4,7 @@ apiVersion: {{ template "prometheus.networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
 metadata:
   name: {{ template "prometheus.server.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+  {{- include "prometheus.namespace" . | nindent 2 }}
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
 spec:

--- a/charts/prometheus/templates/server/pdb.yaml
+++ b/charts/prometheus/templates/server/pdb.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ template "prometheus.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "prometheus.server.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+  {{- include "prometheus.namespace" . | nindent 2 }}
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
 spec:

--- a/charts/prometheus/templates/server/pdb.yaml
+++ b/charts/prometheus/templates/server/pdb.yaml
@@ -1,14 +1,14 @@
 {{- if .Values.server.podDisruptionBudget.enabled }}
-apiVersion: {{ template "prometheus.podDisruptionBudget.apiVersion" . }}
+apiVersion: {{ template "prometheus.podDisruptionBudget.apiVersion" $ }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "prometheus.server.fullname" . }}
-  {{- include "prometheus.namespace" . | nindent 2 }}
+  {{- include "prometheus.namespace" $ | nindent 2 }}
   labels:
-    {{- include "prometheus.server.labels" . | nindent 4 }}
+    {{- include "prometheus.server.labels" $ | nindent 4 }}
 spec:
   maxUnavailable: {{ .Values.server.podDisruptionBudget.maxUnavailable }}
   selector:
     matchLabels:
-      {{- include "prometheus.server.labels" . | nindent 6 }}
+      {{- include "prometheus.server.labels" $ | nindent 6 }}
 {{- end }}

--- a/charts/prometheus/templates/server/psp.yaml
+++ b/charts/prometheus/templates/server/psp.yaml
@@ -1,7 +1,4 @@
-{{- if and .Values.server.enabled 
-           .Values.rbac.create
-           .Values.podSecurityPolicy.enabled
-           (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
+{{- if and .Values.server.enabled .Values.rbac.create .Values.podSecurityPolicy.enabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 {{- with .Values.server }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy

--- a/charts/prometheus/templates/server/psp.yaml
+++ b/charts/prometheus/templates/server/psp.yaml
@@ -1,12 +1,15 @@
-{{- if and .Values.server.enabled .Values.rbac.create .Values.podSecurityPolicy.enabled }}
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+{{- if and .Values.server.enabled 
+           .Values.rbac.create
+           .Values.podSecurityPolicy.enabled
+           (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
+{{- with .Values.server }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ template "prometheus.server.fullname" . }}
+  name: {{ template "prometheus.server.fullname" $ }}
   labels:
-    {{- include "prometheus.server.labels" . | nindent 4 }}
-  {{- with .Values.server.podSecurityPolicy.annotations }}
+    {{- include "prometheus.server.labels" $ | nindent 4 }}
+  {{- with .podSecurityPolicy.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -24,8 +27,8 @@ spec:
   allowedHostPaths:
     - pathPrefix: /etc
       readOnly: true
-    - pathPrefix: {{ .Values.server.persistentVolume.mountPath }}
-    {{- range .Values.server.extraHostPathMounts }}
+    - pathPrefix: {{ .persistentVolume.mountPath }}
+    {{- range .extraHostPathMounts }}
     - pathPrefix: {{ .hostPath }}
       readOnly: {{ .readOnly }}
     {{- end }}

--- a/charts/prometheus/templates/server/psp.yaml
+++ b/charts/prometheus/templates/server/psp.yaml
@@ -25,10 +25,10 @@ spec:
     - pathPrefix: /etc
       readOnly: true
     - pathPrefix: {{ .Values.server.persistentVolume.mountPath }}
-  {{- range .Values.server.extraHostPathMounts }}
+    {{- range .Values.server.extraHostPathMounts }}
     - pathPrefix: {{ .hostPath }}
       readOnly: {{ .readOnly }}
-  {{- end }}
+    {{- end }}
   hostNetwork: false
   hostPID: false
   hostIPC: false

--- a/charts/prometheus/templates/server/pvc.yaml
+++ b/charts/prometheus/templates/server/pvc.yaml
@@ -1,42 +1,41 @@
-{{- if .Values.server.enabled -}}
-{{- if not .Values.server.statefulSet.enabled -}}
-{{- if .Values.server.persistentVolume.enabled -}}
-{{- if not .Values.server.persistentVolume.existingClaim -}}
+{{- if and .Values.server.enabled 
+           (not .Values.server.statefulSet.enabled)
+           .Values.server.persistentVolume.enabled
+           (not .Values.server.persistentVolume.existingClaim) -}}
+{{- with .Values.server.persistentVolume }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  {{- with .Values.server.persistentVolume.annotations }}
+  {{- with .annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    {{- include "prometheus.server.labels" . | nindent 4 }}
-  name: {{ template "prometheus.server.fullname" . }}
-  {{- include "prometheus.namespace" . | nindent 2 }}
+    {{- include "prometheus.server.labels" $ | nindent 4 }}
+  name: {{ template "prometheus.server.fullname" $ }}
+  {{- include "prometheus.namespace" $ | nindent 2 }}
 spec:
   accessModes:
-    {{ toYaml .Values.server.persistentVolume.accessModes | nindent 4 }}
-  {{- if .Values.server.persistentVolume.storageClass }}
-  {{- if (eq "-" .Values.server.persistentVolume.storageClass) }}
+    {{- toYaml .accessModes | nindent 4 }}
+  {{- if .storageClass }}
+  {{- if (eq "-" .storageClass) }}
   storageClassName: ""
   {{- else }}
-  storageClassName: "{{ .Values.server.persistentVolume.storageClass }}"
+  storageClassName: "{{ .storageClass }}"
   {{- end }}
   {{- end }}
-  {{- with .Values.server.persistentVolume.volumeBindingMode }}
+  {{- with .volumeBindingMode }}
   volumeBindingMode: "{{ . }}"
   {{- end }}
   resources:
     requests:
-      storage: "{{ .Values.server.persistentVolume.size }}"
-  {{- with .Values.server.persistentVolume.selector }}
+      storage: "{{ .size }}"
+  {{- with .selector }}
   selector:
     {{- toYaml . | nindent 4 }}
-  {{- end -}}
-  {{- with .Values.server.persistentVolume.volumeName }}
+  {{- end }}
+  {{- with .volumeName }}
   volumeName: "{{ . }}"
   {{- end -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
+{{- end }}
 {{- end -}}

--- a/charts/prometheus/templates/server/pvc.yaml
+++ b/charts/prometheus/templates/server/pvc.yaml
@@ -1,7 +1,4 @@
-{{- if and .Values.server.enabled 
-           (not .Values.server.statefulSet.enabled)
-           .Values.server.persistentVolume.enabled
-           (not .Values.server.persistentVolume.existingClaim) -}}
+{{- if and .Values.server.enabled (not .Values.server.statefulSet.enabled) .Values.server.persistentVolume.enabled (not .Values.server.persistentVolume.existingClaim) -}}
 {{- with .Values.server.persistentVolume }}
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/charts/prometheus/templates/server/pvc.yaml
+++ b/charts/prometheus/templates/server/pvc.yaml
@@ -5,37 +5,37 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  {{- if .Values.server.persistentVolume.annotations }}
+  {{- with .Values.server.persistentVolume.annotations }}
   annotations:
-{{ toYaml .Values.server.persistentVolume.annotations | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
   name: {{ template "prometheus.server.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+  {{- include "prometheus.namespace" . | nindent 2 }}
 spec:
   accessModes:
-{{ toYaml .Values.server.persistentVolume.accessModes | indent 4 }}
-{{- if .Values.server.persistentVolume.storageClass }}
-{{- if (eq "-" .Values.server.persistentVolume.storageClass) }}
+    {{ toYaml .Values.server.persistentVolume.accessModes | nindent 4 }}
+  {{- if .Values.server.persistentVolume.storageClass }}
+  {{- if (eq "-" .Values.server.persistentVolume.storageClass) }}
   storageClassName: ""
-{{- else }}
+  {{- else }}
   storageClassName: "{{ .Values.server.persistentVolume.storageClass }}"
-{{- end }}
-{{- end }}
-{{- if .Values.server.persistentVolume.volumeBindingMode }}
-  volumeBindingMode: "{{ .Values.server.persistentVolume.volumeBindingMode }}"
-{{- end }}
+  {{- end }}
+  {{- end }}
+  {{- with .Values.server.persistentVolume.volumeBindingMode }}
+  volumeBindingMode: "{{ . }}"
+  {{- end }}
   resources:
     requests:
       storage: "{{ .Values.server.persistentVolume.size }}"
-{{- if .Values.server.persistentVolume.selector }}
+  {{- with .Values.server.persistentVolume.selector }}
   selector:
-  {{- toYaml .Values.server.persistentVolume.selector | nindent 4 }}
-{{- end -}}
-{{- if .Values.server.persistentVolume.volumeName }}
-  volumeName: "{{ .Values.server.persistentVolume.volumeName }}"
-{{- end -}}
+    {{- toYaml . | nindent 4 }}
+  {{- end -}}
+  {{- with .Values.server.persistentVolume.volumeName }}
+  volumeName: "{{ . }}"
+  {{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/prometheus/templates/server/rolebinding.yaml
+++ b/charts/prometheus/templates/server/rolebinding.yaml
@@ -1,4 +1,7 @@
-{{- if and .Values.server.enabled .Values.rbac.create .Values.server.useExistingClusterRoleName .Values.server.namespaces -}}
+{{- if and .Values.server.enabled
+           .Values.rbac.create
+           .Values.server.useExistingClusterRoleName
+           .Values.server.namespaces -}}
 {{ range $.Values.server.namespaces -}}
 ---
 apiVersion: {{ template "rbac.apiVersion" $ }}

--- a/charts/prometheus/templates/server/rolebinding.yaml
+++ b/charts/prometheus/templates/server/rolebinding.yaml
@@ -11,7 +11,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "prometheus.serviceAccountName.server" $ }}
-{{ include "prometheus.namespace" $ | indent 4 }}
+    {{- include "prometheus.namespace" $ | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/prometheus/templates/server/rolebinding.yaml
+++ b/charts/prometheus/templates/server/rolebinding.yaml
@@ -1,7 +1,4 @@
-{{- if and .Values.server.enabled
-           .Values.rbac.create
-           .Values.server.useExistingClusterRoleName
-           .Values.server.namespaces -}}
+{{- if and .Values.server.enabled .Values.rbac.create .Values.server.useExistingClusterRoleName .Values.server.namespaces -}}
 {{ range $.Values.server.namespaces -}}
 ---
 apiVersion: {{ template "rbac.apiVersion" $ }}

--- a/charts/prometheus/templates/server/service.yaml
+++ b/charts/prometheus/templates/server/service.yaml
@@ -2,59 +2,59 @@
 apiVersion: v1
 kind: Service
 metadata:
-{{- if .Values.server.service.annotations }}
+  {{- with .Values.server.service.annotations }}
   annotations:
-{{ toYaml .Values.server.service.annotations | indent 4 }}
-{{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
-{{- if .Values.server.service.labels }}
-{{ toYaml .Values.server.service.labels | indent 4 }}
-{{- end }}
+    {{- with .Values.server.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ template "prometheus.server.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+  {{- include "prometheus.namespace" . | nindent 2 }}
 spec:
-{{- if .Values.server.service.clusterIP }}
-  clusterIP: {{ .Values.server.service.clusterIP }}
-{{- end }}
-{{- if .Values.server.service.externalIPs }}
+  {{- with .Values.server.service.clusterIP }}
+  clusterIP: {{ . }}
+  {{- end }}
+  {{- with .Values.server.service.externalIPs }}
   externalIPs:
-{{ toYaml .Values.server.service.externalIPs | indent 4 }}
-{{- end }}
-{{- if .Values.server.service.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.server.service.loadBalancerIP }}
-{{- end }}
-{{- if .Values.server.service.loadBalancerSourceRanges }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.server.service.loadBalancerIP }}
+  loadBalancerIP: {{ . }}
+  {{- end }}
+  {{- if .Values.server.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
   {{- range $cidr := .Values.server.service.loadBalancerSourceRanges }}
     - {{ $cidr }}
   {{- end }}
-{{- end }}
+  {{- end }}
   ports:
     - name: http
       port: {{ .Values.server.service.servicePort }}
       protocol: TCP
       targetPort: 9090
-    {{- if .Values.server.service.nodePort }}
-      nodePort: {{ .Values.server.service.nodePort }}
-    {{- end }}
+      {{- with .Values.server.service.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
     {{- if .Values.server.service.gRPC.enabled }}
     - name: grpc
       port: {{ .Values.server.service.gRPC.servicePort }}
       protocol: TCP
       targetPort: 10901
-    {{- if .Values.server.service.gRPC.nodePort }}
-      nodePort: {{ .Values.server.service.gRPC.nodePort }}
-    {{- end }}
+      {{- with .Values.server.service.gRPC.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
     {{- end }}
   selector:
   {{- if and .Values.server.statefulSet.enabled .Values.server.service.statefulsetReplica.enabled }}
     statefulset.kubernetes.io/pod-name: {{ template "prometheus.server.fullname" . }}-{{ .Values.server.service.statefulsetReplica.replica }}
   {{- else -}}
     {{- include "prometheus.server.matchLabels" . | nindent 4 }}
-{{- if .Values.server.service.sessionAffinity }}
-  sessionAffinity: {{ .Values.server.service.sessionAffinity }}
-{{- end }}
+  {{- with .Values.server.service.sessionAffinity }}
+  sessionAffinity: {{ . }}
+  {{- end }}
   {{- end }}
   type: "{{ .Values.server.service.type }}"
 {{- end -}}

--- a/charts/prometheus/templates/server/service.yaml
+++ b/charts/prometheus/templates/server/service.yaml
@@ -1,60 +1,62 @@
 {{- if and .Values.server.enabled .Values.server.service.enabled -}}
+{{- with .Values.server.service }}
 apiVersion: v1
 kind: Service
 metadata:
-  {{- with .Values.server.service.annotations }}
+  {{- with .annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    {{- include "prometheus.server.labels" . | nindent 4 }}
-    {{- with .Values.server.service.labels }}
+    {{- include "prometheus.server.labels" $ | nindent 4 }}
+    {{- with .labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  name: {{ template "prometheus.server.fullname" . }}
-  {{- include "prometheus.namespace" . | nindent 2 }}
+  name: {{ template "prometheus.server.fullname" $ }}
+  {{- include "prometheus.namespace" $ | nindent 2 }}
 spec:
-  {{- with .Values.server.service.clusterIP }}
+  {{- with .clusterIP }}
   clusterIP: {{ . }}
   {{- end }}
-  {{- with .Values.server.service.externalIPs }}
+  {{- with .externalIPs }}
   externalIPs:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with .Values.server.service.loadBalancerIP }}
+  {{- with .loadBalancerIP }}
   loadBalancerIP: {{ . }}
   {{- end }}
-  {{- if .Values.server.service.loadBalancerSourceRanges }}
+  {{- with .loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
-  {{- range $cidr := .Values.server.service.loadBalancerSourceRanges }}
+    {{- range $cidr := . }}
     - {{ $cidr }}
-  {{- end }}
+    {{- end }}
   {{- end }}
   ports:
     - name: http
-      port: {{ .Values.server.service.servicePort }}
+      port: {{ .servicePort }}
       protocol: TCP
       targetPort: 9090
-      {{- with .Values.server.service.nodePort }}
+      {{- with .nodePort }}
       nodePort: {{ . }}
       {{- end }}
-    {{- if .Values.server.service.gRPC.enabled }}
+    {{- if .gRPC.enabled }}
     - name: grpc
-      port: {{ .Values.server.service.gRPC.servicePort }}
+      port: {{ .gRPC.servicePort }}
       protocol: TCP
       targetPort: 10901
-      {{- with .Values.server.service.gRPC.nodePort }}
+      {{- with .gRPC.nodePort }}
       nodePort: {{ . }}
       {{- end }}
     {{- end }}
   selector:
-  {{- if and .Values.server.statefulSet.enabled .Values.server.service.statefulsetReplica.enabled }}
-    statefulset.kubernetes.io/pod-name: {{ template "prometheus.server.fullname" . }}-{{ .Values.server.service.statefulsetReplica.replica }}
+  {{- if and $.Values.server.statefulSet.enabled .statefulsetReplica.enabled }}
+    statefulset.kubernetes.io/pod-name: {{ template "prometheus.server.fullname" $ }}-{{ .statefulsetReplica.replica }}
   {{- else -}}
-    {{- include "prometheus.server.matchLabels" . | nindent 4 }}
-  {{- with .Values.server.service.sessionAffinity }}
+    {{- include "prometheus.server.matchLabels" $ | nindent 4 }}
+  {{- with .sessionAffinity }}
   sessionAffinity: {{ . }}
   {{- end }}
   {{- end }}
-  type: "{{ .Values.server.service.type }}"
+  type: "{{ .type }}"
+{{- end -}}
 {{- end -}}

--- a/charts/prometheus/templates/server/serviceaccount.yaml
+++ b/charts/prometheus/templates/server/serviceaccount.yaml
@@ -1,13 +1,13 @@
-{{- if .Values.server.enabled -}}
-{{- if .Values.serviceAccounts.server.create }}
+{{- if and .Values.server.enabled .Values.serviceAccounts.server.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
   name: {{ template "prometheus.serviceAccountName.server" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+  {{- include "prometheus.namespace" . | nindent 2 }}
+  {{- with .Values.serviceAccounts.server.annotations }}
   annotations:
-{{ toYaml .Values.serviceAccounts.server.annotations | indent 4 }}
-{{- end }}
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/prometheus/templates/server/serviceaccount.yaml
+++ b/charts/prometheus/templates/server/serviceaccount.yaml
@@ -1,13 +1,13 @@
-{{- if and .Values.server.enabled .Values.serviceAccounts.server.create }}
+{{- if and .Values.server.enabled .Values.serviceAccounts.server.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    {{- include "prometheus.server.labels" . | nindent 4 }}
-  name: {{ template "prometheus.serviceAccountName.server" . }}
-  {{- include "prometheus.namespace" . | nindent 2 }}
+    {{- include "prometheus.server.labels" $ | nindent 4 }}
+  name: {{ template "prometheus.serviceAccountName.server" $ }}
+  {{- include "prometheus.namespace" $ | nindent 2 }}
   {{- with .Values.serviceAccounts.server.annotations }}
   annotations:
-    {{ toYaml . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- end }}
+{{- end -}}

--- a/charts/prometheus/templates/server/sts.yaml
+++ b/charts/prometheus/templates/server/sts.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "prometheus.server.labels" $ | nindent 4 }}
     {{- with .statefulSet.labels }}
     {{- toYaml . | nindent 4 }}
-    {{- end}}
+    {{- end }}
   name: {{ template "prometheus.server.fullname" $ }}
   {{- include "prometheus.namespace" $ | nindent 2 }}
 spec:
@@ -59,15 +59,15 @@ spec:
           args:
             - --volume-dir=/etc/config
             - --webhook-url=http://127.0.0.1:9090{{ .prefixURL }}/-/reload
-          {{- range $key, $value := $cmReloadProm.extraArgs }}
+            {{- range $key, $value := $cmReloadProm.extraArgs }}
             - --{{ $key }}={{ $value }}
-          {{- end }}
-          {{- range $cmReloadProm.extraVolumeDirs }}
+            {{- end }}
+            {{- range $cmReloadProm.extraVolumeDirs }}
             - --volume-dir={{ . }}
-          {{- end }}
-          {{- if $cmReloadProm.containerPort }}
+            {{- end }}
+          {{- with $cmReloadProm.containerPort }}
           ports:
-            - containerPort: {{ $cmReloadProm.containerPort }}
+            - containerPort: {{ . }}
           {{- end }}
           {{- with $cmReloadProm.resources }}          
           resources:
@@ -265,13 +265,13 @@ spec:
       terminationGracePeriodSeconds: {{ .terminationGracePeriodSeconds }}
       volumes:
         - name: config-volume
-        {{- if empty .configFromSecret }}
-          configMap:
-            name: {{ if .configMapOverrideName }}{{ $.Release.Name }}-{{ .configMapOverrideName }}{{- else }}{{ template "prometheus.server.fullname" $ }}{{- end }}
-        {{- else }}
+          {{- with .configFromSecret }}
           secret:
             secretName: {{ .configFromSecret }}
-        {{- end }}
+          {{- else }}
+          configMap:
+            name: {{ if .configMapOverrideName }}{{ $.Release.Name }}-{{ .configMapOverrideName }}{{- else }}{{ template "prometheus.server.fullname" $ }}{{- end }}
+          {{- end }}
         {{- range .extraHostPathMounts }}
         - name: {{ .name }}
           hostPath:
@@ -324,18 +324,18 @@ spec:
         resources:
           requests:
             storage: "{{ .persistentVolume.size }}"
-      {{- if .persistentVolume.storageClass }}
-      {{- if (eq "-" .persistentVolume.storageClass) }}
+        {{- if .persistentVolume.storageClass }}
+        {{- if (eq "-" .persistentVolume.storageClass) }}
         storageClassName: ""
-      {{- else }}
+        {{- else }}
         storageClassName: "{{ .persistentVolume.storageClass }}"
-      {{- end }}
-      {{- end }}
+        {{- end }}
+        {{- end }}
   {{- else }}
         - name: storage-volume
           emptyDir:
-          {{- if .emptyDir.sizeLimit }}
-            sizeLimit: {{ .emptyDir.sizeLimit }}
+          {{- with .emptyDir.sizeLimit }}
+            sizeLimit: {{ . }}
           {{- else }}
             {}
           {{- end -}}

--- a/charts/prometheus/templates/server/sts.yaml
+++ b/charts/prometheus/templates/server/sts.yaml
@@ -1,79 +1,75 @@
-{{- if .Values.server.enabled -}}
-{{- if .Values.server.statefulSet.enabled -}}
+{{- $cmReloadProm := $.Values.configmapReload.prometheus -}}
+
+{{- with .Values.server }}
+{{- if and .enabled .statefulSet.enabled -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  {{- with .Values.server.statefulSet.annotations }}
+  {{- with .statefulSet.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    {{- include "prometheus.server.labels" . | nindent 4 }}
-    {{- with .Values.server.statefulSet.labels }}
+    {{- include "prometheus.server.labels" $ | nindent 4 }}
+    {{- with .statefulSet.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end}}
-  name: {{ template "prometheus.server.fullname" . }}
-  {{- include "prometheus.namespace" . | nindent 2 }}
+  name: {{ template "prometheus.server.fullname" $ }}
+  {{- include "prometheus.namespace" $ | nindent 2 }}
 spec:
-  serviceName: {{ template "prometheus.server.fullname" . }}-headless
+  serviceName: {{ template "prometheus.server.fullname" $ }}-headless
   selector:
     matchLabels:
-      {{- include "prometheus.server.matchLabels" . | nindent 6 }}
-  replicas: {{ .Values.server.replicaCount }}
-  podManagementPolicy: {{ .Values.server.statefulSet.podManagementPolicy }}
+      {{- include "prometheus.server.matchLabels" $ | nindent 6 }}
+  replicas: {{ .replicaCount }}
+  podManagementPolicy: {{ .statefulSet.podManagementPolicy }}
   template:
     metadata:
-      {{- with .Values.server.podAnnotations }}
+      {{- with .podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "prometheus.server.labels" . | nindent 8 }}
-        {{- with .Values.server.podLabels }}
+        {{- include "prometheus.server.labels" $ | nindent 8 }}
+        {{- with .podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end}}
     spec:
-      {{- with .Values.server.priorityClassName }}
+      {{- with .priorityClassName }}
       priorityClassName: "{{ . }}"
       {{- end }}
-      {{- with .Values.server.schedulerName }}
+      {{- with .schedulerName }}
       schedulerName: "{{ . }}"
       {{- end }}
-      {{- if semverCompare ">=1.13-0" .Capabilities.KubeVersion.GitVersion }}
-      {{- if or (.Values.server.enableServiceLinks) (eq (.Values.server.enableServiceLinks | toString) "<nil>") }}
-      enableServiceLinks: true
-      {{- else }}
-      enableServiceLinks: false
-      {{- end }}
-      {{- end }}
-      serviceAccountName: {{ template "prometheus.serviceAccountName.server" . }}
-      {{- with .Values.server.extraInitContainers }}
+      {{- include "prometheus.server.enableServiceLinks" $ | nindent 6 }}
+      serviceAccountName: {{ template "prometheus.serviceAccountName.server" $ }}
+      {{- with .extraInitContainers }}
       initContainers:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-        {{- if .Values.configmapReload.prometheus.enabled }}
-        - name: {{ template "prometheus.name" . }}-{{ .Values.server.name }}-{{ .Values.configmapReload.prometheus.name }}
-          image: "{{ .Values.configmapReload.prometheus.image.repository }}:{{ .Values.configmapReload.prometheus.image.tag }}"
-          imagePullPolicy: "{{ .Values.configmapReload.prometheus.image.pullPolicy }}"
-          {{- with .Values.configmapReload.prometheus.containerSecurityContext }}
+        {{- if $cmReloadProm.enabled }}
+        - name: {{ template "prometheus.name" $ }}-{{ .name }}-{{ $cmReloadProm.name }}
+          image: "{{ $cmReloadProm.image.repository }}:{{ $cmReloadProm.image.tag }}"
+          imagePullPolicy: "{{ $cmReloadProm.image.pullPolicy }}"
+          {{- with $cmReloadProm.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           args:
             - --volume-dir=/etc/config
-            - --webhook-url=http://127.0.0.1:9090{{ .Values.server.prefixURL }}/-/reload
-          {{- range $key, $value := .Values.configmapReload.prometheus.extraArgs }}
+            - --webhook-url=http://127.0.0.1:9090{{ .prefixURL }}/-/reload
+          {{- range $key, $value := $cmReloadProm.extraArgs }}
             - --{{ $key }}={{ $value }}
           {{- end }}
-          {{- range .Values.configmapReload.prometheus.extraVolumeDirs }}
+          {{- range $cmReloadProm.extraVolumeDirs }}
             - --volume-dir={{ . }}
           {{- end }}
-          {{- if .Values.configmapReload.prometheus.containerPort }}
+          {{- if $cmReloadProm.containerPort }}
           ports:
-            - containerPort: {{ .Values.configmapReload.prometheus.containerPort }}
+            - containerPort: {{ $cmReloadProm.containerPort }}
           {{- end }}
-          {{- with .Values.configmapReload.prometheus.resources }}          
+          {{- with $cmReloadProm.resources }}          
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -81,61 +77,61 @@ spec:
             - name: config-volume
               mountPath: /etc/config
               readOnly: true
-            {{- range .Values.configmapReload.prometheus.extraConfigmapMounts }}
-            - name: {{ $.Values.configmapReload.prometheus.name }}-{{ .name }}
+            {{- range $cmReloadProm.extraConfigmapMounts }}
+            - name: {{ $cmReloadProm.name }}-{{ .name }}
               mountPath: {{ .mountPath }}
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
             {{- end }}
         {{- end }}
 
-        - name: {{ template "prometheus.name" . }}-{{ .Values.server.name }}
-          image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
-          imagePullPolicy: "{{ .Values.server.image.pullPolicy }}"
-          {{- with .Values.server.env }}
+        - name: {{ template "prometheus.name" $ }}-{{ .name }}
+          image: "{{ .image.repository }}:{{ .image.tag }}"
+          imagePullPolicy: "{{ .image.pullPolicy }}"
+          {{- with .env }}
           env:
             {{- toYaml . | nindent 12}}
           {{- end }}
           args:
-            {{- with .Values.server.defaultFlagsOverride }}
+            {{- with .defaultFlagsOverride }}
             {{- toYaml . | nindent 12}}
             {{- else }}
-            {{- with .Values.server.prefixURL }}
+            {{- with .prefixURL }}
             - --web.route-prefix={{ . }}
             {{- end }}
-            {{- with .Values.server.retention }}
+            {{- with .retention }}
             - --storage.tsdb.retention.time={{ . }}
             {{- end }}
-            - --config.file={{ .Values.server.configPath }}
-            {{- with .Values.server.storagePath }}
+            - --config.file={{ .configPath }}
+            {{- with .storagePath }}
             - --storage.tsdb.path={{ . }}
             {{- else }}
-            - --storage.tsdb.path={{ .Values.server.persistentVolume.mountPath }}
+            - --storage.tsdb.path={{ .persistentVolume.mountPath }}
             {{- end }}
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
-            {{- range .Values.server.extraFlags }}
+            {{- range .extraFlags }}
             - --{{ . }}
             {{- end }}
-            {{- range $key, $value := .Values.server.extraArgs }}
+            {{- range $key, $value := .extraArgs }}
             - --{{ $key }}={{ $value }}
             {{- end }}
-            {{- with .Values.server.baseURL }}
+            {{- with .baseURL }}
             - --web.external-url={{ . }}
             {{- end }}
-        {{- end }}
+            {{- end }}
           ports:
             - containerPort: 9090
-              {{- with .Values.server.hostPort }}
+              {{- with .hostPort }}
               hostPort: {{ . }}
               {{- end }}
           readinessProbe:
-            {{- if not .Values.server.tcpSocketProbeEnabled }}
+            {{- if not .tcpSocketProbeEnabled }}
             httpGet:
-              path: {{ .Values.server.prefixURL }}/-/ready
+              path: {{ .prefixURL }}/-/ready
               port: 9090
-              scheme: {{ .Values.server.probeScheme }}
-              {{- with .Values.server.probeHeaders }}
+              scheme: {{ .probeScheme }}
+              {{- with .probeHeaders }}
               httpHeaders:
                 {{- toYaml . | nindent 16 }}
               {{- end }}
@@ -143,18 +139,18 @@ spec:
             tcpSocket:
               port: 9090
             {{- end }}
-            initialDelaySeconds: {{ .Values.server.readinessProbeInitialDelay }}
-            periodSeconds: {{ .Values.server.readinessProbePeriodSeconds }}
-            timeoutSeconds: {{ .Values.server.readinessProbeTimeout }}
-            failureThreshold: {{ .Values.server.readinessProbeFailureThreshold }}
-            successThreshold: {{ .Values.server.readinessProbeSuccessThreshold }}
+            initialDelaySeconds: {{ .readinessProbeInitialDelay }}
+            periodSeconds: {{ .readinessProbePeriodSeconds }}
+            timeoutSeconds: {{ .readinessProbeTimeout }}
+            failureThreshold: {{ .readinessProbeFailureThreshold }}
+            successThreshold: {{ .readinessProbeSuccessThreshold }}
           livenessProbe:
-            {{- if not .Values.server.tcpSocketProbeEnabled }}
+            {{- if not .tcpSocketProbeEnabled }}
             httpGet:
-              path: {{ .Values.server.prefixURL }}/-/healthy
+              path: {{ .prefixURL }}/-/healthy
               port: 9090
-              scheme: {{ .Values.server.probeScheme }}
-              {{- with .Values.server.probeHeaders }}
+              scheme: {{ .probeScheme }}
+              {{- with .probeHeaders }}
               httpHeaders:
                 {{- toYaml . | nindent 16 }}
               {{- end }}
@@ -162,21 +158,21 @@ spec:
             tcpSocket:
               port: 9090
             {{- end }}
-            initialDelaySeconds: {{ .Values.server.livenessProbeInitialDelay }}
-            periodSeconds: {{ .Values.server.livenessProbePeriodSeconds }}
-            timeoutSeconds: {{ .Values.server.livenessProbeTimeout }}
-            failureThreshold: {{ .Values.server.livenessProbeFailureThreshold }}
-            successThreshold: {{ .Values.server.livenessProbeSuccessThreshold }}
-          {{- if .Values.server.startupProbe.enabled }}
+            initialDelaySeconds: {{ .livenessProbeInitialDelay }}
+            periodSeconds: {{ .livenessProbePeriodSeconds }}
+            timeoutSeconds: {{ .livenessProbeTimeout }}
+            failureThreshold: {{ .livenessProbeFailureThreshold }}
+            successThreshold: {{ .livenessProbeSuccessThreshold }}
+          {{- if .startupProbe.enabled }}
           startupProbe:
-            {{- if not .Values.server.tcpSocketProbeEnabled }}
+            {{- if not .tcpSocketProbeEnabled }}
             httpGet:
-              path: {{ .Values.server.prefixURL }}/-/healthy
+              path: {{ .prefixURL }}/-/healthy
               port: 9090
-              scheme: {{ .Values.server.probeScheme }}
-              {{- if .Values.server.probeHeaders }}
+              scheme: {{ .probeScheme }}
+              {{- if .probeHeaders }}
               httpHeaders:
-                {{- range .Values.server.probeHeaders}}
+                {{- range .probeHeaders}}
                 - name: {{ .name }}
                   value: {{ .value }}
                 {{- end }}
@@ -185,11 +181,11 @@ spec:
             tcpSocket:
               port: 9090
             {{- end }}
-            failureThreshold: {{ .Values.server.startupProbe.failureThreshold }}
-            periodSeconds: {{ .Values.server.startupProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.server.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .startupProbe.failureThreshold }}
+            periodSeconds: {{ .startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .startupProbe.timeoutSeconds }}
           {{- end }}
-          {{- with .Values.server.resources }}
+          {{- with .resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -197,35 +193,35 @@ spec:
             - name: config-volume
               mountPath: /etc/config
             - name: storage-volume
-              mountPath: {{ .Values.server.persistentVolume.mountPath }}
-              subPath: "{{ .Values.server.persistentVolume.subPath }}"
-            {{- range .Values.server.extraHostPathMounts }}
+              mountPath: {{ .persistentVolume.mountPath }}
+              subPath: "{{ .persistentVolume.subPath }}"
+            {{- range .extraHostPathMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
             {{- end }}
-            {{- range .Values.server.extraConfigmapMounts }}
-            - name: {{ $.Values.server.name }}-{{ .name }}
+            {{- range .extraConfigmapMounts }}
+            - name: {{ $.name }}-{{ .name }}
               mountPath: {{ .mountPath }}
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
             {{- end }}
-            {{- range .Values.server.extraSecretMounts }}
+            {{- range .extraSecretMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
             {{- end }}
-            {{- with .Values.server.extraVolumeMounts }}
+            {{- with .extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- with .Values.server.containerSecurityContext }}
+          {{- with .containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-        {{- if .Values.server.sidecarContainers }}
-        {{- range $name, $spec :=  .Values.server.sidecarContainers }}
+        {{- if .sidecarContainers }}
+        {{- range $name, $spec :=  .sidecarContainers }}
         - name: {{ $name }}
           {{- if kindIs "string" $spec }}
             {{- tpl $spec $ | nindent 10 }}
@@ -234,64 +230,64 @@ spec:
           {{- end }}
         {{- end }}
         {{- end }}
-      hostNetwork: {{ .Values.server.hostNetwork }}
-      {{- with .Values.server.dnsPolicy }}
+      hostNetwork: {{ .hostNetwork }}
+      {{- with .dnsPolicy }}
       dnsPolicy: {{ . }}
       {{- end }}
-      {{- with .Values.imagePullSecrets }}
+      {{- with $.Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.server.nodeSelector }}
+      {{- with .nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.server.hostAliases }}
+      {{- with .hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.server.dnsConfig }}
+      {{- with .dnsConfig }}
       dnsConfig:
         {{- toYaml . | indent 8 }}
       {{- end }}
-      {{- with .Values.server.securityContext }}
+      {{- with .securityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.server.tolerations }}
+      {{- with .tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.server.affinity }}
+      {{- with .affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      terminationGracePeriodSeconds: {{ .Values.server.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .terminationGracePeriodSeconds }}
       volumes:
         - name: config-volume
-        {{- if empty .Values.server.configFromSecret }}
+        {{- if empty .configFromSecret }}
           configMap:
-            name: {{ if .Values.server.configMapOverrideName }}{{ .Release.Name }}-{{ .Values.server.configMapOverrideName }}{{- else }}{{ template "prometheus.server.fullname" . }}{{- end }}
+            name: {{ if .configMapOverrideName }}{{ $.Release.Name }}-{{ .configMapOverrideName }}{{- else }}{{ template "prometheus.server.fullname" $ }}{{- end }}
         {{- else }}
           secret:
-            secretName: {{ .Values.server.configFromSecret }}
+            secretName: {{ .configFromSecret }}
         {{- end }}
-        {{- range .Values.server.extraHostPathMounts }}
+        {{- range .extraHostPathMounts }}
         - name: {{ .name }}
           hostPath:
             path: {{ .hostPath }}
         {{- end }}
-        {{- range .Values.configmapReload.prometheus.extraConfigmapMounts }}
-        - name: {{ $.Values.configmapReload.prometheus.name }}-{{ .name }}
+        {{- range $cmReloadProm.extraConfigmapMounts }}
+        - name: {{ $cmReloadProm.name }}-{{ .name }}
           configMap:
             name: {{ .configMap }}
         {{- end }}
-        {{- range .Values.server.extraConfigmapMounts }}
+        {{- range .extraConfigmapMounts }}
         - name: {{ $.Values.server.name }}-{{ .name }}
           configMap:
             name: {{ .configMap }}
         {{- end }}
-        {{- range .Values.server.extraSecretMounts }}
+        {{- range .extraSecretMounts }}
         - name: {{ .name }}
           secret:
             secretName: {{ .secretName }}
@@ -299,7 +295,7 @@ spec:
             optional: {{ . }}
             {{- end }}
         {{- end }}
-        {{- range .Values.configmapReload.prometheus.extraConfigmapMounts }}
+        {{- range $cmReloadProm.extraConfigmapMounts }}
         - name: {{ .name }}
           configMap:
             name: {{ .configMap }}
@@ -307,39 +303,39 @@ spec:
             optional: {{ . }}
             {{- end }}
         {{- end }}
-        {{- with .Values.server.extraVolumes }}
+        {{- with .extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-  {{- if .Values.server.persistentVolume.enabled }}
+  {{- if .persistentVolume.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: storage-volume
-        {{- with .Values.server.persistentVolume.annotations }}
+        {{- with .persistentVolume.annotations }}
         annotations:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{- with .Values.server.persistentVolume.labels }}
+        {{- with .persistentVolume.labels }}
         labels:
           {{- toYaml . | nindent 10 }}
         {{- end }}
       spec:
         accessModes:
-          {{- toYaml .Values.server.persistentVolume.accessModes | nindent 10 }}
+          {{- toYaml .persistentVolume.accessModes | nindent 10 }}
         resources:
           requests:
-            storage: "{{ .Values.server.persistentVolume.size }}"
-      {{- if .Values.server.persistentVolume.storageClass }}
-      {{- if (eq "-" .Values.server.persistentVolume.storageClass) }}
+            storage: "{{ .persistentVolume.size }}"
+      {{- if .persistentVolume.storageClass }}
+      {{- if (eq "-" .persistentVolume.storageClass) }}
         storageClassName: ""
       {{- else }}
-        storageClassName: "{{ .Values.server.persistentVolume.storageClass }}"
+        storageClassName: "{{ .persistentVolume.storageClass }}"
       {{- end }}
       {{- end }}
   {{- else }}
         - name: storage-volume
           emptyDir:
-          {{- if .Values.server.emptyDir.sizeLimit }}
-            sizeLimit: {{ .Values.server.emptyDir.sizeLimit }}
+          {{- if .emptyDir.sizeLimit }}
+            sizeLimit: {{ .emptyDir.sizeLimit }}
           {{- else }}
             {}
           {{- end -}}

--- a/charts/prometheus/templates/server/sts.yaml
+++ b/charts/prometheus/templates/server/sts.yaml
@@ -3,17 +3,17 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-{{- if .Values.server.statefulSet.annotations }}
+  {{- with .Values.server.statefulSet.annotations }}
   annotations:
-    {{ toYaml .Values.server.statefulSet.annotations | nindent 4 }}
-{{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
-    {{- if .Values.server.statefulSet.labels}}
-    {{ toYaml .Values.server.statefulSet.labels | nindent 4 }}
+    {{- with .Values.server.statefulSet.labels }}
+    {{- toYaml . | nindent 4 }}
     {{- end}}
   name: {{ template "prometheus.server.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+  {{- include "prometheus.namespace" . | nindent 2 }}
 spec:
   serviceName: {{ template "prometheus.server.fullname" . }}-headless
   selector:
@@ -23,33 +23,33 @@ spec:
   podManagementPolicy: {{ .Values.server.statefulSet.podManagementPolicy }}
   template:
     metadata:
-    {{- if .Values.server.podAnnotations }}
+      {{- with .Values.server.podAnnotations }}
       annotations:
-        {{ toYaml .Values.server.podAnnotations | nindent 8 }}
-    {{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         {{- include "prometheus.server.labels" . | nindent 8 }}
-        {{- if .Values.server.podLabels}}
-        {{ toYaml .Values.server.podLabels | nindent 8 }}
+        {{- with .Values.server.podLabels }}
+        {{- toYaml . | nindent 8 }}
         {{- end}}
     spec:
-{{- if .Values.server.priorityClassName }}
-      priorityClassName: "{{ .Values.server.priorityClassName }}"
-{{- end }}
-{{- if .Values.server.schedulerName }}
-      schedulerName: "{{ .Values.server.schedulerName }}"
-{{- end }}
-{{- if semverCompare ">=1.13-0" .Capabilities.KubeVersion.GitVersion }}
+      {{- with .Values.server.priorityClassName }}
+      priorityClassName: "{{ . }}"
+      {{- end }}
+      {{- with .Values.server.schedulerName }}
+      schedulerName: "{{ . }}"
+      {{- end }}
+      {{- if semverCompare ">=1.13-0" .Capabilities.KubeVersion.GitVersion }}
       {{- if or (.Values.server.enableServiceLinks) (eq (.Values.server.enableServiceLinks | toString) "<nil>") }}
       enableServiceLinks: true
       {{- else }}
       enableServiceLinks: false
       {{- end }}
-{{- end }}
+      {{- end }}
       serviceAccountName: {{ template "prometheus.serviceAccountName.server" . }}
-      {{- if .Values.server.extraInitContainers }}
+      {{- with .Values.server.extraInitContainers }}
       initContainers:
-{{ toYaml .Values.server.extraInitContainers | indent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         {{- if .Values.configmapReload.prometheus.enabled }}
@@ -73,60 +73,62 @@ spec:
           ports:
             - containerPort: {{ .Values.configmapReload.prometheus.containerPort }}
           {{- end }}
+          {{- with .Values.configmapReload.prometheus.resources }}          
           resources:
-{{ toYaml .Values.configmapReload.prometheus.resources | indent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config
               readOnly: true
-          {{- range .Values.configmapReload.prometheus.extraConfigmapMounts }}
+            {{- range .Values.configmapReload.prometheus.extraConfigmapMounts }}
             - name: {{ $.Values.configmapReload.prometheus.name }}-{{ .name }}
               mountPath: {{ .mountPath }}
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
-          {{- end }}
+            {{- end }}
         {{- end }}
 
         - name: {{ template "prometheus.name" . }}-{{ .Values.server.name }}
           image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
           imagePullPolicy: "{{ .Values.server.image.pullPolicy }}"
-          {{- if .Values.server.env }}
+          {{- with .Values.server.env }}
           env:
-{{ toYaml .Values.server.env | indent 12}}
+            {{- toYaml . | nindent 12}}
           {{- end }}
           args:
-        {{- if .Values.server.defaultFlagsOverride }}
-        {{ toYaml .Values.server.defaultFlagsOverride | nindent 12}}
-        {{- else }}
-          {{- if .Values.server.prefixURL }}
-            - --web.route-prefix={{ .Values.server.prefixURL }}
-          {{- end }}
-          {{- if .Values.server.retention }}
-            - --storage.tsdb.retention.time={{ .Values.server.retention }}
-          {{- end }}
+            {{- with .Values.server.defaultFlagsOverride }}
+            {{- toYaml . | nindent 12}}
+            {{- else }}
+            {{- with .Values.server.prefixURL }}
+            - --web.route-prefix={{ . }}
+            {{- end }}
+            {{- with .Values.server.retention }}
+            - --storage.tsdb.retention.time={{ . }}
+            {{- end }}
             - --config.file={{ .Values.server.configPath }}
-          {{- if .Values.server.storagePath }}
-            - --storage.tsdb.path={{ .Values.server.storagePath }}
-          {{- else }}
+            {{- with .Values.server.storagePath }}
+            - --storage.tsdb.path={{ . }}
+            {{- else }}
             - --storage.tsdb.path={{ .Values.server.persistentVolume.mountPath }}
-          {{- end }}
+            {{- end }}
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
-          {{- range .Values.server.extraFlags }}
+            {{- range .Values.server.extraFlags }}
             - --{{ . }}
-          {{- end }}
-          {{- range $key, $value := .Values.server.extraArgs }}
+            {{- end }}
+            {{- range $key, $value := .Values.server.extraArgs }}
             - --{{ $key }}={{ $value }}
-          {{- end }}
-          {{- if .Values.server.baseURL }}
-            - --web.external-url={{ .Values.server.baseURL }}
-          {{- end }}
+            {{- end }}
+            {{- with .Values.server.baseURL }}
+            - --web.external-url={{ . }}
+            {{- end }}
         {{- end }}
           ports:
             - containerPort: 9090
-          {{- if .Values.server.hostPort }}
-              hostPort: {{ .Values.server.hostPort }}
-          {{- end }}
+              {{- with .Values.server.hostPort }}
+              hostPort: {{ . }}
+              {{- end }}
           readinessProbe:
             {{- if not .Values.server.tcpSocketProbeEnabled }}
             httpGet:
@@ -135,7 +137,7 @@ spec:
               scheme: {{ .Values.server.probeScheme }}
               {{- with .Values.server.probeHeaders }}
               httpHeaders:
-{{- toYaml . | nindent 14 }}
+                {{- toYaml . | nindent 16 }}
               {{- end }}
             {{- else }}
             tcpSocket:
@@ -154,7 +156,7 @@ spec:
               scheme: {{ .Values.server.probeScheme }}
               {{- with .Values.server.probeHeaders }}
               httpHeaders:
-{{- toYaml . | nindent 14 }}
+                {{- toYaml . | nindent 16 }}
               {{- end }}
             {{- else }}
             tcpSocket:
@@ -174,10 +176,10 @@ spec:
               scheme: {{ .Values.server.probeScheme }}
               {{- if .Values.server.probeHeaders }}
               httpHeaders:
-              {{- range .Values.server.probeHeaders}}
-              - name: {{ .name }}
-                value: {{ .value }}
-              {{- end }}
+                {{- range .Values.server.probeHeaders}}
+                - name: {{ .name }}
+                  value: {{ .value }}
+                {{- end }}
               {{- end }}
             {{- else }}
             tcpSocket:
@@ -187,81 +189,83 @@ spec:
             periodSeconds: {{ .Values.server.startupProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.server.startupProbe.timeoutSeconds }}
           {{- end }}
+          {{- with .Values.server.resources }}
           resources:
-{{ toYaml .Values.server.resources | indent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config
             - name: storage-volume
               mountPath: {{ .Values.server.persistentVolume.mountPath }}
               subPath: "{{ .Values.server.persistentVolume.subPath }}"
-          {{- range .Values.server.extraHostPathMounts }}
+            {{- range .Values.server.extraHostPathMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
-          {{- end }}
-          {{- range .Values.server.extraConfigmapMounts }}
+            {{- end }}
+            {{- range .Values.server.extraConfigmapMounts }}
             - name: {{ $.Values.server.name }}-{{ .name }}
               mountPath: {{ .mountPath }}
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
-          {{- end }}
-          {{- range .Values.server.extraSecretMounts }}
+            {{- end }}
+            {{- range .Values.server.extraSecretMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
-          {{- end }}
-          {{- if .Values.server.extraVolumeMounts }}
-          {{ toYaml .Values.server.extraVolumeMounts | nindent 12 }}
-          {{- end }}
+            {{- end }}
+            {{- with .Values.server.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.server.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-    {{- if .Values.server.sidecarContainers }}
-      {{- range $name, $spec :=  .Values.server.sidecarContainers }}
+        {{- if .Values.server.sidecarContainers }}
+        {{- range $name, $spec :=  .Values.server.sidecarContainers }}
         - name: {{ $name }}
           {{- if kindIs "string" $spec }}
             {{- tpl $spec $ | nindent 10 }}
           {{- else }}
             {{- toYaml $spec | nindent 10 }}
           {{- end }}
-      {{- end }}
-    {{- end }}
+        {{- end }}
+        {{- end }}
       hostNetwork: {{ .Values.server.hostNetwork }}
-    {{- if .Values.server.dnsPolicy }}
-      dnsPolicy: {{ .Values.server.dnsPolicy }}
-    {{- end }}
-    {{- if .Values.imagePullSecrets }}
+      {{- with .Values.server.dnsPolicy }}
+      dnsPolicy: {{ . }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-{{ toYaml .Values.imagePullSecrets | indent 8 }}
-    {{- end }}
-    {{- if .Values.server.nodeSelector }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.server.nodeSelector | indent 8 }}
-    {{- end }}
-    {{- if .Values.server.hostAliases }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.hostAliases }}
       hostAliases:
-{{ toYaml .Values.server.hostAliases | indent 8 }}
-    {{- end }}
-    {{- if .Values.server.dnsConfig }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.dnsConfig }}
       dnsConfig:
-{{ toYaml .Values.server.dnsConfig | indent 8 }}
-    {{- end }}
-    {{- with .Values.server.securityContext }}
+        {{- toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.server.securityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- if .Values.server.tolerations }}
+      {{- end }}
+      {{- with .Values.server.tolerations }}
       tolerations:
-{{ toYaml .Values.server.tolerations | indent 8 }}
-    {{- end }}
-    {{- if .Values.server.affinity }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.affinity }}
       affinity:
-{{ toYaml .Values.server.affinity | indent 8 }}
-    {{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.server.terminationGracePeriodSeconds }}
       volumes:
         - name: config-volume
@@ -272,55 +276,55 @@ spec:
           secret:
             secretName: {{ .Values.server.configFromSecret }}
         {{- end }}
-      {{- range .Values.server.extraHostPathMounts }}
+        {{- range .Values.server.extraHostPathMounts }}
         - name: {{ .name }}
           hostPath:
             path: {{ .hostPath }}
-      {{- end }}
-      {{- range .Values.configmapReload.prometheus.extraConfigmapMounts }}
+        {{- end }}
+        {{- range .Values.configmapReload.prometheus.extraConfigmapMounts }}
         - name: {{ $.Values.configmapReload.prometheus.name }}-{{ .name }}
           configMap:
             name: {{ .configMap }}
-      {{- end }}
-      {{- range .Values.server.extraConfigmapMounts }}
+        {{- end }}
+        {{- range .Values.server.extraConfigmapMounts }}
         - name: {{ $.Values.server.name }}-{{ .name }}
           configMap:
             name: {{ .configMap }}
-      {{- end }}
-      {{- range .Values.server.extraSecretMounts }}
+        {{- end }}
+        {{- range .Values.server.extraSecretMounts }}
         - name: {{ .name }}
           secret:
             secretName: {{ .secretName }}
             {{- with .optional }}
             optional: {{ . }}
             {{- end }}
-      {{- end }}
-      {{- range .Values.configmapReload.prometheus.extraConfigmapMounts }}
+        {{- end }}
+        {{- range .Values.configmapReload.prometheus.extraConfigmapMounts }}
         - name: {{ .name }}
           configMap:
             name: {{ .configMap }}
             {{- with .optional }}
             optional: {{ . }}
             {{- end }}
-      {{- end }}
-{{- if .Values.server.extraVolumes }}
-{{ toYaml .Values.server.extraVolumes | indent 8}}
-{{- end }}
-{{- if .Values.server.persistentVolume.enabled }}
+        {{- end }}
+        {{- with .Values.server.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+  {{- if .Values.server.persistentVolume.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: storage-volume
-        {{- if .Values.server.persistentVolume.annotations }}
+        {{- with .Values.server.persistentVolume.annotations }}
         annotations:
-{{ toYaml .Values.server.persistentVolume.annotations | indent 10 }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{- if .Values.server.persistentVolume.labels }}
+        {{- with .Values.server.persistentVolume.labels }}
         labels:
-{{ toYaml .Values.server.persistentVolume.labels | indent 10 }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
       spec:
         accessModes:
-{{ toYaml .Values.server.persistentVolume.accessModes | indent 10 }}
+          {{- toYaml .Values.server.persistentVolume.accessModes | nindent 10 }}
         resources:
           requests:
             storage: "{{ .Values.server.persistentVolume.size }}"
@@ -331,7 +335,7 @@ spec:
         storageClassName: "{{ .Values.server.persistentVolume.storageClass }}"
       {{- end }}
       {{- end }}
-{{- else }}
+  {{- else }}
         - name: storage-volume
           emptyDir:
           {{- if .Values.server.emptyDir.sizeLimit }}
@@ -339,6 +343,6 @@ spec:
           {{- else }}
             {}
           {{- end -}}
-{{- end }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/prometheus/templates/server/vpa.yaml
+++ b/charts/prometheus/templates/server/vpa.yaml
@@ -1,24 +1,26 @@
-{{- with .Values.server }}
-{{- if and .enabled .verticalAutoscaler.enabled -}}
+{{- if and .Values.server.enabled .Values.server.verticalAutoscaler.enabled -}}
+{{- with .Values.server.verticalAutoscaler }}
 apiVersion: autoscaling.k8s.io/v1beta2
 kind: VerticalPodAutoscaler
 metadata:
   labels:
-    {{- include "prometheus.server.labels" . | nindent 4 }}
-  name: {{ template "prometheus.server.fullname" . }}-vpa
-  {{- include "prometheus.namespace" . | nindent 2 }}
+    {{- include "prometheus.server.labels" $ | nindent 4 }}
+  name: {{ template "prometheus.server.fullname" $ }}-vpa
+  {{- include "prometheus.namespace" $ | nindent 2 }}
 spec:
   targetRef:
     apiVersion: "apps/v1"
-    {{- if .statefulSet.enabled }}
+    {{- with $.Values.server.statefulSet.enabled }}
     kind: StatefulSet
     {{- else }}
     kind: Deployment
     {{- end }}
-    name: {{ template "prometheus.server.fullname" . }}
+    name: {{ template "prometheus.server.fullname" $ }}
   updatePolicy:
-    updateMode: {{ .verticalAutoscaler.updateMode | default "Off" | quote }}
+    updateMode: {{ .updateMode | default "Off" | quote }}
+  {{- with .containerPolicies }}
   resourcePolicy:
-    containerPolicies: {{ .verticalAutoscaler.containerPolicies | default list | toYaml | trim | nindent 4 }}
+    containerPolicies: {{ . | default list | toYaml | trim | nindent 4 }}
+  {{- end }}
 {{- end -}}
 {{- end -}}

--- a/charts/prometheus/templates/server/vpa.yaml
+++ b/charts/prometheus/templates/server/vpa.yaml
@@ -1,24 +1,24 @@
-{{- if .Values.server.enabled -}}
-{{- if .Values.server.verticalAutoscaler.enabled -}}
+{{- with .Values.server }}
+{{- if and .enabled .verticalAutoscaler.enabled -}}
 apiVersion: autoscaling.k8s.io/v1beta2
 kind: VerticalPodAutoscaler
 metadata:
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
   name: {{ template "prometheus.server.fullname" . }}-vpa
-{{ include "prometheus.namespace" . | indent 2 }}
+  {{- include "prometheus.namespace" . | nindent 2 }}
 spec:
   targetRef:
     apiVersion: "apps/v1"
-{{- if .Values.server.statefulSet.enabled }}
+    {{- if .statefulSet.enabled }}
     kind: StatefulSet
-{{- else }}
+    {{- else }}
     kind: Deployment
-{{- end }}
+    {{- end }}
     name: {{ template "prometheus.server.fullname" . }}
   updatePolicy:
-    updateMode: {{ .Values.server.verticalAutoscaler.updateMode | default "Off" | quote }}
+    updateMode: {{ .verticalAutoscaler.updateMode | default "Off" | quote }}
   resourcePolicy:
-    containerPolicies: {{ .Values.server.verticalAutoscaler.containerPolicies | default list | toYaml | trim | nindent 4 }}
-{{- end -}} {{/* if .Values.server.verticalAutoscaler.enabled */}}
-{{- end -}} {{/* .Values.server.enabled */}}
+    containerPolicies: {{ .verticalAutoscaler.containerPolicies | default list | toYaml | trim | nindent 4 }}
+{{- end -}}
+{{- end -}}

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -1331,6 +1331,10 @@ pushgateway:
     #     value: "2"
   #   - name: edns0
 
+  ## Non-persist volume resource limit
+  emptyDir:
+    sizeLimit: ""
+
   ## Security context to be added to push-gateway pods
   ##
   securityContext:


### PR DESCRIPTION
#### What this PR does / why we need it

Major refactoring several syntax and fixing mis-alignment across chart components

#### Which issue this PR fixes

- Empty values (e.g. `[]`, `{}`) shall omit.
```
# from
{{- if .resources }}
resources:
  {{- toYaml .resource | nindent 2 }}
{{- end }}
# to
{{- with .resources }}
resources:
  {{- toYaml . | nindent 2 }}
{{- end }}
```
- Misuse truncate empty spaces + indention.
```
# from
metadata:
  ...
  name: foo
{{ include "foo.namespace" $ | indent 2 }}
...
# to
metadata:
  ...
  name: foo
  {{- include "foo.namespace" $ | nindent 2 }}
...
```
- Use scope. Note that we have to change all `include` and `template` as root based (`.` -> `$`).
```
# from
apiVersion: v1
kind: Service
metadata:
{{- if .Values.foo.a.super.super.long.miles.away.annotations }}
  annotations:
{{ toYaml .Values.foo.a.super.super.long.miles.away.annotations | indent 4 }}
{{- end }}
  labels:
    {{- include "foo.labels" . | nindent 4 }}
{{- if .Values.foo.a.super.super.long.miles.away.labels }}
{{ toYaml .Values.foo.a.super.super.long.miles.away.labels | indent 4 }}
{{- end }}
  name: {{ template "foo.fullname" . }}-headless
{{ include "foo.namespace" . | indent 2 }}
spec:
  clusterIP: None
  ports:
    - name: http
      port: {{ .Values.foo.a.super.super.long.miles.away.servicePort }}
      protocol: TCP
      targetPort: 9093
{{- if .Values.foo.a.super.super.long.miles.away.enableMeshPeer }}
    - name: meshpeer
      port: 6783
      protocol: TCP
      targetPort: 6783
{{- end }}
  selector:
    {{- include "foo.matchLabels" . | nindent 4 }}
{{- end }}

# to
{{- with .Values.foo.a.super.super.long.miles.away }}
apiVersion: v1
kind: Service
metadata:
  {{- with .annotations }}
  annotations:
    {{ toYaml . | nindent 4 }}
  {{- end }}
  labels:
    {{- include "foo.labels" $ | nindent 4 }}
    {{- with .labels }}
    {{- toYaml . | nindent 4 }}
    {{- end }}
  name: {{ template "foo.fullname" $ }}-headless
  {{- include "foo.namespace" $ | indent 2 }}
spec:
  clusterIP: None
  ports:
    - name: http
      port: {{ .servicePort }}
      protocol: TCP
      targetPort: 9093
    {{- if .enableMeshPeer }}
    - name: meshpeer
      port: 6783
      protocol: TCP
      targetPort: 6783
    {{- end }}
  selector:
    {{- include "foo.matchLabels" $ | nindent 4 }}
{{- end }}
{{- end }}
```
- Flipping unnecessary condition `if` statement.
```
# from
{{- if (not condition) }}
statement_0
{{- else }}
statement_1

# to
{{- if condition }}
statement_1
{{- else }}
statement_0
```
- Adapt [k8s default labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/).

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name