### PR TITLE
[prometheus-mysql-exporter] add imagePullSecrets and fullname override

### DIFF
--- a/charts/prometheus-mysql-exporter/Chart.yaml
+++ b/charts/prometheus-mysql-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for prometheus mysql exporter with cloudsqlproxy
 name: prometheus-mysql-exporter
-version: 1.11.1
+version: 1.11.2
 home: https://github.com/prometheus/mysqld_exporter
 appVersion: v0.14.0
 sources:

--- a/charts/prometheus-mysql-exporter/Chart.yaml
+++ b/charts/prometheus-mysql-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for prometheus mysql exporter with cloudsqlproxy
 name: prometheus-mysql-exporter
-version: 1.11.2
+version: 1.12.1
 home: https://github.com/prometheus/mysqld_exporter
 appVersion: v0.14.0
 sources:

--- a/charts/prometheus-mysql-exporter/templates/deployment.yaml
+++ b/charts/prometheus-mysql-exporter/templates/deployment.yaml
@@ -30,11 +30,15 @@ spec:
       serviceAccountName: {{ template "prometheus-mysql-exporter.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if and .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if or .Values.config .Values.collectors }}
           args:

--- a/charts/prometheus-mysql-exporter/values.yaml
+++ b/charts/prometheus-mysql-exporter/values.yaml
@@ -1,13 +1,21 @@
-# Default values for prometheus-mysql-exporter.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
+## Default values for prometheus-mysql-exporter.
+## This is a YAML-formatted file.
+## Declare variables to be passed into your templates.
+
+## override release name
+fullnameOverride: ""
 
 replicaCount: 1
 
 image:
   repository: "prom/mysqld-exporter"
-  tag: "v0.14.0"
+  ## default on chart appVersion
+  tag: ""
   pullPolicy: "IfNotPresent"
+
+# imagePullSecrets:
+# - name: secret-name
+imagePullSecrets: []
 
 service:
   labels: {}

--- a/charts/prometheus-mysql-exporter/values.yaml
+++ b/charts/prometheus-mysql-exporter/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 1
 
 image:
   repository: "prom/mysqld-exporter"
-  ## default on chart appVersion
+  ## if not set charts appVersion var is used
   tag: ""
   pullPolicy: "IfNotPresent"
 


### PR DESCRIPTION
#### What this PR does / why we need it
let user set registry pull secrets if they want to use their private registry.

#### Which issue this PR fixes
add imagePullSecrets to mysql-exporter chart  
add fullname override(You had it in helpers templates but not in values file)  
set default image tag from .Values.image.tag to .Chart.AppVersion  


- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
