### PR TITLE
[prometheus-pgbouncer-exporter] add initial helm chart for pgbouncer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,6 +30,7 @@
 /charts/prometheus-nginx-exporter/ @nlamirault
 /charts/prometheus-node-exporter/ @gianrubio @zanhsieh
 /charts/prometheus-operator-crds/ @dacamposol @desaintmartin
+/charts/prometheus-pgbouncer-exporter/ @stewartshea
 /charts/prometheus-pingdom-exporter/ @monotek @rpahli
 /charts/prometheus-postgres-exporter/ @gianrubio @zanhsieh
 /charts/prometheus-pgbouncer-exporter/ @stewartshea

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,7 +33,6 @@
 /charts/prometheus-pgbouncer-exporter/ @stewartshea
 /charts/prometheus-pingdom-exporter/ @monotek @rpahli
 /charts/prometheus-postgres-exporter/ @gianrubio @zanhsieh
-/charts/prometheus-pgbouncer-exporter/ @stewartshea
 /charts/prometheus-pushgateway/ @cstaud @gianrubio
 /charts/prometheus-rabbitmq-exporter/ @desaintmartin @iamabhishek-dubey @juanchimienti @monotek
 /charts/prometheus-redis-exporter/ @acondrat @zanhsieh

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,6 +32,7 @@
 /charts/prometheus-operator-crds/ @dacamposol @desaintmartin
 /charts/prometheus-pingdom-exporter/ @monotek @rpahli
 /charts/prometheus-postgres-exporter/ @gianrubio @zanhsieh
+/charts/prometheus-pgbouncer-exporter/ @stewartshea
 /charts/prometheus-pushgateway/ @cstaud @gianrubio
 /charts/prometheus-rabbitmq-exporter/ @desaintmartin @iamabhishek-dubey @juanchimienti @monotek
 /charts/prometheus-redis-exporter/ @acondrat @zanhsieh

--- a/charts/prometheus-pgbouncer-exporter/.helmignore
+++ b/charts/prometheus-pgbouncer-exporter/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/prometheus-pgbouncer-exporter/Chart.yaml
+++ b/charts/prometheus-pgbouncer-exporter/Chart.yaml
@@ -14,3 +14,8 @@ maintainers:
 - email: stewart.shea@gmail.com
   name: stewartshea
 type: application
+dependencies:
+- name: postgresql
+  version: "~12.2.2"
+  repository: https://charts.bitnami.com/bitnami
+  condition: postgresql.enabled

--- a/charts/prometheus-pgbouncer-exporter/Chart.yaml
+++ b/charts/prometheus-pgbouncer-exporter/Chart.yaml
@@ -19,3 +19,4 @@ dependencies:
   version: "~12.2.2"
   repository: https://charts.bitnami.com/bitnami
   condition: postgresql.enabled
+  

--- a/charts/prometheus-pgbouncer-exporter/Chart.yaml
+++ b/charts/prometheus-pgbouncer-exporter/Chart.yaml
@@ -19,4 +19,3 @@ dependencies:
   version: "~12.2.2"
   repository: https://charts.bitnami.com/bitnami
   condition: postgresql.enabled
-  

--- a/charts/prometheus-pgbouncer-exporter/Chart.yaml
+++ b/charts/prometheus-pgbouncer-exporter/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+appVersion: "1.18.0"
+description: A Helm chart for prometheus pgbouncer-exporter
+name: prometheus-pgbouncer-exporter
+version: 0.1.0
+home: https://github.com/prometheus-community/pgbouncer_exporter
+sources:
+- https://github.com/prometheus-community/pgbouncer_exporter
+keywords:
+- pgbouncer
+- prometheus
+- exporter
+maintainers:
+- email: stewart.shea@gmail.com
+  name: stewartshea
+type: application

--- a/charts/prometheus-pgbouncer-exporter/README.md
+++ b/charts/prometheus-pgbouncer-exporter/README.md
@@ -1,0 +1,47 @@
+# Prometheus Postgres Exporter
+
+Prometheus exporter for [PgBouncer](https://www.pgbouncer.org/) server metrics.
+
+This chart bootstraps a prometheus [pgbouncer exporter](https://github.com/prometheus-community/pgbouncer_exporter) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.16+
+- Helm 3+
+
+## Add Helm Chart Repository
+
+```console
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+```
+
+_See [`helm repo`](https://helm.sh/docs/helm/helm_repo/) for command documentation._
+
+## Install Chart
+
+```console
+helm install [RELEASE_NAME] prometheus-community/prometheus-pgbouncer-exporter
+```
+
+_See [configuration](#configuring) below._
+
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
+
+## Uninstall Chart
+
+```console
+helm uninstall [RELEASE_NAME]
+```
+
+This removes all the Kubernetes components associated with the chart and deletes the release.
+
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+
+## Configuring
+
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
+
+```console
+helm show values prometheus-community/prometheus-pgbouncer-exporter
+```

--- a/charts/prometheus-pgbouncer-exporter/ci/ci-values.yaml
+++ b/charts/prometheus-pgbouncer-exporter/ci/ci-values.yaml
@@ -4,7 +4,7 @@ postgresql:
   global:
     postgresql:
       auth:
-        postgresPassword: "password"  
+        postgresPassword: "password"
 rbac:
   create: true
   pspEnabled: false
@@ -23,12 +23,12 @@ extraContainers:
       - name: PGBOUNCER_IGNORE_STARTUP_PARAMETERS
         value: "extra_float_digits"
     volumeMounts:
-    - name: pgbouncer-config
-      mountPath: /opt/bitnami/pgbouncer/conf
-    - name: pgbouncer-logs
-      mountPath: /opt/bitnami/pgbouncer/logs
-    - name: pgbouncer-tmp
-      mountPath: /opt/bitnami/pgbouncer/tmp
+      - name: pgbouncer-config
+        mountPath: /opt/bitnami/pgbouncer/conf
+      - name: pgbouncer-logs
+        mountPath: /opt/bitnami/pgbouncer/logs
+      - name: pgbouncer-tmp
+        mountPath: /opt/bitnami/pgbouncer/tmp
 extraVolumes:
   - name: pgbouncer-config
     emptyDir: {}

--- a/charts/prometheus-pgbouncer-exporter/ci/ci-values.yaml
+++ b/charts/prometheus-pgbouncer-exporter/ci/ci-values.yaml
@@ -11,7 +11,7 @@ rbac:
 extraContainers:
   - name: pgbouncer
     image: bitnami/pgbouncer:latest
-    env: 
+    env:
       - name: POSTGRESQL_PASSWORD
         value: "password"
       - name: PGBOUNCER_EXTRA_FLAGS

--- a/charts/prometheus-pgbouncer-exporter/ci/ci-values.yaml
+++ b/charts/prometheus-pgbouncer-exporter/ci/ci-values.yaml
@@ -1,9 +1,9 @@
-postgresql: 
+postgresql:
   enabled: true
   fullnameOverride: ci-postgres
-  global: 
-    postgresql: 
-      auth: 
+  global:
+    postgresql:
+      auth:
         postgresPassword: "password"  
 rbac:
   create: true
@@ -36,8 +36,8 @@ extraVolumes:
     emptyDir: {}
   - name: pgbouncer-tmp
     emptyDir: {}
-config: 
-  datasource: 
+config:
+  datasource:
     host: localhost
     port: 6432
     password: "password"

--- a/charts/prometheus-pgbouncer-exporter/ci/ci-values.yaml
+++ b/charts/prometheus-pgbouncer-exporter/ci/ci-values.yaml
@@ -1,0 +1,43 @@
+postgresql: 
+  enabled: true
+  fullnameOverride: ci-postgres
+  global: 
+    postgresql: 
+      auth: 
+        postgresPassword: "password"  
+rbac:
+  create: true
+  pspEnabled: false
+extraContainers:
+  - name: pgbouncer
+    image: bitnami/pgbouncer:latest
+    env: 
+      - name: POSTGRESQL_PASSWORD
+        value: "password"
+      - name: PGBOUNCER_EXTRA_FLAGS
+        value: "--verbose"
+      - name: "POSTGRESQL_HOST"
+        value: ci-postgres
+      - name: PGBOUNCER_AUTH_USER
+        value: "postgres"
+      - name: PGBOUNCER_IGNORE_STARTUP_PARAMETERS
+        value: "extra_float_digits"
+    volumeMounts:
+    - name: pgbouncer-config
+      mountPath: /opt/bitnami/pgbouncer/conf
+    - name: pgbouncer-logs
+      mountPath: /opt/bitnami/pgbouncer/logs
+    - name: pgbouncer-tmp
+      mountPath: /opt/bitnami/pgbouncer/tmp
+extraVolumes:
+  - name: pgbouncer-config
+    emptyDir: {}
+  - name: pgbouncer-logs
+    emptyDir: {}
+  - name: pgbouncer-tmp
+    emptyDir: {}
+config: 
+  datasource: 
+    host: localhost
+    port: 6432
+    password: "password"

--- a/charts/prometheus-pgbouncer-exporter/templates/NOTES.txt
+++ b/charts/prometheus-pgbouncer-exporter/templates/NOTES.txt
@@ -1,0 +1,15 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "prometheus-pgbouncer-exporter.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "prometheus-pgbouncer-exporter.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "prometheus-pgbouncer-exporter.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "prometheus-pgbouncer-exporter.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:9187
+{{- end }}

--- a/charts/prometheus-pgbouncer-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-pgbouncer-exporter/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "prometheus-pgbouncer-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "prometheus-pgbouncer-exporter.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "prometheus-pgbouncer-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "prometheus-pgbouncer-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "prometheus-pgbouncer-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+
+{{/*
+Set DATA_SOURCE_URI environment variable
+*/}}
+{{- define "prometheus-pgbouncer-exporter.data_source_uri" -}}
+{{ printf "%s:%d/%s?sslmode=%s&%s" .Values.config.datasource.host ( .Values.config.datasource.port | int) .Values.config.datasource.database .Values.config.datasource.sslmode .Values.config.datasource.extraParams | trimSuffix "&" | quote }}
+{{- end }}
+
+{{/*
+Return the appropriate apiVersion for rbac.
+*/}}
+{{- define "rbac.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
+{{- print "rbac.authorization.k8s.io/v1" -}}
+{{- else -}}
+{{- print "rbac.authorization.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/prometheus-pgbouncer-exporter/templates/deployment.yaml
+++ b/charts/prometheus-pgbouncer-exporter/templates/deployment.yaml
@@ -1,0 +1,149 @@
+{{- if and .Values.config.datasource.passwordSecret .Values.config.datasource.password -}}
+{{ fail (printf "ERROR: only one of .Values.config.datasource.passwordSecret and .Values.config.datasource.password must be defined") }}
+{{- end -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "prometheus-pgbouncer-exporter.fullname" . }}
+  labels:
+    app: {{ template "prometheus-pgbouncer-exporter.name" . }}
+    chart: {{ template "prometheus-pgbouncer-exporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "prometheus-pgbouncer-exporter.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "prometheus-pgbouncer-exporter.name" . }}
+        release: {{ .Release.Name }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | trim | indent 8 }}
+{{- end }}
+      annotations:
+        kubectl.kubernetes.io/default-container: {{ .Chart.Name }}
+{{- if .Values.annotations }}
+{{ toYaml .Values.annotations | indent 8 }}
+{{- end }}
+    spec:
+      serviceAccountName: {{ template "prometheus-pgbouncer-exporter.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- if .Values.initContainers }}
+      initContainers:
+{{ toYaml .Values.initContainers | indent 8 }}
+{{- end }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          command: 
+          args:
+          - "--web.listen-address=:{{ .Values.service.targetPort }}"
+          {{- if .Values.config.logLevel }}
+          - "--log.level={{ .Values.config.logLevel }}"
+          {{- end }}
+          {{- if .Values.config.logFormat }}
+          - "--log.format={{ .Values.config.logFormat }}"
+          {{- end }}
+          - "--pgBouncer.connectionString=user={{ .Values.config.datasource.user }} password='$(DATA_SOURCE_PASS)' host={{ .Values.config.datasource.host }} port={{ .Values.config.datasource.port }} dbname={{ .Values.config.datasource.database }} sslmode='{{ .Values.config.datasource.sslmode }}'"
+          env:
+          {{- if .Values.config.datasourceSecret }}
+          - name: DATA_SOURCE_NAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.config.datasourceSecret.name }}
+                key: {{ .Values.config.datasourceSecret.key }}
+          {{- else }}
+          - name: DATA_SOURCE_URI
+            value: {{ template "prometheus-pgbouncer-exporter.data_source_uri" . }}
+          - name: DATA_SOURCE_USER
+            value: {{ .Values.config.datasource.user }}
+          {{- if .Values.config.datasource.passwordFile }}
+          - name: DATA_SOURCE_PASS_FILE
+            value: {{ .Values.config.datasource.passwordFile }}
+          {{- else }}
+          - name: DATA_SOURCE_PASS
+            valueFrom:
+              secretKeyRef:
+          {{- if .Values.config.datasource.passwordSecret }}
+                name: {{ .Values.config.datasource.passwordSecret.name }}
+                key: {{ .Values.config.datasource.passwordSecret.key }}
+          {{- else }}
+                name: {{ template "prometheus-pgbouncer-exporter.fullname" . }}
+                key: data_source_password
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- with .Values.extraEnvs }}
+          {{- if kindIs "map" . }}
+          {{- range $name, $value := . }}
+          - name: {{ $name }}
+            value: {{ tpl $value $ | quote }}
+          {{- end }}
+          {{- end }}
+          {{- if kindIs "slice" . -}}
+          {{ toYaml . | nindent 10 }}
+          {{- end }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          livenessProbe:
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            httpGet:
+              path: /
+              port: http
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+{{- with .Values.extraVolumeMounts }}
+{{ toYaml . | indent 12 }}
+{{- end }}
+{{- with .Values.extraContainers }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- if .Values.hostAliases }}
+      hostAliases:
+{{ toYaml .Values.hostAliases | indent 8 }}
+{{- end }}
+     {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+      volumes:
+{{- with .Values.extraVolumes }}
+{{ toYaml . | indent 6 }}
+{{- end }}

--- a/charts/prometheus-pgbouncer-exporter/templates/networkpolicy.yaml
+++ b/charts/prometheus-pgbouncer-exporter/templates/networkpolicy.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "prometheus-pgbouncer-exporter.fullname" . }}
+  labels:
+    {{- if .Values.networkPolicy.labels }}
+      {{ toYaml .Values.networkPolicy.labels | indent 4 }}
+    {{- end }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "prometheus-pgbouncer-exporter.name" . }}
+      release: {{ .Release.Name }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+      - port: {{ .Values.service.targetPort }}
+{{- end }}

--- a/charts/prometheus-pgbouncer-exporter/templates/pdb.yaml
+++ b/charts/prometheus-pgbouncer-exporter/templates/pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "prometheus-pgbouncer-exporter.fullname" . }}
+  labels:
+    app: {{ template "prometheus-pgbouncer-exporter.name" . }}
+    chart: {{ template "prometheus-pgbouncer-exporter.chart" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels:
+      app: {{ template "prometheus-pgbouncer-exporter.name" . }}
+      release: {{ .Release.Name }}
+{{- end }}

--- a/charts/prometheus-pgbouncer-exporter/templates/prometheusrule.yaml
+++ b/charts/prometheus-pgbouncer-exporter/templates/prometheusrule.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ template "prometheus-pgbouncer-exporter.fullname" . }}
+{{- with .Values.prometheusRule.namespace }}
+  namespace: {{ . }}
+{{- end }}
+  labels:
+    app: {{ template "prometheus-pgbouncer-exporter.name" . }}
+    chart: {{ template "prometheus-pgbouncer-exporter.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+{{- with .Values.prometheusRule.additionalLabels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- with .Values.prometheusRule.rules }}
+  groups:
+    - name: {{ template "prometheus-pgbouncer-exporter.name" $ }}
+      rules: {{ tpl (toYaml .) $ | nindent 8 }}
+{{- end }}
+{{- end }}

--- a/charts/prometheus-pgbouncer-exporter/templates/role.yaml
+++ b/charts/prometheus-pgbouncer-exporter/templates/role.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.rbac.create }}
+apiVersion: {{ template "rbac.apiVersion" . }}
+kind: Role
+metadata:
+  name: {{ template "prometheus-pgbouncer-exporter.fullname" . }}
+  labels:
+    app: {{ template "prometheus-pgbouncer-exporter.name" . }}
+    chart: {{ template "prometheus-pgbouncer-exporter.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- if .Values.rbac.pspEnabled }}
+rules:
+- apiGroups:      ['extensions']
+  resources:      ['podsecuritypolicies']
+  verbs:          ['use']
+  resourceNames:  [{{ template "prometheus-pgbouncer-exporter.fullname" . }}]
+{{- end }}
+{{- end }}

--- a/charts/prometheus-pgbouncer-exporter/templates/rolebinding.yaml
+++ b/charts/prometheus-pgbouncer-exporter/templates/rolebinding.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.rbac.create -}}
+apiVersion: {{ template "rbac.apiVersion" . }}
+kind: RoleBinding
+metadata:
+  name: {{ template "prometheus-pgbouncer-exporter.fullname" . }}
+  labels:
+    app: {{ template "prometheus-pgbouncer-exporter.name" . }}
+    chart: {{ template "prometheus-pgbouncer-exporter.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "prometheus-pgbouncer-exporter.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "prometheus-pgbouncer-exporter.serviceAccountName" . }}
+{{- end -}}

--- a/charts/prometheus-pgbouncer-exporter/templates/secrets.yaml
+++ b/charts/prometheus-pgbouncer-exporter/templates/secrets.yaml
@@ -1,0 +1,14 @@
+{{- if not (or .Values.config.datasource.passwordSecret .Values.config.datasourceSecret .Values.config.datasource.passwordFile ) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "prometheus-pgbouncer-exporter.fullname" . }}
+  labels:
+    app: {{ template "prometheus-pgbouncer-exporter.name" . }}
+    chart: {{ template "prometheus-pgbouncer-exporter.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+type: Opaque
+data:
+  data_source_password: {{ .Values.config.datasource.password | default "somepaswword" | b64enc }}
+{{- end -}}

--- a/charts/prometheus-pgbouncer-exporter/templates/service.yaml
+++ b/charts/prometheus-pgbouncer-exporter/templates/service.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "prometheus-pgbouncer-exporter.fullname" . }}
+  {{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app: {{ template "prometheus-pgbouncer-exporter.name" . }}
+    chart: {{ template "prometheus-pgbouncer-exporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | trim | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: {{ .Values.service.name }}
+  selector:
+    app: {{ template "prometheus-pgbouncer-exporter.name" . }}
+    release: {{ .Release.Name }}

--- a/charts/prometheus-pgbouncer-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-pgbouncer-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "prometheus-pgbouncer-exporter.serviceAccountName" . }}
+  labels:
+    app: {{ template "prometheus-pgbouncer-exporter.name" . }}
+    chart: {{ template "prometheus-pgbouncer-exporter.chart" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  {{- if .Values.serviceAccount.annotations }}
+  annotations:
+    {{ toYaml .Values.serviceAccount.annotations }}
+  {{- end }}
+{{- end -}}

--- a/charts/prometheus-pgbouncer-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-pgbouncer-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+{{- if .Values.serviceMonitor.labels }}
+  labels:
+{{ toYaml .Values.serviceMonitor.labels | indent 4}}
+{{- end }}
+  name: {{ template "prometheus-pgbouncer-exporter.fullname" . }}
+{{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+{{- end }}
+spec:
+  endpoints:
+  - targetPort: {{ .Values.service.name }}
+{{- if .Values.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
+{{- end }}
+{{- if .Values.serviceMonitor.telemetryPath }}
+    path: {{ .Values.serviceMonitor.telemetryPath }}
+{{- end }}
+{{- if .Values.serviceMonitor.timeout }}
+    scrapeTimeout: {{ .Values.serviceMonitor.timeout }}
+{{- end }}
+{{- if .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ toYaml .Values.serviceMonitor.metricRelabelings | indent 4 }}
+{{- end }}
+{{- if .Values.serviceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.serviceMonitor.relabelings | nindent 4 }}
+{{- end }}
+  jobLabel: {{ template "prometheus-pgbouncer-exporter.fullname" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ template "prometheus-pgbouncer-exporter.name" . }}
+      release: {{ .Release.Name }}
+{{- if .Values.serviceMonitor.targetLabels }}
+  targetLabels:
+{{- range .Values.serviceMonitor.targetLabels }}
+  - {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/prometheus-pgbouncer-exporter/values.yaml
+++ b/charts/prometheus-pgbouncer-exporter/values.yaml
@@ -1,6 +1,8 @@
 # Default values for prometheus-pgbouncer-exporter.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
+
+# Also deploy the postgresql helm chart dependency 
+postgresql: 
+  enabled: false
 
 replicaCount: 1
 

--- a/charts/prometheus-pgbouncer-exporter/values.yaml
+++ b/charts/prometheus-pgbouncer-exporter/values.yaml
@@ -1,0 +1,219 @@
+# Default values for prometheus-pgbouncer-exporter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: quay.io/prometheuscommunity/pgbouncer-exporter
+  tag: latest
+  pullPolicy: IfNotPresent
+
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # pullSecrets:
+  #   - myRegistrKeySecretName
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 9127
+  name: http
+  labels: {}
+  annotations: {}
+
+serviceMonitor:
+  # When set true then use a ServiceMonitor to configure scraping
+  enabled: false
+  # Set the namespace the ServiceMonitor should be deployed
+  # namespace: monitoring
+  # Set how frequently Prometheus should scrape
+  # interval: 30s
+  # Set path to cloudwatch-exporter telemtery-path
+  # telemetryPath: /metrics
+  # Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator
+  # labels:
+  # Set timeout for scrape
+  # timeout: 10s
+  # Set of labels to transfer from the Kubernetes Service onto the target
+  # targetLabels: []
+  # MetricRelabelConfigs to apply to samples before ingestion
+  # metricRelabelings: []
+  # Set relabel_configs as per https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+  # relabelings: []
+
+prometheusRule:
+  enabled: false
+  additionalLabels: {}
+  namespace: ""
+  rules: []
+    ## These are just examples rules, please adapt them to your needs.
+    ## Make sure to constraint the rules to the current prometheus-pgbouncer-exporter service.
+    # - alert: HugeReplicationLag
+    #   expr: pg_replication_lag{service="{{ template "prometheus-pgbouncer-exporter.fullname" . }}"} / 3600 > 1
+    #   for: 1m
+    #   labels:
+    #     severity: critical
+    #   annotations:
+    #     description: replication for {{ template "prometheus-pgbouncer-exporter.fullname" . }} PostgreSQL is lagging by {{ "{{ $value }}" }} hour(s).
+    #     summary: PostgreSQL replication is lagging by {{ "{{ $value }}" }} hour(s).
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #    memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+  # Add annotations to the ServiceAccount, useful for EKS IAM Roles for Service Accounts or Google Workload Identity.
+  annotations: {}
+
+# Add a default ingress to allow namespace access to service.targetPort
+# Helpful if other NetworkPolicies are configured in the namespace
+networkPolicy:
+  # Specifies whether a NetworkPolicy should be created
+  enabled: false
+  # Set labels for the NetworkPolicy
+  labels: {}
+
+# The securityContext of the pod.
+# See https://kubernetes.io/docs/concepts/policy/security-context/ for more.
+podSecurityContext:
+  runAsUser: 1001
+  runAsGroup: 1001
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+# The securityContext of the container.
+# See https://kubernetes.io/docs/concepts/policy/security-context/ for more.
+securityContext:
+  runAsUser: 1001
+  runAsGroup: 1001
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  seccompProfile:
+    type: RuntimeDefault
+
+hostAliases: []
+  # Set Host Aliases as per https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/
+  # - ip: "127.0.0.1"
+  #   hostnames:
+  #   - "foo.local"
+  #   - "bar.local"
+
+config:
+  # Specify logLevel as debug, info, warn, error
+  datasource:
+    # Specify one of both datasource or datasourceSecret
+    host:
+    user: postgres
+    # Only one of password, passwordFile, passwordSecret and pgpassfile can be specified
+    password:
+    # Specify passwordFile if DB password is stored in a file.
+    # For example, to use with vault-injector from Hashicorp
+    passwordFile: ''
+    # Specify passwordSecret if DB password is stored in secret.
+    passwordSecret: {}
+    # Secret name
+    #  name:
+    # Password key inside secret
+    #  key:
+    port: "5432"
+    database: 'pgbouncer'
+    sslmode: disable
+    extraParams: ''
+  datasourceSecret: {}
+    # Specifies if datasource should be sourced from secret value in format: postgresql://login:password@hostname:port/dbname?sslmode=disable
+    # Multiple Postgres databases can be configured by comma separated postgres connection strings
+    # Secret name
+    #  name:
+    # Connection string key inside secret
+    #  key:
+  constantLabels: {}
+  # possible values debug, info, warn, error, fatal
+  logLevel: ""
+  # possible values logfmt, json
+  logFormat: "json"
+  extraArgs: []
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+annotations: {}
+
+podLabels: {}
+
+# Configurable health checks
+livenessProbe:
+  initialDelaySeconds: 3
+  timeoutSeconds: 3
+
+readinessProbe:
+  initialDelaySeconds: 5
+  timeoutSeconds: 10
+
+# ExtraEnvs
+extraEnvs: []
+  # - name: EXTRA_ENV
+  #   value: value
+  # - name: POD_NAMESPACE
+  #   valueFrom:
+  #     fieldRef:
+  #       fieldPath: metadata.namespace
+
+# Init containers, e. g. for secrets creation before the exporter
+initContainers: []
+  # - name:
+  #   image:
+  #   volumeMounts:
+  #     - name: creds
+  #       mountPath: /creds
+
+# Additional sidecar containers, e. g. for a database proxy, such as Google's cloudsql-proxy
+extraContainers: []
+
+# Additional volumes, e. g. for secrets used in an extraContainer
+extraVolumes: []
+# Uncomment for mounting custom ca-certificates
+#  - name: ssl-certs
+#    secret:
+#      defaultMode: 420
+#      items:
+#      - key: ca-certificates.crt
+#        path: ca-certificates.crt
+#      secretName: ssl-certs
+
+# Additional volume mounts
+extraVolumeMounts: []
+# Uncomment for mounting custom ca-certificates file into container
+#  - name: ssl-certs
+#    mountPath: /etc/ssl/certs/ca-certificates.crt
+#    subPath: ca-certificates.crt
+
+podDisruptionBudget:
+  enabled: false
+  maxUnavailable: 1

--- a/charts/prometheus-pgbouncer-exporter/values.yaml
+++ b/charts/prometheus-pgbouncer-exporter/values.yaml
@@ -1,9 +1,6 @@
 # Default values for prometheus-pgbouncer-exporter.
 
 # Also deploy the postgresql helm chart dependency
-postgresql:
-  enabled: false
-
 replicaCount: 1
 
 image:

--- a/charts/prometheus-pgbouncer-exporter/values.yaml
+++ b/charts/prometheus-pgbouncer-exporter/values.yaml
@@ -1,6 +1,5 @@
 # Default values for prometheus-pgbouncer-exporter.
 
-# Also deploy the postgresql helm chart dependency
 replicaCount: 1
 
 image:

--- a/charts/prometheus-pgbouncer-exporter/values.yaml
+++ b/charts/prometheus-pgbouncer-exporter/values.yaml
@@ -1,7 +1,7 @@
 # Default values for prometheus-pgbouncer-exporter.
 
-# Also deploy the postgresql helm chart dependency 
-postgresql: 
+# Also deploy the postgresql helm chart dependency
+postgresql:
   enabled: false
 
 replicaCount: 1


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
This PR adds a helm chart for deploying pgbouncer_exporter. 

#### Which issue this PR fixes
Fixes #3048 

#### Special notes for your reviewer
This work was directly copied from the prometheus-postgres-exporter chart and tweaked accordingly. There would likely be some room for improvement on this, but it has been tested with a crunchydata deployment of pgbouncer in GKE successfully. The connectionstring has been crafted to support a complex autogenerated password from crunchydata, though this might need to updated/tested with other connection string variations. Happy to take some guidance 

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
