### PR TITLE
[kube-prometheus-stack] Fix metrics for prometheus-adapter

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 43.1.1
+version: 43.1.2
 appVersion: 0.61.1
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1002,10 +1002,10 @@ kubelet:
       - sourceLabels: [__name__]
         action: drop
         regex: 'container_spec.*'
-      # Drop cgroup metrics with no pod.
+      # Drop cgroup metrics with no pod, where the id is not exactly '/' (used by prometheus-adapter for `kubectl top node`)
       - sourceLabels: [id, pod]
         action: drop
-        regex: '.+;'
+        regex: "(/.+|[^/;]+|);"
     # - sourceLabels: [__name__, image]
     #   separator: ;
     #   regex: container_([a-z_]+);


### PR DESCRIPTION
#### What this PR does / why we need it

`prometheus-adapter` queries for cgroup metrics that have the ID '/' when responding to `kubectl top node`. These metrics don't have a pod set, so are dropped by the current config.

Previously, the regex would match `.+;` - i.e any non-empty ID, and no pod. Now, it matches (if I've done this right) any ID except '/', and no pod.

#### Which issue this PR fixes

- fixes: kubernetes-sigs/prometheus-adapter#549

#### Special notes for your reviewer

- I'm no regex expert, there may be more efficient ways to achieve this. 
- Do  I need to bump the chart major version for this? All metrics that were previously collected still are, this just adds a few more.
- @SuperQ, who originally configured the metrics to drop might be well placed to review this.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
