### PR TITLE
[kube-prometheus-stack] Remove false alarm on a volume with infinite inodes

### DIFF
--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-storage.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-storage.yaml
@@ -100,6 +100,8 @@ spec:
         ) < 0.03
         and
         kubelet_volume_stats_inodes_used{job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics"} > 0
+        and
+        kubelet_volume_stats_inodes_free{job="kubelet", namespace=~"{{ $targetNamespace }}", metrics_path="/metrics"} > 0
         unless on(namespace, persistentvolumeclaim)
         kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
         unless on(namespace, persistentvolumeclaim)


### PR DESCRIPTION
On some storage systems, such as a CephFS filesystem, the underlying storage doesn't have any limit on inodes.

If the kubelet_volume_stats_inodes_free metric is always zero, then the KubePersistentVolumeInodesFillingUp alert will always fire.

This patch adds a simple conditional to ensure that the kubelet_volume_stats_inodes_free is meaningful for the volume and thus fixing the false alert on this edge case.

Signed-off-by: Juho Mäkinen <juho.makinen@gmail.com>

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
