### PR TITLE
[kube-prometheus-stack] updates alertmanager image to v0.25.0

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 43.1.4
+version: 43.2.0
 appVersion: 0.61.1
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -30,6 +30,7 @@ keywords:
   - prometheus
   - kube-prometheus
 annotations:
+  "artifacthub.io/license": Apache-2.0
   "artifacthub.io/operator": "true"
   "artifacthub.io/links": |
     - name: Chart Source

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -463,7 +463,7 @@ alertmanager:
     image:
       registry: quay.io
       repository: prometheus/alertmanager
-      tag: v0.24.0
+      tag: v0.25.0
       sha: ""
 
     ## If true then the user will be responsible to provide a secret with alertmanager configuration


### PR DESCRIPTION
### What this PR does / why we need it

- this pr updates [alertmanager image(to v0.25.0)](quay.io/prometheus/alertmanager:v0.25.0)
- [add license annotations](https://artifacthub.io/docs/topics/annotations/helm/)

#### Which issue this PR fixes

None.

#### Special notes for your reviewer

- referred to #2846

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)