### PR TITLE
[kube-state-metrics] Allow parent charts to override registry hostname

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 4.30.1
+version: 4.31.0
 appVersion: 2.8.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 4.30.0
+version: 4.30.1
 appVersion: 2.8.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/kube-state-metrics/templates/deployment.yaml
@@ -120,9 +120,9 @@ spec:
         {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- if .Values.image.sha }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (print "v" .Chart.AppVersion) }}@sha256:{{ .Values.image.sha }}"
+        image: "{{ .Values.global.imageRegistry | default .Values.image.repository }}:{{ .Values.image.tag | default (print "v" .Chart.AppVersion) }}@sha256:{{ .Values.image.sha }}"
         {{- else }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (print "v" .Chart.AppVersion) }}"
+        image: "{{ .Values.global.imageRegistry | default .Values.image.repository }}:{{ .Values.image.tag | default (print "v" .Chart.AppVersion) }}"
         {{- end }}
         {{- if eq .Values.kubeRBACProxy.enabled false }}
         ports:
@@ -168,9 +168,9 @@ spec:
             mountPath: /etc/kube-rbac-proxy-config
         imagePullPolicy: {{ .Values.kubeRBACProxy.image.pullPolicy }}
         {{- if .Values.kubeRBACProxy.image.sha }}
-        image: "{{ .Values.kubeRBACProxy.image.repository }}:{{ .Values.kubeRBACProxy.image.tag }}@sha256:{{ .Values.kubeRBACProxy.image.sha }}"
+        image: "{{ .Values.global.imageRegistry | default .Values.kubeRBACProxy.image.repository }}:{{ .Values.kubeRBACProxy.image.tag }}@sha256:{{ .Values.kubeRBACProxy.image.sha }}"
         {{- else }}
-        image: "{{ .Values.kubeRBACProxy.image.repository }}:{{ .Values.kubeRBACProxy.image.tag }}"
+        image: "{{ .Values.global.imageRegistry | default .Values.kubeRBACProxy.image.repository }}:{{ .Values.kubeRBACProxy.image.tag }}"
         {{- end }}
         ports:
           - containerPort: {{ .Values.service.port | default 8080}}
@@ -207,9 +207,9 @@ spec:
             mountPath: /etc/kube-rbac-proxy-config
         imagePullPolicy: {{ .Values.kubeRBACProxy.image.pullPolicy }}
         {{- if .Values.kubeRBACProxy.image.sha }}
-        image: "{{ .Values.kubeRBACProxy.image.repository }}:{{ .Values.kubeRBACProxy.image.tag }}@sha256:{{ .Values.kubeRBACProxy.image.sha }}"
+        image: "{{ .Values.global.imageRegistry | default .Values.kubeRBACProxy.image.repository }}:{{ .Values.kubeRBACProxy.image.tag }}@sha256:{{ .Values.kubeRBACProxy.image.sha }}"
         {{- else }}
-        image: "{{ .Values.kubeRBACProxy.image.repository }}:{{ .Values.kubeRBACProxy.image.tag }}"
+        image: "{{ .Values.global.imageRegistry | default .Values.kubeRBACProxy.image.repository }}:{{ .Values.kubeRBACProxy.image.tag }}"
         {{- end }}
         ports:
           - containerPort: {{ .Values.selfMonitor.telemetryPort | default 8081 }}

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -23,6 +23,9 @@ global:
   #   - pullSecret1
   #   - pullSecret2
   imagePullSecrets: []
+  #
+  # Allow parent charts to override registry hostname
+  imageRegistry: ""
 
 # If set to true, this will deploy kube-state-metrics as a StatefulSet and the data
 # will be automatically sharded across <.Values.replicas> pods using the built-in


### PR DESCRIPTION
Add support for optionally overriding the registry hostname from a parent chart.

This is important for air-gapped installations which do not have direct access to the public internet and must use a private, internal container registry.

It also avoids having to modify the Kube-State-Metrics Helm chart directly.

FAO: @tariq1890  @mrueg @dotdc 