### PR TITLE
[prometheus-snmp-exporter] Action name in relabelings

### DIFF
--- a/charts/prometheus-snmp-exporter/Chart.yaml
+++ b/charts/prometheus-snmp-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus SNMP Exporter
 name: prometheus-snmp-exporter
-version: 1.2.1
+version: 1.2.2
 appVersion: 0.19.0
 home: https://github.com/prometheus/snmp_exporter
 sources:

--- a/charts/prometheus-snmp-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-snmp-exporter/templates/servicemonitor.yaml
@@ -27,10 +27,12 @@ spec:
       target:
       - {{ .target }}
     metricRelabelings:
-      - sourceLabels: [instance]
+      - action: replace
+        sourceLabels: [instance]
         targetLabel: instance
         replacement: {{ .target }}
-      - sourceLabels: [target]
+      - action: replace
+        sourceLabels: [target]
         targetLabel: target
         replacement: {{ .name }}
         {{- range $targetLabel, $replacement := .additionalMetricsRelabels | default $.Values.serviceMonitor.additionalMetricsRelabels }}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

If i send this configuration to my cluster (with Prom Operator deployed),

```yaml
  serviceMonitor:
    scrapeTimeout: 30s
    interval: 60s
    params:
      - name: nas
        target: 192.168.0.100
        module:
          # - if_mib
          - synology
        labels:
          monitoring: portefaix
```

the ServiceMonitor object seems changed in Kubernetes:

```yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: snmp-exporter-prometheus-snmp-exporter-nas
  namespace: monitoring
spec:
  endpoints:
  - honorLabels: true
    interval: 60s
    metricRelabelings:
    - action: replace
      replacement: 192.168.0.100
      sourceLabels:
      - instance
      targetLabel: instance
    - action: replace
      replacement: nas
      sourceLabels:
      - target
      targetLabel: target
    params:
      module:
      - synology
      target:
      - 192.168.0.100
    path: /snmp
    port: http
    scrapeTimeout: 30s
  jobLabel: snmp-exporter
  selector:
    matchLabels:
      app.kubernetes.io/instance: snmp-exporter
      app.kubernetes.io/name: prometheus-snmp-exporter
```

![2022-11-02_19-17](https://user-images.githubusercontent.com/29233/199571180-a95ea5cb-d830-448e-852d-3d24b98c6c16.png)


#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
