### PR TITLE
[kube-prometheus-stack] allow updating alertmanager/status

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 45.0.0
+version: 45.0.1
 appVersion: v0.63.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/clusterrole.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/clusterrole.yaml
@@ -11,6 +11,7 @@ rules:
   - monitoring.coreos.com
   resources:
   - alertmanagers
+  - alertmanagers/status
   - alertmanagers/finalizers
   - alertmanagerconfigs
   - prometheuses


### PR DESCRIPTION
#### What this PR does / why we need it

Fixes the following error:

```
level=error ts=2023-02-10T17:48:20.564893817Z caller=klog.go:116 component=k8s_client_runtime func=ErrorDepth msg="status \"kube-system/kube-prometheus-stack-alertmanager\" failed: failed to update status subresource: alertmanagers.monitoring.coreos.com \"kube-prometheus-stack-alertmanager\" is forbidden: User \"system:serviceaccount:kube-system:kube-prometheus-stack-operator\" cannot update resource \"alertmanagers/status\" in API group \"monitoring.coreos.com\" in the namespace \"kube-system\""
```

- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
