### PR TITLE
[prometheus-smartctl-exporter]: allow annotation to daemonset 

### DIFF
--- a/charts/prometheus-smartctl-exporter/Chart.yaml
+++ b/charts/prometheus-smartctl-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/prometheus-smartctl-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-smartctl-exporter/templates/daemonset.yaml
@@ -1,5 +1,5 @@
 {{- $global := . }}
-{{- $base := dict "resources" .Values.resources "nodeSelector" .Values.nodeSelector "affinity" .Values.affinity "tolerations" .Values.tolerations "config" .Values.config }}
+{{- $base := dict "annotations" .Values.annotations "resources" .Values.resources "nodeSelector" .Values.nodeSelector "affinity" .Values.affinity "tolerations" .Values.tolerations "config" .Values.config }}
 {{- $items := prepend .Values.extraInstances $base }}
 {{- range $idx, $item := $items }}
 {{- $config := mergeOverwrite $item.config $global.Values.common.config }}
@@ -9,6 +9,10 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "prometheus-smartctl-exporter.fullname" $global }}-{{ $idx }}
+  {{- with $item.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "prometheus-smartctl-exporter.labels" $global | nindent 4 }}
     idx: i{{ $idx }}

--- a/charts/prometheus-smartctl-exporter/values.yaml
+++ b/charts/prometheus-smartctl-exporter/values.yaml
@@ -65,6 +65,8 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 
+annotations: {}
+
 nodeSelector: {}
 
 tolerations:


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->

#### What this PR does / why we need it

Allow to add custom annotations to the `daemonset` from `values.yaml`.

#### Which issue this PR fixes

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)