### PR TITLE
change default strategy to recreate for alertmanager and server

### DIFF
--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -157,8 +157,8 @@ alertmanager:
     #       - alertmanager.domain.com
 
   ## Alertmanager Deployment Strategy type
-  # strategy:
-  #   type: Recreate
+  strategy:
+    type: Recreate
 
   ## Node tolerations for alertmanager scheduling to nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -1011,8 +1011,8 @@ server:
     #       - prometheus.domain.com
 
   ## Server Deployment Strategy type
-  # strategy:
-  #   type: Recreate
+  strategy:
+    type: Recreate
 
   ## hostAliases allows adding entries to /etc/hosts inside the containers
   hostAliases: []


### PR DESCRIPTION
Signed-off-by: mcallaghan-geotab <78922178+mcallaghan-geotab@users.noreply.github.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

By default both `prometheus-alertmanager` and `prometheus-server` are using persistent volumes, therefore we would want the default deployment strategy to be `Recreate` rather than `RollingUpdate`.

See https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy

The problem with PVC (persistent volumes) and using rolling update, is that during a deployment upgrade (`helm upgrade ...`) when new pods come online they cannot claim the mount because the previous/existing (older) pod is holding the claim.

To be honest, I'm not sure why the prometheus stack/chart has been this way for so long? (anyone attempting to upgrade the stack over time while using persistent volumes would run into this problem)

The WORKAROUND (fwiw), without this fix, is to run the `helm upgrade ...` command, and then scale the deployment down to `0` and back up to `1`.

FIRST INTENT:  is to propose the idea (if maintainers agree) - then we can bump chart version, update docs if needed, etc.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #421


#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
