### PR TITLE
[prometheus-kafka-exporter] Add support for securityContext

### DIFF
--- a/charts/prometheus-kafka-exporter/Chart.yaml
+++ b/charts/prometheus-kafka-exporter/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v1.6.0"
 description: A Helm chart to export the metrics from Kafka in Prometheus format using the kafka-exporter from https://github.com/danielqsj/kafka_exporter
 name: prometheus-kafka-exporter
 home: https://github.com/danielqsj/kafka_exporter
-version: 1.7.0
+version: 1.8.0
 sources:
   - https://gkarthiks.github.io/helm-charts/charts/prometheus-kafka-exporter
 keywords:

--- a/charts/prometheus-kafka-exporter/Chart.yaml
+++ b/charts/prometheus-kafka-exporter/Chart.yaml
@@ -21,6 +21,6 @@ annotations:
       url: https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-kafka-exporter
 dependencies:
 - name: kafka
-  version: "14.9.3"
+  version: "18.5.0"
   repository: https://charts.bitnami.com/bitnami
   condition: kafka.enabled

--- a/charts/prometheus-kafka-exporter/templates/deployment.yaml
+++ b/charts/prometheus-kafka-exporter/templates/deployment.yaml
@@ -114,6 +114,10 @@ spec:
 {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if or (.Values.tls.mountPath) (.Values.sasl.kerberos.mountPath) }}
           volumeMounts:
             {{- if .Values.tls.mountPath }}

--- a/charts/prometheus-kafka-exporter/values.yaml
+++ b/charts/prometheus-kafka-exporter/values.yaml
@@ -143,8 +143,19 @@ server:
 kafka:
   enabled: false
 
-# Set security context for the kafka-exporter container. Useful when you need to adapt to an existing PSP
+# Set security context for the kafka-exporter pod. Useful when you need to adapt to an existing PSP
 securityContext: {}
   # runAsUser:
   # runAsGroup:
   # fsGroup:
+
+# Set securityContext for the kafka-exporter container
+containerSecurityContext: {}
+  # runAsUser: 10001
+  # runAsNonRoot: true
+  # allowPrivilegeEscalation: false
+  # capabilities:
+  #   drop: ["all"]
+  # readOnlyRootFilesystem: true
+  # seccompProfile:
+  #   type: RuntimeDefault

--- a/charts/prometheus-kafka-exporter/values.yaml
+++ b/charts/prometheus-kafka-exporter/values.yaml
@@ -145,17 +145,20 @@ kafka:
 
 # Set security context for the kafka-exporter pod. Useful when you need to adapt to an existing PSP
 securityContext: {}
-  # runAsUser:
-  # runAsGroup:
-  # fsGroup:
+  # fsGroup: 2000
+  # runAsGroup: 10002
+  # runAsUser: 10001
+  # seccompProfile:
+  #   type: RuntimeDefault
 
 # Set securityContext for the kafka-exporter container
 containerSecurityContext: {}
-  # runAsUser: 10001
-  # runAsNonRoot: true
   # allowPrivilegeEscalation: false
   # capabilities:
   #   drop: ["all"]
   # readOnlyRootFilesystem: true
+  # runAsGroup: 10002
+  # runAsNonRoot: true
+  # runAsUser: 10001
   # seccompProfile:
   #   type: RuntimeDefault


### PR DESCRIPTION
Signed-off-by: zeritti <47476160+zeritti@users.noreply.github.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
This PR adds support for `securityContext` in the kafka-exporter's container enabling thus transition from PSP to Pod Security Standards. 

Since value `securityContext` is already used for pod's security context, `containerSecurityContext` has been chosen for that of the container.

#### Which issue this PR fixes
None

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
