### PR TITLE
[kube-prometheus-stack] fix: add missing dependency for sync_prometheus_rules.py

### DIFF
--- a/charts/kube-prometheus-stack/hack/requirements.txt
+++ b/charts/kube-prometheus-stack/hack/requirements.txt
@@ -1,2 +1,3 @@
 PyYAML==5.4
 requests==2.22.0
+jsonnet==0.19.1


### PR DESCRIPTION
Signed-off-by: dani-CO-CN <23180005+dani-CO-CN@users.noreply.github.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Add missing dependency for sync_prometheus_rules.py in kube-prometheus-stack. Jsonnet was introduced in [this pr](https://github.com/prometheus-community/helm-charts/pull/2340) but never added to requirements.txt

#### Which issue this PR fixes


- fixes #

#### Special notes for your reviewer
Did not bump helm chart version as the change does not impact the chart.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
