### PR TITLE
[prometheus] update chart dependency alertmanager (to 0.24)

### DIFF
--- a/charts/prometheus/.gitignore
+++ b/charts/prometheus/.gitignore
@@ -1,2 +1,0 @@
-requirements.lock
-Chart.lock

--- a/charts/prometheus/Chart.lock
+++ b/charts/prometheus/Chart.lock
@@ -1,0 +1,15 @@
+dependencies:
+- name: alertmanager
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 0.24.1
+- name: kube-state-metrics
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 4.24.0
+- name: prometheus-node-exporter
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 4.8.1
+- name: prometheus-pushgateway
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 2.0.3
+digest: sha256:60ee7f7ff18e682cac905d6675fea2e7c95abbbe881882bb124698827bafdd41
+generated: "2022-12-24T20:28:03.0914286+09:00"

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
-appVersion: v2.40.5
-version: 19.0.2
+appVersion: v2.41.0
+version: 19.1.0
 kubeVersion: ">=1.16.0-0"
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
@@ -24,7 +24,7 @@ maintainers:
 type: application
 dependencies:
   - name: alertmanager
-    version: "0.22.*"
+    version: "0.24.*"
     repository: https://prometheus-community.github.io/helm-charts
     condition: alertmanager.enabled
   - name: kube-state-metrics


### PR DESCRIPTION
### What this PR does / why we need it

- update chart dependency [alertmanager (to 0.24)](https://artifacthub.io/packages/helm/prometheus-community/alertmanager/0.24.0)
  -  updates [alertmanager image(to v0.25.0)](https://quay.io/prometheus/alertmanager:v0.25.0)
-  updates [prometheus image(to v2.41.0)](https://quay.io/prometheus/prometheus:v2.41.0)
-  add [Chart.lock](https://helm.sh/docs/helm/helm_dependency_build/#synopsis)

#### Which issue this PR fixes

- Closes #2855

#### Special notes for your reviewer

- upstream https://github.com/prometheus-community/helm-charts/pull/2846

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)