### PR TITLE
[kube-prometheus-stack] bump chart dependencies

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 45.10.1
+version: 45.11.0
 appVersion: v0.63.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus
@@ -40,7 +40,7 @@ annotations:
 
 dependencies:
   - name: kube-state-metrics
-    version: "5.4.*"
+    version: "5.5.*"
     repository: https://prometheus-community.github.io/helm-charts
     condition: kubeStateMetrics.enabled
   - name: prometheus-node-exporter
@@ -48,6 +48,6 @@ dependencies:
     repository: https://prometheus-community.github.io/helm-charts
     condition: nodeExporter.enabled
   - name: grafana
-    version: "6.52.*"
+    version: "6.53.*"
     repository: https://grafana.github.io/helm-charts
     condition: grafana.enabled


### PR DESCRIPTION
#### What this PR does / why we need it
Updates kube-prometheus-stack dependencies (kube-state-metrics and grafana). 

This brings improved securityContext to both.

#### Special notes for your reviewer
SecurityContext diffs:
grafana:
![image](https://user-images.githubusercontent.com/7985687/232838884-45842943-a1a4-487b-aca2-66ed8f7325a8.png)
kube-state-metrics
![image](https://user-images.githubusercontent.com/7985687/232839010-f523a98f-3fd1-45a4-bc7e-c7268dc2e579.png)
![image](https://user-images.githubusercontent.com/7985687/232839105-143cbf77-58e6-4247-a51a-cdf8d330a169.png)

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
