### PR TITLE
[kube-state-metrics] Fix body must be of type string bug for cilium network policy

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 5.6.1
+version: 5.6.2
 appVersion: 2.8.2
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/ciliumnetworkpolicy.yaml
+++ b/charts/kube-state-metrics/templates/ciliumnetworkpolicy.yaml
@@ -24,10 +24,10 @@ spec:
   ingress:
   - toPorts:
     - ports:
-      - port: {{ .Values.service.port }}
+      - port: {{ .Values.service.port | quote }}
         protocol: TCP
       {{- if .Values.selfMonitor.enabled }}
-      - port: {{ .Values.selfMonitor.telemetryPort | default 8081 }}
+      - port: {{ .Values.selfMonitor.telemetryPort | default 8081 | quote }}
         protocol: TCP
       {{ end }}
 {{ end }}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Ensures cilium network policy configured correctly templated for kube-state-metrics

#### Which issue this PR fixes

none

#### Special notes for your reviewer

```
$kubectl explain CiliumNetworkPolicy.spec.ingress.toPorts.ports
KIND:     CiliumNetworkPolicy
VERSION:  cilium.io/v2

RESOURCE: ports <[]Object>

DESCRIPTION:
     Ports is a list of L4 port/protocol

     PortProtocol specifies an L4 port with an optional transport protocol

FIELDS:
   port	<string> -required-
     Port is an L4 port number. For now the string will be strictly parsed as a
     single uint16. In the future, this field may support ranges in the form
     "1024-2048 Port can also be a port name, which must contain at least one
     [a-z], and may also contain [0-9] and '-' anywhere except adjacent to
     another '-' or in the beginning or the end.

   protocol	<string>
     Protocol is the L4 protocol. If omitted or empty, any protocol matches.
     Accepted values: "TCP", "UDP", "SCTP", "ANY" Matching on ICMP is not
     supported. Named port specified for a container may narrow this down, but
     may not contradict this.
```

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
