### PR TITLE
[prometheus]: Add relabel configs for dual stack to kubernetes-pods jobs

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: v2.41.0
-version: 19.5.0
+version: 19.5.1
 kubeVersion: ">=1.16.0-0"
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -943,18 +943,15 @@ serverFiles:
             action: replace
             target_label: __metrics_path__
             regex: (.+)
-          - source_labels: [__meta_kubernetes_pod_ip]
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port, __meta_kubernetes_pod_ip]
             action: replace
-            regex: (([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})
-            replacement: '[$1]'
+            regex: (\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})
+            replacement: '[$2]:$1'
             target_label: __address__
-          - source_labels: [__meta_kubernetes_pod_ip]
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port, __meta_kubernetes_pod_ip]
             action: replace
-            regex: ((([0-9]+?)(\.|$)){4})
-            replacement: $1
-            target_label: __address__
-          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
-            separator: ':'
+            regex: (\d+);((([0-9]+?)(\.|$)){4})
+            replacement: $2:$1
             target_label: __address__
           - action: labelmap
             regex: __meta_kubernetes_pod_annotation_prometheus_io_param_(.+)
@@ -1003,18 +1000,15 @@ serverFiles:
             action: replace
             target_label: __metrics_path__
             regex: (.+)
-          - source_labels: [__meta_kubernetes_pod_ip]
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port, __meta_kubernetes_pod_ip]
             action: replace
-            regex: (([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})
-            replacement: '[$1]'
+            regex: (\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})
+            replacement: '[$2]:$1'
             target_label: __address__
-          - source_labels: [__meta_kubernetes_pod_ip]
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port, __meta_kubernetes_pod_ip]
             action: replace
-            regex: ((([0-9]+?)(\.|$)){4})
-            replacement: $1
-            target_label: __address__
-          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
-            separator: ':'
+            regex: (\d+);((([0-9]+?)(\.|$)){4})
+            replacement: $2:$1
             target_label: __address__
           - action: labelmap
             regex: __meta_kubernetes_pod_annotation_prometheus_io_param_(.+)

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -943,10 +943,18 @@ serverFiles:
             action: replace
             target_label: __metrics_path__
             regex: (.+)
-          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+          - source_labels: [__meta_kubernetes_pod_ip]
             action: replace
-            regex: (.+?)(?::\d+)?;(\d+)
-            replacement: $1:$2
+            regex: (([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})
+            replacement: '[$1]'
+            target_label: __address__
+          - source_labels: [__meta_kubernetes_pod_ip]
+            action: replace
+            regex: ((([0-9]+?)(\.|$)){4})
+            replacement: $1
+            target_label: __address__
+          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+            separator: ':'
             target_label: __address__
           - action: labelmap
             regex: __meta_kubernetes_pod_annotation_prometheus_io_param_(.+)
@@ -995,10 +1003,18 @@ serverFiles:
             action: replace
             target_label: __metrics_path__
             regex: (.+)
-          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+          - source_labels: [__meta_kubernetes_pod_ip]
             action: replace
-            regex: (.+?)(?::\d+)?;(\d+)
-            replacement: $1:$2
+            regex: (([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})
+            replacement: '[$1]'
+            target_label: __address__
+          - source_labels: [__meta_kubernetes_pod_ip]
+            action: replace
+            regex: ((([0-9]+?)(\.|$)){4})
+            replacement: $1
+            target_label: __address__
+          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+            separator: ':'
             target_label: __address__
           - action: labelmap
             regex: __meta_kubernetes_pod_annotation_prometheus_io_param_(.+)


### PR DESCRIPTION
Signed-off-by: Jacek Ewertowski <jacek.ewertowski1@gmail.com>

#### Which issue this PR fixes

- #1470
- [istio-35915](https://github.com/istio/istio/issues/35915)

#### Special notes for your reviewer

This relabel configuration works with IPv4 and IPv6 without specifying networking stack, like it was in [#1502](https://github.com/prometheus-community/helm-charts/pull/1502).
I tested this change on OpenShift clusters with IPv4 and IPv6 networking and I also verified these rules in Prometheus [unit tests](https://github.com/prometheus/prometheus/compare/main...jewertow:prometheus:relabel-dual-stack-ip?expand=1).

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
