### PR TITLE
[alertmanager-snmp-notifier] add SNMP notifer chart

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,7 @@
 * @prometheus-community/helm-charts-admins
 
 /charts/alertmanager/ @monotek @naseemkullah
+/charts/alertmanager-snmp-notifier/ @maxwo
 /charts/jiralert/ @jkroepke @zanhsieh
 /charts/kube-prometheus-stack/ @andrewgkew @gianrubio @gkarthiks @GMartinez-Sisti @QuentinBisson @scottrigby @Xtigyro
 /charts/kube-state-metrics/ @dotdc @mrueg @tariq1890

--- a/charts/alertmanager-snmp-notifier/.helmignore
+++ b/charts/alertmanager-snmp-notifier/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/alertmanager-snmp-notifier/Chart.yaml
+++ b/charts/alertmanager-snmp-notifier/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: alertmanager-snmp-notifier
+description: The SNMP Notifier handles alerts coming from Prometheus Alertmanager and relay them as SNMP traps.
+home: https://github.com/maxwo/snmp_notifier
+sources:
+  - https://github.com/maxwo/snmp_notifier
+type: application
+version: 0.1.0
+appVersion: v1.4.0
+keywords:
+  - monitoring
+maintainers:
+  - name: maxwo
+    email: maxime.wojtczak.pub@icloud.com
+annotations:
+  "artifacthub.io/links": |
+    - name: Chart Source
+      url: https://github.com/prometheus-community/helm-charts

--- a/charts/alertmanager-snmp-notifier/README.md
+++ b/charts/alertmanager-snmp-notifier/README.md
@@ -1,0 +1,58 @@
+# Prometheus SNMP Notifier
+
+An Alertmanager webhook that relays alerts as SNMP traps.
+
+This chart creates a [SNMP Notifier](https://github.com/maxwo/snmp_notifier) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.21+
+
+## Get Repository Info
+
+```console
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+```
+
+_See [helm repository](https://helm.sh/docs/helm/helm_repo/) for command documentation._
+
+## Install Chart
+
+```console
+helm install [RELEASE_NAME] prometheus-community/snmp-notifier
+```
+
+_See [configuration](#configuration) below._
+
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
+
+## Uninstall Chart
+
+```console
+helm uninstall [RELEASE_NAME]
+```
+
+This removes all the Kubernetes components associated with the chart and deletes the release.
+
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+
+## Upgrading Chart
+
+```console
+helm upgrade [RELEASE_NAME] [CHART] --install
+```
+
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+## Configuration
+
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
+
+```console
+helm show values prometheus-community/alertmanager-snmp-notifier
+```
+
+### Flags
+
+Check the [configuration section](https://github.com/maxwo/snmp_notifier#snmp-notifier-configuration) list and add to the `snmpNotifier.extraArgs` block in your value overrides.

--- a/charts/alertmanager-snmp-notifier/ci/default-values.yaml
+++ b/charts/alertmanager-snmp-notifier/ci/default-values.yaml
@@ -1,0 +1,3 @@
+snmpNotifier:
+  snmpDestinations:
+    - 127.0.0.1:162

--- a/charts/alertmanager-snmp-notifier/ci/ingress-values.yaml
+++ b/charts/alertmanager-snmp-notifier/ci/ingress-values.yaml
@@ -1,0 +1,6 @@
+snmpNotifier:
+  snmpDestinations:
+    - 127.0.0.1:162
+
+ingress:
+  enabled: true

--- a/charts/alertmanager-snmp-notifier/ci/secret-values.yaml
+++ b/charts/alertmanager-snmp-notifier/ci/secret-values.yaml
@@ -1,0 +1,7 @@
+snmpNotifier:
+  snmpDestinations:
+    - 127.0.0.1:162
+  snmpCommunity: public
+  snmpAuthenticationUsername: my_authentication_username
+  snmpAuthenticationPassword: my_authentication_password
+  snmpPrivatePassword: my_private_password

--- a/charts/alertmanager-snmp-notifier/ci/templates-values.yaml
+++ b/charts/alertmanager-snmp-notifier/ci/templates-values.yaml
@@ -1,0 +1,33 @@
+snmpNotifier:
+  snmpDestinations:
+    - 127.0.0.1:162
+
+  snmpTemplates:
+    description: |
+      {{- if .Alerts -}}
+      {{ len .Alerts }}/{{ len .DeclaredAlerts }} alerts are firing:
+
+      {{ range $severity, $alerts := (groupAlertsByLabel .Alerts "severity") -}}
+      Status: {{ $severity }}
+
+      {{- range $index, $alert := $alerts }}
+      - Alert: {{ $alert.Labels.alertname }}
+        Summary: {{ $alert.Annotations.summary }}
+        Description: {{ $alert.Annotations.description }}
+      {{ end }}
+      {{ end }}
+      {{ else -}}
+      Status: OK
+      {{- end -}}
+
+    extraFields:
+      - subId: 4
+        template: |
+          {{- if .Alerts -}}
+          Status: NOK
+          {{- else -}}
+          Status: OK
+          {{- end -}}
+      - subId: 5
+        template: |
+          This is a constant

--- a/charts/alertmanager-snmp-notifier/templates/NOTES.txt
+++ b/charts/alertmanager-snmp-notifier/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "alertmanager-snmp-notifier.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "alertmanager-snmp-notifier.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "alertmanager-snmp-notifier.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "alertmanager-snmp-notifier.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/alertmanager-snmp-notifier/templates/_helpers.tpl
+++ b/charts/alertmanager-snmp-notifier/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "alertmanager-snmp-notifier.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "alertmanager-snmp-notifier.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "alertmanager-snmp-notifier.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "alertmanager-snmp-notifier.labels" -}}
+helm.sh/chart: {{ include "alertmanager-snmp-notifier.chart" . }}
+{{ include "alertmanager-snmp-notifier.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "alertmanager-snmp-notifier.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "alertmanager-snmp-notifier.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "alertmanager-snmp-notifier.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "alertmanager-snmp-notifier.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/alertmanager-snmp-notifier/templates/configmap.yaml
+++ b/charts/alertmanager-snmp-notifier/templates/configmap.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.snmpNotifier.snmpTemplates }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "alertmanager-snmp-notifier.fullname" . }}
+  labels:
+    {{- include "alertmanager-snmp-notifier.labels" . | nindent 4 }}
+data:
+{{- if .Values.snmpNotifier.snmpTemplates.description }}
+  description-template.tpl: |
+{{ .Values.snmpNotifier.snmpTemplates.description | indent 4 }}
+{{- end }}
+{{- if .Values.snmpNotifier.snmpTemplates.extraFields }}
+  {{- range $element := .Values.snmpNotifier.snmpTemplates.extraFields }}
+  extra-field-{{ $element.subId }}-template.tpl: |
+{{ $element.template | indent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/alertmanager-snmp-notifier/templates/deployment.yaml
+++ b/charts/alertmanager-snmp-notifier/templates/deployment.yaml
@@ -1,0 +1,166 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "alertmanager-snmp-notifier.fullname" . }}
+  labels:
+    {{- include "alertmanager-snmp-notifier.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "alertmanager-snmp-notifier.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "alertmanager-snmp-notifier.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "alertmanager-snmp-notifier.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+        {{- if .Values.snmpNotifier.snmpDestinations }}
+        {{- range $destination := .Values.snmpNotifier.snmpDestinations }}
+            - --snmp.destination={{ $destination }}
+        {{- end }}
+        {{- end }}
+        {{ if .Values.snmpNotifier.extraArgs }}
+        {{- range $extraArg := .Values.snmpNotifier.extraArgs }}
+            - {{ $extraArg }}
+        {{- end }}
+        {{- end }}
+        {{- if (and .Values.snmpNotifier.snmpTemplates .Values.snmpNotifier.snmpTemplates.description) }}
+            - --snmp.trap-description-template=/templates/description-template.tpl
+        {{- else }}
+            - --snmp.trap-description-template=/etc/snmp_notifier/description-template.tpl
+        {{- end }}
+        {{- if (and .Values.snmpNotifier.snmpTemplates .Values.snmpNotifier.snmpTemplates.extraFields) }}
+        {{- range $element := .Values.snmpNotifier.snmpTemplates.extraFields }}
+            - --snmp.extra-field-template={{ $element.subId }}=/templates/extra-field-{{ $element.subId }}-template.tpl
+        {{- end }}
+        {{ end }}
+          env:
+          {{- if (or .Values.snmpNotifier.snmpCommunity .Values.snmpNotifier.snmpCommunitySecret) }}
+          - name: SNMP_NOTIFIER_COMMUNITY
+            valueFrom:
+              secretKeyRef:
+          {{- if .Values.snmpNotifier.snmpCommunitySecret }}
+                name: {{ .Values.snmpNotifier.snmpCommunitySecret.name }}
+                key: {{ .Values.snmpNotifier.snmpCommunitySecret.key }}
+          {{- else }}
+                name: {{ template "alertmanager-snmp-notifier.fullname" . }}
+                key: community
+          {{- end }}
+          {{- end }}
+          {{- if (or .Values.snmpNotifier.snmpAuthenticationUsername .Values.snmpNotifier.snmpAuthenticationUsernameSecret) }}
+          - name: SNMP_NOTIFIER_AUTH_USERNAME
+            valueFrom:
+              secretKeyRef:
+          {{- if .Values.snmpNotifier.snmpAuthenticationUsernameSecret }}
+                name: {{ .Values.snmpNotifier.snmpAuthenticationUsernameSecret.name }}
+                key: {{ .Values.snmpNotifier.snmpAuthenticationUsernameSecret.key }}
+          {{- else }}
+                name: {{ template "alertmanager-snmp-notifier.fullname" . }}
+                key: authenticationUsername
+          {{- end }}
+          {{- end }}
+          {{- if (or .Values.snmpNotifier.snmpAuthenticationPassword .Values.snmpNotifier.snmpAuthenticationPasswordSecret) }}
+          - name: SNMP_NOTIFIER_AUTH_PASSWORD
+            valueFrom:
+              secretKeyRef:
+          {{- if .Values.snmpNotifier.snmpAuthenticationPasswordSecret }}
+                name: {{ .Values.snmpNotifier.snmpAuthenticationPasswordSecret.name }}
+                key: {{ .Values.snmpNotifier.snmpAuthenticationPasswordSecret.key }}
+          {{- else }}
+                name: {{ template "alertmanager-snmp-notifier.fullname" . }}
+                key: authenticationPassword
+          {{- end }}
+          {{- end }}
+          {{- if (or .Values.snmpNotifier.snmpPrivatePassword .Values.snmpNotifier.snmpPrivatePasswordSecret) }}
+          - name: SNMP_NOTIFIER_PRIV_PASSWORD
+            valueFrom:
+              secretKeyRef:
+          {{- if .Values.snmpNotifier.snmpPrivatePasswordSecret }}
+                name: {{ .Values.snmpNotifier.snmpPrivatePasswordSecret.name }}
+                key: {{ .Values.snmpNotifier.snmpPrivatePasswordSecret.key }}
+          {{- else }}
+                name: {{ template "alertmanager-snmp-notifier.fullname" . }}
+                key: privatePassword
+          {{- end }}
+          {{- end }}
+          volumeMounts:
+          {{- if .Values.snmpNotifier.snmpTemplates }}
+            - mountPath: /templates
+              name: templates
+          {{- end }}
+          {{- range .Values.extraConfigmapMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              subPath: {{ .subPath | default "" }}
+              readOnly: {{ .readOnly }}
+          {{- end }}
+          {{- range .Values.extraSecretMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              subPath: {{ .subPath }}
+              readOnly: {{ .readOnly }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      {{- if .Values.snmpNotifier.snmpTemplates }}
+        - name: templates
+          configMap:
+            name: {{ template "alertmanager-snmp-notifier.fullname" . }}
+      {{- end }}
+      {{- range .Values.extraConfigmapMounts }}
+        - name: {{ .name }}
+          configMap:
+            name: {{ .configMap }}
+            defaultMode: {{ .defaultMode }}
+      {{- end }}
+      {{- range .Values.extraSecretMounts }}
+        - name: {{ .name }}
+          secret:
+            secretName: {{ .secretName }}
+            defaultMode: {{ .defaultMode }}
+      {{- end }}

--- a/charts/alertmanager-snmp-notifier/templates/hpa.yaml
+++ b/charts/alertmanager-snmp-notifier/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "alertmanager-snmp-notifier.fullname" . }}
+  labels:
+    {{- include "alertmanager-snmp-notifier.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "alertmanager-snmp-notifier.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/alertmanager-snmp-notifier/templates/ingress.yaml
+++ b/charts/alertmanager-snmp-notifier/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "alertmanager-snmp-notifier.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "alertmanager-snmp-notifier.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/alertmanager-snmp-notifier/templates/secrets.yaml
+++ b/charts/alertmanager-snmp-notifier/templates/secrets.yaml
@@ -1,0 +1,29 @@
+{{ $community := (and .Values.snmpNotifier.snmpCommunity (not .Values.snmpNotifier.snmpCommunitySecret)) }}
+{{ $authenticationUsername := (and .Values.snmpNotifier.snmpAuthenticationUsername (not .Values.snmpNotifier.snmpAuthenticationUsernameSecret)) }}
+{{ $authenticationPassword := (and .Values.snmpNotifier.snmpAuthenticationPassword (not .Values.snmpNotifier.snmpAuthenticationPasswordSecret)) }}
+{{ $privatePassword := (and .Values.snmpNotifier.snmpPrivatePassword (not .Values.snmpNotifier.snmpPrivatePasswordSecret)) }}
+{{- if (or $community $authenticationUsername $authenticationPassword $privatePassword) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "alertmanager-snmp-notifier.fullname" . }}
+  labels:
+    app: {{ template "alertmanager-snmp-notifier.name" . }}
+    chart: {{ template "alertmanager-snmp-notifier.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+type: Opaque
+data:
+  {{- if $community }}
+  community: {{ .Values.snmpNotifier.snmpCommunity | b64enc }}
+  {{- end -}}
+  {{- if $authenticationUsername }}
+  authenticationUsername: {{ .Values.snmpNotifier.snmpAuthenticationUsername | b64enc }}
+  {{- end -}}
+  {{- if $authenticationPassword }}
+  authenticationPassword: {{ .Values.snmpNotifier.snmpAuthenticationPassword | b64enc }}
+  {{- end -}}
+  {{- if $privatePassword }}
+  privatePassword: {{ .Values.snmpNotifier.snmpPrivatePassword | b64enc }}
+  {{- end -}}
+{{- end -}}

--- a/charts/alertmanager-snmp-notifier/templates/service.yaml
+++ b/charts/alertmanager-snmp-notifier/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "alertmanager-snmp-notifier.fullname" . }}
+  labels:
+    {{- include "alertmanager-snmp-notifier.labels" . | nindent 4 }}
+  {{- if .Values.service.annotations }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "alertmanager-snmp-notifier.selectorLabels" . | nindent 4 }}

--- a/charts/alertmanager-snmp-notifier/templates/serviceaccount.yaml
+++ b/charts/alertmanager-snmp-notifier/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "alertmanager-snmp-notifier.serviceAccountName" . }}
+  labels:
+    {{- include "alertmanager-snmp-notifier.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/alertmanager-snmp-notifier/templates/servicemonitor.yaml
+++ b/charts/alertmanager-snmp-notifier/templates/servicemonitor.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+{{- if .Values.serviceMonitor.labels }}
+  labels:
+{{ toYaml .Values.serviceMonitor.labels | indent 4}}
+{{- end }}
+  name: {{ template "alertmanager-snmp-notifier.fullname" . }}
+{{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+{{- end }}
+spec:
+  endpoints:
+  - port: http
+{{- if .Values.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
+{{- end }}
+{{- if .Values.serviceMonitor.telemetryPath }}
+    path: {{ .Values.serviceMonitor.telemetryPath }}
+{{- end }}
+{{- if .Values.serviceMonitor.timeout }}
+    scrapeTimeout: {{ .Values.serviceMonitor.timeout }}
+{{- end }}
+{{- if .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ toYaml .Values.serviceMonitor.metricRelabelings | indent 4 }}
+{{- end }}
+{{- if .Values.serviceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.serviceMonitor.relabelings | nindent 4 }}
+{{- end }}
+  jobLabel: {{ template "alertmanager-snmp-notifier.fullname" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "alertmanager-snmp-notifier.selectorLabels" . | nindent 6 }}
+{{- if .Values.serviceMonitor.targetLabels }}
+  targetLabels:
+{{- range .Values.serviceMonitor.targetLabels }}
+  - {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/alertmanager-snmp-notifier/values.yaml
+++ b/charts/alertmanager-snmp-notifier/values.yaml
@@ -1,0 +1,157 @@
+image:
+  repository: maxwo/snmp-notifier
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+snmpNotifier:
+  # extraArgs allows to pass SNMP notifier configurations, as described on https://github.com/maxwo/snmp_notifier#snmp-notifier-configuration
+  extraArgs: []
+  # - --alert.severity-label=severity
+
+  # snmpDestinations is the list of SNMP servers to send the traps to
+  snmpDestinations:
+    - snmp-server:162
+
+  # SNMP authentication secrets, that may be instanciated by the chart, or may use an already created secret
+  # snmpCommunity: public
+  # snmpAuthenticationUsername: my_authentication_username
+  # snmpAuthenticationPassword: my_authentication_password
+  # snmpPrivatePassword: my_private_password
+  # snmpCommunitySecret:
+  #   name: existingsecret
+  #   key: community
+  # snmpAuthenticationUsernameSecret:
+  #   name: existingsecret
+  #   key: authenticationUsername
+  # snmpAuthenticationPasswordSecret:
+  #   name: existingsecret
+  #   key: authenticationPassword
+  # snmpPrivatePasswordSecret:
+  #   name: existingsecret
+  #   key: privatePassword
+
+  # snmpTemplates allows to customize the description of the traps, and add extra trap fields
+  snmpTemplates: {}
+  #   description: |
+  #     {{- if .Alerts -}}
+  #     {{ len .Alerts }}/{{ len .DeclaredAlerts }} alerts are firing:
+
+  #     {{ range $severity, $alerts := (groupAlertsByLabel .Alerts "severity") -}}
+  #     Status: {{ $severity }}
+
+  #     {{- range $index, $alert := $alerts }}
+  #     - Alert: {{ $alert.Labels.alertname }}
+  #       Summary: {{ $alert.Annotations.summary }}
+  #       Description: {{ $alert.Annotations.description }}
+  #     {{ end }}
+  #     {{ end }}
+  #     {{ else -}}
+  #     Status: OK
+  #     {{- end -}}
+
+  #   extraFields:
+  #     - subId: 4
+  #       template: |
+  #         {{- if .Alerts -}}
+  #         Status: NOK
+  #         {{- else -}}
+  #         Status: OK
+  #         {{- end -}}
+  #     - subId: 5
+  #       template: |
+  #         This is a constant
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+replicaCount: 1
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 9464
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: snmp-notifier.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: snmp-notifier-tls
+  #    hosts:
+  #      - snmp-notifier.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Enable this if you're using https://github.com/coreos/prometheus-operator
+serviceMonitor:
+  # When set true then use a ServiceMonitor to configure scraping
+  enabled: false
+  # Set the namespace the ServiceMonitor should be deployed
+  namespace: monitoring
+  # Set how frequently Prometheus should scrape
+  interval: 30s
+  # Set path to cloudwatch-exporter telemtery-path
+  telemetryPath: /metrics
+  # Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator
+  labels:
+  # Set timeout for scrape
+  timeout: 10s
+  # Set of labels to transfer from the Kubernetes Service onto the target
+  targetLabels: []
+  # MetricRelabelConfigs to apply to samples before ingestion
+  metricRelabelings: []
+  # Set relabel_configs as per https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+  relabelings: []


### PR DESCRIPTION
#### What this PR does / why we need it

This PR creates a SNMP notifier chart, for creating an alertmanager webhook that sends alerts as SNMP traps.

#### Which issue this PR fixes

#### Special notes for your reviewer

I created a previous PR, but closed and created a new one, squashed, and up-to-date with a newest version.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
