### PR TITLE
[ALL CHARTS] Fix version regex for cosign and annotate

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,9 +62,9 @@ jobs:
               break
             fi
             helm push "${pkg}" oci://ghcr.io/"${GITHUB_REPOSITORY_OWNER}"/charts
-            file=${pkg##*/}
-            name=${file%-*}
-            version=${file%.*}
-            version=${version#*-}
+            file=${pkg##*/}       # extracts file name from full directory path
+            name=${file%-*}       # extracts chart name from filename
+            noext=${file%.tgz}    # extracts string (NAME-1.2.3) without extension to get version below
+            version=${noext##*-}  # extracts version
             cosign sign ghcr.io/"${GITHUB_REPOSITORY_OWNER}"/charts/"${name}":"${version}"
           done


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

I made a regex mistake in #2631. The result is that charts with names containing dashes do not get added to the transparency log with cosign. Here is an example of the failed GH action run, before it was re-run (it would not fail on re-run because chart release has already released, so it will stop at "nothing to do") https://github.com/prometheus-community/helm-charts/actions/runs/3423809885/jobs/5702815968.

#### Notes for reviewers

You can simulate the regex fix locally:

```console
$ helm pull prometheus-community/kube-prometheus-stack
$ mkdir .cr-release-packages && mv kube-prometheus-stack-41.7.3.tgz .cr-release-packages/
$ pkg=.cr-release-packages/kube-prometheus-stack-41.7.3.tgz
$ file=${pkg##*/} && echo $file
kube-prometheus-stack-41.7.3.tgz
$ name=${file%-*} && echo $name
kube-prometheus-stack
$ noext=${file%.tgz} && echo $noext
kube-prometheus-stack-41.7.3
$ version=${noext##*-} && echo $version
41.7.3
```

whereas `$version` before this fix looked like `prometheus-stack-41.7.3`. See the linked failed action above to see an example:

> Error: signing [ghcr.io/prometheus-community/charts/prometheus-redis-exporter:redis-exporter-5.3.0]: accessing entity: entity not found in registry
> main.go:62: error during command execution: signing [ghcr.io/prometheus-community/charts/prometheus-redis-exporter:redis-exporter-5.3.0]: accessing entity: entity not found in registry
> Error: Process completed with exit code 1.

in this case because the tag was `redis-exporter-5.3.0` rather than `5.3.0`.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- ~~[ ] Chart Version bumped~~
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
