### PR TITLE
[alertmanager] fix broken PDB due to missing line break

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 0.22.1
+version: 0.22.2
 appVersion: v0.24.0
 maintainers:
   - name: monotek

--- a/charts/alertmanager/templates/pdb.yaml
+++ b/charts/alertmanager/templates/pdb.yaml
@@ -9,5 +9,5 @@ spec:
   selector:
     matchLabels:
       {{- include "alertmanager.selectorLabels" . | nindent 6 }}
-  {{- toYaml .Values.podDisruptionBudget | indent 2 }}
+  {{- toYaml .Values.podDisruptionBudget | nindent 2 }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: toVersus <toversus2357@gmail.com>

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Fix a regression introduced in the part of refactoring. (#2781)
After this patch, we can generate manifests without any errors.

Enable PDB on default values file:

```yaml
podDisruptionBudget:
  maxUnavailable: 1
```

Genarate manifests using Helm template:

```console
❯ helm template alertmanager .
---
# Source: alertmanager/templates/pdb.yaml
apiVersion: policy/v1beta1
kind: PodDisruptionBudget
metadata:
  name: alertmanager
  labels:
    helm.sh/chart: alertmanager-0.22.2
    app.kubernetes.io/name: alertmanager
    app.kubernetes.io/instance: alertmanager
    app.kubernetes.io/version: "v0.24.0"
    app.kubernetes.io/managed-by: Helm
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: alertmanager
      app.kubernetes.io/instance: alertmanager
  maxUnavailable: 1
```

#### Which issue this PR fixes

- fixes #2795

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
