### PR TITLE
[prometheus] Add support for pod topology spread constraints

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: v2.43.0
-version: 20.1.0
+version: 20.2.0
 kubeVersion: ">=1.16.0-0"
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/templates/deploy.yaml
+++ b/charts/prometheus/templates/deploy.yaml
@@ -271,9 +271,9 @@ spec:
       affinity:
 {{ toYaml .Values.server.affinity | indent 8 }}
     {{- end }}
-    {{- if .Values.server.topologySpreadConstraints }}
+    {{- with .Values.server.topologySpreadConstraints }}
       topologySpreadConstraints:
-{{ toYaml .Values.server.topologySpreadConstraints | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
       terminationGracePeriodSeconds: {{ .Values.server.terminationGracePeriodSeconds }}
       volumes:

--- a/charts/prometheus/templates/deploy.yaml
+++ b/charts/prometheus/templates/deploy.yaml
@@ -271,6 +271,10 @@ spec:
       affinity:
 {{ toYaml .Values.server.affinity | indent 8 }}
     {{- end }}
+    {{- if .Values.server.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml .Values.server.topologySpreadConstraints | indent 8 }}
+    {{- end }}
       terminationGracePeriodSeconds: {{ .Values.server.terminationGracePeriodSeconds }}
       volumes:
         - name: config-volume

--- a/charts/prometheus/templates/sts.yaml
+++ b/charts/prometheus/templates/sts.yaml
@@ -269,9 +269,9 @@ spec:
       affinity:
 {{ toYaml .Values.server.affinity | indent 8 }}
     {{- end }}
-    {{- if .Values.server.topologySpreadConstraints }}
+    {{- with .Values.server.topologySpreadConstraints }}
       topologySpreadConstraints:
-{{ toYaml .Values.server.topologySpreadConstraints | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
       terminationGracePeriodSeconds: {{ .Values.server.terminationGracePeriodSeconds }}
       volumes:

--- a/charts/prometheus/templates/sts.yaml
+++ b/charts/prometheus/templates/sts.yaml
@@ -269,6 +269,10 @@ spec:
       affinity:
 {{ toYaml .Values.server.affinity | indent 8 }}
     {{- end }}
+    {{- if .Values.server.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml .Values.server.topologySpreadConstraints | indent 8 }}
+    {{- end }}
       terminationGracePeriodSeconds: {{ .Values.server.terminationGracePeriodSeconds }}
       volumes:
         - name: config-volume

--- a/charts/prometheus/values.schema.json
+++ b/charts/prometheus/values.schema.json
@@ -598,6 +598,9 @@
                 "tolerations": {
                     "type": "array"
                 },
+                "topologySpreadConstraints": {
+                    "type": "array"
+                },
                 "tsdb": {
                     "type": "object"
                 },

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -332,6 +332,10 @@ server:
   ##
   affinity: {}
 
+  ## Pod topology spread constraints
+  ## ref. https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+  topologySpreadConstraints: []
+
   ## PodDisruptionBudget settings
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
   ##


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
Signed-off-by: zeritti <47476160+zeritti@users.noreply.github.com>
#### What this PR does / why we need it

With this PR I am proposing to introduce support for [pod topology spread constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) in deployment and statefulset templates allowing for desired distribution of Prometheus' pods across zones and nodes.

#### Which issue this PR fixes

- fixes #3164

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
