### PR TITLE
[prometheus]update chart dependency kube-state-metrics (4.22 to 4.24), image 2.7.0

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.39.1
-version: 18.1.1
+version: 18.2.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
@@ -24,7 +24,7 @@ engine: gotpl
 type: application
 dependencies:
   - name: kube-state-metrics
-    version: "4.22.*"
+    version: "4.24.*"
     repository: https://prometheus-community.github.io/helm-charts
     condition: kubeStateMetrics.enabled
   - name: prometheus-node-exporter


### PR DESCRIPTION
### What this PR does / why we need it

- update chart dependency, kube-state-metrics (4.22 to 4.24)
  -  update image, kube-state-metrics(2.6.0 to 2.7.0)
- images security rating will be restored

#### Which issue this PR fixes

None.

#### Special notes for your reviewer

- relates #2737

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)