### PR TITLE
[prometheus-postgres-exporter] template apiVersion based on capabilities for the pod disruption budget

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.11.1"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 4.4.2
+version: 4.4.3
 home: https://github.com/prometheus-community/postgres_exporter
 sources:
 - https://github.com/prometheus-community/postgres_exporter

--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.11.1"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 4.4.1
+version: 4.4.2
 home: https://github.com/prometheus-community/postgres_exporter
 sources:
 - https://github.com/prometheus-community/postgres_exporter

--- a/charts/prometheus-postgres-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-postgres-exporter/templates/_helpers.tpl
@@ -61,3 +61,12 @@ Return the appropriate apiVersion for rbac.
 {{- print "rbac.authorization.k8s.io/v1beta1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/* Get Policy API Version */}}
+{{- define "prometheus-postgres-exporter.pdb.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+    {{- print "policy/v1" -}}
+{{- else -}}
+  {{- print "policy/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/prometheus-postgres-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-postgres-exporter/templates/_helpers.tpl
@@ -65,8 +65,8 @@ Return the appropriate apiVersion for rbac.
 {{/* Get Policy API Version */}}
 {{- define "prometheus-postgres-exporter.pdb.apiVersion" -}}
 {{- if .Capabilities.APIVersions.Has "policy/v1" }}
-    {{- print "policy/v1" -}}
+{{- print "policy/v1" -}}
 {{- else -}}
-  {{- print "policy/v1beta1" -}}
+{{- print "policy/v1beta1" -}}
 {{- end -}}
 {{- end -}}

--- a/charts/prometheus-postgres-exporter/templates/pdb.yaml
+++ b/charts/prometheus-postgres-exporter/templates/pdb.yaml
@@ -1,9 +1,5 @@
 {{- if .Values.podDisruptionBudget.enabled }}
-{{- if .Capabilities.APIVersions.Has "policy/v1" }}
-apiVersion: policy/v1
-{{ else }}
-apiVersion: policy/v1beta1
-{{ end -}}
+apiVersion: {{ include "prometheus-postgres-exporter.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "prometheus-postgres-exporter.fullname" . }}

--- a/charts/prometheus-postgres-exporter/templates/pdb.yaml
+++ b/charts/prometheus-postgres-exporter/templates/pdb.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.podDisruptionBudget.enabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{ else }}
 apiVersion: policy/v1beta1
+{{ end -}}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "prometheus-postgres-exporter.fullname" . }}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This feature templates the `apiVersion` of the Prometheus Postgres Exporter's `PodDisruptionBudget` based on the capabilities of the utilized k8s API version (`.Capabilities.APIVersions.Has`).
Due to the previously hard-coded `apiVersion: policy/v1beta1` , this helm chart is not compatible for k8s versions >= 1.25 from which this `apiVersion` got removed.
`apiVersion: policy/v1` replaces the deprecated `apiVersion: policy/v1beta1` since k8s v1.21.

#### Which issue this PR fixes

–

#### Special notes for your reviewer

–

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
