### PR TITLE
[prometheus]Remove 'app.kubernetes.io/version' label from selector

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: v2.43.0
-version: 21.1.2
+version: 22.0.0
 kubeVersion: ">=1.16.0-0"
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/README.md
+++ b/charts/prometheus/README.md
@@ -67,7 +67,9 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 
 ### To 22.0
 
-The `app.kubernetes.io/version` label has been removed from the selector. Therefore, you must delete the previous StatefulSet or Deployment before performing the upgrade.
+The `app.kubernetes.io/version` label has been removed from the pod selector.
+
+Therefore, you must delete the previous StatefulSet or Deployment before upgrading. Performing this operation will cause **Prometheus to stop functioning** until the upgrade is complete.
 
 ```console
 kubectl delete deploy,sts -l app.kubernetes.io/name=prometheus

--- a/charts/prometheus/README.md
+++ b/charts/prometheus/README.md
@@ -65,6 +65,14 @@ helm upgrade [RELEASE_NAME] [CHART] --install
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
+### To 22.0
+
+The `app.kubernetes.io/version` label has been removed from the selector. Therefore, you must delete the previous StatefulSet or Deployment before performing the upgrade.
+
+```console
+kubectl delete deploy,sts -l app.kubernetes.io/name=prometheus
+```
+
 ### To 21.0
 
 The Kubernetes labels have been updated to follow [Helm 3 label and annotation best practices](https://helm.sh/docs/chart_best_practices/labels/).

--- a/charts/prometheus/templates/_helpers.tpl
+++ b/charts/prometheus/templates/_helpers.tpl
@@ -19,13 +19,13 @@ Create labels for prometheus
 {{- define "prometheus.common.matchLabels" -}}
 app.kubernetes.io/name: {{ include "prometheus.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/version: {{ .Chart.AppVersion }}
 {{- end -}}
 
 {{/*
 Create unified labels for prometheus components
 */}}
 {{- define "prometheus.common.metaLabels" -}}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
 helm.sh/chart: {{ include "prometheus.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: {{ include "prometheus.name" . }}

--- a/charts/prometheus/templates/pdb.yaml
+++ b/charts/prometheus/templates/pdb.yaml
@@ -10,5 +10,5 @@ spec:
   maxUnavailable: {{ .Values.server.podDisruptionBudget.maxUnavailable }}
   selector:
     matchLabels:
-      {{- include "prometheus.server.labels" . | nindent 6 }}
+      {{- include "prometheus.server.matchLabels" . | nindent 6 }}
 {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
prometheus chart is in violation of the guidelines for this section:
https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md#deployments-statefulsets-daemonsets-selectors
>spec.selector.matchLabels defined in Deployments/StatefulSets/DaemonSets >=v1/beta2 must not contain helm.sh/chart label or any label containing a version of the chart, because the selector is immutable. The chart label string contains the version, so if it is specified, whenever the Chart.yaml version changes, Helm's attempt to change this immutable field would cause the upgrade to fail.

#### Which issue this PR fixes
This PR resolves failures that may occur when updating to future Chart versions.

#### Special notes for your reviewer
none

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
