### PR TITLE
[alertmanager] updates alertmanager image to v0.25.0

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,8 +6,8 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 0.23.0
-appVersion: v0.24.0
+version: 0.24.0
+appVersion: v0.25.0
 maintainers:
   - name: monotek
     email: monotek23@gmail.com

--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -8,8 +8,15 @@ sources:
 type: application
 version: 0.24.0
 appVersion: v0.25.0
+kubeVersion: ">=1.16.0-0"
+keywords:
+  - monitoring
 maintainers:
   - name: monotek
     email: monotek23@gmail.com
   - name: naseemkullah
     email: naseem@transit.app
+annotations:
+  "artifacthub.io/links": |
+    - name: Chart Source
+      url: https://github.com/prometheus-community/helm-charts


### PR DESCRIPTION
### What this PR does / why we need it

- this pr updates [alertmanager image(to v0.25.0)](quay.io/prometheus/alertmanager:v0.25.0)

#### Which issue this PR fixes
None.

#### Special notes for your reviewer

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)