### PR TITLE
Add podLabels to prom-label-proxy

### DIFF
--- a/charts/prom-label-proxy/Chart.yaml
+++ b/charts/prom-label-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prom-label-proxy
 description: A proxy that enforces a given label in a given PromQL query.
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "v0.5.0"
 home: "https://github.com/prometheus-community/prom-label-proxy"
 keywords:

--- a/charts/prom-label-proxy/Chart.yaml
+++ b/charts/prom-label-proxy/Chart.yaml
@@ -3,7 +3,7 @@ name: prom-label-proxy
 description: A proxy that enforces a given label in a given PromQL query.
 type: application
 version: 0.2.0
-appVersion: "v0.5.0"
+appVersion: "v0.6.0"
 home: "https://github.com/prometheus-community/prom-label-proxy"
 keywords:
   - metric

--- a/charts/prom-label-proxy/templates/deployment.yaml
+++ b/charts/prom-label-proxy/templates/deployment.yaml
@@ -18,6 +18,9 @@ spec:
       {{- end }}
       labels:
         {{- include "prom-label-proxy.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/prom-label-proxy/values.yaml
+++ b/charts/prom-label-proxy/values.yaml
@@ -33,6 +33,9 @@ serviceAccount:
 # -- Annotations for prom-label-proxy pods
 podAnnotations: {}
 
+# -- Labels for prom-label-proxy pods
+podLabels: {}
+
 # -- prom-label-proxy pods' Security Context.
 podSecurityContext: {}
   # fsGroup: 2000


### PR DESCRIPTION
#### What this PR does / why we need it
This PR adds the possibility to add labels for pods.

Some network policies from helm charts have restrictive filters that only pods with certain label can reach a pod. In our current case, this is the case with Thanos: [Bitnami Thanos Chart](https://github.com/bitnami/charts/blob/main/bitnami/thanos/templates/networkpolicy.yaml)

#### Which issue this PR fixes
not opened

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
