### PR TITLE
[kube-prometheus-stack] update prometheus rules

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 45.21.0
+version: 45.21.1
 appVersion: v0.63.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/alertmanager.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/alertmanager.rules.yaml
@@ -101,7 +101,7 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/alertmanager/alertmanagerclusterfailedtosendalerts
         summary: All Alertmanager instances in a cluster failed to send notifications to a critical integration.
       expr: |-
-        min by (namespace,service, integration) (
+        min by (namespace,service, integration, job) (
           rate(alertmanager_notifications_failed_total{job="{{ $alertmanagerJob }}",namespace="{{ $namespace }}", integration=~`.*`}[5m])
         /
           rate(alertmanager_notifications_total{job="{{ $alertmanagerJob }}",namespace="{{ $namespace }}", integration=~`.*`}[5m])
@@ -124,7 +124,7 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/alertmanager/alertmanagerclusterfailedtosendalerts
         summary: All Alertmanager instances in a cluster failed to send notifications to a non-critical integration.
       expr: |-
-        min by (namespace,service, integration) (
+        min by (namespace,service, integration, job) (
           rate(alertmanager_notifications_failed_total{job="{{ $alertmanagerJob }}",namespace="{{ $namespace }}", integration!~`.*`}[5m])
         /
           rate(alertmanager_notifications_total{job="{{ $alertmanagerJob }}",namespace="{{ $namespace }}", integration!~`.*`}[5m])
@@ -147,8 +147,8 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/alertmanager/alertmanagerconfiginconsistent
         summary: Alertmanager instances within the same cluster have different configurations.
       expr: |-
-        count by (namespace,service) (
-          count_values by (namespace,service) ("config_hash", alertmanager_config_hash{job="{{ $alertmanagerJob }}",namespace="{{ $namespace }}"})
+        count by (namespace,service,job) (
+          count_values by (namespace,service,job) ("config_hash", alertmanager_config_hash{job="{{ $alertmanagerJob }}",namespace="{{ $namespace }}"})
         )
         != 1
       for: 20m
@@ -169,11 +169,11 @@ spec:
         summary: Half or more of the Alertmanager instances within the same cluster are down.
       expr: |-
         (
-          count by (namespace,service) (
+          count by (namespace,service,job) (
             avg_over_time(up{job="{{ $alertmanagerJob }}",namespace="{{ $namespace }}"}[5m]) < 0.5
           )
         /
-          count by (namespace,service) (
+          count by (namespace,service,job) (
             up{job="{{ $alertmanagerJob }}",namespace="{{ $namespace }}"}
           )
         )
@@ -196,11 +196,11 @@ spec:
         summary: Half or more of the Alertmanager instances within the same cluster are crashlooping.
       expr: |-
         (
-          count by (namespace,service) (
+          count by (namespace,service,job) (
             changes(process_start_time_seconds{job="{{ $alertmanagerJob }}",namespace="{{ $namespace }}"}[10m]) > 4
           )
         /
-          count by (namespace,service) (
+          count by (namespace,service,job) (
             up{job="{{ $alertmanagerJob }}",namespace="{{ $namespace }}"}
           )
         )

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/etcd.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/etcd.yaml
@@ -86,7 +86,7 @@ spec:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
 {{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
 {{- end }}
-        description: 'etcd cluster "{{`{{`}} $labels.job {{`}}`}}": {{`{{`}} $value {{`}}`}} leader changes within the last 15 minutes. Frequent elections may be a sign of insufficient resources, high network latency, or disruptions by other components and should be investigated.'
+        description: 'etcd cluster {{`{{`}} $value {{`}}`}} leader changes within the last 15 minutes. Frequent elections may be a sign of insufficient resources, high network latency, or disruptions by other components and should be investigated.'
         summary: etcd cluster has high number of leader changes.
       expr: increase((max without (instance) (etcd_server_leader_changes_seen_total{job=~".*etcd.*"}) or 0*absent(etcd_server_leader_changes_seen_total{job=~".*etcd.*"}))[15m:1m]) >= 4
       for: 5m

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/prometheus.yaml
@@ -432,9 +432,9 @@ spec:
         summary: Prometheus encounters more than 3% errors sending alerts to any Alertmanager.
       expr: |-
         min without (alertmanager) (
-          rate(prometheus_notifications_errors_total{job="{{ $prometheusJob }}",namespace="{{ $namespace }}",alertmanager!~``}[5m])
+          rate(prometheus_notifications_errors_total{job="{{ $prometheusJob }}",namespace="{{ $namespace }}",alertmanager!=``}[5m])
         /
-          rate(prometheus_notifications_sent_total{job="{{ $prometheusJob }}",namespace="{{ $namespace }}",alertmanager!~``}[5m])
+          rate(prometheus_notifications_sent_total{job="{{ $prometheusJob }}",namespace="{{ $namespace }}",alertmanager!=``}[5m])
         )
         * 100
         > 3


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

We used [pint](https://github.com/cloudflare/pint) to check Prometheus rules and found that some official rules did not pass the verification, so we tried to modify it to make it more standardized.
```
pint_problem{filename="/rules/monitoring-kube-prom-kube-prometheus-alertmanager.rules-d734d4d6-ebb1-41b4-a01d-ff84fa579c5c.yaml",kind="alerting",name="AlertmanagerClusterCrashlooping",owner="",problem="template is using \"job\" label but the query removes it",reporter="alerts/template",severity="bug"} 1
pint_problem{filename="/rules/monitoring-kube-prom-kube-prometheus-alertmanager.rules-d734d4d6-ebb1-41b4-a01d-ff84fa579c5c.yaml",kind="alerting",name="AlertmanagerClusterDown",owner="",problem="template is using \"job\" label but the query removes it",reporter="alerts/template",severity="bug"} 1
pint_problem{filename="/rules/monitoring-kube-prom-kube-prometheus-alertmanager.rules-d734d4d6-ebb1-41b4-a01d-ff84fa579c5c.yaml",kind="alerting",name="AlertmanagerClusterFailedToSendAlerts",owner="",problem="template is using \"job\" label but the query removes it",reporter="alerts/template",severity="bug"} 1
pint_problem{filename="/rules/monitoring-kube-prom-kube-prometheus-alertmanager.rules-d734d4d6-ebb1-41b4-a01d-ff84fa579c5c.yaml",kind="alerting",name="AlertmanagerConfigInconsistent",owner="",problem="template is using \"job\" label but the query removes it",reporter="alerts/template",severity="bug"} 1
pint_problem{filename="/rules/monitoring-kube-prom-kube-prometheus-etcd-85549b8e-0791-4646-a0db-e8b71f7e09c5.yaml",kind="alerting",name="etcdHighNumberOfLeaderChanges",owner="",problem="template is using \"job\" label but absent() is not passing it",reporter="alerts/template",severity="bug"} 1
pint_problem{filename="/rules/monitoring-kube-prom-kube-prometheus-prometheus-8c8f7cef-a3cf-4507-a2cb-023201ad2cf2.yaml",kind="alerting",name="PrometheusErrorSendingAlertsToAnyAlertmanager",owner="",problem="unnecessary regexp match on static string alertmanager!~\"\", use alertmanager!=\"\" instead",reporter="promql/regexp",severity="bug"} 1
```

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
