### PR TITLE
[prometheus]updates configmap-reload image to v0.8.0

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.39.1
-version: 18.2.0
+version: 18.3.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -318,7 +318,7 @@ configmapReload:
     ##
     image:
       repository: jimmidyson/configmap-reload
-      tag: v0.5.0
+      tag: v0.8.0
       pullPolicy: IfNotPresent
 
     # containerPort: 9533


### PR DESCRIPTION
### What this PR does / why we need it

- this pr updates [configmap-reload image(to v0.8.0)](https://hub.docker.com/layers/jimmidyson/configmap-reload/v0.8.0/images/sha256-084de2d3533f9215eceef9a1feccfc11cad43cf382ea82ddfa4272f68df0614f?context=explore)

#### Which issue this PR fixes
None.

#### Special notes for your reviewer

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
