### PR TITLE
[kube-prometheus-stack] Avoid diff with server-side apply when enforcedNamespaceLabel is set

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 45.27.0
+version: 45.27.1
 appVersion: v0.65.1
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -361,7 +361,8 @@ spec:
 {{- end }}
   excludedFromEnforcement:
 {{- range $prometheusDefaultRulesExcludedFromEnforce.rules }}
-    - resource: prometheusrules
+    - group: monitoring.coreos.com
+      resource: prometheusrules
       namespace: "{{ template "kube-prometheus-stack.namespace" $ }}"
       name: "{{ printf "%s-%s" (include "kube-prometheus-stack.fullname" $) . | trunc 63 | trimSuffix "-" }}"
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it

To avoid the following diff with server-side apply:

```diff
  excludedFromEnforcement:
-    - group: monitoring.coreos.com
-      name: prometheus-stack-kube-prom-alertmanager.rules
+    - name: prometheus-stack-kube-prom-alertmanager.rules
...
```
#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
