### PR TITLE
[kube-prometheus-stack] Fix netpol to allow access to the api-server

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -22,7 +22,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 42.2.0
+version: 42.2.1
 appVersion: 0.60.1
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/networkpolicy.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/networkpolicy.yaml
@@ -7,10 +7,8 @@ metadata:
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}-operator
 spec:
-  podSelector:
-    matchLabels:
-      app: {{ template "kube-prometheus-stack.name" . }}-operator
-      release: {{ $.Release.Name | quote }}
+  egress: 
+    - {}
   ingress:
     - ports:
       {{- if .Values.prometheusOperator.tls.enabled }}
@@ -18,4 +16,11 @@ spec:
       {{- else }}
       - port: 8080
       {{- end }}
+  policyTypes:
+    - Egress
+    - Ingress
+  podSelector:
+    matchLabels:
+      app: {{ template "kube-prometheus-stack.name" . }}-operator
+      release: {{ $.Release.Name | quote }}
 {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR fixes the network policy for the prometheus-operator that prevents the prometheus-operator to call the apiserver `/version` endpoint

#### Which issue this PR fixes

Before:

```sh
k logs -n kube-system prometheus-operator-app-operator-6476f7ffd4-m45ff
level=info ts=2022-12-05T19:59:21.088271586Z caller=main.go:220 msg="Starting Prometheus Operator" version="(version=0.60.1, branch=refs/tags/v0.60.1, revision=ab3fe2aba8f6e43461819d9648e2b8fae9d74c43)"
level=info ts=2022-12-05T19:59:21.088315531Z caller=main.go:221 build_context="(go=go1.18.6, user=Action-Run-ID-3224998444, date=20221011-07:43:14)"
level=warn ts=2022-12-05T19:59:51.097587134Z caller=operator.go:328 component=prometheusoperator msg="failed to check if the API supports the endpointslice resources" err="Get \"https://172.31.0.1:443/apis/discovery.k8s.io\": dial tcp 172.31.0.1:443: i/o timeout"
level=info ts=2022-12-05T19:59:51.097632007Z caller=operator.go:330 component=prometheusoperator msg="Kubernetes API capabilities" endpointslices=false
level=info ts=2022-12-05T19:59:51.099522576Z caller=main.go:113 msg="Starting secure server on [::]:10250"
level=warn ts=2022-12-05T20:00:21.099847473Z caller=main.go:413 msg="Server shutdown error" err="context canceled"
level=warn ts=2022-12-05T20:00:21.099900954Z caller=main.go:418 msg="Unhandled error received. Exiting..." err="communicating with server failed: Get \"https://172.31.0.1:443/version\": dial tcp 172.31.0.1:443: i/o timeout"
```

After:

```sh
k logs -n kube-system kube-prometheus-stack-1670-operator-84485485f8-c2xg6
level=info ts=2022-12-05T20:49:52.135468111Z caller=main.go:220 msg="Starting Prometheus Operator" version="(version=0.60.1, branch=refs/tags/v0.60.1, revision=ab3fe2aba8f6e43461819d9648e2b8fae9d74c43)"
level=info ts=2022-12-05T20:49:52.135514701Z caller=main.go:221 build_context="(go=go1.18.6, user=Action-Run-ID-3224998444, date=20221011-07:43:14)"
level=warn ts=2022-12-05T20:49:53.153644025Z caller=operator.go:328 component=prometheusoperator msg="failed to check if the API supports the endpointslice resources" err="converting (v1.APIGroup) to (v1.APIResourceList): unknown conversion"
level=info ts=2022-12-05T20:49:53.153683556Z caller=operator.go:330 component=prometheusoperator msg="Kubernetes API capabilities" endpointslices=false
level=info ts=2022-12-05T20:49:53.157834235Z caller=main.go:113 msg="Starting secure server on [::]:10250"
level=info ts=2022-12-05T20:49:53.157838935Z caller=operator.go:440 component=prometheusoperator msg="connection established" cluster-version=v1.23.14
level=info ts=2022-12-05T20:49:53.158065821Z caller=operator.go:449 component=prometheusoperator msg="CRD API endpoints ready"
level=info ts=2022-12-05T20:49:53.158275447Z caller=operator.go:457 component=alertmanageroperator msg="connection established" cluster-version=v1.23.14
level=info ts=2022-12-05T20:49:53.158404493Z caller=operator.go:466 component=alertmanageroperator msg="CRD API endpoints ready"
level=info ts=2022-12-05T20:49:53.160004966Z caller=operator.go:311 component=thanosoperator msg="connection established" cluster-version=v1.23.14
level=info ts=2022-12-05T20:49:53.160048337Z caller=operator.go:320 component=thanosoperator msg="CRD API endpoints ready"
level=info ts=2022-12-05T20:49:53.261425098Z caller=operator.go:263 component=thanosoperator msg="successfully synced all caches"
level=info ts=2022-12-05T20:49:53.359262224Z caller=operator.go:369 component=prometheusoperator msg="successfully synced all caches"
```
#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
