### PR TITLE
[prometheus-mysql-exporter] Support Workload Identity

### DIFF
--- a/charts/prometheus-mysql-exporter/Chart.yaml
+++ b/charts/prometheus-mysql-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for prometheus mysql exporter with cloudsqlproxy
 name: prometheus-mysql-exporter
-version: 1.9.1
+version: 1.10.0
 home: https://github.com/prometheus/mysqld_exporter
 appVersion: v0.14.0
 sources:

--- a/charts/prometheus-mysql-exporter/README.md
+++ b/charts/prometheus-mysql-exporter/README.md
@@ -77,3 +77,8 @@ A mysql params overview can be found here: (<https://github.com/go-sql-driver/my
 ### Collector Flags
 
 Available collector flags can be found in the [values.yaml](https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus-mysql-exporter/values.yaml) and a description of each flag can be found in the [mysqld_exporter](https://github.com/prometheus/mysqld_exporter#collector-flags) repository.
+
+### CloudSql Proxy Workload Identity
+
+Enable it with flag  [`cloudsqlproxy.workloadIdentity`](https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus-mysql-exporter/values.yaml)
+To more details about Workload Identity visit [Use Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)

--- a/charts/prometheus-mysql-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-mysql-exporter/templates/_helpers.tpl
@@ -30,6 +30,7 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "prometheus-mysql-exporter.serviceAccountName" -}}
@@ -75,5 +76,15 @@ Secret name for DATA_SOURCE_NAME
         {{- printf "%s" .Values.mysql.existingSecret -}}
     {{- else -}}
         {{ template "prometheus-mysql-exporter.fullname" . }}
+    {{- end -}}
+{{- end -}}
+*/}}
+
+{{/*
+CloudSqlProxy Workload Identity Service Account Annotation
+*/}}
+{{- define "prometheus-mysql-exporter.workloadIdentityAnnotation" -}}
+    {{- if .Values.cloudsqlproxy.workloadIdentity.enabled -}}
+         {{- printf "%s: %s" "iam.gke.io/gcp-service-account" .Values.cloudsqlproxy.workloadIdentity.serviceAccountEmail -}}
     {{- end -}}
 {{- end -}}

--- a/charts/prometheus-mysql-exporter/templates/deployment.yaml
+++ b/charts/prometheus-mysql-exporter/templates/deployment.yaml
@@ -92,19 +92,24 @@ spec:
         - name: cloudsql-proxy
           image: "{{ .Values.cloudsqlproxy.image.repo }}:{{ .Values.cloudsqlproxy.image.tag }}"
           imagePullPolicy: "{{ .Values.cloudsqlproxy.image.PullPolicy  }}"
-          command: ["/cloud_sql_proxy",
-                    "-instances={{ .Values.cloudsqlproxy.instanceConnectionName }}=tcp:{{ .Values.cloudsqlproxy.port }}",
+          command: ["/cloud_sql_proxy"
+                    ,"-instances={{ .Values.cloudsqlproxy.instanceConnectionName }}=tcp:{{ .Values.cloudsqlproxy.port }}"
                     {{- if .Values.cloudsqlproxy.ipAddressTypes }}
-                    "-ip_address_types={{ .Values.cloudsqlproxy.ipAddressTypes }}",
+                    ,"-ip_address_types={{ .Values.cloudsqlproxy.ipAddressTypes }}"
                     {{- end }}
-                    "-credential_file=/secrets/cloudsql/credentials.json"]
+                    {{- if not .Values.cloudsqlproxy.workloadIdentity.enabled }}
+                    ,"-credential_file=/secrets/cloudsql/credentials.json"
+                    {{- end }}
+                    ]
           livenessProbe:
             exec:
               command: ["nc", "-z", "127.0.0.1", "3306"]
+          {{- if not .Values.cloudsqlproxy.workloadIdentity.enabled }}
           volumeMounts:
             - name: cloudsql-proxy-sa-credentials
               mountPath: /secrets/cloudsql
               readOnly: true
+          {{- end }}
         {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
@@ -120,7 +125,7 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- if .Values.cloudsqlproxy.enabled }}
+    {{- if and (.Values.cloudsqlproxy.enabled) (not .Values.cloudsqlproxy.workloadIdentity.enabled) }}
       volumes:
         - name: cloudsql-proxy-sa-credentials
           secret:

--- a/charts/prometheus-mysql-exporter/templates/secret.yaml
+++ b/charts/prometheus-mysql-exporter/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if and ( .Values.cloudsqlproxy.enabled ) ( not .Values.cloudsqlproxy.credentialsSecret ) }}
+{{- if and ( .Values.cloudsqlproxy.enabled ) ( not .Values.cloudsqlproxy.credentialsSecret ) ( not .Values.cloudsqlproxy.workloadIdentity.enabled ) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/prometheus-mysql-exporter/templates/service.yaml
+++ b/charts/prometheus-mysql-exporter/templates/service.yaml
@@ -20,4 +20,3 @@ spec:
       name: {{ .Values.service.name }}
   selector:
     {{- include "prometheus-mysql-exporter.selectorLabels" . | nindent 4 }}
-

--- a/charts/prometheus-mysql-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-mysql-exporter/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if or ( .Values.serviceAccount.create ) ( .Values.cloudsqlproxy.workloadIdentity.enabled ) -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -8,8 +8,11 @@ metadata:
     chart: {{ template "prometheus-mysql-exporter.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  {{- with .Values.serviceAccount.annotations }}
   annotations:
+  {{- with .Values.serviceAccount.annotations  }}
     {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if .Values.cloudsqlproxy.workloadIdentity.enabled }}
+    {{ include "prometheus-mysql-exporter.workloadIdentityAnnotation" . }}
   {{- end }}
 {{- end -}}

--- a/charts/prometheus-mysql-exporter/values.yaml
+++ b/charts/prometheus-mysql-exporter/values.yaml
@@ -141,7 +141,7 @@ cloudsqlproxy:
   enabled: false
   image:
     repo: "gcr.io/cloudsql-docker/gce-proxy"
-    tag: "1.30.1-alpine"
+    tag: "1.33.0-alpine"
     pullPolicy: "IfNotPresent"
   instanceConnectionName: "project:us-central1:dbname"
   ipAddressTypes: ""
@@ -149,3 +149,6 @@ cloudsqlproxy:
   credentialsSecret: ""
   # service account json
   credentials: ""
+  workloadIdentity:
+    enabled: false
+    serviceAccountEmail: ""


### PR DESCRIPTION
#### What this PR does / why we need it

This PR enables support for [Workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) for cloudsqlproxy, Adding the parameters for workload identity
```
cloudsqlproxy:
  workloadIdentity: 
    enabled: false
    serviceAccountEmail: ""
```
When workload identity is enabled, you should provide a google service account email.

#### Which issue this PR fixes
No issue

#### Special notes for your reviewer
Also updated the cloudsql proxy image

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
