### PR TITLE
[prometheus-smartctl-exporter]: expose serviceMonitor `interval` and `scrapeTimeout`

### DIFF
--- a/charts/prometheus-smartctl-exporter/Chart.yaml
+++ b/charts/prometheus-smartctl-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/prometheus-smartctl-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-smartctl-exporter/templates/servicemonitor.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ template "prometheus-smartctl-exporter.fullname" . }}
   labels:
     {{- include "prometheus-smartctl-exporter.labels" . | nindent 4 }}
-    {{- if ne (len .Values.serviceMonitor.extraLabels) 0 }}
-    {{ toYaml .Values.serviceMonitor.extraLabels | indent 4 }}
+    {{- with .Values.serviceMonitor.extraLabels }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
 {{- if hasKey .Values.serviceMonitor "namespace" }}
   namespace: {{ .Values.serviceMonitor.namespace }}

--- a/charts/prometheus-smartctl-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-smartctl-exporter/templates/servicemonitor.yaml
@@ -5,22 +5,22 @@ metadata:
   name: {{ template "prometheus-smartctl-exporter.fullname" . }}
   labels:
     {{- include "prometheus-smartctl-exporter.labels" . | nindent 4 }}
-{{- if ne (len .Values.serviceMonitor.extraLabels) 0 }}
-{{ toYaml .Values.serviceMonitor.extraLabels | indent 4 }}
-{{- end }}
+    {{- if ne (len .Values.serviceMonitor.extraLabels) 0 }}
+    {{ toYaml .Values.serviceMonitor.extraLabels | indent 4 }}
+    {{- end }}
 {{- if hasKey .Values.serviceMonitor "namespace" }}
   namespace: {{ .Values.serviceMonitor.namespace }}
 {{- end }}
 spec:
   endpoints:
-  - interval: 60s
-    path: /metrics
-    port: http
-    scheme: http
-    scrapeTimeout: 30s
+    - interval: {{ .Values.serviceMonitor.interval }}
+      path: /metrics
+      port: http
+      scheme: http
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
   namespaceSelector:
     matchNames:
-    - {{ .Release.Namespace }}
+      - {{ .Release.Namespace }}
   selector:
     matchLabels:
       {{- include "prometheus-smartctl-exporter.labels" . | nindent 6 }}

--- a/charts/prometheus-smartctl-exporter/values.yaml
+++ b/charts/prometheus-smartctl-exporter/values.yaml
@@ -23,6 +23,8 @@ serviceMonitor:
   # Add Extra labels if needed. Prometeus operator may need them to find it.
   extraLabels: {}
   # release: prometheus-operator
+  interval: 60s
+  scrapeTimeout: 30s
 
 prometheusRules:
   enabled: false


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

* expose serviceMonitor `interval` option
* expose serviceMonitor `scrapeTimeout` option

#### Which issue this PR fixes

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-smartctl-exporter]`)