### PR TITLE
[prometheus-smartctl-exporter] Upgrade to smartctl exporter v0.9.1

### DIFF
--- a/charts/prometheus-smartctl-exporter/Chart.yaml
+++ b/charts/prometheus-smartctl-exporter/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.8.0"
+appVersion: "v0.9.1"
 
 maintainers:
   - name: kfox1111


### PR DESCRIPTION
Signed-off-by: yellowhat <yellowhat46@gmail.com>

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR updates the image of smartctl-importer to v0.9.1.

* https://github.com/prometheus-community/smartctl_exporter/releases/tag/v0.9.1

#### Which issue this PR fixes

-

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)