### PR TITLE
[prometheus-elasticsearch-exporter] Refactor securityContext configuration

### DIFF
--- a/charts/prometheus-elasticsearch-exporter/Chart.yaml
+++ b/charts/prometheus-elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: prometheus-elasticsearch-exporter
-version: 4.15.1
+version: 5.0.0
 kubeVersion: ">=1.10.0-0"
 appVersion: 1.5.0
 home: https://github.com/prometheus-community/elasticsearch_exporter

--- a/charts/prometheus-elasticsearch-exporter/README.md
+++ b/charts/prometheus-elasticsearch-exporter/README.md
@@ -59,6 +59,18 @@ $ helm upgrade [RELEASE_NAME] [CHART] --install
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
+### To 5.0.0
+
+`securityContext` has been renamed to `podSecurityContext` and `securityContext.enabled` has no effect anymore. To mirror the behaviour of `securityContext.enabled=false` of 4.x unset `podSecurityContext`.
+
+```
+helm install --set podSecurityContext=null my-exporter stable/elasticsearch-exporter
+```
+
+In 5.0.0 `securityContext` refers to the container's securityContext instead which was not configurable in earlier versions. The naming is aligned with the base charts created by Helm.
+
+Default values for `podSecurityContext` and `securityContext` have been updated to be compatible with the Pod Security Standard level "restricted". Most notably `seccompProfile.type` is set to `RuntimeDefault`.
+
 ### To 4.0.0
 
 While migrating the chart from `stable/elasticsearch-exporter` it was renamed to `prometheus-elasticsearch-exporter`.

--- a/charts/prometheus-elasticsearch-exporter/README.md
+++ b/charts/prometheus-elasticsearch-exporter/README.md
@@ -18,7 +18,7 @@ helm repo add prometheus-community https://prometheus-community.github.io/helm-c
 helm repo update
 ```
 
-_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
+_See the [command documentation](https://helm.sh/docs/helm/helm_repo/) for `helm repo` for more information._
 
 ## Install Chart
 

--- a/charts/prometheus-elasticsearch-exporter/README.md
+++ b/charts/prometheus-elasticsearch-exporter/README.md
@@ -11,16 +11,16 @@ cluster using the [Helm](https://helm.sh) package manager.
 
 - Kubernetes 1.10+
 
-## Get Repository Info
+## Get Helm Repository Info
 
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update
 ```
 
-_See the [command documentation](https://helm.sh/docs/helm/helm_repo/) for `helm repo` for more information._
+_See [`helm repo`](https://helm.sh/docs/helm/helm_repo/) for command documentation._
 
-## Install Chart
+## Install Helm Chart
 
 ```console
 # Helm 3
@@ -36,7 +36,7 @@ _See [configuration](#configuration) below._
 
 _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
 
-## Uninstall Chart
+## Uninstall Helm Chart
 
 ```console
 # Helm 3
@@ -50,7 +50,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 
 _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
 
-## Upgrading Chart
+## Upgrading Helm Chart
 
 ```console
 # Helm 3 or 2

--- a/charts/prometheus-elasticsearch-exporter/README.md
+++ b/charts/prometheus-elasticsearch-exporter/README.md
@@ -11,7 +11,7 @@ cluster using the [Helm](https://helm.sh) package manager.
 
 - Kubernetes 1.10+
 
-## Get Repo Info
+## Get Repository Info
 
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
@@ -63,7 +63,7 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 
 `securityContext` has been renamed to `podSecurityContext` and `securityContext.enabled` has no effect anymore. To mirror the behaviour of `securityContext.enabled=false` of 4.x unset `podSecurityContext`.
 
-```
+```console
 helm install --set podSecurityContext=null my-exporter stable/elasticsearch-exporter
 ```
 
@@ -92,7 +92,7 @@ You now need to escape the rules (see `values.yaml`) for examples.
 
 ### To 2.0.0
 
-Some Kubernetes apis used from 1.x have been deprecated. You need to update your cluster to Kubernetes 1.10+ to support new definitions used in 2.x.
+Some Kubernetes APIs used from 1.x have been deprecated. You need to update your cluster to Kubernetes 1.10+ to support new definitions used in 2.x.
 
 ## Configuration
 

--- a/charts/prometheus-elasticsearch-exporter/ci/security-context.yaml
+++ b/charts/prometheus-elasticsearch-exporter/ci/security-context.yaml
@@ -1,5 +1,5 @@
 ---
-# Set default security context for kubernetes
+# Set default security context for Openshift
 
-securityContext:
-  disable: true
+podSecurityContext:
+  runAsUser: null

--- a/charts/prometheus-elasticsearch-exporter/ci/security-context.yaml
+++ b/charts/prometheus-elasticsearch-exporter/ci/security-context.yaml
@@ -1,5 +1,4 @@
 ---
-# Set default security context for Openshift
+# Unset pod level securityContext
 
-podSecurityContext:
-  runAsUser: null
+podSecurityContext: null

--- a/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
+++ b/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
@@ -48,10 +48,9 @@ spec:
 {{- end }}
       {{- include "elasticsearch-exporter.image.pullSecret.name" (dict "images" (list .Values.image) "context" $) | nindent 6 }}
       restartPolicy: {{ .Values.restartPolicy }}
-      {{- if .Values.securityContext.enabled }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        runAsNonRoot: true
-        runAsUser: {{ .Values.securityContext.runAsUser }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.dnsConfig }}
       dnsConfig:
@@ -125,24 +124,10 @@ spec:
                     {{- end }}
                     "--web.listen-address=:{{ .Values.service.httpPort }}",
                     "--web.telemetry-path={{ .Values.web.path }}"]
+          {{- with .Values.securityContext }}
           securityContext:
-            capabilities:
-              drop:
-                - SETPCAP
-                - MKNOD
-                - AUDIT_WRITE
-                - CHOWN
-                - NET_RAW
-                - DAC_OVERRIDE
-                - FOWNER
-                - FSETID
-                - KILL
-                - SETGID
-                - SETUID
-                - NET_BIND_SERVICE
-                - SYS_CHROOT
-                - SETFCAP
-            readOnlyRootFilesystem: true
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/prometheus-elasticsearch-exporter/values.yaml
+++ b/charts/prometheus-elasticsearch-exporter/values.yaml
@@ -18,19 +18,12 @@ image:
   pullPolicy: IfNotPresent
   pullSecret: ""
 
-## Set to `null` to keep pod level securityContext unspecified
-#podSecurityContext: null
 podSecurityContext:
   runAsNonRoot: true
-  ## Openshift won't deploy with runAsUser: 1000 without additional permissions.
-  ## Remove the field by setting it to `null`:
-  #runAsUser: null
   runAsUser: 1000
   seccompProfile:
     type: "RuntimeDefault"
 
-## Set to `null` to keep container level securityContext unspecified
-#securityContext: null
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/charts/prometheus-elasticsearch-exporter/values.yaml
+++ b/charts/prometheus-elasticsearch-exporter/values.yaml
@@ -18,13 +18,25 @@ image:
   pullPolicy: IfNotPresent
   pullSecret: ""
 
-## Set enabled to false if you don't want securityContext
-## in your Deployment.
-## The below values are the default for kubernetes.
-## Openshift won't deploy with runAsUser: 1000 without additional permissions.
-securityContext:
-  enabled: true  # Should be set to false when running on OpenShift
+## Set to `null` to keep pod level securityContext unspecified
+#podSecurityContext: null
+podSecurityContext:
+  runAsNonRoot: true
+  ## Openshift won't deploy with runAsUser: 1000 without additional permissions.
+  ## Remove the field by setting it to `null`:
+  #runAsUser: null
   runAsUser: 1000
+  seccompProfile:
+    type: "RuntimeDefault"
+
+## Set to `null` to keep container level securityContext unspecified
+#securityContext: null
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
 
 # Custom DNS configuration to be added to prometheus-elasticsearch-exporter pods
 dnsConfig: {}


### PR DESCRIPTION
#### What this PR does / why we need it
To allow the use of configuration conforming to the Pod Security Standard level "restricted" it is necessary to be able to adapt the securityContext on pod and container level. Since the implementation up to now is not very flexible and a bit misleading (securityContext.enabled only affects the pod level securityContext) the approach taken is to align it with the way of charts created by `helm create` implement this. 

#### Which issue this PR fixes

- fixes #2617
- fixes #2494 

#### Special notes for your reviewer
Unfortunately aligning it with the behaviour of other charts implies a breaking change as "securityContext" of 4.x is renamed to "podSecurityContext" and "securityContext" is used for the container level "securityContext" going forward. "securityContext.enabled" is removed altogether. To remove the configuration from the pod users should set `podSecurityContext: null` instead. Additionally it is now possible to also remove the container level configuration by setting `securityContext: null`.

Last but not least `seccompProfile` and `allowPrivilegeEscalation` settings were added to the default configuration and all capabilities are dropped to comply with the PSS level `restricted` without further intervention.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
