### PR TITLE
[kube-state-metrics] fix/split Registry and Repository Values in a proper way

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 4.31.0
+version: 4.32.0
 appVersion: 2.8.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 4.32.0
+version: 5.0.0
 appVersion: 2.8.1
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/_helpers.tpl
+++ b/charts/kube-state-metrics/templates/_helpers.tpl
@@ -104,7 +104,7 @@ labelValueLengthLimit: {{ . }}
 {{- end }}
 {{- end -}}
 
-{{/* 
+{{/*
 Formats imagePullSecrets. Input is (dict "Values" .Values "imagePullSecrets" .{specific imagePullSecrets})
 */}}
 {{- define "kube-state-metrics.imagePullSecrets" -}}
@@ -116,3 +116,41 @@ Formats imagePullSecrets. Input is (dict "Values" .Values "imagePullSecrets" .{s
   {{- end }}
 {{- end }}
 {{- end -}}
+
+{{/*
+The image to use for kube-state-metrics
+*/}}
+{{- define "kube-state-metrics.image" -}}
+{{- if .Values.image.sha }}
+{{- if .Values.global.imageRegistry }}
+{{- printf "%s/%s:%s@%s" .Values.global.imageRegistry .Values.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) .Values.image.sha }}
+{{- else }}
+{{- printf "%s/%s:%s@%s" .Values.image.registry .Values.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) .Values.image.sha }}
+{{- end }}
+{{- else }}
+{{- if .Values.global.imageRegistry }}
+{{- printf "%s/%s:%s" .Values.global.imageRegistry .Values.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) }}
+{{- else }}
+{{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+The image to use for kubeRBACProxy
+*/}}
+{{- define "kubeRBACProxy.image" -}}
+{{- if .Values.kubeRBACProxy.image.sha }}
+{{- if .Values.global.imageRegistry }}
+{{- printf "%s/%s:%s@%s" .Values.global.imageRegistry .Values.kubeRBACProxy.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.kubeRBACProxy.image.tag) .Values.kubeRBACProxy.image.sha }}
+{{- else }}
+{{- printf "%s/%s:%s@%s" .Values.kubeRBACProxy.image.registry .Values.kubeRBACProxy.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.kubeRBACProxy.image.tag) .Values.kubeRBACProxy.image.sha }}
+{{- end }}
+{{- else }}
+{{- if .Values.global.imageRegistry }}
+{{- printf "%s/%s:%s" .Values.global.imageRegistry .Values.kubeRBACProxy.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.kubeRBACProxy.image.tag) }}
+{{- else }}
+{{- printf "%s/%s:%s" .Values.kubeRBACProxy.image.registry .Values.kubeRBACProxy.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.kubeRBACProxy.image.tag) }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/kube-state-metrics/templates/deployment.yaml
@@ -119,11 +119,7 @@ spec:
         {{- end }}
         {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        {{- if .Values.image.sha }}
-        image: "{{ .Values.global.imageRegistry | default .Values.image.repository }}:{{ .Values.image.tag | default (print "v" .Chart.AppVersion) }}@sha256:{{ .Values.image.sha }}"
-        {{- else }}
-        image: "{{ .Values.global.imageRegistry | default .Values.image.repository }}:{{ .Values.image.tag | default (print "v" .Chart.AppVersion) }}"
-        {{- end }}
+        image: {{ include "kube-state-metrics.image" . }}
         {{- if eq .Values.kubeRBACProxy.enabled false }}
         ports:
         - containerPort: {{ .Values.service.port | default 8080}}
@@ -167,11 +163,7 @@ spec:
           - name: kube-rbac-proxy-config
             mountPath: /etc/kube-rbac-proxy-config
         imagePullPolicy: {{ .Values.kubeRBACProxy.image.pullPolicy }}
-        {{- if .Values.kubeRBACProxy.image.sha }}
-        image: "{{ .Values.global.imageRegistry | default .Values.kubeRBACProxy.image.repository }}:{{ .Values.kubeRBACProxy.image.tag }}@sha256:{{ .Values.kubeRBACProxy.image.sha }}"
-        {{- else }}
-        image: "{{ .Values.global.imageRegistry | default .Values.kubeRBACProxy.image.repository }}:{{ .Values.kubeRBACProxy.image.tag }}"
-        {{- end }}
+        image: {{ include "kubeRBACProxy.image" . }}
         ports:
           - containerPort: {{ .Values.service.port | default 8080}}
             name: "http"
@@ -206,11 +198,7 @@ spec:
           - name: kube-rbac-proxy-config
             mountPath: /etc/kube-rbac-proxy-config
         imagePullPolicy: {{ .Values.kubeRBACProxy.image.pullPolicy }}
-        {{- if .Values.kubeRBACProxy.image.sha }}
-        image: "{{ .Values.global.imageRegistry | default .Values.kubeRBACProxy.image.repository }}:{{ .Values.kubeRBACProxy.image.tag }}@sha256:{{ .Values.kubeRBACProxy.image.sha }}"
-        {{- else }}
-        image: "{{ .Values.global.imageRegistry | default .Values.kubeRBACProxy.image.repository }}:{{ .Values.kubeRBACProxy.image.tag }}"
-        {{- end }}
+        image: {{ include "kubeRBACProxy.image" . }}
         ports:
           - containerPort: {{ .Values.selfMonitor.telemetryPort | default 8081 }}
             name: "metrics"

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -1,7 +1,8 @@
 # Default values for kube-state-metrics.
 prometheusScrape: true
 image:
-  repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
+  registry: registry.k8s.io
+  repository: kube-state-metrics/kube-state-metrics
   # If unset use v + .Charts.appVersion
   tag: ""
   sha: ""
@@ -86,7 +87,8 @@ rbac:
 kubeRBACProxy:
   enabled: false
   image:
-    repository: quay.io/brancz/kube-rbac-proxy
+    registry: quay.io
+    repository: brancz/kube-rbac-proxy
     tag: v0.14.0
     sha: ""
     pullPolicy: IfNotPresent


### PR DESCRIPTION
#### What this PR does / why we need it

We need to split registry and repository values in a proper way as usual in another charts. Also currently it's a bug if you want to use the global imageRegistry variable in kube-prometheus-stack it actually broke this sub chart, because currently, we expect a full path for the image, but in all others, we expect here only the registry name.

#### Which issue this PR fixes

- fixes #3075 

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
