### PR TITLE
[kube-prometheus-stack] Add cilium networkpolicy support

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 45.20.0
+version: 45.21.0
 appVersion: v0.63.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 45.22.0
+version: 45.21.0
 appVersion: v0.63.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 45.21.0
+version: 45.22.0
 appVersion: v0.63.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/ciliumnetworkpolicy-createSecret.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/ciliumnetworkpolicy-createSecret.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.prometheusOperator.networkPolicy.enabled (eq .Values.prometheusOperator.networkPolicy.flavor "cilium") }}
+{{- if and .Values.prometheusOperator.enabled .Values.prometheusOperator.admissionWebhooks.enabled .Values.prometheusOperator.admissionWebhooks.patch.enabled (not .Values.prometheusOperator.admissionWebhooks.certManager.enabled) }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name:  {{ template "kube-prometheus-stack.fullname" . }}-admission-create
+  namespace: {{ template "kube-prometheus-stack.namespace" . }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    ## Ensure this is run before the job
+    helm.sh/hook-weight: "-5"
+    {{- with .Values.prometheusOperator.admissionWebhooks.annotations }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}  
+  labels:
+    app: {{ template "kube-prometheus-stack.name" $ }}-admission-create
+    {{- include "kube-prometheus-stack.labels" $ | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app: {{ template "kube-prometheus-stack.name" $ }}-admission-create
+      {{- include "kube-prometheus-stack.labels" $ | nindent 6 }}
+  egress:
+    {{- if and .Values.prometheusOperator.networkPolicy.cilium .Values.prometheusOperator.networkPolicy.cilium.egress }}
+      {{ toYaml .Values.prometheusOperator.networkPolicy.cilium.egress | nindent 6 }}
+    {{- else }}
+    - toEntities:
+      - kube-apiserver
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/ciliumnetworkpolicy-patchWebhook.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/ciliumnetworkpolicy-patchWebhook.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.prometheusOperator.networkPolicy.enabled (eq .Values.prometheusOperator.networkPolicy.flavor "cilium") }}
+{{- if and .Values.prometheusOperator.enabled .Values.prometheusOperator.admissionWebhooks.enabled .Values.prometheusOperator.admissionWebhooks.patch.enabled (not .Values.prometheusOperator.admissionWebhooks.certManager.enabled) }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name:  {{ template "kube-prometheus-stack.fullname" . }}-admission-patch
+  namespace: {{ template "kube-prometheus-stack.namespace" . }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    ## Ensure this is run before the job
+    helm.sh/hook-weight: "-5"
+    {{- with .Values.prometheusOperator.admissionWebhooks.patch.annotations }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}   
+  labels:
+    app: {{ template "kube-prometheus-stack.name" $ }}-admission-patch
+    {{- include "kube-prometheus-stack.labels" $ | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app: {{ template "kube-prometheus-stack.name" $ }}-admission-patch
+      {{- include "kube-prometheus-stack.labels" $ | nindent 6 }}
+  egress:
+    {{- if and .Values.prometheusOperator.networkPolicy.cilium .Values.prometheusOperator.networkPolicy.cilium.egress }}
+      {{ toYaml .Values.prometheusOperator.networkPolicy.cilium.egress | nindent 6 }}
+    {{- else }}
+    - toEntities:
+      - kube-apiserver
+    {{- end }}
+{{- end }}
+{{- end }}
+

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/networkpolicy-createSecret.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/networkpolicy-createSecret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.prometheusOperator.networkPolicy.enabled }}
+{{- if and .Values.prometheusOperator.networkPolicy.enabled (eq .Values.prometheusOperator.networkPolicy.flavor "kubernetes") }}
 {{- if and .Values.prometheusOperator.enabled .Values.prometheusOperator.admissionWebhooks.enabled .Values.prometheusOperator.admissionWebhooks.patch.enabled (not .Values.prometheusOperator.admissionWebhooks.certManager.enabled) }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/networkpolicy-patchWebhook.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/job-patch/networkpolicy-patchWebhook.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.prometheusOperator.networkPolicy.enabled }}
+{{- if and .Values.prometheusOperator.networkPolicy.enabled (eq .Values.prometheusOperator.networkPolicy.flavor "kubernetes") }}
 {{- if and .Values.prometheusOperator.enabled .Values.prometheusOperator.admissionWebhooks.enabled .Values.prometheusOperator.admissionWebhooks.patch.enabled (not .Values.prometheusOperator.admissionWebhooks.certManager.enabled) }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/ciliumnetworkpolicy.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/ciliumnetworkpolicy.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.prometheusOperator.networkPolicy.enabled (eq .Values.prometheusOperator.networkPolicy.flavor "cilium") }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ template "kube-prometheus-stack.fullname" . }}-operator
+  namespace: {{ template "kube-prometheus-stack.namespace" . }}
+  labels:
+    app: {{ template "kube-prometheus-stack.name" . }}-operator
+    {{- include "kube-prometheus-stack.labels" . | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app: {{ template "kube-prometheus-stack.name" . }}-operator
+      {{- include "kube-prometheus-stack.labels" $ | nindent 6 }}
+  egress:
+  {{- if and .Values.prometheusOperator.networkPolicy.cilium .Values.prometheusOperator.networkPolicy.cilium.egress }}
+    {{ toYaml .Values.prometheusOperator.networkPolicy.cilium.egress | nindent 6 }}
+  {{- else }}
+  - toEntities:
+    - kube-apiserver
+  {{- end }}
+  ingress:
+  - toPorts:
+    - ports:
+      {{- if .Values.prometheusOperator.tls.enabled }}
+      - port: {{ .Values.prometheusOperator.tls.internalPort }}
+      {{- else }}
+      - port: 8080
+      {{- end }}
+        protocol: "TCP"
+      rules:
+        http:
+        - method: "GET"
+          path: "/metrics"
+{{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/networkpolicy.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.prometheusOperator.networkPolicy.enabled }}
+{{- if and .Values.prometheusOperator.networkPolicy.enabled (eq .Values.prometheusOperator.networkPolicy.flavor "kubernetes") }}
 apiVersion: {{ template "kube-prometheus-stack.prometheus.networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
 metadata:

--- a/charts/kube-prometheus-stack/templates/prometheus/ciliumnetworkpolicy.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/ciliumnetworkpolicy.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.prometheus.networkPolicy.enabled (eq .Values.prometheus.networkPolicy.flavor "cilium") }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ template "kube-prometheus-stack.fullname" . }}-prometheus
+  namespace: {{ template "kube-prometheus-stack.namespace" . }}
+  labels:
+    app: {{ template "kube-prometheus-stack.name" . }}-prometheus
+    {{- include "kube-prometheus-stack.labels" . | nindent 4 }}
+spec:
+  endpointSelector:
+    {{- if .Values.prometheus.networkPolicy.cilium.endpointSelector }}
+    {{- toYaml .Values.prometheus.networkPolicy.cilium.endpointSelector | nindent 4 }}
+    {{- else }}
+    matchExpressions:
+      - {key: app.kubernetes.io/name, operator: In, values: [prometheus]}
+      - {key: prometheus, operator: In, values: [{{ template "kube-prometheus-stack.prometheus.crname" . }}]}
+    {{- end }}
+  {{- if and .Values.prometheus.networkPolicy.cilium .Values.prometheus.networkPolicy.cilium.egress }}  
+  egress:
+    {{ toYaml .Values.prometheus.networkPolicy.cilium.egress | nindent 4 }}
+  {{- end }}
+  {{- if and .Values.prometheus.networkPolicy.cilium .Values.prometheus.networkPolicy.cilium.ingress }}  
+  ingress:
+    {{ toYaml .Values.prometheus.networkPolicy.cilium.ingress | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/networkpolicy.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.prometheus.networkPolicy.enabled }}
+{{- if and .Values.prometheus.networkPolicy.enabled (eq .Values.prometheus.networkPolicy.flavor "kubernetes") }}
 apiVersion: {{ template "kube-prometheus-stack.prometheus.networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
 metadata:
@@ -9,12 +9,10 @@ metadata:
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
 spec:
   {{- if .Values.prometheus.networkPolicy.egress }}
-  ## Deny all egress by default
   egress:
     {{- toYaml .Values.prometheus.networkPolicy.egress | nindent 4 }}
   {{- end }}
   {{- if .Values.prometheus.networkPolicy.ingress }}
-  # Deny all ingress by default (prometheus scrapes itself using localhost)
   ingress:
     {{- toYaml .Values.prometheus.networkPolicy.ingress | nindent 4 }}
   {{- end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1963,6 +1963,15 @@ prometheusOperator:
     ##
     enabled: false
 
+    ## Flavor of the network policy to use.
+    #  Can be:
+    #  * kubernetes for networking.k8s.io/v1/NetworkPolicy
+    #  * cilium     for cilium.io/v2/CiliumNetworkPolicy
+    flavor: kubernetes
+
+    # cilium:
+    #   egress:
+
   ## Service account for Alertmanager to use.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
   ##
@@ -2260,6 +2269,18 @@ prometheus:
   ## Configure network policy for the prometheus
   networkPolicy:
     enabled: false
+
+    ## Flavor of the network policy to use.
+    #  Can be:
+    #  * kubernetes for networking.k8s.io/v1/NetworkPolicy
+    #  * cilium     for cilium.io/v2/CiliumNetworkPolicy
+    flavor: kubernetes
+
+    # cilium:
+    #   endpointSelector:
+    #   egress:
+    #   ingress:
+
     # egress:
     # - {}
     # ingress:


### PR DESCRIPTION

#### What this PR does / why we need it

This PR adds ciliumnetworkpolicy support to kps

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
