### PR TITLE
[kube-prometheus-stack] fixing role labels issue introduced in 45.28.1

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 45.28.1
+version: 45.28.2
 appVersion: v0.65.1
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/k8s.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/k8s.rules.yaml
@@ -31,8 +31,8 @@ spec:
           1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
         )
       record: node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: |-
@@ -41,8 +41,8 @@ spec:
           max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
         )
       record: node_namespace_pod_container:container_memory_working_set_bytes
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: |-
@@ -51,8 +51,8 @@ spec:
           max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
         )
       record: node_namespace_pod_container:container_memory_rss
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: |-
@@ -61,8 +61,8 @@ spec:
           max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
         )
       record: node_namespace_pod_container:container_memory_cache
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: |-
@@ -71,8 +71,8 @@ spec:
           max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
         )
       record: node_namespace_pod_container:container_memory_swap
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: |-
@@ -81,8 +81,8 @@ spec:
           (kube_pod_status_phase{phase=~"Pending|Running"} == 1)
         )
       record: cluster:namespace:pod_memory:active:kube_pod_container_resource_requests
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: |-
@@ -96,8 +96,8 @@ spec:
             )
         )
       record: namespace_memory:kube_pod_container_resource_requests:sum
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: |-
@@ -106,8 +106,8 @@ spec:
           (kube_pod_status_phase{phase=~"Pending|Running"} == 1)
         )
       record: cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: |-
@@ -121,8 +121,8 @@ spec:
             )
         )
       record: namespace_cpu:kube_pod_container_resource_requests:sum
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: |-
@@ -131,8 +131,8 @@ spec:
           (kube_pod_status_phase{phase=~"Pending|Running"} == 1)
         )
       record: cluster:namespace:pod_memory:active:kube_pod_container_resource_limits
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: |-
@@ -146,8 +146,8 @@ spec:
             )
         )
       record: namespace_memory:kube_pod_container_resource_limits:sum
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: |-
@@ -156,8 +156,8 @@ spec:
          (kube_pod_status_phase{phase=~"Pending|Running"} == 1)
          )
       record: cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: |-
@@ -171,8 +171,8 @@ spec:
             )
         )
       record: namespace_cpu:kube_pod_container_resource_limits:sum
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: |-

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-availability.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-availability.rules.yaml
@@ -27,8 +27,8 @@ spec:
     rules:
     - expr: avg_over_time(code_verb:apiserver_request_total:increase1h[30d]) * 24 * 30
       record: code_verb:apiserver_request_total:increase30d
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: sum by (cluster, code) (code_verb:apiserver_request_total:increase30d{verb=~"LIST|GET"})
@@ -47,26 +47,26 @@ spec:
       record: code:apiserver_request_total:increase30d
     - expr: sum by (cluster, verb, scope) (increase(apiserver_request_slo_duration_seconds_count[1h]))
       record: cluster_verb_scope:apiserver_request_slo_duration_seconds_count:increase1h
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: sum by (cluster, verb, scope) (avg_over_time(cluster_verb_scope:apiserver_request_slo_duration_seconds_count:increase1h[30d]) * 24 * 30)
       record: cluster_verb_scope:apiserver_request_slo_duration_seconds_count:increase30d
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: sum by (cluster, verb, scope, le) (increase(apiserver_request_slo_duration_seconds_bucket[1h]))
       record: cluster_verb_scope_le:apiserver_request_slo_duration_seconds_bucket:increase1h
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: sum by (cluster, verb, scope, le) (avg_over_time(cluster_verb_scope_le:apiserver_request_slo_duration_seconds_bucket:increase1h[30d]) * 24 * 30)
       record: cluster_verb_scope_le:apiserver_request_slo_duration_seconds_bucket:increase30d
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: |-
@@ -168,26 +168,26 @@ spec:
       record: code_resource:apiserver_request_total:rate5m
     - expr: sum by (cluster, code, verb) (increase(apiserver_request_total{job="apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"2.."}[1h]))
       record: code_verb:apiserver_request_total:increase1h
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: sum by (cluster, code, verb) (increase(apiserver_request_total{job="apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"3.."}[1h]))
       record: code_verb:apiserver_request_total:increase1h
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: sum by (cluster, code, verb) (increase(apiserver_request_total{job="apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"4.."}[1h]))
       record: code_verb:apiserver_request_total:increase1h
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: sum by (cluster, code, verb) (increase(apiserver_request_total{job="apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"5.."}[1h]))
       record: code_verb:apiserver_request_total:increase1h
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-prometheus-general.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-prometheus-general.rules.yaml
@@ -26,14 +26,14 @@ spec:
     rules:
     - expr: count without(instance, pod, node) (up == 1)
       record: count:up1
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: count without(instance, pod, node) (up == 0)
       record: count:up0
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-prometheus-node-recording.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-prometheus-node-recording.rules.yaml
@@ -26,38 +26,38 @@ spec:
     rules:
     - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[3m])) BY (instance)
       record: instance:node_cpu:rate:sum
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: sum(rate(node_network_receive_bytes_total[3m])) BY (instance)
       record: instance:node_network_receive_bytes:rate:sum
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: sum(rate(node_network_transmit_bytes_total[3m])) BY (instance)
       record: instance:node_network_transmit_bytes:rate:sum
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[5m])) WITHOUT (cpu, mode) / ON(instance) GROUP_LEFT() count(sum(node_cpu_seconds_total) BY (instance, cpu)) BY (instance)
       record: instance:node_cpu:ratio
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[5m]))
       record: cluster:node_cpu:sum_rate5m
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: cluster:node_cpu:sum_rate5m / count(sum(node_cpu_seconds_total) BY (instance, cpu))
       record: cluster:node_cpu:ratio
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-exporter.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-exporter.rules.yaml
@@ -29,8 +29,8 @@ spec:
           node_cpu_seconds_total{job="node-exporter",mode="idle"}
         )
       record: instance:node_num_cpu:sum
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: |-
@@ -38,8 +38,8 @@ spec:
           sum without (mode) (rate(node_cpu_seconds_total{job="node-exporter", mode=~"idle|iowait|steal"}[5m]))
         )
       record: instance:node_cpu_utilisation:rate5m
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: |-
@@ -49,8 +49,8 @@ spec:
           instance:node_num_cpu:sum{job="node-exporter"}
         )
       record: instance:node_load1_per_cpu:ratio
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: |-
@@ -72,26 +72,26 @@ spec:
           node_memory_MemTotal_bytes{job="node-exporter"}
         )
       record: instance:node_memory_utilisation:ratio
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: rate(node_vmstat_pgmajfault{job="node-exporter"}[5m])
       record: instance:node_vmstat_pgmajfault:rate5m
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: rate(node_disk_io_time_seconds_total{job="node-exporter", device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"}[5m])
       record: instance_device:node_disk_io_time_seconds:rate5m
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: rate(node_disk_io_time_weighted_seconds_total{job="node-exporter", device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"}[5m])
       record: instance_device:node_disk_io_time_weighted_seconds:rate5m
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: |-
@@ -99,8 +99,8 @@ spec:
           rate(node_network_receive_bytes_total{job="node-exporter", device!="lo"}[5m])
         )
       record: instance:node_network_receive_bytes_excluding_lo:rate5m
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: |-
@@ -108,8 +108,8 @@ spec:
           rate(node_network_transmit_bytes_total{job="node-exporter", device!="lo"}[5m])
         )
       record: instance:node_network_transmit_bytes_excluding_lo:rate5m
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: |-
@@ -117,8 +117,8 @@ spec:
           rate(node_network_receive_drop_total{job="node-exporter", device!="lo"}[5m])
         )
       record: instance:node_network_receive_drop_excluding_lo:rate5m
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: |-
@@ -126,8 +126,8 @@ spec:
           rate(node_network_transmit_drop_total{job="node-exporter", device!="lo"}[5m])
         )
       record: instance:node_network_transmit_drop_excluding_lo:rate5m
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node.rules.yaml
@@ -30,8 +30,8 @@ spec:
             label_replace(kube_pod_info{job="kube-state-metrics",node!=""}, "pod", "$1", "pod", "(.*)")
         ))
       record: 'node_namespace_pod:kube_pod_info:'
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: |-
@@ -41,8 +41,8 @@ spec:
           topk by(namespace, pod) (1, node_namespace_pod:kube_pod_info:)
         )
       record: node:node_num_cpu:sum
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: |-
@@ -56,8 +56,8 @@ spec:
           )
         ) by (cluster)
       record: :node_memory_MemAvailable_bytes:sum
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: |-
@@ -67,8 +67,8 @@ spec:
           )
         )
       record: node:node_cpu_utilization:ratio_rate5m
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
     - expr: |-
@@ -76,8 +76,8 @@ spec:
           node:node_cpu_utilization:ratio_rate5m
         )
       record: cluster:node_cpu:ratio_rate5m
-      labels:
 {{- if .Values.defaultRules.additionalRuleLabels }}
+      labels:
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it

Moves down the `labels` key under the `if` statement so it's rendered (added) only if `additionalRuleLabels ` are present.

#### Which issue this PR fixes

- fixes #3398

#### Special notes for your reviewer

#### Checklist

- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
