### PR TITLE
fix: correct the readiness and liveness probe addr

### DIFF
--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -105,12 +105,12 @@ securityContext:
 
 livenessProbe:
   httpGet:
-    path: /health
+    path: /-/healthy
     port: http
 
 readinessProbe:
   httpGet:
-    path: /health
+    path: /-/healthy
     port: http
 
 nodeSelector: {}


### PR DESCRIPTION

#### What this PR does / why we need it

The address for liveness and readiness was wrong. This PR fixes it. You can check the correct endpoint [here](https://github.com/prometheus/blackbox_exporter/blob/master/main.go#L173).

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
