### PR TITLE
jiralert: values: fixed config: there is no need to do escaping

### DIFF
--- a/charts/jiralert/Chart.yaml
+++ b/charts/jiralert/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jiralert
 description: A Helm chart for Kubernetes to install jiralert
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: "v1.3.0"
 home: "https://github.com/prometheus-community/jiralert"
 keywords:

--- a/charts/jiralert/values.yaml
+++ b/charts/jiralert/values.yaml
@@ -99,8 +99,8 @@ config:
     api_url: "https://example.atlassian.net"
     # user: {{ .config.jiraUser }}
     # password: '{{ .config.jiraToken }}'
-    summary: '{{`{{ template "jira.summary" . }}`}}'
-    description: '{{`{{ template "jira.description" . }}`}}'
+    summary: '{{ template "jira.summary" . }}'
+    description: '{{ template "jira.description" . }}'
     issue_type: Bug
     reopen_state: "To Do"
     reopen_duration: 0h


### PR DESCRIPTION
#### What this PR does / why we need it

Escaping really breaks the template engine - bare string comes to JIRA, instead templated result

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
