### PR TITLE
[prometheus] hotfix CVE-2022-28391

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
-appVersion: v2.41.0
-version: 20.0.1
+appVersion: v2.43.0
+version: 20.0.2
 kubeVersion: ">=1.16.0-0"
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/


### PR DESCRIPTION
#### What this PR does / why we need it
Bump AppVersion to fix GHSA-vvpx-j8f3-3w6h and CVE-2022-28391.
See: https://github.com/prometheus-community/helm-charts/issues/3139

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
