### PR TITLE
[kube-prometheus-stack] Remove deprecated sha in prometheusSpec

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 45.26.0
+version: 45.27.0
 appVersion: v0.65.1
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -43,9 +43,6 @@ spec:
   image: "{{ $registry }}/{{ .Values.prometheus.prometheusSpec.image.repository }}"
   {{- end }}
   version: {{ default .Values.prometheus.prometheusSpec.image.tag .Values.prometheus.prometheusSpec.version }}
-  {{- if .Values.prometheus.prometheusSpec.image.sha }}
-  sha: {{ .Values.prometheus.prometheusSpec.image.sha }}
-  {{- end }}
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.additionalArgs }}
   additionalArgs:


### PR DESCRIPTION
See https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.AlertmanagerSpec

