### PR TITLE
[kube-prometheus-stack] - resolve issue 3396, no null labels allowed for PrometheusRules

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 45.28.1
+version: 45.28.2
 appVersion: v0.65.1
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/hack/sync_prometheus_rules.py
+++ b/charts/kube-prometheus-stack/hack/sync_prometheus_rules.py
@@ -264,20 +264,24 @@ def add_rules_per_rule_conditions(rules, group, indent=4):
     return rules
 
 
-def add_custom_labels(rules_str, indent=4):
+def add_custom_labels(rules_str, indent=4, label_indent=6):
     """Add if wrapper for additional rules labels"""
-    rule_condition = '{{- if .Values.defaultRules.additionalRuleLabels }}\n{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}\n{{- end }}'
+    additonal_rule_labels = '\n' + " " * label_indent + '  {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}'
+    additional_rule_labels_condition_start = "\n" + " " * label_indent + '{{- if .Values.defaultRules.additionalRuleLabels }}'
+    additional_rule_labels_condition_end =  "\n" + " " * label_indent + '{{- end }}'
+    # labels: cannot be null, if a rule does not have any labels by default, the labels block
+    # should only be added if there are .Values defaultRules.additionalRuleLabels defined
     rule_seperator = "\n" + " " * indent + "-.*"
     label_seperator = "\n" + " " * indent + "  labels:"
     section_seperator = "\n" + " " * indent + "  \S"
     section_seperator_len = len(section_seperator)-1
     rules_positions = re.finditer(rule_seperator,rules_str)
-    
+
     # fetch breakpoint between each set of rules
     ruleStartingLine = [(rule_position.start(),rule_position.end()) for rule_position in rules_positions]
     head = rules_str[:ruleStartingLine[0][0]]
 
-    # construct array of rules so they can be handled individually 
+    # construct array of rules so they can be handled individually
     rules = []
     # pylint: disable=E1136
     # See https://github.com/pylint-dev/pylint/issues/1498 for None Values
@@ -297,15 +301,16 @@ def add_custom_labels(rules_str, indent=4):
             if entries:
                 entries_start = current_label.end()
                 entries_end = entries.end()+current_label.end()-section_seperator_len
-                rules[i] = rule[:entries_end] + "\n" + rule_condition  + rule[entries_end:]
+                rules[i] = rule[:entries_end] + additional_rule_labels_condition_start + additonal_rule_labels + additional_rule_labels_condition_end + rule[entries_end:]
             else:
                 # `labels:` does not contain any entries
                 # append template to label section
-                rules[i]+= "\n" + rule_condition
+                rules[i]+= additional_rule_labels_condition_start + additonal_rule_labels + additional_rule_labels_condition_end
         else:
             # `labels:` block does not exist
             # create it and append template
-            rules[i]+= label_seperator + "\n" + rule_condition
+            print(i,rule)
+            rules[i]+= additional_rule_labels_condition_start + "\n" + " " * indent + "  labels:" + additonal_rule_labels + additional_rule_labels_condition_end
     return head + "".join(rules) + "\n"
 
 

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/alertmanager.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/alertmanager.rules.yaml
@@ -42,9 +42,9 @@ spec:
       for: 10m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.AlertmanagerMembersInconsistent | default false) }}
     - alert: AlertmanagerMembersInconsistent
@@ -64,9 +64,9 @@ spec:
       for: 15m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.AlertmanagerFailedToSendAlerts | default false) }}
     - alert: AlertmanagerFailedToSendAlerts
@@ -87,9 +87,9 @@ spec:
       for: 5m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.AlertmanagerClusterFailedToSendAlerts | default false) }}
     - alert: AlertmanagerClusterFailedToSendAlerts
@@ -110,9 +110,9 @@ spec:
       for: 5m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.AlertmanagerClusterFailedToSendAlerts | default false) }}
     - alert: AlertmanagerClusterFailedToSendAlerts
@@ -133,9 +133,9 @@ spec:
       for: 5m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.AlertmanagerConfigInconsistent | default false) }}
     - alert: AlertmanagerConfigInconsistent
@@ -154,9 +154,9 @@ spec:
       for: 20m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.AlertmanagerClusterDown | default false) }}
     - alert: AlertmanagerClusterDown
@@ -181,9 +181,9 @@ spec:
       for: 5m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.AlertmanagerClusterCrashlooping | default false) }}
     - alert: AlertmanagerClusterCrashlooping
@@ -208,8 +208,8 @@ spec:
       for: 5m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/config-reloaders.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/config-reloaders.yaml
@@ -39,8 +39,8 @@ spec:
       for: 10m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/etcd.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/etcd.yaml
@@ -44,9 +44,9 @@ spec:
       for: 10m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.etcdInsufficientMembers | default false) }}
     - alert: etcdInsufficientMembers
@@ -60,9 +60,9 @@ spec:
       for: 3m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.etcdNoLeader | default false) }}
     - alert: etcdNoLeader
@@ -76,9 +76,9 @@ spec:
       for: 1m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.etcdHighNumberOfLeaderChanges | default false) }}
     - alert: etcdHighNumberOfLeaderChanges
@@ -92,9 +92,9 @@ spec:
       for: 5m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.etcdHighNumberOfFailedGRPCRequests | default false) }}
     - alert: etcdHighNumberOfFailedGRPCRequests
@@ -112,9 +112,9 @@ spec:
       for: 10m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.etcdHighNumberOfFailedGRPCRequests | default false) }}
     - alert: etcdHighNumberOfFailedGRPCRequests
@@ -132,9 +132,9 @@ spec:
       for: 5m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.etcdGRPCRequestsSlow | default false) }}
     - alert: etcdGRPCRequestsSlow
@@ -150,9 +150,9 @@ spec:
       for: 10m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.etcdMemberCommunicationSlow | default false) }}
     - alert: etcdMemberCommunicationSlow
@@ -168,9 +168,9 @@ spec:
       for: 10m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.etcdHighNumberOfFailedProposals | default false) }}
     - alert: etcdHighNumberOfFailedProposals
@@ -184,9 +184,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.etcdHighFsyncDurations | default false) }}
     - alert: etcdHighFsyncDurations
@@ -202,9 +202,9 @@ spec:
       for: 10m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.etcdHighFsyncDurations | default false) }}
     - alert: etcdHighFsyncDurations
@@ -220,9 +220,9 @@ spec:
       for: 10m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.etcdHighCommitDurations | default false) }}
     - alert: etcdHighCommitDurations
@@ -238,9 +238,9 @@ spec:
       for: 10m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.etcdDatabaseQuotaLowSpace | default false) }}
     - alert: etcdDatabaseQuotaLowSpace
@@ -254,9 +254,9 @@ spec:
       for: 10m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.etcdExcessiveDatabaseGrowth | default false) }}
     - alert: etcdExcessiveDatabaseGrowth
@@ -270,9 +270,9 @@ spec:
       for: 10m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.etcdDatabaseHighFragmentationRatio | default false) }}
     - alert: etcdDatabaseHighFragmentationRatio
@@ -287,8 +287,8 @@ spec:
       for: 10m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/general.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/general.rules.yaml
@@ -37,9 +37,9 @@ spec:
       for: 10m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.Watchdog | default false) }}
     - alert: Watchdog
@@ -63,9 +63,9 @@ spec:
       expr: vector(1)
       labels:
         severity: none
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.InfoInhibitor | default false) }}
     - alert: InfoInhibitor
@@ -91,8 +91,8 @@ spec:
       expr: ALERTS{severity = "info"} == 1 unless on(namespace) ALERTS{alertname != "InfoInhibitor", severity =~ "warning|critical", alertstate="firing"} == 1
       labels:
         severity: none
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/k8s.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/k8s.rules.yaml
@@ -31,60 +31,60 @@ spec:
           1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
         )
       record: node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: |-
         container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
         * on (cluster, namespace, pod) group_left(node) topk by(cluster, namespace, pod) (1,
           max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
         )
       record: node_namespace_pod_container:container_memory_working_set_bytes
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: |-
         container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
         * on (cluster, namespace, pod) group_left(node) topk by(cluster, namespace, pod) (1,
           max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
         )
       record: node_namespace_pod_container:container_memory_rss
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: |-
         container_memory_cache{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
         * on (cluster, namespace, pod) group_left(node) topk by(cluster, namespace, pod) (1,
           max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
         )
       record: node_namespace_pod_container:container_memory_cache
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: |-
         container_memory_swap{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
         * on (cluster, namespace, pod) group_left(node) topk by(cluster, namespace, pod) (1,
           max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
         )
       record: node_namespace_pod_container:container_memory_swap
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: |-
         kube_pod_container_resource_requests{resource="memory",job="kube-state-metrics"}  * on (namespace, pod, cluster)
         group_left() max by (namespace, pod, cluster) (
           (kube_pod_status_phase{phase=~"Pending|Running"} == 1)
         )
       record: cluster:namespace:pod_memory:active:kube_pod_container_resource_requests
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: |-
         sum by (namespace, cluster) (
             sum by (namespace, pod, cluster) (
@@ -96,20 +96,20 @@ spec:
             )
         )
       record: namespace_memory:kube_pod_container_resource_requests:sum
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: |-
         kube_pod_container_resource_requests{resource="cpu",job="kube-state-metrics"}  * on (namespace, pod, cluster)
         group_left() max by (namespace, pod, cluster) (
           (kube_pod_status_phase{phase=~"Pending|Running"} == 1)
         )
       record: cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: |-
         sum by (namespace, cluster) (
             sum by (namespace, pod, cluster) (
@@ -121,20 +121,20 @@ spec:
             )
         )
       record: namespace_cpu:kube_pod_container_resource_requests:sum
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: |-
         kube_pod_container_resource_limits{resource="memory",job="kube-state-metrics"}  * on (namespace, pod, cluster)
         group_left() max by (namespace, pod, cluster) (
           (kube_pod_status_phase{phase=~"Pending|Running"} == 1)
         )
       record: cluster:namespace:pod_memory:active:kube_pod_container_resource_limits
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: |-
         sum by (namespace, cluster) (
             sum by (namespace, pod, cluster) (
@@ -146,20 +146,20 @@ spec:
             )
         )
       record: namespace_memory:kube_pod_container_resource_limits:sum
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: |-
         kube_pod_container_resource_limits{resource="cpu",job="kube-state-metrics"}  * on (namespace, pod, cluster)
         group_left() max by (namespace, pod, cluster) (
          (kube_pod_status_phase{phase=~"Pending|Running"} == 1)
          )
       record: cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: |-
         sum by (namespace, cluster) (
             sum by (namespace, pod, cluster) (
@@ -171,10 +171,10 @@ spec:
             )
         )
       record: namespace_cpu:kube_pod_container_resource_limits:sum
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: |-
         max by (cluster, namespace, workload, pod) (
           label_replace(
@@ -191,9 +191,9 @@ spec:
         )
       labels:
         workload_type: deployment
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: namespace_workload_pod:kube_pod_owner:relabel
     - expr: |-
         max by (cluster, namespace, workload, pod) (
@@ -204,9 +204,9 @@ spec:
         )
       labels:
         workload_type: daemonset
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: namespace_workload_pod:kube_pod_owner:relabel
     - expr: |-
         max by (cluster, namespace, workload, pod) (
@@ -217,9 +217,9 @@ spec:
         )
       labels:
         workload_type: statefulset
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: namespace_workload_pod:kube_pod_owner:relabel
     - expr: |-
         max by (cluster, namespace, workload, pod) (
@@ -230,8 +230,8 @@ spec:
         )
       labels:
         workload_type: job
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: namespace_workload_pod:kube_pod_owner:relabel
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-availability.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-availability.rules.yaml
@@ -27,48 +27,48 @@ spec:
     rules:
     - expr: avg_over_time(code_verb:apiserver_request_total:increase1h[30d]) * 24 * 30
       record: code_verb:apiserver_request_total:increase30d
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: sum by (cluster, code) (code_verb:apiserver_request_total:increase30d{verb=~"LIST|GET"})
       labels:
         verb: read
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: code:apiserver_request_total:increase30d
     - expr: sum by (cluster, code) (code_verb:apiserver_request_total:increase30d{verb=~"POST|PUT|PATCH|DELETE"})
       labels:
         verb: write
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: code:apiserver_request_total:increase30d
     - expr: sum by (cluster, verb, scope) (increase(apiserver_request_slo_duration_seconds_count[1h]))
       record: cluster_verb_scope:apiserver_request_slo_duration_seconds_count:increase1h
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: sum by (cluster, verb, scope) (avg_over_time(cluster_verb_scope:apiserver_request_slo_duration_seconds_count:increase1h[30d]) * 24 * 30)
       record: cluster_verb_scope:apiserver_request_slo_duration_seconds_count:increase30d
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: sum by (cluster, verb, scope, le) (increase(apiserver_request_slo_duration_seconds_bucket[1h]))
       record: cluster_verb_scope_le:apiserver_request_slo_duration_seconds_bucket:increase1h
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: sum by (cluster, verb, scope, le) (avg_over_time(cluster_verb_scope_le:apiserver_request_slo_duration_seconds_bucket:increase1h[30d]) * 24 * 30)
       record: cluster_verb_scope_le:apiserver_request_slo_duration_seconds_bucket:increase30d
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: |-
         1 - (
           (
@@ -100,9 +100,9 @@ spec:
         sum by (cluster) (code:apiserver_request_total:increase30d)
       labels:
         verb: all
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: apiserver_request:availability30d
     - expr: |-
         1 - (
@@ -128,9 +128,9 @@ spec:
         sum by (cluster) (code:apiserver_request_total:increase30d{verb="read"})
       labels:
         verb: read
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: apiserver_request:availability30d
     - expr: |-
         1 - (
@@ -148,46 +148,46 @@ spec:
         sum by (cluster) (code:apiserver_request_total:increase30d{verb="write"})
       labels:
         verb: write
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: apiserver_request:availability30d
     - expr: sum by (cluster,code,resource) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET"}[5m]))
       labels:
         verb: read
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: code_resource:apiserver_request_total:rate5m
     - expr: sum by (cluster,code,resource) (rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[5m]))
       labels:
         verb: write
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: code_resource:apiserver_request_total:rate5m
     - expr: sum by (cluster, code, verb) (increase(apiserver_request_total{job="apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"2.."}[1h]))
       record: code_verb:apiserver_request_total:increase1h
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: sum by (cluster, code, verb) (increase(apiserver_request_total{job="apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"3.."}[1h]))
       record: code_verb:apiserver_request_total:increase1h
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: sum by (cluster, code, verb) (increase(apiserver_request_total{job="apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"4.."}[1h]))
       record: code_verb:apiserver_request_total:increase1h
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: sum by (cluster, code, verb) (increase(apiserver_request_total{job="apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"5.."}[1h]))
       record: code_verb:apiserver_request_total:increase1h
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-burnrate.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-burnrate.rules.yaml
@@ -50,9 +50,9 @@ spec:
         sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET"}[1d]))
       labels:
         verb: read
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: apiserver_request:burnrate1d
     - expr: |-
         (
@@ -80,9 +80,9 @@ spec:
         sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET"}[1h]))
       labels:
         verb: read
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: apiserver_request:burnrate1h
     - expr: |-
         (
@@ -110,9 +110,9 @@ spec:
         sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET"}[2h]))
       labels:
         verb: read
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: apiserver_request:burnrate2h
     - expr: |-
         (
@@ -140,9 +140,9 @@ spec:
         sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET"}[30m]))
       labels:
         verb: read
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: apiserver_request:burnrate30m
     - expr: |-
         (
@@ -170,9 +170,9 @@ spec:
         sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET"}[3d]))
       labels:
         verb: read
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: apiserver_request:burnrate3d
     - expr: |-
         (
@@ -200,9 +200,9 @@ spec:
         sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET"}[5m]))
       labels:
         verb: read
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: apiserver_request:burnrate5m
     - expr: |-
         (
@@ -230,9 +230,9 @@ spec:
         sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET"}[6h]))
       labels:
         verb: read
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: apiserver_request:burnrate6h
     - expr: |-
         (
@@ -249,9 +249,9 @@ spec:
         sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[1d]))
       labels:
         verb: write
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: apiserver_request:burnrate1d
     - expr: |-
         (
@@ -268,9 +268,9 @@ spec:
         sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[1h]))
       labels:
         verb: write
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: apiserver_request:burnrate1h
     - expr: |-
         (
@@ -287,9 +287,9 @@ spec:
         sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[2h]))
       labels:
         verb: write
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: apiserver_request:burnrate2h
     - expr: |-
         (
@@ -306,9 +306,9 @@ spec:
         sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[30m]))
       labels:
         verb: write
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: apiserver_request:burnrate30m
     - expr: |-
         (
@@ -325,9 +325,9 @@ spec:
         sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[3d]))
       labels:
         verb: write
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: apiserver_request:burnrate3d
     - expr: |-
         (
@@ -344,9 +344,9 @@ spec:
         sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[5m]))
       labels:
         verb: write
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: apiserver_request:burnrate5m
     - expr: |-
         (
@@ -363,8 +363,8 @@ spec:
         sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[6h]))
       labels:
         verb: write
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: apiserver_request:burnrate6h
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-histogram.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-histogram.rules.yaml
@@ -28,16 +28,16 @@ spec:
       labels:
         quantile: '0.99'
         verb: read
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: cluster_quantile:apiserver_request_slo_duration_seconds:histogram_quantile
     - expr: histogram_quantile(0.99, sum by (cluster, le, resource) (rate(apiserver_request_slo_duration_seconds_bucket{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",subresource!~"proxy|attach|log|exec|portforward"}[5m]))) > 0
       labels:
         quantile: '0.99'
         verb: write
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: cluster_quantile:apiserver_request_slo_duration_seconds:histogram_quantile
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-slos.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-slos.yaml
@@ -42,9 +42,9 @@ spec:
         long: 1h
         severity: critical
         short: 5m
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeAPIErrorBudgetBurn | default false) }}
     - alert: KubeAPIErrorBudgetBurn
@@ -64,9 +64,9 @@ spec:
         long: 6h
         severity: critical
         short: 30m
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeAPIErrorBudgetBurn | default false) }}
     - alert: KubeAPIErrorBudgetBurn
@@ -86,9 +86,9 @@ spec:
         long: 1d
         severity: warning
         short: 2h
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeAPIErrorBudgetBurn | default false) }}
     - alert: KubeAPIErrorBudgetBurn
@@ -108,8 +108,8 @@ spec:
         long: 3d
         severity: warning
         short: 6h
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-prometheus-general.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-prometheus-general.rules.yaml
@@ -26,14 +26,14 @@ spec:
     rules:
     - expr: count without(instance, pod, node) (up == 1)
       record: count:up1
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: count without(instance, pod, node) (up == 0)
       record: count:up0
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-prometheus-node-recording.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-prometheus-node-recording.rules.yaml
@@ -26,38 +26,38 @@ spec:
     rules:
     - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[3m])) BY (instance)
       record: instance:node_cpu:rate:sum
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: sum(rate(node_network_receive_bytes_total[3m])) BY (instance)
       record: instance:node_network_receive_bytes:rate:sum
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: sum(rate(node_network_transmit_bytes_total[3m])) BY (instance)
       record: instance:node_network_transmit_bytes:rate:sum
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[5m])) WITHOUT (cpu, mode) / ON(instance) GROUP_LEFT() count(sum(node_cpu_seconds_total) BY (instance, cpu)) BY (instance)
       record: instance:node_cpu:ratio
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[5m]))
       record: cluster:node_cpu:sum_rate5m
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: cluster:node_cpu:sum_rate5m / count(sum(node_cpu_seconds_total) BY (instance, cpu))
       record: cluster:node_cpu:ratio
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-scheduler.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-scheduler.rules.yaml
@@ -27,64 +27,64 @@ spec:
     - expr: histogram_quantile(0.99, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
       labels:
         quantile: '0.99'
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
     - expr: histogram_quantile(0.99, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
       labels:
         quantile: '0.99'
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
     - expr: histogram_quantile(0.99, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
       labels:
         quantile: '0.99'
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
     - expr: histogram_quantile(0.9, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
       labels:
         quantile: '0.9'
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
     - expr: histogram_quantile(0.9, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
       labels:
         quantile: '0.9'
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
     - expr: histogram_quantile(0.9, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
       labels:
         quantile: '0.9'
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
     - expr: histogram_quantile(0.5, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
       labels:
         quantile: '0.5'
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
     - expr: histogram_quantile(0.5, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
       labels:
         quantile: '0.5'
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
     - expr: histogram_quantile(0.5, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
       labels:
         quantile: '0.5'
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-state-metrics.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-state-metrics.yaml
@@ -34,16 +34,16 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kube-state-metrics/kubestatemetricslisterrors
         summary: kube-state-metrics is experiencing errors in list operations.
       expr: |-
-        (sum(rate(kube_state_metrics_list_total{job="kube-state-metrics",result="error"}[5m]))
+        (sum(rate(kube_state_metrics_list_total{job="kube-state-metrics",result="error"}[5m])) by (cluster)
           /
-        sum(rate(kube_state_metrics_list_total{job="kube-state-metrics"}[5m])))
+        sum(rate(kube_state_metrics_list_total{job="kube-state-metrics"}[5m])) by (cluster))
         > 0.01
       for: 15m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeStateMetricsWatchErrors | default false) }}
     - alert: KubeStateMetricsWatchErrors
@@ -55,16 +55,16 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kube-state-metrics/kubestatemetricswatcherrors
         summary: kube-state-metrics is experiencing errors in watch operations.
       expr: |-
-        (sum(rate(kube_state_metrics_watch_total{job="kube-state-metrics",result="error"}[5m]))
+        (sum(rate(kube_state_metrics_watch_total{job="kube-state-metrics",result="error"}[5m])) by (cluster)
           /
-        sum(rate(kube_state_metrics_watch_total{job="kube-state-metrics"}[5m])))
+        sum(rate(kube_state_metrics_watch_total{job="kube-state-metrics"}[5m])) by (cluster))
         > 0.01
       for: 15m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeStateMetricsShardingMismatch | default false) }}
     - alert: KubeStateMetricsShardingMismatch
@@ -75,13 +75,13 @@ spec:
         description: kube-state-metrics pods are running with different --total-shards configuration, some Kubernetes objects may be exposed multiple times or not exposed at all.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kube-state-metrics/kubestatemetricsshardingmismatch
         summary: kube-state-metrics sharding is misconfigured.
-      expr: stdvar (kube_state_metrics_total_shards{job="kube-state-metrics"}) != 0
+      expr: stdvar (kube_state_metrics_total_shards{job="kube-state-metrics"}) by (cluster) != 0
       for: 15m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeStateMetricsShardsMissing | default false) }}
     - alert: KubeStateMetricsShardsMissing
@@ -93,15 +93,15 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kube-state-metrics/kubestatemetricsshardsmissing
         summary: kube-state-metrics shards are missing.
       expr: |-
-        2^max(kube_state_metrics_total_shards{job="kube-state-metrics"}) - 1
+        2^max(kube_state_metrics_total_shards{job="kube-state-metrics"}) by (cluster) - 1
           -
-        sum( 2 ^ max by (shard_ordinal) (kube_state_metrics_shard_ordinal{job="kube-state-metrics"}) )
+        sum( 2 ^ max by (cluster, shard_ordinal) (kube_state_metrics_shard_ordinal{job="kube-state-metrics"}) ) by (cluster)
         != 0
       for: 15m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubelet.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubelet.rules.yaml
@@ -27,22 +27,22 @@ spec:
     - expr: histogram_quantile(0.99, sum(rate(kubelet_pleg_relist_duration_seconds_bucket{job="kubelet", metrics_path="/metrics"}[5m])) by (cluster, instance, le) * on(cluster, instance) group_left(node) kubelet_node_name{job="kubelet", metrics_path="/metrics"})
       labels:
         quantile: '0.99'
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile
     - expr: histogram_quantile(0.9, sum(rate(kubelet_pleg_relist_duration_seconds_bucket{job="kubelet", metrics_path="/metrics"}[5m])) by (cluster, instance, le) * on(cluster, instance) group_left(node) kubelet_node_name{job="kubelet", metrics_path="/metrics"})
       labels:
         quantile: '0.9'
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile
     - expr: histogram_quantile(0.5, sum(rate(kubelet_pleg_relist_duration_seconds_bucket{job="kubelet", metrics_path="/metrics"}[5m])) by (cluster, instance, le) * on(cluster, instance) group_left(node) kubelet_node_name{job="kubelet", metrics_path="/metrics"})
       labels:
         quantile: '0.5'
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
       record: node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-apps.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-apps.yaml
@@ -38,9 +38,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubePodNotReady | default false) }}
     - alert: KubePodNotReady
@@ -62,9 +62,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeDeploymentGenerationMismatch | default false) }}
     - alert: KubeDeploymentGenerationMismatch
@@ -82,9 +82,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeDeploymentReplicasMismatch | default false) }}
     - alert: KubeDeploymentReplicasMismatch
@@ -108,9 +108,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeStatefulSetReplicasMismatch | default false) }}
     - alert: KubeStatefulSetReplicasMismatch
@@ -134,9 +134,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeStatefulSetGenerationMismatch | default false) }}
     - alert: KubeStatefulSetGenerationMismatch
@@ -154,9 +154,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeStatefulSetUpdateNotRolledOut | default false) }}
     - alert: KubeStatefulSetUpdateNotRolledOut
@@ -188,9 +188,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeDaemonSetRolloutStuck | default false) }}
     - alert: KubeDaemonSetRolloutStuck
@@ -228,9 +228,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeContainerWaiting | default false) }}
     - alert: KubeContainerWaiting
@@ -245,9 +245,9 @@ spec:
       for: 1h
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeDaemonSetNotScheduled | default false) }}
     - alert: KubeDaemonSetNotScheduled
@@ -265,9 +265,9 @@ spec:
       for: 10m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeDaemonSetMisScheduled | default false) }}
     - alert: KubeDaemonSetMisScheduled
@@ -282,9 +282,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeJobNotCompleted | default false) }}
     - alert: KubeJobNotCompleted
@@ -301,9 +301,9 @@ spec:
         kube_job_status_active{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"} > 0) > 43200
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeJobFailed | default false) }}
     - alert: KubeJobFailed
@@ -318,9 +318,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeHpaReplicasMismatch | default false) }}
     - alert: KubeHpaReplicasMismatch
@@ -348,9 +348,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeHpaMaxedOut | default false) }}
     - alert: KubeHpaMaxedOut
@@ -368,8 +368,8 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-resources.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-resources.yaml
@@ -40,9 +40,9 @@ spec:
       for: 10m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeMemoryOvercommit | default false) }}
     - alert: KubeMemoryOvercommit
@@ -60,9 +60,9 @@ spec:
       for: 10m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeCPUQuotaOvercommit | default false) }}
     - alert: KubeCPUQuotaOvercommit
@@ -81,9 +81,9 @@ spec:
       for: 5m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeMemoryQuotaOvercommit | default false) }}
     - alert: KubeMemoryQuotaOvercommit
@@ -102,9 +102,9 @@ spec:
       for: 5m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeQuotaAlmostFull | default false) }}
     - alert: KubeQuotaAlmostFull
@@ -123,9 +123,9 @@ spec:
       for: 15m
       labels:
         severity: info
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeQuotaFullyUsed | default false) }}
     - alert: KubeQuotaFullyUsed
@@ -144,9 +144,9 @@ spec:
       for: 15m
       labels:
         severity: info
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeQuotaExceeded | default false) }}
     - alert: KubeQuotaExceeded
@@ -165,9 +165,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.CPUThrottlingHigh | default false) }}
     - alert: CPUThrottlingHigh
@@ -186,8 +186,8 @@ spec:
       for: 15m
       labels:
         severity: info
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-storage.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-storage.yaml
@@ -49,9 +49,9 @@ spec:
       for: 1m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubePersistentVolumeFillingUp | default false) }}
     - alert: KubePersistentVolumeFillingUp
@@ -79,9 +79,9 @@ spec:
       for: 1h
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubePersistentVolumeInodesFillingUp | default false) }}
     - alert: KubePersistentVolumeInodesFillingUp
@@ -107,9 +107,9 @@ spec:
       for: 1m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubePersistentVolumeInodesFillingUp | default false) }}
     - alert: KubePersistentVolumeInodesFillingUp
@@ -137,9 +137,9 @@ spec:
       for: 1h
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubePersistentVolumeErrors | default false) }}
     - alert: KubePersistentVolumeErrors
@@ -154,8 +154,8 @@ spec:
       for: 5m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-apiserver.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-apiserver.yaml
@@ -37,9 +37,9 @@ spec:
       for: 5m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeClientCertificateExpiration | default false) }}
     - alert: KubeClientCertificateExpiration
@@ -54,9 +54,9 @@ spec:
       for: 5m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeAggregatedAPIErrors | default false) }}
     - alert: KubeAggregatedAPIErrors
@@ -70,9 +70,9 @@ spec:
       expr: sum by(name, namespace, cluster)(increase(aggregator_unavailable_apiservice_total[10m])) > 4
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeAggregatedAPIDown | default false) }}
     - alert: KubeAggregatedAPIDown
@@ -87,9 +87,9 @@ spec:
       for: 5m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if .Values.kubeApiServer.enabled }}
 {{- if not (.Values.defaultRules.disabled.KubeAPIDown | default false) }}
@@ -105,9 +105,9 @@ spec:
       for: 15m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeAPITerminatedRequests | default false) }}
@@ -123,8 +123,8 @@ spec:
       for: 5m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-controller-manager.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-controller-manager.yaml
@@ -38,9 +38,9 @@ spec:
       for: 15m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-kubelet.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-kubelet.yaml
@@ -37,9 +37,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeNodeUnreachable | default false) }}
     - alert: KubeNodeUnreachable
@@ -54,9 +54,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeletTooManyPods | default false) }}
     - alert: KubeletTooManyPods
@@ -78,9 +78,9 @@ spec:
       for: 15m
       labels:
         severity: info
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeNodeReadinessFlapping | default false) }}
     - alert: KubeNodeReadinessFlapping
@@ -95,9 +95,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeletPlegDurationHigh | default false) }}
     - alert: KubeletPlegDurationHigh
@@ -112,9 +112,9 @@ spec:
       for: 5m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeletPodStartUpLatencyHigh | default false) }}
     - alert: KubeletPodStartUpLatencyHigh
@@ -129,9 +129,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeletClientCertificateExpiration | default false) }}
     - alert: KubeletClientCertificateExpiration
@@ -145,9 +145,9 @@ spec:
       expr: kubelet_certificate_manager_client_ttl_seconds < 604800
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeletClientCertificateExpiration | default false) }}
     - alert: KubeletClientCertificateExpiration
@@ -161,9 +161,9 @@ spec:
       expr: kubelet_certificate_manager_client_ttl_seconds < 86400
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeletServerCertificateExpiration | default false) }}
     - alert: KubeletServerCertificateExpiration
@@ -177,9 +177,9 @@ spec:
       expr: kubelet_certificate_manager_server_ttl_seconds < 604800
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeletServerCertificateExpiration | default false) }}
     - alert: KubeletServerCertificateExpiration
@@ -193,9 +193,9 @@ spec:
       expr: kubelet_certificate_manager_server_ttl_seconds < 86400
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeletClientCertificateRenewalErrors | default false) }}
     - alert: KubeletClientCertificateRenewalErrors
@@ -210,9 +210,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeletServerCertificateRenewalErrors | default false) }}
     - alert: KubeletServerCertificateRenewalErrors
@@ -227,9 +227,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if .Values.prometheusOperator.kubeletService.enabled }}
 {{- if not (.Values.defaultRules.disabled.KubeletDown | default false) }}
@@ -245,9 +245,9 @@ spec:
       for: 15m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-scheduler.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-scheduler.yaml
@@ -38,9 +38,9 @@ spec:
       for: 15m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system.yaml
@@ -37,9 +37,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeClientErrors | default false) }}
     - alert: KubeClientErrors
@@ -58,8 +58,8 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-exporter.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-exporter.rules.yaml
@@ -29,19 +29,19 @@ spec:
           node_cpu_seconds_total{job="node-exporter",mode="idle"}
         )
       record: instance:node_num_cpu:sum
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: |-
         1 - avg without (cpu) (
           sum without (mode) (rate(node_cpu_seconds_total{job="node-exporter", mode=~"idle|iowait|steal"}[5m]))
         )
       record: instance:node_cpu_utilisation:rate5m
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: |-
         (
           node_load1{job="node-exporter"}
@@ -49,10 +49,10 @@ spec:
           instance:node_num_cpu:sum{job="node-exporter"}
         )
       record: instance:node_load1_per_cpu:ratio
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: |-
         1 - (
           (
@@ -72,62 +72,62 @@ spec:
           node_memory_MemTotal_bytes{job="node-exporter"}
         )
       record: instance:node_memory_utilisation:ratio
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: rate(node_vmstat_pgmajfault{job="node-exporter"}[5m])
       record: instance:node_vmstat_pgmajfault:rate5m
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: rate(node_disk_io_time_seconds_total{job="node-exporter", device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"}[5m])
       record: instance_device:node_disk_io_time_seconds:rate5m
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: rate(node_disk_io_time_weighted_seconds_total{job="node-exporter", device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"}[5m])
       record: instance_device:node_disk_io_time_weighted_seconds:rate5m
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: |-
         sum without (device) (
           rate(node_network_receive_bytes_total{job="node-exporter", device!="lo"}[5m])
         )
       record: instance:node_network_receive_bytes_excluding_lo:rate5m
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: |-
         sum without (device) (
           rate(node_network_transmit_bytes_total{job="node-exporter", device!="lo"}[5m])
         )
       record: instance:node_network_transmit_bytes_excluding_lo:rate5m
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: |-
         sum without (device) (
           rate(node_network_receive_drop_total{job="node-exporter", device!="lo"}[5m])
         )
       record: instance:node_network_receive_drop_excluding_lo:rate5m
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: |-
         sum without (device) (
           rate(node_network_transmit_drop_total{job="node-exporter", device!="lo"}[5m])
         )
       record: instance:node_network_transmit_drop_excluding_lo:rate5m
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-exporter.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-exporter.yaml
@@ -44,9 +44,9 @@ spec:
       for: 1h
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeFilesystemSpaceFillingUp | default false) }}
     - alert: NodeFilesystemSpaceFillingUp
@@ -68,9 +68,9 @@ spec:
       for: 1h
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeFilesystemAlmostOutOfSpace | default false) }}
     - alert: NodeFilesystemAlmostOutOfSpace
@@ -90,9 +90,9 @@ spec:
       for: 30m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeFilesystemAlmostOutOfSpace | default false) }}
     - alert: NodeFilesystemAlmostOutOfSpace
@@ -112,9 +112,9 @@ spec:
       for: 30m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeFilesystemFilesFillingUp | default false) }}
     - alert: NodeFilesystemFilesFillingUp
@@ -136,9 +136,9 @@ spec:
       for: 1h
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeFilesystemFilesFillingUp | default false) }}
     - alert: NodeFilesystemFilesFillingUp
@@ -160,9 +160,9 @@ spec:
       for: 1h
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeFilesystemAlmostOutOfFiles | default false) }}
     - alert: NodeFilesystemAlmostOutOfFiles
@@ -182,9 +182,9 @@ spec:
       for: 1h
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeFilesystemAlmostOutOfFiles | default false) }}
     - alert: NodeFilesystemAlmostOutOfFiles
@@ -204,9 +204,9 @@ spec:
       for: 1h
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeNetworkReceiveErrs | default false) }}
     - alert: NodeNetworkReceiveErrs
@@ -221,9 +221,9 @@ spec:
       for: 1h
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeNetworkTransmitErrs | default false) }}
     - alert: NodeNetworkTransmitErrs
@@ -238,9 +238,9 @@ spec:
       for: 1h
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeHighNumberConntrackEntriesUsed | default false) }}
     - alert: NodeHighNumberConntrackEntriesUsed
@@ -254,9 +254,9 @@ spec:
       expr: (node_nf_conntrack_entries / node_nf_conntrack_entries_limit) > 0.75
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeTextFileCollectorScrapeError | default false) }}
     - alert: NodeTextFileCollectorScrapeError
@@ -270,9 +270,9 @@ spec:
       expr: node_textfile_scrape_error{job="node-exporter"} == 1
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeClockSkewDetected | default false) }}
     - alert: NodeClockSkewDetected
@@ -280,7 +280,7 @@ spec:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
 {{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
 {{- end }}
-        description: Clock on {{`{{`}} $labels.instance {{`}}`}} is out of sync by more than 300s. Ensure NTP is configured correctly on this host.
+        description: Clock on {{`{{`}} $labels.instance {{`}}`}} is out of sync by more than 0.05s. Ensure NTP is configured correctly on this host.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodeclockskewdetected
         summary: Clock skew detected.
       expr: |-
@@ -298,9 +298,9 @@ spec:
       for: 10m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeClockNotSynchronising | default false) }}
     - alert: NodeClockNotSynchronising
@@ -318,9 +318,9 @@ spec:
       for: 10m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeRAIDDegraded | default false) }}
     - alert: NodeRAIDDegraded
@@ -335,9 +335,9 @@ spec:
       for: 15m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeRAIDDiskFailure | default false) }}
     - alert: NodeRAIDDiskFailure
@@ -351,9 +351,9 @@ spec:
       expr: node_md_disks{state="failed",job="node-exporter",device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"} > 0
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeFileDescriptorLimit | default false) }}
     - alert: NodeFileDescriptorLimit
@@ -371,9 +371,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeFileDescriptorLimit | default false) }}
     - alert: NodeFileDescriptorLimit
@@ -391,8 +391,8 @@ spec:
       for: 15m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-network.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-network.yaml
@@ -37,8 +37,8 @@ spec:
       for: 2m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node.rules.yaml
@@ -30,10 +30,10 @@ spec:
             label_replace(kube_pod_info{job="kube-state-metrics",node!=""}, "pod", "$1", "pod", "(.*)")
         ))
       record: 'node_namespace_pod:kube_pod_info:'
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: |-
         count by (cluster, node) (
           node_cpu_seconds_total{mode="idle",job="node-exporter"}
@@ -41,10 +41,10 @@ spec:
           topk by(namespace, pod) (1, node_namespace_pod:kube_pod_info:)
         )
       record: node:node_num_cpu:sum
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: |-
         sum(
           node_memory_MemAvailable_bytes{job="node-exporter"} or
@@ -56,10 +56,10 @@ spec:
           )
         ) by (cluster)
       record: :node_memory_MemAvailable_bytes:sum
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: |-
         avg by (cluster, node) (
           sum without (mode) (
@@ -67,17 +67,17 @@ spec:
           )
         )
       record: node:node_cpu_utilization:ratio_rate5m
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
     - expr: |-
         avg by (cluster) (
           node:node_cpu_utilization:ratio_rate5m
         )
       record: cluster:node_cpu:ratio_rate5m
+      {{- if .Values.defaultRules.additionalRuleLabels }}
       labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/prometheus-operator.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/prometheus-operator.yaml
@@ -39,9 +39,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusOperatorWatchErrors | default false) }}
     - alert: PrometheusOperatorWatchErrors
@@ -56,9 +56,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusOperatorSyncFailed | default false) }}
     - alert: PrometheusOperatorSyncFailed
@@ -73,9 +73,9 @@ spec:
       for: 10m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusOperatorReconcileErrors | default false) }}
     - alert: PrometheusOperatorReconcileErrors
@@ -90,9 +90,9 @@ spec:
       for: 10m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusOperatorNodeLookupErrors | default false) }}
     - alert: PrometheusOperatorNodeLookupErrors
@@ -107,9 +107,9 @@ spec:
       for: 10m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusOperatorNotReady | default false) }}
     - alert: PrometheusOperatorNotReady
@@ -124,9 +124,9 @@ spec:
       for: 5m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusOperatorRejectedResources | default false) }}
     - alert: PrometheusOperatorRejectedResources
@@ -141,8 +141,8 @@ spec:
       for: 5m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/prometheus.yaml
@@ -42,9 +42,9 @@ spec:
       for: 10m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusNotificationQueueRunningFull | default false) }}
     - alert: PrometheusNotificationQueueRunningFull
@@ -66,9 +66,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusErrorSendingAlertsToSomeAlertmanagers | default false) }}
     - alert: PrometheusErrorSendingAlertsToSomeAlertmanagers
@@ -90,9 +90,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusNotConnectedToAlertmanagers | default false) }}
     - alert: PrometheusNotConnectedToAlertmanagers
@@ -110,9 +110,9 @@ spec:
       for: 10m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusTSDBReloadsFailing | default false) }}
     - alert: PrometheusTSDBReloadsFailing
@@ -127,9 +127,9 @@ spec:
       for: 4h
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusTSDBCompactionsFailing | default false) }}
     - alert: PrometheusTSDBCompactionsFailing
@@ -144,9 +144,9 @@ spec:
       for: 4h
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusNotIngestingSamples | default false) }}
     - alert: PrometheusNotIngestingSamples
@@ -170,9 +170,9 @@ spec:
       for: 10m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusDuplicateTimestamps | default false) }}
     - alert: PrometheusDuplicateTimestamps
@@ -187,9 +187,9 @@ spec:
       for: 10m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusOutOfOrderTimestamps | default false) }}
     - alert: PrometheusOutOfOrderTimestamps
@@ -204,9 +204,9 @@ spec:
       for: 10m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusRemoteStorageFailures | default false) }}
     - alert: PrometheusRemoteStorageFailures
@@ -232,9 +232,9 @@ spec:
       for: 15m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusRemoteWriteBehind | default false) }}
     - alert: PrometheusRemoteWriteBehind
@@ -257,9 +257,9 @@ spec:
       for: 15m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusRemoteWriteDesiredShards | default false) }}
     - alert: PrometheusRemoteWriteDesiredShards
@@ -281,9 +281,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusRuleFailures | default false) }}
     - alert: PrometheusRuleFailures
@@ -298,9 +298,9 @@ spec:
       for: 15m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusMissingRuleEvaluations | default false) }}
     - alert: PrometheusMissingRuleEvaluations
@@ -315,9 +315,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusTargetLimitHit | default false) }}
     - alert: PrometheusTargetLimitHit
@@ -332,9 +332,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusLabelLimitHit | default false) }}
     - alert: PrometheusLabelLimitHit
@@ -349,9 +349,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusScrapeBodySizeLimitHit | default false) }}
     - alert: PrometheusScrapeBodySizeLimitHit
@@ -366,9 +366,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusScrapeSampleLimitHit | default false) }}
     - alert: PrometheusScrapeSampleLimitHit
@@ -383,9 +383,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusTargetSyncFailure | default false) }}
     - alert: PrometheusTargetSyncFailure
@@ -400,9 +400,9 @@ spec:
       for: 5m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusHighQueryLoad | default false) }}
     - alert: PrometheusHighQueryLoad
@@ -417,9 +417,9 @@ spec:
       for: 15m
       labels:
         severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusErrorSendingAlertsToAnyAlertmanager | default false) }}
     - alert: PrometheusErrorSendingAlertsToAnyAlertmanager
@@ -441,8 +441,8 @@ spec:
       for: 15m
       labels:
         severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+      {{- if .Values.defaultRules.additionalRuleLabels }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Resolves bug for issue #3396 , PrometheusRule cannot have null labels

#### Which issue this PR fixes

- fixes #3396

#### Special notes for your reviewer

If the given rule does not already have a label, and the user has not passed in their own, the empty `labels:` field is now omitted 

```diff
 expr: |-
        kube_pod_container_resource_limits{resource="cpu",job="kube-state-metrics"}  * on (namespace, pod, cluster)
        group_left() max by (namespace, pod, cluster) (
         (kube_pod_status_phase{phase=~"Pending|Running"} == 1)
         )
      record: cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits
+     {{- if .Values.defaultRules.additionalRuleLabels }}
      labels:
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.defaultRules.additionalRuleLabels | nindent 8 }}
+     {{- end }}
```


#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
