### PR TITLE
[kube-state-metrics] Use digest instead of sha

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 5.6.1
+version: 6.0.0
 appVersion: 2.8.2
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/README.md
+++ b/charts/kube-state-metrics/README.md
@@ -40,12 +40,9 @@ helm upgrade [RELEASE_NAME] prometheus-community/kube-state-metrics [flags]
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
-### Migrating from stable/kube-state-metrics and kubernetes/kube-state-metrics
+## From 5.x to 6.x
 
-You can upgrade in-place:
-
-1. [get repository info](#get-repository-info)
-1. [upgrade](#upgrading-chart) your existing release name using the new chart repository
+This version renames `image.sha` to `image.digest` and `kubeRBACProxy.image.sha` to `kubeRBACProxy.image.digest`.
 
 ## Upgrading to v3.0.0
 
@@ -56,6 +53,13 @@ The upgraded chart now the following changes:
 * Dropped support for helm v2 (helm v3 or later is required)
 * collectors key was renamed to resources
 * namespace key was renamed to namespaces
+
+### Migrating from stable/kube-state-metrics and kubernetes/kube-state-metrics
+
+You can upgrade in-place:
+
+1. [get repository info](#get-repository-info)
+1. [upgrade](#upgrading-chart) your existing release name using the new chart repository
 
 ## Configuration
 

--- a/charts/kube-state-metrics/templates/_helpers.tpl
+++ b/charts/kube-state-metrics/templates/_helpers.tpl
@@ -122,10 +122,12 @@ The image to use for kube-state-metrics
 */}}
 {{- define "kube-state-metrics.image" -}}
 {{- if .Values.image.sha }}
+{{- fail "image.sha forbidden. Use image.digest instead" }}
+{{- else if .Values.image.digest }}
 {{- if .Values.global.imageRegistry }}
-{{- printf "%s/%s:%s@%s" .Values.global.imageRegistry .Values.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) .Values.image.sha }}
+{{- printf "%s/%s:%s@%s" .Values.global.imageRegistry .Values.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) .Values.image.digest }}
 {{- else }}
-{{- printf "%s/%s:%s@%s" .Values.image.registry .Values.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) .Values.image.sha }}
+{{- printf "%s/%s:%s@%s" .Values.image.registry .Values.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) .Values.image.digest }}
 {{- end }}
 {{- else }}
 {{- if .Values.global.imageRegistry }}
@@ -141,10 +143,12 @@ The image to use for kubeRBACProxy
 */}}
 {{- define "kubeRBACProxy.image" -}}
 {{- if .Values.kubeRBACProxy.image.sha }}
+{{- fail "kubeRBACProxy.image.sha forbidden. Use kubeRBACProxy.image.digest instead" }}
+{{- else if .Values.kubeRBACProxy.image.digest }}
 {{- if .Values.global.imageRegistry }}
-{{- printf "%s/%s:%s@%s" .Values.global.imageRegistry .Values.kubeRBACProxy.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.kubeRBACProxy.image.tag) .Values.kubeRBACProxy.image.sha }}
+{{- printf "%s/%s:%s@%s" .Values.global.imageRegistry .Values.kubeRBACProxy.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.kubeRBACProxy.image.tag) .Values.kubeRBACProxy.image.digest }}
 {{- else }}
-{{- printf "%s/%s:%s@%s" .Values.kubeRBACProxy.image.registry .Values.kubeRBACProxy.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.kubeRBACProxy.image.tag) .Values.kubeRBACProxy.image.sha }}
+{{- printf "%s/%s:%s@%s" .Values.kubeRBACProxy.image.registry .Values.kubeRBACProxy.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.kubeRBACProxy.image.tag) .Values.kubeRBACProxy.image.digest }}
 {{- end }}
 {{- else }}
 {{- if .Values.global.imageRegistry }}

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -5,7 +5,7 @@ image:
   repository: kube-state-metrics/kube-state-metrics
   # If unset use v + .Charts.appVersion
   tag: ""
-  sha: ""
+  digest: ""
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -90,7 +90,7 @@ kubeRBACProxy:
     registry: quay.io
     repository: brancz/kube-rbac-proxy
     tag: v0.14.0
-    sha: ""
+    digest: ""
     pullPolicy: IfNotPresent
 
   # List of additional cli arguments to configure kube-rbac-prxy


### PR DESCRIPTION
#### What this PR does / why we need it

sha is for digest without digest type.

digest is more commonly used, and prepare for possible future digest types

Same as #3130.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
