### PR TITLE
[prometheus] Add support for renaming Cluster Role and Binding

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 45.26.0
+version: 45.27.0
 appVersion: v0.65.1
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 45.27.0
+version: 45.27.1
 appVersion: v0.65.1
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -361,7 +361,8 @@ spec:
 {{- end }}
   excludedFromEnforcement:
 {{- range $prometheusDefaultRulesExcludedFromEnforce.rules }}
-    - resource: prometheusrules
+    - group: monitoring.coreos.com
+      resource: prometheusrules
       namespace: "{{ template "kube-prometheus-stack.namespace" $ }}"
       name: "{{ printf "%s-%s" (include "kube-prometheus-stack.fullname" $) . | trunc 63 | trimSuffix "-" }}"
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -43,9 +43,6 @@ spec:
   image: "{{ $registry }}/{{ .Values.prometheus.prometheusSpec.image.repository }}"
   {{- end }}
   version: {{ default .Values.prometheus.prometheusSpec.image.tag .Values.prometheus.prometheusSpec.version }}
-  {{- if .Values.prometheus.prometheusSpec.image.sha }}
-  sha: {{ .Values.prometheus.prometheusSpec.image.sha }}
-  {{- end }}
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.additionalArgs }}
   additionalArgs:

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: v2.43.1
-version: 22.5.1
+version: 22.5.0
 kubeVersion: ">=1.16.0-0"
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
-appVersion: v2.43.2
-version: 22.4.1
+appVersion: v2.43.1
+version: 22.4.2
 kubeVersion: ">=1.16.0-0"
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: v2.43.1
-version: 22.4.2
+version: 22.5.1
 kubeVersion: ">=1.16.0-0"
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: prometheus
-appVersion: v2.43.1
+appVersion: v2.43.2
 version: 22.4.1
 kubeVersion: ">=1.16.0-0"
 description: Prometheus is a monitoring system and time series database.

--- a/charts/prometheus/README.md
+++ b/charts/prometheus/README.md
@@ -65,6 +65,10 @@ helm upgrade [RELEASE_NAME] [CHART] --install
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
+### To 22.5
+
+clusterRoleNameOverride has been added to deal with situations where there is a use-case to deploy Prometheus server per namespace and hence being able to set the names of ClusterRole and ClusterRoleBinding independently
+
 ### To 22.4
 
 Support for environment variables in the _prometheus-config-reloader_'s container has been added through `configmapReload.env`. These can be useful together with `configmapReload.reloadUrl` if basic authentication is set at Prometheus.

--- a/charts/prometheus/templates/_helpers.tpl
+++ b/charts/prometheus/templates/_helpers.tpl
@@ -89,6 +89,23 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+Create a fully qualified ClusterRole name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "prometheus.clusterRoleNameOverride" -}}
+{{- if .Values.server.clusterRoleNameOverride -}}
+{{- .Values.server.clusterRoleNameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create a fully qualified alertmanager name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/charts/prometheus/templates/_helpers.tpl
+++ b/charts/prometheus/templates/_helpers.tpl
@@ -92,16 +92,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Create a fully qualified ClusterRole name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "prometheus.clusterRoleNameOverride" -}}
+{{- define "prometheus.clusterRoleName" -}}
 {{- if .Values.server.clusterRoleNameOverride -}}
-{{- .Values.server.clusterRoleNameOverride | trunc 63 | trimSuffix "-" -}}
+{{ .Values.server.clusterRoleNameOverride | trunc 63 | trimSuffix "-" }}
 {{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{ default (include "prometheus.server.fullname" .) }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/prometheus/templates/_helpers.tpl
+++ b/charts/prometheus/templates/_helpers.tpl
@@ -96,7 +96,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- if .Values.server.clusterRoleNameOverride -}}
 {{ .Values.server.clusterRoleNameOverride | trunc 63 | trimSuffix "-" }}
 {{- else -}}
-{{ default (include "prometheus.server.fullname" .) }}
+{{ include "prometheus.server.fullname" . }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/prometheus/templates/clusterrole.yaml
+++ b/charts/prometheus/templates/clusterrole.yaml
@@ -4,7 +4,11 @@ kind: ClusterRole
 metadata:
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
+{{- if .Values.server.clusterRoleNameOverride }}
+  name: {{ template "prometheus.clusterRoleNameOverride" . }}
+  {{- else }}
   name: {{ template "prometheus.server.fullname" . }}
+{{- end }}
 rules:
 {{- if .Values.podSecurityPolicy.enabled }}
   - apiGroups:

--- a/charts/prometheus/templates/clusterrole.yaml
+++ b/charts/prometheus/templates/clusterrole.yaml
@@ -4,11 +4,7 @@ kind: ClusterRole
 metadata:
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
-{{- if .Values.server.clusterRoleNameOverride }}
-  name: {{ template "prometheus.clusterRoleNameOverride" . }}
-  {{- else }}
-  name: {{ template "prometheus.server.fullname" . }}
-{{- end }}
+  name: {{ include "prometheus.clusterRoleName" . }}
 rules:
 {{- if .Values.podSecurityPolicy.enabled }}
   - apiGroups:

--- a/charts/prometheus/templates/clusterrolebinding.yaml
+++ b/charts/prometheus/templates/clusterrolebinding.yaml
@@ -4,7 +4,11 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
+{{- if .Values.server.clusterRoleNameOverride }}
+  name: {{ template "prometheus.clusterRoleNameOverride" . }}
+  {{- else }}
   name: {{ template "prometheus.server.fullname" . }}
+{{- end }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "prometheus.serviceAccountName.server" . }}
@@ -12,5 +16,9 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
+{{- if .Values.server.clusterRoleNameOverride }}
+  name: {{ template "prometheus.clusterRoleNameOverride" . }}
+  {{- else }}
   name: {{ template "prometheus.server.fullname" . }}
+{{- end }}
 {{- end }}

--- a/charts/prometheus/templates/clusterrolebinding.yaml
+++ b/charts/prometheus/templates/clusterrolebinding.yaml
@@ -4,11 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     {{- include "prometheus.server.labels" . | nindent 4 }}
-{{- if .Values.server.clusterRoleNameOverride }}
-  name: {{ template "prometheus.clusterRoleNameOverride" . }}
-  {{- else }}
-  name: {{ template "prometheus.server.fullname" . }}
-{{- end }}
+  name: {{ include "prometheus.clusterRoleName" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "prometheus.serviceAccountName.server" . }}
@@ -16,9 +12,5 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-{{- if .Values.server.clusterRoleNameOverride }}
-  name: {{ template "prometheus.clusterRoleNameOverride" . }}
-  {{- else }}
-  name: {{ template "prometheus.server.fullname" . }}
-{{- end }}
+  name: {{ include "prometheus.clusterRoleName" . }}
 {{- end }}

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -95,6 +95,10 @@ server:
   ##
   # useExistingClusterRoleName: nameofclusterrole
 
+  ## If set it will override prometheus.server.fullname value for ClusterRole and ClusterRoleBinding
+  ##
+  clusterRoleNameOverride: ""
+
   ## namespaces to monitor (instead of monitoring all - clusterwide). Needed if you want to run without Cluster-admin privileges.
   # namespaces:
   #   - yournamespace


### PR DESCRIPTION
#### What this PR does / why we need it
I will be deploying Prometheus in N number of namespaces per cluster and currently `ClusterRole` and `ClusterRoleBinding` get created with the same name as PVC and VolumeMounts which already exists and need to follow specific naming convention

In the interest of not having to decouple the `ClusterRole` and `ClusterRoleBinding` away from the community chart it would be great to be able to rename the 2 objects independently from `fullnameOverride` 

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer

N/A

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
