### PR TITLE
[jiralert] Standardize labels

### DIFF
--- a/charts/jiralert/Chart.yaml
+++ b/charts/jiralert/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jiralert
 description: A Helm chart for Kubernetes to install jiralert
 type: application
-version: 0.2.0
+version: 1.0.0
 appVersion: "1.2"
 home: "https://github.com/prometheus-community/jiralert"
 keywords:

--- a/charts/jiralert/templates/_helpers.tpl
+++ b/charts/jiralert/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Expand the name of the chart.
 */}}
 {{- define "jiralert.name" -}}
-{{- default .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end }}
 
 {{/*
@@ -33,23 +33,30 @@ Create chart name and version as used by the chart label.
 {{/*
 Common labels
 */}}
-{{- define "jiralert.labels" -}}
-helm.sh/chart: {{ include "jiralert.chart" . }}
-{{ include "jiralert.selectorLabels" . }}
+{{- define "jiralert.labels" }}
+helm.sh/chart: {{ template "jiralert.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: metrics
+app.kubernetes.io/part-of: {{ template "jiralert.name" . }}
+{{- include "jiralert.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels }}
+{{- end }}
+{{- if .Values.releaseLabel }}
+release: {{ .Release.Name }}
+{{- end }}
 {{- end }}
 
 {{/*
 Selector labels
 */}}
-{{- define "jiralert.selectorLabels" -}}
+{{- define "jiralert.selectorLabels" }}
 app.kubernetes.io/name: {{ include "jiralert.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
-
 
 {{/*
 Create the name of the service account to use


### PR DESCRIPTION
Signed-off-by: Jan-Otto Kröpke <jok@cloudeteer.de>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Standardized Kubernetes labels on all objects. initially copied from kube-state-metrics.

#### Which issue this PR fixes

#### Special notes for your reviewer

Since the template jiralert.name has been changed, labelSelector has been changed, too. This is a backward incompatible changes. This is the reason for a major version bump. In umbraella chart situations, if `app.kubernetes.io/name` is set to release.name, the resource has no good known unique labels.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
