### PR TITLE
kube-prometheus-stack: change admission webhook image registry defaults

### DIFF
--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -34,7 +34,7 @@ spec:
       {{- end }}
       containers:
         - name: patch
-          {{- $registry := .Values.global.imageRegistry | default .Values.prometheusOperator.admissionWebhooks.patch.image.registry -}}
+          {{- $registry := .Values.prometheusOperator.admissionWebhooks.patch.image.registry | default .Values.global.imageRegistry -}}
           {{- if .Values.prometheusOperator.admissionWebhooks.patch.image.sha }}
           image: {{ $registry }}/{{ .Values.prometheusOperator.admissionWebhooks.patch.image.repository }}:{{ .Values.prometheusOperator.admissionWebhooks.patch.image.tag }}@sha256:{{ .Values.prometheusOperator.admissionWebhooks.patch.image.sha }}
           {{- else }}


### PR DESCRIPTION
Right now, even if `prometheusOperator.admissionWebhooks.patch.image.registry` is defined, `global.imageRegistry` is preferred for webhook image.
