### PR TITLE
[prometheus-kafka-exporter] fix Chart.yaml - remove engine: gotpl

### DIFF
--- a/charts/prometheus-kafka-exporter/Chart.lock
+++ b/charts/prometheus-kafka-exporter/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: kafka
+  repository: https://charts.bitnami.com/bitnami
+  version: 18.5.0
+digest: sha256:4f64699ad60e23f399546dd55e18ceed6f329b046c694b6ecff22aefad709ffb
+generated: "2023-04-06T22:25:36.6695595+09:00"

--- a/charts/prometheus-kafka-exporter/Chart.yaml
+++ b/charts/prometheus-kafka-exporter/Chart.yaml
@@ -3,7 +3,8 @@ appVersion: "v1.6.0"
 description: A Helm chart to export the metrics from Kafka in Prometheus format using the kafka-exporter from https://github.com/danielqsj/kafka_exporter
 name: prometheus-kafka-exporter
 home: https://github.com/danielqsj/kafka_exporter
-version: 1.8.1
+version: 2.0.0
+kubeVersion: ">=1.19.0-0"
 sources:
   - https://gkarthiks.github.io/helm-charts/charts/prometheus-kafka-exporter
 keywords:
@@ -16,7 +17,6 @@ maintainers:
     email: golgoth31@notrenet.com
   - name: zeritti
     email: rootsandtrees@posteo.de
-engine: gotpl
 annotations:
   "artifacthub.io/links": |
     - name: Chart Source

--- a/charts/prometheus-kafka-exporter/README.md
+++ b/charts/prometheus-kafka-exporter/README.md
@@ -9,7 +9,7 @@ This chart bootstraps a [Kafka Exporter](https://github.com/danielqsj/kafka_expo
 - Kubernetes 1.19+
 - Helm 3
 
-Helm v2 was no longer supported from chart version 2.0.0.
+Helm v2 is no longer supported from chart version 2.0.0.
 
 ## Get Repository Info
 

--- a/charts/prometheus-kafka-exporter/README.md
+++ b/charts/prometheus-kafka-exporter/README.md
@@ -4,29 +4,27 @@ A Prometheus exporter for [Apacher Kafka](https://kafka.apache.org/) metrics.
 
 This chart bootstraps a [Kafka Exporter](https://github.com/danielqsj/kafka_exporter) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
-
 ## Prerequisites
 
-- Kubernetes 1.8+ with Beta APIs enabled
+- Kubernetes 1.19+
+- Helm 3
 
-## Get Repo Info
+Helm v2 was no longer supported from chart version 2.0.0.
+
+## Get repository Info
 
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update
 ```
 
-_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
-
+_See [`helm repo`](https://helm.sh/docs/helm/helm_repo/) for command documentation._
 
 ## Install Chart
 
 ```console
-# Helm 3
-$ helm install [RELEASE_NAME] prometheus-community/prometheus-kafka-exporter
-
-# Helm 2
-$ helm install --name [RELEASE_NAME] prometheus-community/prometheus-kafka-exporter
+helm dependency build
+helm install [RELEASE_NAME] prometheus-community/prometheus-kafka-exporter
 ```
 
 _See [configuration](#configuration) below._
@@ -36,11 +34,7 @@ _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documen
 ## Uninstall Chart
 
 ```console
-# Helm 3
-$ helm uninstall [RELEASE_NAME]
-
-# Helm 2
-# helm delete --purge [RELEASE_NAME]
+helm uninstall [RELEASE_NAME]
 ```
 
 This removes all the Kubernetes components associated with the chart and deletes the release.
@@ -50,8 +44,7 @@ _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command doc
 ## Upgrading Chart
 
 ```console
-# Helm 3 or 2
-$ helm upgrade [RELEASE_NAME] [CHART] --install
+helm upgrade [RELEASE_NAME] [CHART] --install
 ```
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
@@ -61,9 +54,5 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-kafka-exporter/values.yaml), or run these configuration commands:
 
 ```console
-# Helm 2
-$ helm inspect values prometheus-community/prometheus-kafka-exporter
-
-# Helm 3
-$ helm show values prometheus-community/prometheus-kafka-exporter
+helm show values prometheus-community/prometheus-kafka-exporter
 ```

--- a/charts/prometheus-kafka-exporter/README.md
+++ b/charts/prometheus-kafka-exporter/README.md
@@ -11,7 +11,7 @@ This chart bootstraps a [Kafka Exporter](https://github.com/danielqsj/kafka_expo
 
 Helm v2 was no longer supported from chart version 2.0.0.
 
-## Get repository Info
+## Get Repository Info
 
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts


### PR DESCRIPTION
### What this PR does / why we need it

- fix Chart.yaml - remove engine: gotpl , see #2813
  - drop Helm v2 support
  - add Chart.lock

#### Which issue this PR fixes

- https://github.com/prometheus-community/helm-charts/issues/2813

#### Special notes for your reviewer

- This does not change the template. 
  - But, I think it's a major bump, because dropped Helmv2

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
  - [x] Has breaking change, bump major.
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
