### PR TITLE
[prometheus-node-exporter] updates Prometheus Node Exporter image(to 1.5.0)

### DIFF
--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -6,8 +6,8 @@ keywords:
   - prometheus
   - exporter
 type: application
-version: 4.7.1
-appVersion: 1.4.0
+version: 4.8.0
+appVersion: 1.5.0
 home: https://github.com/prometheus/node_exporter/
 sources:
   - https://github.com/prometheus/node_exporter/


### PR DESCRIPTION
#### What this PR does / why we need it

- this pr updates [Prometheus Node Exporter image(to 1.5.0)](quay.io/prometheus/node-exporter:v1.5.0)

#### Which issue this PR fixes

None.

#### Special notes for your reviewer

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
  - [x] App Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
