### PR TITLE
[prometheus] kubeStateMetrics.enabled is now kube-state-metrics.enabled

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: v2.41.0
-version: 19.2.1
+version: 19.2.2
 kubeVersion: ">=1.16.0-0"
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/README.md
+++ b/charts/prometheus/README.md
@@ -39,7 +39,7 @@ By default this chart installs additional, dependent charts:
 - [prometheus-node-exporter](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-node-exporter)
 - [prometheus-pushgateway](https://github.com/walker-tom/helm-charts/tree/main/charts/prometheus-pushgateway)
 
-To disable the dependency during installation, set `alertmanager.enabled`, `kubeStateMetrics.enabled`, `prometheus-node-exporter.enabled` and `prometheus-pushgateway.enabled` to `false`.
+To disable the dependency during installation, set `alertmanager.enabled`, `kube-state-metrics.enabled`, `prometheus-node-exporter.enabled` and `prometheus-pushgateway.enabled` to `false`.
 
 _See [helm dependency](https://helm.sh/docs/helm/helm_dependency/) for command documentation._
 


### PR DESCRIPTION
#### What this PR does / why we need it
Updates documentation in README.md

#### Which issue this PR fixes

The documentation. There was a minor typo using camelCase instead of kebab-case.

#### Special notes for your reviewer

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
