### PR TITLE
[prometheus-operator-admission-webhook] Add chart prometheus-operator…

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,6 +29,7 @@
 /charts/prometheus-nats-exporter/ @caarlos0 @okgolove
 /charts/prometheus-nginx-exporter/ @nlamirault
 /charts/prometheus-node-exporter/ @gianrubio @zanhsieh
+/charts/prometheus-operator-admission-webhook/ @zeritti
 /charts/prometheus-operator-crds/ @dacamposol @desaintmartin
 /charts/prometheus-pgbouncer-exporter/ @stewartshea
 /charts/prometheus-pingdom-exporter/ @monotek @rpahli

--- a/charts/prometheus-operator-admission-webhook/.helmignore
+++ b/charts/prometheus-operator-admission-webhook/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/prometheus-operator-admission-webhook/Chart.yaml
+++ b/charts/prometheus-operator-admission-webhook/Chart.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v2
+description: Prometheus Operator Admission Webhook
+name: prometheus-operator-admission-webhook
+version: 0.1.0
+appVersion: 0.63.0
+home: https://github.com/prometheus-operator/prometheus-operator
+keywords:
+  - admission
+  - monitoring
+  - prometheus-operator
+  - webhook
+maintainers:
+  - name: zeritti
+    email: rootsandtrees@posteo.de
+sources:
+  - https://github.com/prometheus-operator/prometheus-operator
+  - https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-operator-admission-webhook
+type: application
+annotations:
+  "artifacthub.io/license": Apache-2.0
+  "artifacthub.io/links": |
+   - name: Chart Source
+     url: https://github.com/prometheus-community/helm-charts
+   - name: Upstream Project
+     url: https://github.com/prometheus-operator/prometheus-operator

--- a/charts/prometheus-operator-admission-webhook/README.md
+++ b/charts/prometheus-operator-admission-webhook/README.md
@@ -1,0 +1,61 @@
+# Prometheus Operator Admission Webhook
+
+> The admission webhook service is able to
+>
+> - Validate requests ensuring that PrometheusRule and AlertmanagerConfig objects are semantically valid
+> - Mutate requests enforcing that all annotations of PrometheusRule objects are coerced into string values
+> - Convert AlertmanagerConfig objects between v1alpha1 and v1beta1 versions
+
+For more info, please, see the [Prometheus Operator](https://prometheus-operator.dev/docs) documentation.
+
+## Prerequisites
+
+- Kubernetes 1.13+ with Beta APIs enabled
+- Helm 3
+
+## Get Repository Info
+<!-- textlint-disable terminology -->
+```console
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+```
+
+_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
+<!-- textlint-enable -->
+## Install Chart
+
+```console
+helm install [RELEASE_NAME] prometheus-community/prometheus-operator-admission-webhook
+```
+
+_See [configuration](#configuration) below._
+
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
+
+## Uninstall Chart
+
+```console
+helm uninstall [RELEASE_NAME]
+```
+
+This removes all the Kubernetes components associated with the chart and deletes the release.
+
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+
+## Upgrading Chart
+
+```console
+helm upgrade [RELEASE_NAME] [CHART] --install
+```
+
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+## Configuration
+
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing).
+
+To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
+
+```console
+helm show values prometheus-community/prometheus-operator-admission-webhook
+```

--- a/charts/prometheus-operator-admission-webhook/templates/NOTES.txt
+++ b/charts/prometheus-operator-admission-webhook/templates/NOTES.txt
@@ -1,0 +1,16 @@
+See https://prometheus-operator.dev/docs/user-guides/webhook/ for more information on the admission webhook.
+
+1. Get the webhook's URL by running these commands:
+
+  export POD_NAME="$(kubectl get pods --namespace {{ template "prometheus-operator-admission-webhook.namespace" . }} -l "app.kubernetes.io/name={{ include "prometheus-operator-admission-webhook.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")"
+  export CONTAINER_PORT="$(kubectl get pod --namespace {{ template "prometheus-operator-admission-webhook.namespace" . }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")"
+
+2. Set port forwarding:
+
+   kubectl --namespace {{ template "prometheus-operator-admission-webhook.namespace" . }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+
+3. Verify the admission-webhook's deployment by checking its health endpoint by command
+
+   curl -k https://127.0.0.1:8080/healthz
+
+   JSON-formatted "status: up" is expected at that point.

--- a/charts/prometheus-operator-admission-webhook/templates/_helpers.tpl
+++ b/charts/prometheus-operator-admission-webhook/templates/_helpers.tpl
@@ -62,17 +62,6 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
-Return the appropriate apiVersion for rbac.
-*/}}
-{{- define "rbac.apiVersion" -}}
-{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" -}}
-{{- print "rbac.authorization.k8s.io/v1" -}}
-{{- else -}}
-{{- print "rbac.authorization.k8s.io/v1beta1" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Define overriding namespace
 */}}
 {{- define "prometheus-operator-admission-webhook.namespace" -}}

--- a/charts/prometheus-operator-admission-webhook/templates/_helpers.tpl
+++ b/charts/prometheus-operator-admission-webhook/templates/_helpers.tpl
@@ -84,17 +84,6 @@ Define overriding namespace
 {{- end -}}
 
 {{/*
-Define Pdb apiVersion
-*/}}
-{{- define "pdb.apiVersion" -}}
-{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
-{{- printf "policy/v1" }}
-{{- else }}
-{{- printf "policy/v1beta1" }}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Define image tag by attaching "v" to the application version
 preferring to keep the application version according to its release
 */}}

--- a/charts/prometheus-operator-admission-webhook/templates/_helpers.tpl
+++ b/charts/prometheus-operator-admission-webhook/templates/_helpers.tpl
@@ -1,0 +1,107 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "prometheus-operator-admission-webhook.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "prometheus-operator-admission-webhook.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "prometheus-operator-admission-webhook.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "prometheus-operator-admission-webhook.labels" -}}
+helm.sh/chart: {{ include "prometheus-operator-admission-webhook.chart" . }}
+{{ include "prometheus-operator-admission-webhook.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "prometheus-operator-admission-webhook.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "prometheus-operator-admission-webhook.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "prometheus-operator-admission-webhook.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "prometheus-operator-admission-webhook.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for rbac.
+*/}}
+{{- define "rbac.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" -}}
+{{- print "rbac.authorization.k8s.io/v1" -}}
+{{- else -}}
+{{- print "rbac.authorization.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Define overriding namespace
+*/}}
+{{- define "prometheus-operator-admission-webhook.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Define Pdb apiVersion
+*/}}
+{{- define "pdb.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
+{{- printf "policy/v1" }}
+{{- else }}
+{{- printf "policy/v1beta1" }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Define image tag by attaching "v" to the application version
+preferring to keep the application version according to its release
+*/}}
+{{- define "prometheus-operator-admission-webhook.imageTag" -}}
+{{- if .Values.image.tag -}}
+{{- .Values.image.tag -}}
+{{- else -}}
+{{- print "v" .Chart.AppVersion -}}
+{{- end -}}
+{{- end -}}

--- a/charts/prometheus-operator-admission-webhook/templates/certmanager.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/certmanager.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.certManager.enabled -}}
+{{- if not .Values.certManager.issuerRef -}}
+# Create a selfsigned Issuer in order to create a root CA certificate for
+# signing webhook serving certificates
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ template "prometheus-operator-admission-webhook.fullname" . }}-self-signed-issuer
+  namespace: {{ template "prometheus-operator-admission-webhook.namespace" . }}
+spec:
+  selfSigned: {}
+---
+# Generate a CA Certificate used to sign certificates for the webhook
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ template "prometheus-operator-admission-webhook.fullname" . }}-root-cert
+  namespace: {{ template "prometheus-operator-admission-webhook.namespace" . }}
+spec:
+  secretName: {{ template "prometheus-operator-admission-webhook.fullname" . }}-root-cert
+  duration: {{ .Values.certManager.rootCert.duration | default "43800h0m0s" | quote }}
+  issuerRef:
+    name: {{ template "prometheus-operator-admission-webhook.fullname" . }}-self-signed-issuer
+  commonName: "ca.webhook.prometheus-operator-admission-webhook"
+  isCA: true
+---
+# Create an Issuer that uses the above generated CA certificate to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ template "prometheus-operator-admission-webhook.fullname" . }}-root-issuer
+  namespace: {{ template "prometheus-operator-admission-webhook.namespace" . }}
+spec:
+  ca:
+    secretName: {{ template "prometheus-operator-admission-webhook.fullname" . }}-root-cert
+{{- end }}
+---
+# generate a server certificate for the apiservices to use
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ template "prometheus-operator-admission-webhook.fullname" . }}-cert
+  namespace: {{ template "prometheus-operator-admission-webhook.namespace" . }}
+spec:
+  secretName: {{ template "prometheus-operator-admission-webhook.fullname" . }}-cert
+  duration: {{ .Values.certManager.webhookCert.duration | default "8760h0m0s" | quote }}
+  issuerRef:
+    {{- if .Values.certManager.issuerRef }}
+    {{- toYaml .Values.certManager.issuerRef | nindent 4 }}
+    {{- else }}
+    name: {{ template "prometheus-operator-admission-webhook.fullname" . }}-root-issuer
+    {{- end }}
+  dnsNames:
+  - {{ template "prometheus-operator-admission-webhook.fullname" . }}
+  - {{ template "prometheus-operator-admission-webhook.fullname" . }}.{{ template "prometheus-operator-admission-webhook.namespace" . }}
+  - {{ template "prometheus-operator-admission-webhook.fullname" . }}.{{ template "prometheus-operator-admission-webhook.namespace" . }}.svc
+{{- end -}}

--- a/charts/prometheus-operator-admission-webhook/templates/deployment.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/deployment.yaml
@@ -1,0 +1,136 @@
+{{- $registry := .Values.image.registry }}
+{{- $repository := .Values.image.repository }}
+{{- $digest := .Values.image.digest }}
+{{- $imageTag := include "prometheus-operator-admission-webhook.imageTag" . }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  {{- with .Values.deployment.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "prometheus-operator-admission-webhook.labels" . | nindent 4 }}
+    {{- with .Values.deployment.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "prometheus-operator-admission-webhook.fullname" . }}
+  namespace: {{ include "prometheus-operator-admission-webhook.namespace" . }}
+spec:
+  replicas: {{ default 1 .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "prometheus-operator-admission-webhook.selectorLabels" . | nindent 6 }}
+  {{- with .Values.updateStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  template:
+    metadata:
+      {{- with .Values.pod.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "prometheus-operator-admission-webhook.labels" . | nindent 8 }}
+        {{- with .Values.pod.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      restartPolicy: {{ .Values.restartPolicy }}
+      serviceAccountName: {{ include "prometheus-operator-admission-webhook.serviceAccountName" . }}
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        {{- with .Values.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        - name: {{ .Chart.Name }}
+          args:
+            - --web.enable-tls=true
+            {{- if .Values.tlsSecret }}
+            - --web.cert-file=/etc/tls/private/{{ default "tls.crt" .Values.tlsSecret.certItem }}
+            - --web.key-file=/etc/tls/private/{{ default "tls.key" .Values.tlsSecret.keyItem }}
+            {{- else }}
+            - --web.cert-file=/etc/tls/private/tls.crt
+            - --web.key-file=/etc/tls/private/tls.key
+            {{- end }}
+            - --web.listen-address=:{{ default 10250 .Values.containerPort }}
+            - --web.tls-min-version={{ default "VersionTLS13" .Values.tlsMinVersion }}
+            {{- with .Values.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.image.digest }}
+          image: "{{ $registry }}/{{ $repository }}@sha256:{{ $digest }}"
+          {{- else }}
+          image: "{{ $registry }}/{{ $repository }}:{{ $imageTag }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | trim | nindent 12 }}
+          {{- end }}
+          ports:
+            - containerPort: {{ default 10250 .Values.containerPort }}
+              name: https
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | trim | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - name: tls-certificates
+              mountPath: /etc/tls/private
+              readOnly: true
+      volumes:
+        - name: tls-certificates
+          secret:
+            {{- if .Values.tlsSecret }}
+            secretName: {{ .Values.tlsSecret.name | quote }}
+            {{- else if .Values.certManager.enabled }}
+            secretName: {{ include "prometheus-operator-admission-webhook.fullname" . }}-cert
+            {{- else }}
+            secretName: {{ include "prometheus-operator-admission-webhook.fullname" . }}
+            {{- end }}
+            defaultMode: 420

--- a/charts/prometheus-operator-admission-webhook/templates/hooks/clusterrole.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/hooks/clusterrole.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.jobs.enabled .Values.rbac.create }}
+apiVersion: {{ include "rbac.apiVersion" . }}
+kind: ClusterRole
+metadata:
+  name:  {{ include "prometheus-operator-admission-webhook.fullname" . }}-aux
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- with .Values.jobs.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    app: {{ include "prometheus-operator-admission-webhook.fullname" . }}-aux
+    {{- include "prometheus-operator-admission-webhook.labels" . | nindent 4 }}
+    {{- with .Values.jobs.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - get
+      - update
+{{- if and (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") .Values.rbac.pspEnabled }}
+{{- $kubeTargetVersion := default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride }}
+{{- if semverCompare "> 1.15.0-0" $kubeTargetVersion }}
+  - apiGroups: ['policy']
+{{- else }}
+  - apiGroups: ['extensions']
+{{- end }}
+    resources: ['podsecuritypolicies']
+    verbs:     ['use']
+    resourceNames:
+    - {{ include "prometheus-operator-admission-webhook.fullname" . }}-aux
+{{- end }}
+{{- end }}

--- a/charts/prometheus-operator-admission-webhook/templates/hooks/clusterrole.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/hooks/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.jobs.enabled .Values.rbac.create }}
-apiVersion: {{ include "rbac.apiVersion" . }}
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name:  {{ include "prometheus-operator-admission-webhook.fullname" . }}-aux

--- a/charts/prometheus-operator-admission-webhook/templates/hooks/clusterrolebinding.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/hooks/clusterrolebinding.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.jobs.enabled .Values.rbac.create }}
+apiVersion: {{ include "rbac.apiVersion" . }}
+kind: ClusterRoleBinding
+metadata:
+  name:  {{ include "prometheus-operator-admission-webhook.fullname" . }}-aux
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- with .Values.jobs.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    app: {{ include "prometheus-operator-admission-webhook.fullname" . }}-aux
+    {{- include "prometheus-operator-admission-webhook.labels" . | nindent 4 }}
+    {{- with .Values.jobs.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "prometheus-operator-admission-webhook.fullname" . }}-aux
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "prometheus-operator-admission-webhook.fullname" . }}-aux
+    namespace: {{ include "prometheus-operator-admission-webhook.namespace" . }}
+{{- end }}

--- a/charts/prometheus-operator-admission-webhook/templates/hooks/clusterrolebinding.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/hooks/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.jobs.enabled .Values.rbac.create }}
-apiVersion: {{ include "rbac.apiVersion" . }}
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name:  {{ include "prometheus-operator-admission-webhook.fullname" . }}-aux

--- a/charts/prometheus-operator-admission-webhook/templates/hooks/job-createSecret.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/hooks/job-createSecret.yaml
@@ -1,0 +1,86 @@
+{{- if .Values.jobs.enabled }}
+{{- $registry := .Values.jobs.image.registry }}
+{{- $repository := .Values.jobs.image.repository }}
+{{- $imageTag := .Values.jobs.image.tag }}
+{{- $digest := .Values.jobs.image.digest }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name:  {{ template "prometheus-operator-admission-webhook.fullname" . }}-create
+  namespace: {{ template "prometheus-operator-admission-webhook.namespace" . }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- with .Values.jobs.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    app: {{ include "prometheus-operator-admission-webhook.fullname" . }}-aux
+    {{- include "prometheus-operator-admission-webhook.labels" . | nindent 4 }}
+    {{- with .Values.jobs.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Capabilities.APIVersions.Has "batch/v1alpha1" }}
+  ttlSecondsAfterFinished: 60
+  {{- end }}
+  template:
+    metadata:
+      name:  {{ template "prometheus-operator-admission-webhook.fullname" . }}-create
+      {{- with .Values.jobs.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app: {{ include "prometheus-operator-admission-webhook.fullname" . }}-aux
+        {{ include "prometheus-operator-admission-webhook.labels" . | nindent 8 }}
+        {{- with .Values.jobs.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.jobs.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      containers:
+        - name: create
+          {{- if .Values.jobs.image.digest }}
+          image: "{{ $registry }}/{{ $repository }}@sha256:{{ $digest }}"
+          {{- else }}
+          image: "{{ $registry }}/{{ $repository }}:{{ $imageTag }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.jobs.image.pullPolicy }}
+          args:
+            - create
+            - --host={{ template "prometheus-operator-admission-webhook.fullname" . }},{{ template "prometheus-operator-admission-webhook.fullname" . }}.{{ template "prometheus-operator-admission-webhook.namespace" . }}.svc
+            - --namespace={{ template "prometheus-operator-admission-webhook.namespace" . }}
+            - --secret-name={{ template "prometheus-operator-admission-webhook.fullname" . }}
+            - --cert-name=tls.crt
+            - --key-name=tls.key
+          {{- with .Values.jobs.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.jobs.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      restartPolicy: OnFailure
+      serviceAccountName: {{ template "prometheus-operator-admission-webhook.fullname" . }}-aux
+      {{- with .Values.jobs.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.jobs.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.jobs.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.jobs.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/prometheus-operator-admission-webhook/templates/hooks/job-patchWebhook.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/hooks/job-patchWebhook.yaml
@@ -1,0 +1,84 @@
+{{- if .Values.jobs.enabled }}
+{{- $registry := .Values.jobs.image.registry }}
+{{- $repository := .Values.jobs.image.repository }}
+{{- $imageTag := .Values.jobs.image.tag }}
+{{- $digest := .Values.jobs.image.digest }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name:  {{ template "prometheus-operator-admission-webhook.fullname" . }}-patch
+  namespace: {{ template "prometheus-operator-admission-webhook.namespace" . }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- with .Values.jobs.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    app: {{ include "prometheus-operator-admission-webhook.fullname" . }}-aux
+    {{ include "prometheus-operator-admission-webhook.labels" . | nindent 4 }}
+    {{- with .Values.jobs.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Capabilities.APIVersions.Has "batch/v1alpha1" }}
+  ttlSecondsAfterFinished: 0
+  {{- end }}
+  template:
+    metadata:
+      name:  {{ template "prometheus-operator-admission-webhook.fullname" . }}-patch
+      {{- with .Values.jobs.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app: {{ include "prometheus-operator-admission-webhook.fullname" . }}-aux
+        {{ include "prometheus-operator-admission-webhook.labels" . | nindent 8 }}
+        {{- with .Values.jobs.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.jobs.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      containers:
+        - name: patch
+          {{- if .Values.jobs.image.digest }}
+          image: "{{ $registry }}/{{ $repository }}@sha256:{{ $digest }}"
+          {{- else }}
+          image: "{{ $registry }}/{{ $repository }}:{{ $imageTag }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.jobs.image.pullPolicy }}
+          args:
+            - patch
+            - --namespace={{ template "prometheus-operator-admission-webhook.namespace" . }}
+            - --secret-name={{ template "prometheus-operator-admission-webhook.fullname" . }}
+            - --webhook-name={{ template "prometheus-operator-admission-webhook.fullname" . }}
+          {{- with .Values.jobs.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.jobs.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      restartPolicy: OnFailure
+      serviceAccountName: {{ template "prometheus-operator-admission-webhook.fullname" . }}-aux
+      {{- with .Values.jobs.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.jobs.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.jobs.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.jobs.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/prometheus-operator-admission-webhook/templates/hooks/networkpolicy.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/hooks/networkpolicy.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.networkPolicy.enabled .Values.jobs.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name:  {{ include "prometheus-operator-admission-webhook.fullname" . }}-aux
+  namespace: {{ include "prometheus-operator-admission-webhook.namespace" . }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-5"
+    {{- with .Values.jobs.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    app: {{ include "prometheus-operator-admission-webhook.fullname" . }}-aux
+    {{ include "prometheus-operator-admission-webhook.labels" . | nindent 4 }}
+    {{- with .Values.jobs.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ include "prometheus-operator-admission-webhook.fullname" . }}-aux
+  egress:
+  - {}
+  policyTypes:
+  - Egress
+{{- end }}

--- a/charts/prometheus-operator-admission-webhook/templates/hooks/psp.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/hooks/psp.yaml
@@ -1,0 +1,49 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+{{- if and .Values.jobs.enabled .Values.rbac.create .Values.rbac.pspEnabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "prometheus-operator-admission-webhook.fullname" . }}-aux
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- if .Values.jobs.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    app: {{ include "prometheus-operator-admission-webhook.fullname" . }}-aux
+    {{ include "prometheus-operator-admission-webhook.labels" . | nindent 4 }}
+    {{- if .Values.jobs.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  privileged: false
+  volumes:
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    # Permits the container to run with root privileges as well.
+    rule: 'RunAsAny'
+  seLinux:
+    # This policy assumes the nodes are using AppArmor rather than SELinux.
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Allow adding the root group.
+      - min: 0
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Allow adding the root group.
+      - min: 0
+        max: 65535
+  readOnlyRootFilesystem: true
+{{- end }}
+{{- end }}

--- a/charts/prometheus-operator-admission-webhook/templates/hooks/role.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/hooks/role.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.jobs.enabled .Values.rbac.create }}
-apiVersion: {{ include "rbac.apiVersion" . }}
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name:  {{ include "prometheus-operator-admission-webhook.fullname" . }}-aux

--- a/charts/prometheus-operator-admission-webhook/templates/hooks/role.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/hooks/role.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.jobs.enabled .Values.rbac.create }}
+apiVersion: {{ include "rbac.apiVersion" . }}
+kind: Role
+metadata:
+  name:  {{ include "prometheus-operator-admission-webhook.fullname" . }}-aux
+  namespace: {{ include "prometheus-operator-admission-webhook.namespace" . }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- with .Values.jobs.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    app: {{ include "prometheus-operator-admission-webhook.fullname" . }}-aux
+    {{- include "prometheus-operator-admission-webhook.labels" . | nindent 4 }}
+    {{- with .Values.jobs.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - create
+{{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
+  - apiGroups:
+      - policy
+    resources:
+      - podsecuritypolicies
+    resourceNames:
+      - {{ include "prometheus-operator-admission-webhook.fullname" . }}-aux
+    verbs:
+      - use
+{{- end }}
+{{- end }}

--- a/charts/prometheus-operator-admission-webhook/templates/hooks/rolebinding.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/hooks/rolebinding.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.jobs.enabled .Values.rbac.create }}
+apiVersion: {{ include "rbac.apiVersion" . }}
+kind: RoleBinding
+metadata:
+  name:  {{ include "prometheus-operator-admission-webhook.fullname" . }}-aux
+  namespace: {{ template "prometheus-operator-admission-webhook.namespace" . }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- with .Values.jobs.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    app: {{ include "prometheus-operator-admission-webhook.fullname" . }}-aux
+    {{- include "prometheus-operator-admission-webhook.labels" . | nindent 4 }}
+    {{- with .Values.jobs.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "prometheus-operator-admission-webhook.fullname" . }}-aux
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "prometheus-operator-admission-webhook.fullname" . }}-aux
+    namespace: {{ include "prometheus-operator-admission-webhook.namespace" . }}
+{{- end }}

--- a/charts/prometheus-operator-admission-webhook/templates/hooks/rolebinding.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/hooks/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.jobs.enabled .Values.rbac.create }}
-apiVersion: {{ include "rbac.apiVersion" . }}
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name:  {{ include "prometheus-operator-admission-webhook.fullname" . }}-aux

--- a/charts/prometheus-operator-admission-webhook/templates/hooks/serviceaccount.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/hooks/serviceaccount.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.jobs.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name:  {{ include "prometheus-operator-admission-webhook.fullname" . }}-aux
+  namespace: {{ include "prometheus-operator-admission-webhook.namespace" . }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- with .Values.jobs.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    app: {{ include "prometheus-operator-admission-webhook.fullname" . }}-aux
+    {{- include "prometheus-operator-admission-webhook.labels" . | nindent 4 }}
+    {{- with .Values.jobs.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- with .Values.jobs.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | trim | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/prometheus-operator-admission-webhook/templates/mutatingWebhookConfiguration.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/mutatingWebhookConfiguration.yaml
@@ -1,0 +1,50 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name:  {{ include "prometheus-operator-admission-webhook.fullname" . }}
+  {{- if .Values.certManager.enabled }}
+  annotations:
+    certmanager.k8s.io/inject-ca-from: {{ printf "%s/%s-cert" .Release.Namespace (include "prometheus-operator-admission-webhook.fullname" .) | quote }}
+    cert-manager.io/inject-ca-from: {{ printf "%s/%s-cert" .Release.Namespace (include "prometheus-operator-admission-webhook.fullname" .) | quote }}
+    {{- with .Values.webhooks.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- else }}
+  {{- with .Values.webhooks.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+  labels:
+    {{- include "prometheus-operator-admission-webhook.labels" . | nindent 4 }}
+    {{- with .Values.webhooks.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+webhooks:
+  - name: prometheusrulemutate.monitoring.coreos.com
+    failurePolicy: {{ default "Fail" .Values.webhooks.failurePolicy }}
+    {{- with .Values.webhooks.namespaceSelector }}
+    namespaceSelector:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    rules:
+      - apiGroups:
+          - monitoring.coreos.com
+        apiVersions:
+          - "*"
+        resources:
+          - prometheusrules
+        operations:
+          - CREATE
+          - UPDATE
+    clientConfig:
+      service:
+        namespace: {{ include "prometheus-operator-admission-webhook.namespace" . }}
+        name: {{ include "prometheus-operator-admission-webhook.fullname" . }}
+        path: /admission-prometheusrules/mutate
+      {{- with .Values.caBundle }}
+      caBundle: {{ . }}
+      {{- end }}
+    timeoutSeconds: {{ default 10 .Values.webhooks.timeoutSeconds }}
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None

--- a/charts/prometheus-operator-admission-webhook/templates/networkpolicy.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/networkpolicy.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.networkPolicy.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  {{- with .Values.networkPolicy.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{ include "prometheus-operator-admission-webhook.labels" . | nindent 4 }}
+    {{- with .Values.networkPolicy.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "prometheus-operator-admission-webhook.fullname" . }}
+  namespace: {{ include "prometheus-operator-admission-webhook.namespace" . }}
+spec:
+  egress:
+    - {}
+  ingress:
+    - ports:
+      - port: {{ .Values.containerPort }}
+  policyTypes:
+    - Egress
+    - Ingress
+  podSelector:
+    matchLabels:
+      {{ include "prometheus-operator-admission-webhook.selectorLabels" . }}
+{{- end }}

--- a/charts/prometheus-operator-admission-webhook/templates/poddisruptionbudget.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/poddisruptionbudget.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.podDisruptionBudget }}
+apiVersion: {{ include "pdb.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    {{- include "prometheus-operator-admission-webhook.labels" . | nindent 4 }}
+  name: {{ include "prometheus-operator-admission-webhook.fullname" . }}
+  namespace: {{ include "prometheus-operator-admission-webhook.namespace" . }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "prometheus-operator-admission-webhook.selectorLabels" . | nindent 6 }}
+{{ toYaml .Values.podDisruptionBudget | indent 2 }}
+{{- end }}

--- a/charts/prometheus-operator-admission-webhook/templates/poddisruptionbudget.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget }}
-apiVersion: {{ include "pdb.apiVersion" . }}
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/charts/prometheus-operator-admission-webhook/templates/prometheusrule.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/prometheusrule.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.prometheusRule.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "prometheus-operator-admission-webhook.fullname" . }}
+  {{- if .Values.prometheusRule.namespace }}
+  namespace: {{ .Values.prometheusRule.namespace }}
+  {{- else }}
+  namespace: {{ include "prometheus-operator-admission-webhook.namespace" . }}
+  {{- end }}
+  labels:
+    {{- include "prometheus-operator-admission-webhook.labels" . | nindent 4 }}
+    {{- with .Values.prometheusRule.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.prometheusRule.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.prometheusRule.rules }}
+  groups:
+    - name: {{ include "prometheus-operator-admission-webhook.name" $ }}.rules
+      rules: {{ tpl (toYaml .) $ | nindent 8 }}
+  {{- end }}
+{{- end }}

--- a/charts/prometheus-operator-admission-webhook/templates/psp.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/psp.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.rbac.create .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  labels:
+    {{- include "prometheus-operator-admission-webhook.labels" . | nindent 4 }}
+  name: {{ include "prometheus-operator-admission-webhook.fullname" . }}
+  namespace: {{ include "prometheus-operator-admission-webhook.namespace" . }}
+spec:
+  # Prevents running in privileged mode
+  privileged: false
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  volumes:
+    - configMap
+    - secret
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: {{ .Values.containerSecurityContext.readOnlyRootFilesystem }}
+{{- end }}

--- a/charts/prometheus-operator-admission-webhook/templates/role.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/role.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.create }}
 ---
-apiVersion: {{ include "rbac.apiVersion" . }}
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "prometheus-operator-admission-webhook.fullname" . }}

--- a/charts/prometheus-operator-admission-webhook/templates/role.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/role.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.rbac.create }}
+---
+apiVersion: {{ include "rbac.apiVersion" . }}
+kind: Role
+metadata:
+  name: {{ include "prometheus-operator-admission-webhook.fullname" . }}
+  namespace: {{ include "prometheus-operator-admission-webhook.namespace" . }}
+  labels:
+    {{ include "prometheus-operator-admission-webhook.labels" . | nindent 4 }}
+rules:
+  {{- if and .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
+  - apiGroups:
+    - policy
+    resources:
+    - podsecuritypolicies
+    resourceNames:
+    - {{ include "prometheus-operator-admission-webhook.fullname" . }}
+    verbs:
+    - use
+{{- end }}
+{{- end }}

--- a/charts/prometheus-operator-admission-webhook/templates/rolebinding.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/rolebinding.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.create }}
 ---
-apiVersion: {{ include "rbac.apiVersion" . }}
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "prometheus-operator-admission-webhook.fullname" . }}

--- a/charts/prometheus-operator-admission-webhook/templates/rolebinding.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/rolebinding.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.rbac.create }}
+---
+apiVersion: {{ include "rbac.apiVersion" . }}
+kind: RoleBinding
+metadata:
+  name: {{ include "prometheus-operator-admission-webhook.fullname" . }}
+  namespace: {{ include "prometheus-operator-admission-webhook.namespace" . }}
+  labels:
+    {{ include "prometheus-operator-admission-webhook.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "prometheus-operator-admission-webhook.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "prometheus-operator-admission-webhook.serviceAccountName" . }}
+{{- end }}

--- a/charts/prometheus-operator-admission-webhook/templates/service.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/service.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{ include "prometheus-operator-admission-webhook.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "prometheus-operator-admission-webhook.fullname" . }}
+  namespace: {{ include "prometheus-operator-admission-webhook.namespace" . }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ default 443 .Values.service.port }}
+      targetPort: https
+      protocol: TCP
+      name: https
+  selector:
+    {{- include "prometheus-operator-admission-webhook.selectorLabels" . | nindent 4 }}

--- a/charts/prometheus-operator-admission-webhook/templates/serviceaccount.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/serviceaccount.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.serviceAccount.create -}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "prometheus-operator-admission-webhook.labels" . | nindent 4 }}
+    {{- with .Values.serviceAccount.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "prometheus-operator-admission-webhook.serviceAccountName" . }}
+  namespace: {{ include "prometheus-operator-admission-webhook.namespace" . }}
+{{- end }}

--- a/charts/prometheus-operator-admission-webhook/templates/servicemonitor.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/servicemonitor.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  {{- with .Values.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "prometheus-operator-admission-webhook.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "prometheus-operator-admission-webhook.fullname" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- else }}
+  namespace: {{ include "prometheus-operator-admission-webhook.namespace" . }}
+  {{- end }}
+spec:
+  endpoints:
+    - port: https
+      path: /metrics
+      scheme: https
+      interval: {{ default "30s" .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ default "10s" .Values.serviceMonitor.scrapeTimeout }}
+      honorLabels: {{ default false .Values.serviceMonitor.honorLabels }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if .Values.serviceMonitor.jobLabel }}
+  jobLabel: {{ .Values.serviceMonitor.jobLabel }}
+  {{- else }}
+  jobLabel: {{ include "prometheus-operator-admission-webhook.fullname" . }}
+  {{- end }}
+  {{- with .Values.serviceMonitor.targetLabels }}
+  targetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- with .Values.serviceMonitor.attachMetadata }}
+  attachMetadata:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- include "prometheus-operator-admission-webhook.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ include "prometheus-operator-admission-webhook.namespace" . }}
+{{- end }}

--- a/charts/prometheus-operator-admission-webhook/templates/validatingWebhookConfiguration.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/validatingWebhookConfiguration.yaml
@@ -1,0 +1,77 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name:  {{ include "prometheus-operator-admission-webhook.fullname" . }}
+  {{- if .Values.certManager.enabled }}
+  annotations:
+    certmanager.k8s.io/inject-ca-from: {{ printf "%s/%s-cert" .Release.Namespace (include "prometheus-operator-admission-webhook.fullname" .) | quote }}
+    cert-manager.io/inject-ca-from: {{ printf "%s/%s-cert" .Release.Namespace (include "prometheus-operator-admission-webhook.fullname" .) | quote }}
+    {{- with .Values.webhooks.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- else }}
+  {{- with .Values.webhooks.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+  labels:
+    {{- include "prometheus-operator-admission-webhook.labels" . | nindent 4 }}
+    {{- with .Values.webhooks.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+webhooks:
+  - name: prometheusrulevalidate.monitoring.coreos.com
+    failurePolicy: {{ default "Fail" .Values.webhooks.failurePolicy }}
+    {{- with .Values.webhooks.namespaceSelector }}
+    namespaceSelector:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    rules:
+      - apiGroups:
+          - monitoring.coreos.com
+        apiVersions:
+          - "*"
+        resources:
+          - prometheusrules
+        operations:
+          - CREATE
+          - UPDATE
+    clientConfig:
+      service:
+        namespace: {{ include "prometheus-operator-admission-webhook.namespace" . }}
+        name: {{ include "prometheus-operator-admission-webhook.fullname" . }}
+        path: /admission-prometheusrules/validate
+      {{- with .Values.caBundle }}
+      caBundle: {{ . }}
+      {{- end }}
+    timeoutSeconds: {{ default 10 .Values.webhooks.timeoutSeconds }}
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+  - name: alertmanagerconfigsvalidate.monitoring.coreos.com
+    failurePolicy: {{ default "Fail" .Values.webhooks.failurePolicy }}
+    {{- with .Values.webhooks.namespaceSelector }}
+    namespaceSelector:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    rules:
+      - apiGroups:
+          - monitoring.coreos.com
+        apiVersions:
+          - v1alpha1
+        resources:
+          - alertmanagerconfigs
+        operations:
+          - CREATE
+          - UPDATE
+    clientConfig:
+      service:
+        namespace: {{ include "prometheus-operator-admission-webhook.namespace" . }}
+        name: {{ include "prometheus-operator-admission-webhook.fullname" . }}
+        path: /admission-alertmanagerconfigs/validate
+      {{- with .Values.caBundle }}
+      caBundle: {{ . }}
+      {{- end }}
+    timeoutSeconds: {{ default 10 .Values.webhooks.timeoutSeconds }}
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None

--- a/charts/prometheus-operator-admission-webhook/values.schema.json
+++ b/charts/prometheus-operator-admission-webhook/values.schema.json
@@ -1,0 +1,504 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "affinity": {
+            "type": "object"
+        },
+        "automountServiceAccountToken": {
+            "type": "boolean"
+        },
+        "caBundle": {
+            "type": "string"
+        },
+        "certManager": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "issuerRef": {
+                    "type": "string"
+                },
+                "rootCert": {
+                    "type": "object"
+                },
+                "webhookCert": {
+                    "type": "object"
+                }
+            }
+        },
+        "containerPort": {
+            "type": "integer"
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "allowPrivilegeEscalation": {
+                    "type": "boolean"
+                },
+                "capabilities": {
+                    "type": "object",
+                    "properties": {
+                        "drop": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "readOnlyRootFilesystem": {
+                    "type": "boolean"
+                },
+                "runAsGroup": {
+                    "type": "integer"
+                },
+                "runAsNonRoot": {
+                    "type": "boolean"
+                },
+                "runAsUser": {
+                    "type": "integer"
+                },
+                "seccompProfile": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "deployment": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "labels": {
+                    "type": "object"
+                }
+            }
+        },
+        "env": {
+            "type": "array"
+        },
+        "extraArgs": {
+            "type": "array"
+        },
+        "extraContainers": {
+            "type": "array"
+        },
+        "fullnameOverride": {
+            "type": "string"
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "digest": {
+                    "type": "string"
+                },
+                "pullPolicy": {
+                    "type": "string"
+                },
+                "pullSecrets": {
+                    "type": "array"
+                },
+                "registry": {
+                    "type": "string"
+                },
+                "repository": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "initContainers": {
+            "type": "array"
+        },
+        "jobs": {
+            "type": "object",
+            "properties": {
+                "affinity": {
+                    "type": "object"
+                },
+                "annotations": {
+                    "type": "object"
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean"
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean"
+                        },
+                        "runAsGroup": {
+                            "type": "integer"
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean"
+                        },
+                        "runAsUser": {
+                            "type": "integer"
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "digest": {
+                            "type": "string"
+                        },
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "pullSecrets": {
+                            "type": "array"
+                        },
+                        "registry": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "labels": {
+                    "type": "object"
+                },
+                "nodeSelector": {
+                    "type": "object"
+                },
+                "priorityClassName": {
+                    "type": "string"
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "securityContext": {
+                    "type": "object"
+                },
+                "tolerations": {
+                    "type": "object"
+                }
+            }
+        },
+        "kubeVersionOverride": {
+            "type": "string"
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "initialDelaySeconds": {
+                    "type": "integer"
+                },
+                "periodSeconds": {
+                    "type": "integer"
+                },
+                "tcpSocket": {
+                    "type": "object",
+                    "properties": {
+                        "port": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "nameOverride": {
+            "type": "string"
+        },
+        "namespaceOverride": {
+            "type": "string"
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "allowMonitoringNamespace": {
+                    "type": "boolean"
+                },
+                "annotations": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "labels": {
+                    "type": "object"
+                }
+            }
+        },
+        "nodeSelector": {
+            "type": "object"
+        },
+        "pod": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "labels": {
+                    "type": "object"
+                }
+            }
+        },
+        "podDisruptionBudget": {
+            "type": "object"
+        },
+        "priorityClassName": {
+            "type": "string"
+        },
+        "prometheusRule": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "labels": {
+                    "type": "object"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "rules": {
+                    "type": "array"
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean"
+                },
+                "pspEnabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "httpGet": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "string"
+                        },
+                        "scheme": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "periodSeconds": {
+                    "type": "integer"
+                }
+            }
+        },
+        "replicas": {
+            "type": "integer"
+        },
+        "resources": {
+            "type": "object"
+        },
+        "restartPolicy": {
+            "type": "string"
+        },
+        "securityContext": {
+            "type": "object",
+            "properties": {
+                "fsGroup": {
+                    "type": "integer"
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "labels": {
+                    "type": "object"
+                },
+                "port": {
+                    "type": "integer"
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "create": {
+                    "type": "boolean"
+                },
+                "labels": {
+                    "type": "object"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "serviceMonitor": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "attachMetadata": {
+                    "type": "object",
+                    "properties": {
+                        "node": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "honorLabels": {
+                    "type": "boolean"
+                },
+                "interval": {
+                    "type": "string"
+                },
+                "jobLabel": {
+                    "type": "string"
+                },
+                "labels": {
+                    "type": "object"
+                },
+                "metricRelabeling": {
+                    "type": "array"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "relabelings": {
+                    "type": "array"
+                },
+                "scrapeTimeout": {
+                    "type": "string"
+                },
+                "targetLabels": {
+                    "type": "array"
+                },
+                "tlsConfig": {
+                    "type": "object"
+                }
+            }
+        },
+        "tlsMinVersion": {
+            "type": "string"
+        },
+        "tlsSecret": {
+            "type": "object"
+        },
+        "tolerations": {
+            "type": "array"
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "rollingUpdate": {
+                    "type": "object",
+                    "properties": {
+                        "maxSurge": {
+                            "type": "integer"
+                        },
+                        "maxUnavailable": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "webhooks": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "failurePolicy": {
+                    "type": "string"
+                },
+                "labels": {
+                    "type": "object"
+                },
+                "namespaceSelector": {
+                    "type": "object"
+                },
+                "timeoutSeconds": {
+                    "type": "integer"
+                }
+            }
+        }
+    }
+}

--- a/charts/prometheus-operator-admission-webhook/values.schema.json
+++ b/charts/prometheus-operator-admission-webhook/values.schema.json
@@ -203,31 +203,7 @@
                     "type": "string"
                 },
                 "resources": {
-                    "type": "object",
-                    "properties": {
-                        "limits": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": "string"
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "requests": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": "string"
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
+                    "type": "object"
                 },
                 "securityContext": {
                     "type": "object"

--- a/charts/prometheus-operator-admission-webhook/values.yaml
+++ b/charts/prometheus-operator-admission-webhook/values.yaml
@@ -1,0 +1,349 @@
+## Default values for prometheus-operator-admission-webhook
+## This is a YAML-formatted file.
+## Declare variables to be passed into your templates.
+
+## namespaceOverride overrides the namespace which the resources will be deployed in
+namespaceOverride: ""
+
+## fullnameOverride overrides "release name"-"chart name" with a custom string
+fullnameOverride: ""
+
+## nameOverride overrides "chart name" with a custom string
+nameOverride: ""
+
+## kubeVersionOverride overrides Kubernetes version
+kubeVersionOverride: ""
+
+## webhooks provides parameters for webhook configurations.
+## failurePolicy: Fail or Ignore, default Fail
+## timeoutSeconds: 1 to 30, default 10
+## namespaceSelector: {}, defaults to all objects irrespective of their namespace
+## For info on converting Alertmanagerconfigs,
+## see https://prometheus-operator.dev/docs/user-guides/webhook/#converting-alertmanagerconfig-resources
+webhooks:
+  failurePolicy: Fail
+  timeoutSeconds: 10
+  namespaceSelector: {}
+
+  ## Additional labels and annotations for webhook configurations
+  labels: {}
+  annotations: {}
+
+## jobs enables creation of a TLS keypair and a patch of webhook configurations.
+## Jobs and related resources are hooks. Their output is a TLS key pair
+## with a CA certificate stored in a secret and update of the
+## caBundle field in webhook configurations. Should not be used
+## whilst cert-manager or tlsSecret is enabled.
+jobs:
+  enabled: true
+
+  ## Additional labels and annotations
+  annotations: {}
+  labels: {}
+
+  ## securityContext for pod
+  securityContext: {}
+
+  ## containerSecurityContext sets security context for containers
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+    readOnlyRootFilesystem: true
+    runAsGroup: 10000
+    runAsNonRoot: true
+    runAsUser: 10000
+    seccompProfile:
+      type: RuntimeDefault
+
+  ## image sets image-related parameters for jobs' containers
+  image:
+    registry: registry.k8s.io
+    repository: ingress-nginx/kube-webhook-certgen
+    tag: "v20221220-controller-v1.5.1-58-g787ea74b6"
+    ## sha256 digest overrides tag
+    # digest: 4d99688e557396f5baa150e019ff7d5b7334f9b9f9a8dab64038c5c2a006f6b5
+    digest: ""
+    pullPolicy: Always
+    pullSecrets: []
+
+  ## priorityClassName for pods
+  priorityClassName: ""
+
+  ## resources for job containers
+  ## Ref. https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+  resources:
+    limits:
+      cpu: 100m
+      memory: 64Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
+
+  ## affinity
+  affinity: {}
+
+  ## nodeSelector
+  nodeSelector: {}
+
+  ## tolerations
+  tolerations: {}
+
+## certManager enables cert-manager to generate certificate for the webhook.
+## caBundle and jobs should not be set.
+certManager:
+  enabled: false
+  ## issuerRef references an existing issuer for the webhook certificate.
+  ## An issuer represents a certificate issuing authority.
+  ## If not set, new issuers will be created.
+  ## ref. https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.Issuer
+  issuerRef: ""
+  ## rootCert allows setting certificate's lifetime when creating an issuer, defaults to 5y
+  rootCert: {}
+    # duration: "43800h0m0s"
+  ## webhookCert allows setting webhook certificate's lifetime, defaults to 1y
+  webhookCert: {}
+    # duration: "8760h0m0s"
+
+## caBundle allows inserting a CA bundle in webhook configurations
+## (PEM format, base64-encoded) if that CA is unknown at the API server.
+## The same CA signed the webhook's certificate set in tlsSecret.
+## certManager and jobs should not be enabled.
+## Can remain unset if the CA is known as trusted at the API server.
+caBundle: ""
+
+## tlsSecret references a secret holding the corresponding
+## TLS key under key keyItem and certificate under key certItem
+## to be used by the webhook.
+## Default items assumed in the secret are
+## tls.crt and tls.key for certificate and key, respectively.
+tlsSecret: {}
+  # name: prometheus-operator-admission-webhook-tls
+  # keyItem: ""
+  # certItem: ""
+
+## tlsMinVersion is the minimum TLS version the webhook supports
+tlsMinVersion: "VersionTLS13"
+
+## extraArgs for additional arguments passed to the container command
+extraArgs: []
+  # - --log-level=debug
+  # - --log-format=json
+
+## containerPort sets port of the webhook container
+containerPort: 10250
+
+## replicas sets a number of pods to start. For high availability
+## of the webhook, set at least 2.
+replicas: 1
+
+## restartPolicy
+restartPolicy: Always
+
+## podDisruptionBudget sets min/max number of available/unavailable replicas at a time
+podDisruptionBudget: {}
+  # maxUnavailable: 0
+
+## affinity
+affinity: {}
+
+## automountServiceAccountToken allows mounting the service account token automatically
+## for other containers to consume
+automountServiceAccountToken: false
+
+## env sets environment variables to pass to the container. Can be set as name/value pairs,
+## read from secrets or configmaps.
+env: []
+  # - name: VAR1
+  #   value: value1
+  # - name: PASSWORD
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: mysecret
+  #       key: password
+  #       optional: false
+
+## initContainers specifies init containers to execute in the pod
+## Ref. https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+initContainers: []
+
+## extraContainers specifies additional containers to start in the pod
+extraContainers: []
+
+## updateStrategy sets a way of how the deployment gets updated
+updateStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 1
+    maxUnavailable: 0
+
+## rbac allows creating roles and pod security policy
+## Ref. https://kubernetes.io/docs/concepts/security/pod-security-policy/
+rbac:
+  create: true
+  pspEnabled: false
+
+## image sets webhook container image parameters
+image:
+  registry: quay.io
+  repository: prometheus-operator/admission-webhook
+  ## Tag follows Chart.AppVersion by default
+  tag: ""
+  ## sha256 digest overrides tag
+  # digest: 3cd905af5c5504a93e6095af1cfd1db05cd4e1c3fc4ac488fc37fa71b057c93d
+  digest: ""
+  pullPolicy: Always
+  pullSecrets: []
+    # - registrySecret
+
+## serviceAccount for service account configuration
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+  labels: {}
+
+## securityContext for pod
+## Ref. https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+securityContext:
+  fsGroup: 2000
+
+## containerSecurityContext sets security context for container
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  readOnlyRootFilesystem: true
+  runAsGroup: 1000
+  runAsNonRoot: true
+  runAsUser: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+## livenessProbe sets liveness probe parameters
+## Ref. https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe:
+  tcpSocket:
+    port: https
+  periodSeconds: 10
+  initialDelaySeconds: 5
+
+## readinessProbe sets readiness probe parameters
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: https
+    scheme: HTTPS
+  periodSeconds: 10
+
+## nodeSelector
+nodeSelector: {}
+
+## resources for the webhook container
+## Ref. https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+## We usually recommend not to specify default resources and to leave this as a conscious
+## choice for the user. This also increases chances charts run on environments with little
+## resources, such as Minikube. If you do want to specify resources, uncomment the following
+## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 200Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 200Mi
+
+## deployment allows setting additional labels and annotations for deployment
+deployment:
+  annotations: {}
+  labels: {}
+
+## pod allows setting additional labels and annotations for pod
+pod:
+  annotations: {}
+  labels: {}
+
+## priorityClass for the pod
+priorityClassName: ""
+
+## service sets configuration for the webhook service. Service type ClusterIP is supported
+## and set by default.
+service:
+  annotations: {}
+  labels: {}
+  port: 443
+
+## tolerations
+tolerations: []
+
+## prometheusRule for creating prometheus rules
+## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.PrometheusRule
+prometheusRule:
+  enabled: false
+  ## Override namespace where the rules get deployed
+  namespace: ""
+  annotations: {}
+  ## Add labels to match rule selectors
+  labels: {}
+    # release: kube-prometheus-stack
+  rules: []
+    # - alert: Admission webhook target down
+    #   expr: up{namespace="{{ include "prometheus-operator-admission-webhook.namespace" . }}",
+    #       service="{{ include "prometheus-operator-admission-webhook.fullname" . }}"} == 0
+    #   for: 5m
+    #   labels:
+    #     severity: warning
+    #   annotations:
+    #     summary: Scraping {{`{{ $labels.pod }}`}}/{{`{{ $labels.container }}`}}
+    #       in namespace {{`{{ $labels.namespace }}`}} failed.
+
+## serviceMonitor allows creating a service monitor for Prometheus operator to assemble corresponding
+## configuration for Prometheus
+## Ref. https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.ServiceMonitor
+serviceMonitor:
+  ## Enable service monitor
+  enabled: false
+  ## Overrides namespace where the service monitor gets deployed
+  namespace: ""
+  ## Override default job label
+  jobLabel: ""
+  ## MetricRelabelConfigs to apply to samples before ingestion
+  metricRelabeling: []
+  ## RelabelConfigs to apply to targets before scraping
+  relabelings: []
+  ## Add labels to match service monitor selectors
+  labels: {}
+    # release: kube-prometheus-stack
+  ## TargetLabels transfers labels from the Kubernetes Service onto the created metrics
+  targetLabels: []
+  ## Add annotations to the service monitor
+  annotations: {}
+  ## Scrape interval
+  interval: 30s
+  ## Scrape timeout
+  scrapeTimeout: 10s
+  ## HonorLabels chooses the metric labels on collisions with target labels
+  honorLabels: false
+  ## Attach node metadata to discovered targets. Requires Prometheus v2.37.0 and above.
+  attachMetadata:
+    node: false
+  ## TLS configuration to use at scraping the endpoint. The webhook always supports TLS,
+  ## so that tlsConfig is required. The given secret must exist in the service monitor's namespace.
+  tlsConfig: {}
+    # serverName: "prometheus-operator-admission-webhook.monitoring.svc"
+    # ca:
+    #   secret:
+    #     name: "prometheus-operator-admission-webhook-ca"
+    #     key: ca
+    # insecureSkipVerify: false
+
+## networkPolicy allows enabling network policy with custom restrictions
+## Ref. https://kubernetes.io/docs/concepts/services-networking/network-policies/
+networkPolicy:
+  ## Enable network policy and allows access from anywhere
+  enabled: false
+  ## Additional labels and annotations to attach to network policy
+  labels: {}
+  annotations: {}
+  ## If true, limit access only from namespace labelled name=monitoring
+  allowMonitoringNamespace: false

--- a/charts/prometheus-operator-admission-webhook/values.yaml
+++ b/charts/prometheus-operator-admission-webhook/values.yaml
@@ -72,13 +72,17 @@ jobs:
 
   ## resources for job containers
   ## Ref. https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-  resources:
-    limits:
-      cpu: 100m
-      memory: 64Mi
-    requests:
-      cpu: 50m
-      memory: 64Mi
+  ## We usually recommend not to specify default resources and to leave this as a conscious
+  ## choice for the user. This also increases chances charts run on environments with little
+  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 64Mi
+    # requests:
+    #   cpu: 50m
+    #   memory: 64Mi
 
   ## affinity
   affinity: {}


### PR DESCRIPTION
…-admission-webhook

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
Signed-off-by: zeritti <47476160+zeritti@users.noreply.github.com>

#### What this PR does / why we need it

I would like to make chart *prometheus-operator-admission-webhook* available through the Prometheus community to users of the community's charts.

Currently, the *kube-prometheus-stack* chart brings the functionality with Prometheus operator as the admission webhook runs within its code. This is good for development and testing. In a production environment, though, a standalone webhook is recommended.

The Prometheus operator project has made the admission webhook available as a standalone application ([#4494](https://github.com/prometheus-operator/prometheus-operator/pull/4494)) since release 0.55.0 which can thus be deployed independently. This brings benefits such as making it highly available through multiple replicas, making it independent of changes that might be affecting the operator's runtime, deploying it in a different namespace, etc.

This chart draws on the *kube-prometheus-stack* chart and how the admission webhook's resources have been implemented. 

In this chart:
- With the default values, a single webhook replica will be launched with TLS resources produced by the hooks (a secret and patched webhook configurations) 
- Beside mutating and validating `Prometheusrules`, validating `Alertmanagerconfigs` has also been enabled
- Mandatory TLS resources for the webhook are made available through hooks (jobs),
  [cert-manager](https://cert-manager.io/docs/getting-started/) and a custom TLS keypair from a secret through `tlsSecret` with or without `caBundle`
- Security context of all the containers is set to satisfy the Restricted profile of the [Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
- Webhook parameters underneath `webhooks` are currently set globally on the created webhooks
- Support for Prometheus rules and service monitor is present
- RBAC is enabled by default
- Image registry and repository are set via separate values
- A values schema has been added for clarity

#### Which issue this PR fixes

None

#### Special notes for your reviewer
With respect to versioning, I would suggest usual versioning of the chart following semver providing thus means to indicate e.g. breaking changes (beginning with 0.1.0). Mapping the admission webhook's version to the Prometheus operator's version (both should be in sync, indeed) won't be as practical as one would probably desire, though.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
