### PR TITLE
[prometheus-blackbox-exporter] Add ability to define metricRelabelings action

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 7.7.0
+version: 7.8.0
 appVersion: 0.23.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/charts/prometheus-blackbox-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/servicemonitor.yaml
@@ -37,9 +37,15 @@ spec:
       - sourceLabels: [instance]
         targetLabel: instance
         replacement: {{ .url }}
+        {{- with .action }}
+        action: {{ . }}
+        {{- end }}
       - sourceLabels: [target]
         targetLabel: target
         replacement: {{ .name }}
+        {{- with .action }}
+        action: {{ . }}
+        {{- end }}
         {{- range $targetLabel, $replacement := .additionalMetricsRelabels | default $.Values.serviceMonitor.defaults.additionalMetricsRelabels }}
       - targetLabel: {{ $targetLabel | quote }}
         replacement: {{ $replacement | quote }}

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -261,6 +261,7 @@ serviceMonitor:
 #      module: http_2xx                 # Module used for scraping. Overrides value set in `defaults`
 #      additionalMetricsRelabels: {}    # Map of metric labels and values to add
 #      additionalRelabeling: []         # List of metric relabeling actions to run
+#      action: replace                  # Action to perform based on regex matching. Require Prometheus >= 2.36
 
 ## Custom PrometheusRules to be defined
 ## ref: https://github.com/coreos/prometheus-operator#customresourcedefinitions


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Recent Prometheus-Operator versions implicit set the `action` field inside `.spec.endpoints.metricRelabelings` to `replace`. This isn't convenient when doing GitOps eg. via Argo CD. The GitOps tool then always shows a diff to apply:
![image](https://user-images.githubusercontent.com/7290987/231138273-7dd01dee-5679-457c-9a16-dc145fd500c3.png)

The issue is easy to fix by explicitly setting the same value inside the Git repo so that the GitOps tools doesn't detect a diff. Altough I assume that we cannot "hardcode" it as it would require Prometheus instance >= 2.36.

#### Which issue this PR fixes

We did not open an issue yet.

#### Special notes for your reviewer

`---`

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
