### PR TITLE
[prometheus-kube-stack] Adds environment variables to prometheus

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 45.2.0
+version: 45.3.0
 appVersion: v0.63.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -51,6 +51,13 @@ spec:
   additionalArgs:
 {{ toYaml .Values.prometheus.prometheusSpec.additionalArgs | indent 4}}
 {{- end -}}
+{{- if .Values.prometheus.prometheusSpec.additionalArgs }}
+  env:
+  {{- range $key, $value := .Values.prometheus.prometheusSpec.env }}
+  	- name: "{{ $key }}"
+  	  value: "{{ $value }}"
+  {{- end }}
+{{- end -}}
 {{- if .Values.prometheus.prometheusSpec.externalLabels }}
   externalLabels:
 {{ tpl (toYaml .Values.prometheus.prometheusSpec.externalLabels | indent 4) . }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -2624,6 +2624,8 @@ prometheus:
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.Prometheus
     additionalArgs: []
 
+    env: {}
+
     ## Interval between consecutive scrapes.
     ## Defaults to 30s.
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/release-0.44/pkg/prometheus/promcfg.go#L180-L183


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Adds environment variables for prometheus. This can be everything, but specifically I would use it to set the timezone with `TZ`.

#### Which issue this PR fixes

None

#### Special notes for your reviewer

None

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
