### PR TITLE
[alertmanager] Fixing "cannot overwrite table with non table" warning

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 0.29.0
+version: 0.29.1
 appVersion: v0.25.0
 kubeVersion: ">=1.16.0-0"
 keywords:

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -41,7 +41,7 @@ priorityClassName: ""
 
 podSecurityContext:
   fsGroup: 65534
-dnsConfig: {}
+dnsConfig: []
   # nameservers:
   #   - 1.2.3.4
   # searches:
@@ -51,7 +51,7 @@ dnsConfig: {}
   #   - name: ndots
   #     value: "2"
   #   - name: edns0
-hostAliases: {}
+hostAliases: []
   # - ip: "127.0.0.1"
   #   hostnames:
   #   - "foo.local"


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

When overriding either of these fields we get the following warning:

```
coalesce.go:220: warning: cannot overwrite table with non table for monitoring.alertmanager.hostAliases (map[])
```

It's a non-issue but a bit frustrating to encounter. 

#### Special notes for your reviewer

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
