### PR TITLE
[kube-prometheus-stack] use failurePolicy=Fail as default for webhook patch job

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 45.2.0
+version: 45.2.1
 appVersion: v0.63.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -46,7 +46,7 @@ spec:
             - --webhook-name={{ template "kube-prometheus-stack.fullname" . }}-admission
             - --namespace={{ template "kube-prometheus-stack.namespace" . }}
             - --secret-name={{ template "kube-prometheus-stack.fullname" . }}-admission
-            - --patch-failure-policy={{ .Values.prometheusOperator.admissionWebhooks.failurePolicy }}
+            - --patch-failure-policy={{ .Values.prometheusOperator.admissionWebhooks.failurePolicy | default "Fail" }}
           {{- with .Values.prometheusOperator.admissionWebhooks.patchWebhookJob }}
           securityContext:
           {{ toYaml .securityContext | nindent 12 }}


### PR DESCRIPTION
See #2911

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
