### PR TITLE
Bump Grafana Chart to most recent commit

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 4.8.0
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.45.0
-digest: sha256:d7d2a3de9fd0551b72480e3ebc72a9fde58848b9105ed00c37144d375de9b646
-generated: "2022-12-03T14:33:25.910449+01:00"
+  version: 6.47.0
+digest: sha256:d2dd3fce52909fa5b8e2c4e67aebf5dcfa5679a39535b6d14ea3fa3ef8c7f558
+generated: "2022-12-09T12:52:01.598143+01:00"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -22,7 +22,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 42.2.1
+version: 42.3.0
 appVersion: 0.60.1
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus
@@ -48,6 +48,6 @@ dependencies:
     repository: https://prometheus-community.github.io/helm-charts
     condition: nodeExporter.enabled
   - name: grafana
-    version: "6.45.*"
+    version: "6.47.*"
     repository: https://grafana.github.io/helm-charts
     condition: grafana.enabled


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Bumps the Grafana helm chart version to fix stale sidecar issues

#### Which issue this PR fixes

- fixes #2800

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
