### PR TITLE
[prometheus]update chart dependency prometheus-node-exporter (to 4.8.0)

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: 2.39.1
-version: 18.3.0
+version: 18.4.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
@@ -28,7 +28,7 @@ dependencies:
     repository: https://prometheus-community.github.io/helm-charts
     condition: kubeStateMetrics.enabled
   - name: prometheus-node-exporter
-    version: "4.7.*"
+    version: "4.8.*"
     repository: https://prometheus-community.github.io/helm-charts
     condition: prometheus-node-exporter.enabled
   - name: prometheus-pushgateway


### PR DESCRIPTION
### What this PR does / why we need it

- update chart dependency, [prometheus-node-exporter (4.7 to 4.8)](https://artifacthub.io/packages/helm/prometheus-community/prometheus-node-exporter)
  -  update image, [prometheus-node-exporter(1.4.0 to 1.5.0)](https://quay.io/repository/prometheus/node-exporter?tab=tags&tag=v1.5.0)
- images security rating will be restored

#### Which issue this PR fixes

None.

#### Special notes for your reviewer

- upstream #2766

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)