### PR TITLE
[prometheus-pushgateway] Adjust Liveness probe default to /healthy

### DIFF
--- a/charts/prometheus-pushgateway/Chart.yaml
+++ b/charts/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v1.5.1"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 2.1.1
+version: 2.1.2
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/charts/prometheus-pushgateway/values.yaml
+++ b/charts/prometheus-pushgateway/values.yaml
@@ -103,7 +103,7 @@ liveness:
   enabled: true
   probe:
     httpGet:
-      path: /-/ready
+      path: /-/healthy
       port: 9091
     initialDelaySeconds: 10
     timeoutSeconds: 10


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
After a previous change to enable full customisation of the liveness and readiness probes in this helm chart, the liveness probe was altered from using /healthy to /ready. I believe this was likely a copy-paste mistake and this PR aims to alter the default back to /healthy so that others don't need to override the value.

#### Which issue this PR fixes

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
