### PR TITLE
[kube-prometheus-stack] Added namespace selector for webhook configuration

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 44.3.0
+version: 44.3.1
 appVersion: v0.62.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/mutatingWebhookConfiguration.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/mutatingWebhookConfiguration.yaml
@@ -41,4 +41,26 @@ webhooks:
     timeoutSeconds: {{ .Values.prometheusOperator.admissionWebhooks.timeoutSeconds }}
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None
+    {{- if or .Values.prometheusOperator.denyNamespaces .Values.prometheusOperator.namespaces }}
+    namespaceSelector:
+      matchExpressions:
+      {{- if .Values.prometheusOperator.denyNamespaces }}
+      - key: kubernetes.io/metadata.name
+        operator: NotIn
+        values:
+        {{- range $namespace := .Values.prometheusOperator.denyNamespaces }} 
+        - {{ $namespace }}
+        {{- end }}
+      {{- else if and .Values.prometheusOperator.namespaces .Values.prometheusOperator.namespaces.additional }}
+      - key: kubernetes.io/metadata.name
+        operator: In
+        values:
+        {{- if and .Values.prometheusOperator.namespaces.releaseNamespace (default .Values.prometheusOperator.namespaces.releaseNamespace true) }}
+        - {{ .Release.Namespace }}
+        {{- end }}
+        {{- range $namespace := .Values.prometheusOperator.namespaces.additional }} 
+        - {{ $namespace }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/validatingWebhookConfiguration.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/validatingWebhookConfiguration.yaml
@@ -41,4 +41,26 @@ webhooks:
     timeoutSeconds: {{ .Values.prometheusOperator.admissionWebhooks.timeoutSeconds }}
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None
+    {{- if or .Values.prometheusOperator.denyNamespaces .Values.prometheusOperator.namespaces }}
+    namespaceSelector:
+      matchExpressions:
+      {{- if .Values.prometheusOperator.denyNamespaces }}
+      - key: kubernetes.io/metadata.name
+        operator: NotIn
+        values:
+        {{- range $namespace := .Values.prometheusOperator.denyNamespaces }} 
+        - {{ $namespace }}
+        {{- end }}
+      {{- else if and .Values.prometheusOperator.namespaces .Values.prometheusOperator.namespaces.additional }}
+      - key: kubernetes.io/metadata.name
+        operator: In
+        values:
+        {{- if and .Values.prometheusOperator.namespaces.releaseNamespace (default .Values.prometheusOperator.namespaces.releaseNamespace true) }}
+        - {{ .Release.Namespace }}
+        {{- end }}
+        {{- range $namespace := .Values.prometheusOperator.namespaces.additional }} 
+        - {{ $namespace }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
 {{- end }}


### PR DESCRIPTION
Added an ability to override namespace selector for webhook configuration

Signed-off-by: Aleksei Chernyshov <aleksei.chernyshov@sap.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Currently, it is not possible to configure namespaceSelector for ValidatingWebhookConfiguration and MutatingWebhookConfiguration, because there is no namespaceSelector in corresponding template files. This PR adds this functionality. The person can either deny namespaces by setting denyNamespaces, or to allow specific namespaces by setting namespaces.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #2915

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
