### PR TITLE
[prometheus-pushgateway] - Fix api version of PodDisruptionBudget 

### DIFF
--- a/charts/prometheus-pushgateway/Chart.yaml
+++ b/charts/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v1.5.1"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 2.1.3
+version: 2.1.4
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/charts/prometheus-pushgateway/templates/_helpers.tpl
+++ b/charts/prometheus-pushgateway/templates/_helpers.tpl
@@ -94,7 +94,7 @@ Define PDB apiVersion
 {{- if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
 {{- print "policy/v1" }}
 {{- else }}
-{{- print "policy/v1beta" }}
+{{- print "policy/v1beta1" }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
#### What this PR does / why we need it
- fixes api version of PodDisruptionBudget. Currently it renders to 'policy/v1beta' which is not existent for k8s < v1.25.

#### Special notes for your reviewer

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
