### PR TITLE
Broken Link Fix

### DIFF
--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -566,7 +566,7 @@ server:
     clusterIP: ""
 
     ## List of IP addresses at which the Prometheus server service is available
-    ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+    ## Ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips
     ##
     externalIPs: []
 


### PR DESCRIPTION
#### Which issue this PR fixes
  Broken link fix.

- https://kubernetes.io/docs/concepts/services-networking/service/#external-ips should be used instead https://kubernetes.io/docs/user-guide/services/#external-ips
