### PR TITLE
[kube-prometheus-stack] fix Chart.yaml - remove engine: gotpl

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -1,7 +1,6 @@
 apiVersion: v2
 description: kube-prometheus-stack collects Kubernetes manifests, Grafana dashboards, and Prometheus rules combined with documentation and scripts to provide easy to operate end-to-end Kubernetes cluster monitoring with Prometheus using the Prometheus Operator.
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
-engine: gotpl
 type: application
 maintainers:
   - name: andrewgkew
@@ -22,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 43.1.0
+version: 43.1.1
 appVersion: 0.61.1
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus


### PR DESCRIPTION
### What this PR does / why we need it

- fix Chart.yaml - remove engine: gotpl

#### Which issue this PR fixes

https://github.com/prometheus-community/helm-charts/issues/2813

#### Special notes for your reviewer

- This is the patch bump. removing  but it's not allowed.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
