### PR TITLE
[prometheus] Adopt helm standard label format

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: v2.41.0
-version: 19.3.1
+version: 19.4.0
 kubeVersion: ">=1.16.0-0"
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: v2.41.0
-version: 19.3.0
+version: 19.3.1
 kubeVersion: ">=1.16.0-0"
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/templates/_helpers.tpl
+++ b/charts/prometheus/templates/_helpers.tpl
@@ -279,9 +279,5 @@ Create the name of the service account to use for the server component
 Define the prometheus.namespace template if set with forceNamespace or .Release.Namespace is set
 */}}
 {{- define "prometheus.namespace" -}}
-{{- if .Values.forceNamespace -}}
-{{ printf "namespace: %s" .Values.forceNamespace }}
-{{- else -}}
-{{ printf "namespace: %s" .Release.Namespace }}
-{{- end -}}
-{{- end -}}
+  {{- default .Release.Namespace .Values.forceNamespace -}}
+{{- end }}

--- a/charts/prometheus/templates/_helpers.tpl
+++ b/charts/prometheus/templates/_helpers.tpl
@@ -14,16 +14,21 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
-Create unified labels for prometheus components
+Create labels for prometheus
 */}}
 {{- define "prometheus.common.matchLabels" -}}
-app: {{ template "prometheus.name" . }}
-release: {{ .Release.Name }}
+app.kubernetes.io/name: {{ include "prometheus.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
 {{- end -}}
 
+{{/*
+Create unified labels for prometheus components
+*/}}
 {{- define "prometheus.common.metaLabels" -}}
-chart: {{ template "prometheus.chart" . }}
-heritage: {{ .Release.Service }}
+helm.sh/chart: {{ include "prometheus.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: {{ include "prometheus.name" . }}
 {{- end -}}
 
 {{- define "prometheus.alertmanager.labels" -}}
@@ -32,7 +37,7 @@ heritage: {{ .Release.Service }}
 {{- end -}}
 
 {{- define "prometheus.alertmanager.matchLabels" -}}
-component: {{ .Values.alertmanager.name | quote }}
+app.kubernetes.io/component: {{ .Values.alertmanager.name }}
 {{ include "prometheus.common.matchLabels" . }}
 {{- end -}}
 
@@ -42,7 +47,7 @@ component: {{ .Values.alertmanager.name | quote }}
 {{- end -}}
 
 {{- define "prometheus.nodeExporter.matchLabels" -}}
-component: {{ .Values.nodeExporter.name | quote }}
+app.kubernetes.io/component: {{ .Values.nodeExporter.name }}
 {{ include "prometheus.common.matchLabels" . }}
 {{- end -}}
 
@@ -52,7 +57,7 @@ component: {{ .Values.nodeExporter.name | quote }}
 {{- end -}}
 
 {{- define "prometheus.pushgateway.matchLabels" -}}
-component: {{ .Values.pushgateway.name | quote }}
+app.kubernetes.io/component: {{ .Values.pushgateway.name }}
 {{ include "prometheus.common.matchLabels" . }}
 {{- end -}}
 
@@ -62,7 +67,7 @@ component: {{ .Values.pushgateway.name | quote }}
 {{- end -}}
 
 {{- define "prometheus.server.matchLabels" -}}
-component: {{ .Values.server.name | quote }}
+app.kubernetes.io/component: {{ .Values.server.name }}
 {{ include "prometheus.common.matchLabels" . }}
 {{- end -}}
 

--- a/charts/prometheus/templates/clusterrolebinding.yaml
+++ b/charts/prometheus/templates/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "prometheus.serviceAccountName.server" . }}
-{{ include "prometheus.namespace" . | indent 4 }}
+    namespace: {{ include "prometheus.namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/prometheus/templates/cm.yaml
+++ b/charts/prometheus/templates/cm.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
   name: {{ template "prometheus.server.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+  namespace: {{ include "prometheus.namespace" . }}
 data:
   allow-snippet-annotations: "false"
 {{- $root := . -}}

--- a/charts/prometheus/templates/deploy.yaml
+++ b/charts/prometheus/templates/deploy.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
   name: {{ template "prometheus.server.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+  namespace: {{ include "prometheus.namespace" . }}
 spec:
   selector:
     matchLabels:

--- a/charts/prometheus/templates/headless-svc.yaml
+++ b/charts/prometheus/templates/headless-svc.yaml
@@ -12,7 +12,7 @@ metadata:
 {{ toYaml .Values.server.statefulSet.headless.labels | indent 4 }}
 {{- end }}
   name: {{ template "prometheus.server.fullname" . }}-headless
-{{ include "prometheus.namespace" . | indent 2 }}
+  namespace: {{ include "prometheus.namespace" . }}
 spec:
   clusterIP: None
   ports:

--- a/charts/prometheus/templates/ingress.yaml
+++ b/charts/prometheus/templates/ingress.yaml
@@ -21,7 +21,7 @@ metadata:
     {{ $key }}: {{ $value }}
 {{- end }}
   name: {{ template "prometheus.server.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+  namespace: {{ include "prometheus.namespace" . }}
 spec:
   {{- if and $ingressSupportsIngressClassName .Values.server.ingress.ingressClassName }}
   ingressClassName: {{ .Values.server.ingress.ingressClassName }}

--- a/charts/prometheus/templates/network-policy.yaml
+++ b/charts/prometheus/templates/network-policy.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ template "prometheus.networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
 metadata:
   name: {{ template "prometheus.server.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+  namespace: {{ include "prometheus.namespace" . }}
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
 spec:

--- a/charts/prometheus/templates/pdb.yaml
+++ b/charts/prometheus/templates/pdb.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ template "prometheus.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "prometheus.server.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+  namespace: {{ include "prometheus.namespace" . }}
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
 spec:

--- a/charts/prometheus/templates/pvc.yaml
+++ b/charts/prometheus/templates/pvc.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
   name: {{ template "prometheus.server.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+  namespace: {{ include "prometheus.namespace" . }}
 spec:
   accessModes:
 {{ toYaml .Values.server.persistentVolume.accessModes | indent 4 }}

--- a/charts/prometheus/templates/service.yaml
+++ b/charts/prometheus/templates/service.yaml
@@ -12,7 +12,7 @@ metadata:
 {{ toYaml .Values.server.service.labels | indent 4 }}
 {{- end }}
   name: {{ template "prometheus.server.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+  namespace: {{ include "prometheus.namespace" . }}
 spec:
 {{- if .Values.server.service.clusterIP }}
   clusterIP: {{ .Values.server.service.clusterIP }}

--- a/charts/prometheus/templates/serviceaccount.yaml
+++ b/charts/prometheus/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
   name: {{ template "prometheus.serviceAccountName.server" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+  namespace: {{ include "prometheus.namespace" . }}
   annotations:
 {{ toYaml .Values.serviceAccounts.server.annotations | indent 4 }}
 {{- end }}

--- a/charts/prometheus/templates/sts.yaml
+++ b/charts/prometheus/templates/sts.yaml
@@ -12,7 +12,7 @@ metadata:
     {{ toYaml .Values.server.statefulSet.labels | nindent 4 }}
     {{- end}}
   name: {{ template "prometheus.server.fullname" . }}
-{{ include "prometheus.namespace" . | indent 2 }}
+  namespace: {{ include "prometheus.namespace" . }}
 spec:
   serviceName: {{ template "prometheus.server.fullname" . }}-headless
   selector:

--- a/charts/prometheus/templates/vpa.yaml
+++ b/charts/prometheus/templates/vpa.yaml
@@ -2,10 +2,10 @@
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
+  name: {{ template "prometheus.server.fullname" . }}-vpa
+  namespace: {{ include "prometheus.namespace" . }}
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
-  name: {{ template "prometheus.server.fullname" . }}-vpa
-{{ include "prometheus.namespace" . | indent 2 }}
 spec:
   targetRef:
     apiVersion: "apps/v1"


### PR DESCRIPTION
#### What this PR does / why we need it

- Adopt [helm standard label format](https://helm.sh/docs/chart_best_practices/labels/#standard-labels)

#### Which issue this PR fixes

- fixes #2873

#### Special notes for your reviewer

- [x] Has a breakiing change.
  - [ ] Chart Version bumped - major
  - [ ] Add upgrade instructions

- new label

```
metadata:
  labels:
    app.kubernetes.io/component: server
    app.kubernetes.io/name: prometheus
    app.kubernetes.io/instance: prometheus-1673019484
    app.kubernetes.io/version: v2.41.0
    helm.sh/chart: prometheus-19.4.0
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: prometheus
  name: prometheus-1673019484-server
  namespace: default
```

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
