### PR TITLE
[jiralert] fix invalid PodDisruptionBudget

### DIFF
--- a/charts/jiralert/Chart.yaml
+++ b/charts/jiralert/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jiralert
 description: A Helm chart for Kubernetes to install jiralert
 type: application
-version: 1.4.0
+version: 1.4.1
 appVersion: "v1.3.0"
 home: "https://github.com/prometheus-community/jiralert"
 keywords:

--- a/charts/jiralert/templates/pdb.yaml
+++ b/charts/jiralert/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget -}}
-apiVersion: policy/v1{{ ternary "" "beta1" ($.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget") -}}
+apiVersion: policy/v1{{ ternary "" "beta1" ($.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget") }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "jiralert.fullname" . }}


### PR DESCRIPTION
#### What this PR does / why we need it

I do a mistake and I did not revalidate a [suggestion](https://github.com/prometheus-community/helm-charts/pull/3452#event-9414439084) from an other maintainer. This PR fixed the error:

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
