### PR TITLE
[prometheus-postgres-exporter] fix: propagate warning from upstream

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.11.1"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 4.1.0
+version: 4.1.1
 home: https://github.com/prometheus-community/postgres_exporter
 sources:
 - https://github.com/prometheus-community/postgres_exporter

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -315,6 +315,7 @@ config:
             usage: "COUNTER"
             description: "Number of buffer hits in this table's TOAST table indexes (if any)"
 
+    # WARNING: This set of metrics can be very expensive on a busy server as every unique query executed will create an additional time series
     pg_stat_statements:
       query: "SELECT t2.rolname, t3.datname, queryid, calls, ( total_plan_time + total_exec_time ) / 1000 as total_time_seconds, ( min_plan_time + min_exec_time ) / 1000 as min_time_seconds, ( max_plan_time + max_exec_time ) / 1000 as max_time_seconds, ( mean_plan_time + mean_exec_time ) / 1000 as mean_time_seconds, ( stddev_plan_time + stddev_exec_time )  / 1000 as stddev_time_seconds, rows, shared_blks_hit, shared_blks_read, shared_blks_dirtied, shared_blks_written, local_blks_hit, local_blks_read, local_blks_dirtied, local_blks_written, temp_blks_read, temp_blks_written, blk_read_time / 1000 as blk_read_time_seconds, blk_write_time / 1000 as blk_write_time_seconds FROM pg_stat_statements t1 JOIN pg_roles t2 ON (t1.userid=t2.oid) JOIN pg_database t3 ON (t1.dbid=t3.oid) WHERE t2.rolname != 'rdsadmin' AND queryid IS NOT NULL"
       master: true


### PR DESCRIPTION
#### What this PR does / why we need it

This propagates important notification that is available in source and ppl still get caught by that: https://github.com/prometheus-community/postgres_exporter/issues/549

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer
This just propagates the warning from upstream to chart.

#### Checklist

- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped - does it really have to be ??
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
