### PR TITLE
[prometheus-adapter] Update PromQL queries

### DIFF
--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 4.0.1
+version: 4.0.2
 appVersion: v0.10.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/kubernetes-sigs/prometheus-adapter

--- a/charts/prometheus-adapter/README.md
+++ b/charts/prometheus-adapter/README.md
@@ -113,8 +113,14 @@ Enabling this option will cause resource metrics to be served at `/apis/metrics.
 rules:
   resource:
     cpu:
-      containerQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>, container!=""}[3m])) by (<<.GroupBy>>)
-      nodeQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>, id='/'}[3m])) by (<<.GroupBy>>)
+      containerQuery: |
+        sum by (<<.GroupBy>>) (
+          rate(container_cpu_usage_seconds_total{container!="",<<.LabelMatchers>>}[3m])
+        )
+      nodeQuery: |
+        sum  by (<<.GroupBy>>) (
+          rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal",<<.LabelMatchers>>}[3m])
+        )
       resources:
         overrides:
           node:
@@ -125,8 +131,16 @@ rules:
             resource: pod
       containerLabel: container
     memory:
-      containerQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>, container!=""}) by (<<.GroupBy>>)
-      nodeQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>,id='/'}) by (<<.GroupBy>>)
+      containerQuery: |
+        sum by (<<.GroupBy>>) (
+          avg_over_time(container_memory_working_set_bytes{container!="",<<.LabelMatchers>>}[3m])
+        )
+      nodeQuery: |
+        sum by (<<.GroupBy>>) (
+          avg_over_time(node_memory_MemTotal_bytes{<<.LabelMatchers>>}[3m])
+          -
+          avg_over_time(node_memory_MemAvailable_bytes{<<.LabelMatchers>>}[3m])
+        )
       resources:
         overrides:
           node:

--- a/charts/prometheus-adapter/values.yaml
+++ b/charts/prometheus-adapter/values.yaml
@@ -120,8 +120,14 @@ rules:
 
   # resource:
   #   cpu:
-  #     containerQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>, container!=""}[3m])) by (<<.GroupBy>>)
-  #     nodeQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>, id='/'}[3m])) by (<<.GroupBy>>)
+  #     containerQuery: |
+  #       sum by (<<.GroupBy>>) (
+  #         rate(container_cpu_usage_seconds_total{container!="",<<.LabelMatchers>>}[3m])
+  #       )
+  #     nodeQuery: |
+  #       sum  by (<<.GroupBy>>) (
+  #         rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal",<<.LabelMatchers>>}[3m])
+  #       )
   #     resources:
   #       overrides:
   #         node:
@@ -132,8 +138,16 @@ rules:
   #           resource: pod
   #     containerLabel: container
   #   memory:
-  #     containerQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>, container!=""}) by (<<.GroupBy>>)
-  #     nodeQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>,id='/'}) by (<<.GroupBy>>)
+  #     containerQuery: |
+  #       sum by (<<.GroupBy>>) (
+  #         avg_over_time(container_memory_working_set_bytes{container!="",<<.LabelMatchers>>}[3m])
+  #       )
+  #     nodeQuery: |
+  #       sum by (<<.GroupBy>>) (
+  #         avg_over_time(node_memory_MemTotal_bytes{<<.LabelMatchers>>}[3m])
+  #         -
+  #         avg_over_time(node_memory_MemAvailable_bytes{<<.LabelMatchers>>}[3m])
+  #       )
   #     resources:
   #       overrides:
   #         node:


### PR DESCRIPTION
#### What this PR does / why we need it
Update the `prometheus-adpater` chart example PromQL queries to be compatible with the `kube-prometheus-stack` chart defaults.
* Use `node_exporter` metrics for `nodeQuery` examples.
* Use `avg_over_time()` on memory queries to match the 3m window.
* Format queries based on PromQL style guide.

Signed-off-by: SuperQ <superq@gmail.com>

#### Which issue this PR fixes

* https://github.com/kubernetes-sigs/prometheus-adapter/issues/549
* https://github.com/kubernetes-sigs/prometheus-adapter/pull/516
* https://github.com/prometheus-community/helm-charts/pull/2822

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
