### PR TITLE
[prometheus-blackbox-exporter] Make it possible to unset the container "securityContext“

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 7.5.0
+version: 7.6.0
 appVersion: 0.23.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/charts/prometheus-blackbox-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/daemonset.yaml
@@ -66,11 +66,40 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
-            readOnlyRootFilesystem: {{ .Values.readOnlyRootFilesystem }}
-            runAsNonRoot: {{ .Values.runAsNonRoot  }}
-            {{- if .Values.runAsUser }}
-            runAsUser: {{ .Values.runAsUser }}
+          {{- range $k, $v := .Values.securityContext }}
+            {{- if eq $k "runAsUser" }}
+            {{- if $v }}
+            runAsUser: {{ $v }}
             {{- end }}
+            {{- else if eq $k "runAsGroup" }}
+            {{- if $v }}
+            runAsGroup: {{ $v }}
+            {{- end }}
+            {{- else if eq $k "capabilities" }}
+              {{- if $v }}
+            {{ $k }}:
+              {{- range $action, $caps := $v  }}
+              {{ $action }}:
+                {{- range $c := $caps }}
+                - {{ $c }}
+                {{- end }}
+              {{- end }}
+              {{- else }}
+            {{ $k }}: {}
+              {{- end }}
+            {{- else if or (eq $k "seLinuxOptions") (eq $k "seccompProfile") (eq $k "windowsOptions") }}
+              {{- if $v }}
+            {{ $k }}:
+              {{- range $key, $value := $v  }}
+              {{ $key }}: {{ $value }}
+              {{- end }}
+              {{- else }}
+            {{ $k }}: {}
+              {{- end }}
+            {{- else }}
+            {{ $k }}: {{ $v }}
+            {{- end }}
+          {{- end }}
           env:
           {{- range $key, $value := .Values.extraEnv }}
             - name: {{ $key }}

--- a/charts/prometheus-blackbox-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/daemonset.yaml
@@ -65,40 +65,9 @@ spec:
         - name: blackbox-exporter
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
           securityContext:
-          {{- range $k, $v := .Values.securityContext }}
-            {{- if eq $k "runAsUser" }}
-            {{- if $v }}
-            runAsUser: {{ $v }}
-            {{- end }}
-            {{- else if eq $k "runAsGroup" }}
-            {{- if $v }}
-            runAsGroup: {{ $v }}
-            {{- end }}
-            {{- else if eq $k "capabilities" }}
-              {{- if $v }}
-            {{ $k }}:
-              {{- range $action, $caps := $v  }}
-              {{ $action }}:
-                {{- range $c := $caps }}
-                - {{ $c }}
-                {{- end }}
-              {{- end }}
-              {{- else }}
-            {{ $k }}: {}
-              {{- end }}
-            {{- else if or (eq $k "seLinuxOptions") (eq $k "seccompProfile") (eq $k "windowsOptions") }}
-              {{- if $v }}
-            {{ $k }}:
-              {{- range $key, $value := $v  }}
-              {{ $key }}: {{ $value }}
-              {{- end }}
-              {{- else }}
-            {{ $k }}: {}
-              {{- end }}
-            {{- else }}
-            {{ $k }}: {{ $v }}
-            {{- end }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
           {{- range $key, $value := .Values.extraEnv }}

--- a/charts/prometheus-blackbox-exporter/templates/deployment.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/deployment.yaml
@@ -74,40 +74,9 @@ spec:
         - name: blackbox-exporter
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
           securityContext:
-          {{- range $k, $v := .Values.securityContext }}
-            {{- if eq $k "runAsUser" }}
-            {{- if $v }}
-            runAsUser: {{ $v }}
-            {{- end }}
-            {{- else if eq $k "runAsGroup" }}
-            {{- if $v }}
-            runAsGroup: {{ $v }}
-            {{- end }}
-            {{- else if eq $k "capabilities" }}
-              {{- if $v }}
-            {{ $k }}:
-              {{- range $action, $caps := $v  }}
-              {{ $action }}:
-                {{- range $c := $caps }}
-                - {{ $c }}
-                {{- end }}
-              {{- end }}
-              {{- else }}
-            {{ $k }}: {}
-              {{- end }}
-            {{- else if or (eq $k "seLinuxOptions") (eq $k "seccompProfile") (eq $k "windowsOptions") }}
-              {{- if $v }}
-            {{ $k }}:
-              {{- range $key, $value := $v  }}
-              {{ $key }}: {{ $value }}
-              {{- end }}
-              {{- else }}
-            {{ $k }}: {}
-              {{- end }}
-            {{- else }}
-            {{ $k }}: {{ $v }}
-            {{- end }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
           {{- range $key, $value := .Values.extraEnv }}

--- a/charts/prometheus-blackbox-exporter/templates/deployment.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/deployment.yaml
@@ -75,7 +75,40 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
-{{ toYaml .Values.securityContext | indent 12 }}
+          {{- range $k, $v := .Values.securityContext }}
+            {{- if eq $k "runAsUser" }}
+            {{- if $v }}
+            runAsUser: {{ $v }}
+            {{- end }}
+            {{- else if eq $k "runAsGroup" }}
+            {{- if $v }}
+            runAsGroup: {{ $v }}
+            {{- end }}
+            {{- else if eq $k "capabilities" }}
+              {{- if $v }}
+            {{ $k }}:
+              {{- range $action, $caps := $v  }}
+              {{ $action }}:
+                {{- range $c := $caps }}
+                - {{ $c }}
+                {{- end }}
+              {{- end }}
+              {{- else }}
+            {{ $k }}: {}
+              {{- end }}
+            {{- else if or (eq $k "seLinuxOptions") (eq $k "seccompProfile") (eq $k "windowsOptions") }}
+              {{- if $v }}
+            {{ $k }}:
+              {{- range $key, $value := $v  }}
+              {{ $key }}: {{ $value }}
+              {{- end }}
+              {{- else }}
+            {{ $k }}: {}
+              {{- end }}
+            {{- else }}
+            {{ $k }}: {{ $v }}
+            {{- end }}
+          {{- end }}
           env:
           {{- range $key, $value := .Values.extraEnv }}
             - name: {{ $key }}


### PR DESCRIPTION

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

When this chart is used as a subchart, this PR allows the securityContext in the container to be unset from the parent chart without change in previous behaviour.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
