### PR TITLE
[alertmanager-snmp-notifier] add SNMP notifer chart

### DIFF
--- a/charts/alertmanager-snmp-notifier/Chart.yaml
+++ b/charts/alertmanager-snmp-notifier/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+description: SNMP Notifier
+name: alertmanager-snmp-notifier
+version: 0.1.0
+appVersion: 1.3.1
+home: https://github.com/maxwo/snmp_notifier
+sources:
+  - https://github.com/maxwo/snmp_notifier
+keywords:
+  - prometheus
+  - snmp
+  - monitoring
+  - webhook
+  - alertmanager
+maintainers:
+  - name: Maxime Wojtczak
+    email: maxime.wojtczak.pub@icloud.com

--- a/charts/alertmanager-snmp-notifier/README.md
+++ b/charts/alertmanager-snmp-notifier/README.md
@@ -1,0 +1,71 @@
+# Prometheus SNMP Notifier
+
+An Alertmanager webhook that relays alerts as SNMP traps.
+
+This chart creates a [SNMP Notifier](https://github.com/maxwo/snmp_notifier) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.8+ with Beta APIs enabled
+
+## Get Repo Info
+
+```console
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+```
+
+_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
+
+## Install Chart
+
+```console
+# Helm 3
+$ helm install [RELEASE_NAME] prometheus-community/snmp-notifier
+
+# Helm 2
+$ helm install --name [RELEASE_NAME] prometheus-community/snmp-notifier
+```
+
+_See [configuration](#configuration) below._
+
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
+
+## Uninstall Chart
+
+```console
+# Helm 3
+$ helm uninstall [RELEASE_NAME]
+
+# Helm 2
+# helm delete --purge [RELEASE_NAME]
+```
+
+This removes all the Kubernetes components associated with the chart and deletes the release.
+
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+
+## Upgrading Chart
+
+```console
+# Helm 3 or 2
+$ helm upgrade [RELEASE_NAME] [CHART] --install
+```
+
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+## Configuration
+
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
+
+```console
+# Helm 2
+$ helm inspect values prometheus-community/snmp-notifier
+
+# Helm 3
+$ helm show values prometheus-community/snmp-notifier
+```
+
+### Flags
+
+Check the [configuration section](https://github.com/maxwo/snmp_notifier#snmp-notifier-configuration) list and add to the `extraArgs` block in your value overrides.

--- a/charts/alertmanager-snmp-notifier/templates/NOTES.txt
+++ b/charts/alertmanager-snmp-notifier/templates/NOTES.txt
@@ -1,0 +1,1 @@
+See https://github.com/maxwo/snmp_notifier/ for how to configure Prometheus and the SNMP Notifier.

--- a/charts/alertmanager-snmp-notifier/templates/_helpers.tpl
+++ b/charts/alertmanager-snmp-notifier/templates/_helpers.tpl
@@ -1,0 +1,67 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "alertmanager-snmp-notifier.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "alertmanager-snmp-notifier.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "alertmanager-snmp-notifier.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "alertmanager-snmp-notifier.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "alertmanager-snmp-notifier.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "alertmanager-snmp-notifier.labels" }}
+helm.sh/chart: {{ include "alertmanager-snmp-notifier.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: metrics
+app.kubernetes.io/part-of: {{ template "alertmanager-snmp-notifier.name" . }}
+{{- include "alertmanager-snmp-notifier.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "alertmanager-snmp-notifier.selectorLabels" }}
+app.kubernetes.io/name: {{ include "alertmanager-snmp-notifier.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/alertmanager-snmp-notifier/templates/configmap.yaml
+++ b/charts/alertmanager-snmp-notifier/templates/configmap.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.config.snmpTemplates }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "alertmanager-snmp-notifier.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "alertmanager-snmp-notifier.labels" . | indent 4 }}
+data:
+{{- if .Values.config.snmpTemplates.description }}
+  description-template.tpl: |
+{{ .Values.config.snmpTemplates.description | indent 4 }}
+{{- end }}
+{{- if .Values.config.snmpTemplates.extraFields }}
+{{- range $index, $element := .Values.config.snmpTemplates.extraFields }}
+  extra-field-{{ add 4 $index }}-template.tpl: |
+{{ $element.template | indent 4 }}
+{{- end }}
+{{- end }}
+
+
+{{- end }}

--- a/charts/alertmanager-snmp-notifier/templates/deployment.yaml
+++ b/charts/alertmanager-snmp-notifier/templates/deployment.yaml
@@ -1,0 +1,168 @@
+{{- if (eq .Values.kind "Deployment") }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "alertmanager-snmp-notifier.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "alertmanager-snmp-notifier.labels" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "alertmanager-snmp-notifier.selectorLabels" . | indent 6 }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        {{- include "alertmanager-snmp-notifier.labels" . | indent 8 }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+    spec:
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+    {{- end }}
+    {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
+    {{- end }}
+      restartPolicy: {{ .Values.restartPolicy }}
+      serviceAccountName: {{ template "alertmanager-snmp-notifier.serviceAccountName" . }}
+      containers:
+        - name: snmp-notifier
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+{{- if .Values.containerSecurityContext }}
+          securityContext:
+{{ toYaml .Values.containerSecurityContext | indent 12 }}
+        {{- end }}
+          args:
+        {{- if .Values.config.snmpDestinations }}
+        {{- range $destination := .Values.config.snmpDestinations }}
+            - --snmp.destination={{ $destination }}
+        {{- end }}
+        {{- end }}
+        {{- if (and .Values.config.snmpTemplates .Values.config.snmpTemplates.description) }}
+            - --snmp.trap-description-template=/templates/description-template.tpl
+        {{- else }}
+            - --snmp.trap-description-template=/etc/snmp_notifier/description-template.tpl
+        {{- end }}
+        {{ if (and .Values.config.snmpTemplates .Values.config.snmpTemplates.extraFields) }}
+        {{- range $index, $element := .Values.config.snmpTemplates.extraFields }}
+            - --snmp.extra-field-template={{ add 4 $index }}=/templates/extra-field-{{ add 4 $index }}-template.tpl
+        {{- end }}
+        {{- end }}
+        {{- if .Values.extraArgs }}
+{{ toYaml .Values.extraArgs | indent 12 }}
+        {{- end }}
+          env:
+          {{- if (or .Values.config.snmpCommunity .Values.config.snmpCommunitySecret) }}
+          - name: SNMP_NOTIFIER_COMMUNITY
+            valueFrom:
+              secretKeyRef:
+          {{- if .Values.config.snmpCommunitySecret }}
+                name: {{ .Values.config.snmpCommunitySecret.name }}
+                key: {{ .Values.config.snmpCommunitySecret.key }}
+          {{- else }}
+                name: {{ template "alertmanager-snmp-notifier.fullname" . }}
+                key: community
+          {{- end }}
+          {{- end }}
+          {{- if (or .Values.config.snmpAuthenticationUsername .Values.config.snmpAuthenticationUsernameSecret) }}
+          - name: SNMP_NOTIFIER_AUTH_USERNAME
+            valueFrom:
+              secretKeyRef:
+          {{- if .Values.config.snmpAuthenticationUsernameSecret }}
+                name: {{ .Values.config.snmpAuthenticationUsernameSecret.name }}
+                key: {{ .Values.config.snmpAuthenticationUsernameSecret.key }}
+          {{- else }}
+                name: {{ template "alertmanager-snmp-notifier.fullname" . }}
+                key: authenticationUsername
+          {{- end }}
+          {{- end }}
+          {{- if (or .Values.config.snmpAuthenticationPassword .Values.config.snmpAuthenticationPasswordSecret) }}
+          - name: SNMP_NOTIFIER_AUTH_PASSWORD
+            valueFrom:
+              secretKeyRef:
+          {{- if .Values.config.snmpAuthenticationPasswordSecret }}
+                name: {{ .Values.config.snmpAuthenticationPasswordSecret.name }}
+                key: {{ .Values.config.snmpAuthenticationPasswordSecret.key }}
+          {{- else }}
+                name: {{ template "alertmanager-snmp-notifier.fullname" . }}
+                key: authenticationPassword
+          {{- end }}
+          {{- end }}
+          {{- if (or .Values.config.snmpPrivatePassword .Values.config.snmpPrivatePasswordSecret) }}
+          - name: SNMP_NOTIFIER_PRIV_PASSWORD
+            valueFrom:
+              secretKeyRef:
+          {{- if .Values.config.snmpPrivatePasswordSecret }}
+                name: {{ .Values.config.snmpPrivatePasswordSecret.name }}
+                key: {{ .Values.config.snmpPrivatePasswordSecret.key }}
+          {{- else }}
+                name: {{ template "alertmanager-snmp-notifier.fullname" . }}
+                key: privatePassword
+          {{- end }}
+          {{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+              name: http
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | trim | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | trim | nindent 12 }}
+          volumeMounts:
+          {{- if .Values.config.snmpTemplates }}
+            - mountPath: /templates
+              name: templates
+          {{- end }}
+          {{- range .Values.extraConfigmapMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              subPath: {{ .subPath | default "" }}
+              readOnly: {{ .readOnly }}
+          {{- end }}
+          {{- range .Values.extraSecretMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              subPath: {{ .subPath }}
+              readOnly: {{ .readOnly }}
+          {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
+      {{- if .Values.securityContext }}
+      securityContext:
+{{ toYaml .Values.securityContext | indent 8 }}
+      {{- end }}
+      volumes:
+      {{- if .Values.config.snmpTemplates }}
+        - name: templates
+          configMap:
+            name: {{ template "alertmanager-snmp-notifier.fullname" . }}
+      {{- end }}
+      {{- range .Values.extraConfigmapMounts }}
+        - name: {{ .name }}
+          configMap:
+            name: {{ .configMap }}
+            defaultMode: {{ .defaultMode }}
+      {{- end }}
+      {{- range .Values.extraSecretMounts }}
+        - name: {{ .name }}
+          secret:
+            secretName: {{ .secretName }}
+            defaultMode: {{ .defaultMode }}
+      {{- end }}
+{{- end }}

--- a/charts/alertmanager-snmp-notifier/templates/ingress.yaml
+++ b/charts/alertmanager-snmp-notifier/templates/ingress.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.ingress.enabled -}}
+{{- $serviceName := include "alertmanager-snmp-notifier.fullname" . -}}
+{{- $servicePort := .Values.service.port -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ template "alertmanager-snmp-notifier.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "alertmanager-snmp-notifier.labels" . | indent 4 }}
+  annotations:
+{{ toYaml .Values.ingress.annotations | indent 4 }}
+spec:
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/charts/alertmanager-snmp-notifier/templates/role.yaml
+++ b/charts/alertmanager-snmp-notifier/templates/role.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.rbac.create }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "alertmanager-snmp-notifier.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "alertmanager-snmp-notifier.labels" . | indent 4 }}
+rules:
+- apiGroups: [""]
+  resources: ["endpoints"]
+  verbs: ["get"]
+{{- end }}

--- a/charts/alertmanager-snmp-notifier/templates/rolebinding.yaml
+++ b/charts/alertmanager-snmp-notifier/templates/rolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "alertmanager-snmp-notifier.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "alertmanager-snmp-notifier.labels" . | indent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "alertmanager-snmp-notifier.serviceAccountName" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "alertmanager-snmp-notifier.fullname" . }}
+{{- end }}

--- a/charts/alertmanager-snmp-notifier/templates/secrets.yaml
+++ b/charts/alertmanager-snmp-notifier/templates/secrets.yaml
@@ -1,0 +1,29 @@
+{{ $community := (and .Values.config.snmpCommunity (not .Values.config.snmpCommunitySecret)) }}
+{{ $authenticationUsername := (and .Values.config.snmpAuthenticationUsername (not .Values.config.snmpAuthenticationUsernameSecret)) }}
+{{ $authenticationPassword := (and .Values.config.snmpAuthenticationPassword (not .Values.config.snmpAuthenticationPasswordSecret)) }}
+{{ $privatePassword := (and .Values.config.snmpPrivatePassword (not .Values.config.snmpPrivatePasswordSecret)) }}
+{{- if (or $community $authenticationUsername $authenticationPassword $privatePassword) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "alertmanager-snmp-notifier.fullname" . }}
+  labels:
+    app: {{ template "alertmanager-snmp-notifier.name" . }}
+    chart: {{ template "alertmanager-snmp-notifier.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+type: Opaque
+data:
+  {{- if $community }}
+  community: {{ .Values.config.snmpCommunity | b64enc }}
+  {{- end -}}
+  {{- if $authenticationUsername }}
+  authenticationUsername: {{ .Values.config.snmpAuthenticationUsername | b64enc }}
+  {{- end -}}
+  {{- if $authenticationPassword }}
+  authenticationPassword: {{ .Values.config.snmpAuthenticationPassword | b64enc }}
+  {{- end -}}
+  {{- if $privatePassword }}
+  privatePassword: {{ .Values.config.snmpPrivatePassword | b64enc }}
+  {{- end -}}
+{{- end -}}

--- a/charts/alertmanager-snmp-notifier/templates/service.yaml
+++ b/charts/alertmanager-snmp-notifier/templates/service.yaml
@@ -1,0 +1,26 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ template "alertmanager-snmp-notifier.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+  labels:
+    {{- include "alertmanager-snmp-notifier.labels" . | indent 4 }}
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      protocol: TCP
+{{- if .Values.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.service.externalIPs | indent 4 }}
+{{- end }}
+  selector:
+    {{- include "alertmanager-snmp-notifier.selectorLabels" . | indent 4 }}

--- a/charts/alertmanager-snmp-notifier/templates/serviceaccount.yaml
+++ b/charts/alertmanager-snmp-notifier/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{ if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    {{- include "alertmanager-snmp-notifier.labels" . | indent 4 }}
+  name: {{ template "alertmanager-snmp-notifier.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/alertmanager-snmp-notifier/templates/servicemonitor.yaml
+++ b/charts/alertmanager-snmp-notifier/templates/servicemonitor.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+{{- if .Values.serviceMonitor.labels }}
+  labels:
+{{ toYaml .Values.serviceMonitor.labels | indent 4}}
+{{- end }}
+  name: {{ template "alertmanager-snmp-notifier.fullname" . }}
+{{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+{{- end }}
+spec:
+  endpoints:
+  - targetPort: {{ .Values.service.name }}
+{{- if .Values.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
+{{- end }}
+{{- if .Values.serviceMonitor.telemetryPath }}
+    path: {{ .Values.serviceMonitor.telemetryPath }}
+{{- end }}
+{{- if .Values.serviceMonitor.timeout }}
+    scrapeTimeout: {{ .Values.serviceMonitor.timeout }}
+{{- end }}
+{{- if .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ toYaml .Values.serviceMonitor.metricRelabelings | indent 4 }}
+{{- end }}
+{{- if .Values.serviceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.serviceMonitor.relabelings | nindent 4 }}
+{{- end }}
+  jobLabel: {{ template "alertmanager-snmp-notifier.fullname" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ template "alertmanager-snmp-notifier.name" . }}
+      release: {{ .Release.Name }}
+{{- if .Values.serviceMonitor.targetLabels }}
+  targetLabels:
+{{- range .Values.serviceMonitor.targetLabels }}
+  - {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/alertmanager-snmp-notifier/values.yaml
+++ b/charts/alertmanager-snmp-notifier/values.yaml
@@ -1,0 +1,185 @@
+restartPolicy: Always
+
+kind: Deployment
+
+image:
+  repository: maxwo/snmp-notifier
+  tag: v1.4.0
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# extraArgs allows to pass SNMP notifier configurations, as described on https://github.com/maxwo/snmp_notifier#snmp-notifier-configuration
+extraArgs: []
+#  --alert.severity-label=severity
+
+config:
+  # snmpDestinations is the list of SNMP servers to send the traps to
+  snmpDestinations:
+    - snmp-server:162
+
+  # SNMP authentication secrets, that may be instanciated by the chart, or may use an already created secret
+  # snmpCommunity: public
+  # snmpAuthenticationUsername: my_authention_username
+  # snmpAuthenticationPassword: my_authention_password
+  # snmpPrivatePassword: my_private_password
+  # snmpCommunitySecret:
+  #   name: existingsecret
+  #   key: community
+  # snmpAuthenticationUsernameSecret:
+  #   name: existingsecret
+  #   key: authenticationUsername
+  # snmpAuthenticationPasswordSecret:
+  #   name: existingsecret
+  #   key: authenticationPassword
+  # snmpPrivatePasswordSecret:
+  #   name: existingsecret
+  #   key: privatePassword
+
+  # snmpTemplates allows to customize the description of the traps, and add extra trap fields
+  # snmpTemplates:
+  #   description: |
+  #     {{- if .Alerts -}}
+  #     {{ len .Alerts }}/{{ len .DeclaredAlerts }} alerts are firing:
+
+  #     {{ range $severity, $alerts := (groupAlertsByLabel .Alerts "severity") -}}
+  #     Status: {{ $severity }}
+
+  #     {{- range $index, $alert := $alerts }}
+  #     - Alert: {{ $alert.Labels.alertname }}
+  #       Summary: {{ $alert.Annotations.summary }}
+  #       Description: {{ $alert.Annotations.description }}
+  #     {{ end }}
+  #     {{ end }}
+  #     {{ else -}}
+  #     Status: OK
+  #     {{- end -}}
+
+  #   extraFields:
+  #     - template: |
+  #         {{- if .Alerts -}}
+  #         Status: NOK
+  #         {{- else -}}
+  #         Status: OK
+  #         {{- end -}}
+  #     - template: |
+  #         This is a constant
+
+## Security context to be added to snmp-notifier pods
+securityContext:
+  {}
+  # fsGroup: 1000
+  # runAsUser: 1000
+  # runAsNonRoot: true
+
+## Security context to be added to snmp-notifier containers
+containerSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  readOnlyRootFilesystem: true
+
+## Additional labels to add to all resources
+customLabels:
+  {}
+  # app: snmp-notifier
+
+extraConfigmapMounts:
+  []
+  # - name: snmp-notifier-configmap
+  #   mountPath: /run/secrets/snmp-notifier
+  #   subPath: snmp.yaml # (optional)
+  #   configMap: snmp-notifier-configmap-configmap
+  #   readOnly: true
+  #   defaultMode: 420
+
+## Additional secret mounts
+# Defines additional mounts with secrets. Secrets must be manually created in the namespace.
+extraSecretMounts:
+  []
+  # - name: secret-files
+  #   mountPath: /run/secrets/snmp-notifier
+  #   secretName: snmp-notifier-secret-files
+  #   readOnly: true
+  #   defaultMode: 420
+
+## For RBAC support:
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+resources:
+  {}
+  # limits:
+  #   memory: 300Mi
+  # requests:
+  #   memory: 50Mi
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+readinessProbe:
+  httpGet:
+    path: /health
+    port: http
+
+service:
+  annotations: {}
+  type: ClusterIP
+  port: 9464
+
+## An Ingress resource can provide name-based virtual hosting and TLS
+## termination among other things for CouchDB deployments which are accessed
+## from outside the Kubernetes cluster.
+## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
+ingress:
+  enabled: false
+  hosts:
+    []
+    # - chart-example.local
+  annotations:
+    {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  tls:
+    []
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+
+podAnnotations: {}
+
+replicas: 1
+
+# Enable this if you're using https://github.com/coreos/prometheus-operator
+serviceMonitor:
+  # When set true then use a ServiceMonitor to configure scraping
+  enabled: false
+  # Set the namespace the ServiceMonitor should be deployed
+  # namespace: monitoring
+  # Set how frequently Prometheus should scrape
+  # interval: 30s
+  # Set path to cloudwatch-exporter telemtery-path
+  # telemetryPath: /metrics
+  # Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator
+  # labels:
+  # Set timeout for scrape
+  # timeout: 10s
+  # Set of labels to transfer from the Kubernetes Service onto the target
+  # targetLabels: []
+  # MetricRelabelConfigs to apply to samples before ingestion
+  # metricRelabelings: []
+  # Set relabel_configs as per https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+  # relabelings: []


### PR DESCRIPTION
#### What this PR does / why we need it

This PR creates a SNMP notifier chart, for creating an alertmanager webhook that sends alerts as SNMP traps.

#### Which issue this PR fixes

#### Special notes for your reviewer

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
