### PR TITLE
[prometheus-cloudwatch-exporter] Appversion bump to 0.15.3

### DIFF
--- a/charts/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/charts/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.15.3"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.24.0
+version: 0.25.0
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/charts/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/charts/prometheus-cloudwatch-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.15.1"
+appVersion: "0.15.3"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
 version: 0.24.0


### PR DESCRIPTION
@gianrubio @torstenwalter @asherf 

#### What this PR does / why we need it
As discussed in https://github.com/prometheus-community/helm-charts/issues/3240 , we would need to update to the latest version of cloudwatch.

#### Which issue this PR fixes

- fixes #3240 

#### Special notes for your reviewer

#### Checklist

- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
