### PR TITLE
[kube-prometheus-stack] Bump version of kube-webhook-certgen

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -34,7 +34,7 @@ annotations:
   "artifacthub.io/operator": "true"
   "artifacthub.io/links": |
     - name: Chart Source
-      url: https://github.com/prometheus-community/helm-chartswebho
+      url: https://github.com/prometheus-community/helm-charts
     - name: Upstream Project
       url: https://github.com/prometheus-operator/kube-prometheus
 

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 45.2.2
+version: 45.3.0
 appVersion: v0.63.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 45.2.0
+version: 45.2.2
 appVersion: v0.63.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus
@@ -34,7 +34,7 @@ annotations:
   "artifacthub.io/operator": "true"
   "artifacthub.io/links": |
     - name: Chart Source
-      url: https://github.com/prometheus-community/helm-charts
+      url: https://github.com/prometheus-community/helm-chartswebho
     - name: Upstream Project
       url: https://github.com/prometheus-operator/kube-prometheus
 

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1871,7 +1871,7 @@ prometheusOperator:
       image:
         registry: registry.k8s.io
         repository: ingress-nginx/kube-webhook-certgen
-        tag: v1.3.0
+        tag: v20221220-controller-v1.5.1-58-g787ea74b6
         sha: ""
         pullPolicy: IfNotPresent
       resources: {}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Further to https://github.com/prometheus-community/helm-charts/pull/3060, the reason that users may want to disable the admission webhook is because it would seem that kube-webhook-certgen v1.3.0 is incompatible (to some degree) with Kubernetes 1.22+

See a related issue here: https://github.com/kubernetes/ingress-nginx/issues/7418

#### Which issue this PR fixes

This PR bumps the version of kube-webhook-certgen to the latest (per [this link](https://registry.k8s.io/v2/ingress-nginx/kube-webhook-certgen/tags/list), which is currently `v20221220-controller-v1.5.1-58-g787ea74b6` (_no concise tags were published since v1.3.0_).

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
