### PR TITLE
[prometheus-elasticsearch-exporter]: Set Pod container name to Service port name

### DIFF
--- a/charts/prometheus-elasticsearch-exporter/Chart.yaml
+++ b/charts/prometheus-elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: prometheus-elasticsearch-exporter
-version: 5.0.0
+version: 5.0.1
 kubeVersion: ">=1.10.0-0"
 appVersion: 1.5.0
 home: https://github.com/prometheus-community/elasticsearch_exporter

--- a/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
+++ b/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
@@ -134,18 +134,18 @@ spec:
           {{- end }}
           ports:
             - containerPort: {{ .Values.service.httpPort }}
-              name: http
+              name: {{ .Values.service.metricsPort.name }}
           livenessProbe:
             httpGet:
               path: /healthz
-              port: http
+              port: {{ .Values.service.metricsPort.name }}
             initialDelaySeconds: 5
             timeoutSeconds: 5
             periodSeconds: 5
           readinessProbe:
             httpGet:
               path: /healthz
-              port: http
+              port: {{ .Values.service.metricsPort.name }}
             initialDelaySeconds: 1
             timeoutSeconds: 5
             periodSeconds: 5


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
In this PR we add ability to rewrite Pod container port name (set it the same as Service port name) to be able to avoid hardcoded `http` value.

#### Which issue this PR fixes

For our particular case, we use internal rule to name all ports targets of `ClusterPodMonitor` as `metrics` with `NetworkPolicy` where we allow `gmp-system` to collect metrics from named port. 

#### Special notes for your reviewer

Please take a look: @svenmueller , @desaintmartin .

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-elasticsearch-exporter]`)
