### PR TITLE
[prometheus-postgres-exporter] user from secret

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.11.1"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 4.4.5
+version: 4.5.0
 home: https://github.com/prometheus-community/postgres_exporter
 sources:
 - https://github.com/prometheus-community/postgres_exporter

--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.11.1"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 4.4.4
+version: 4.4.5
 home: https://github.com/prometheus-community/postgres_exporter
 sources:
 - https://github.com/prometheus-community/postgres_exporter

--- a/charts/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/charts/prometheus-postgres-exporter/templates/deployment.yaml
@@ -97,8 +97,16 @@ spec:
           {{- else }}
           - name: DATA_SOURCE_URI
             value: {{ template "prometheus-postgres-exporter.data_source_uri" . }}
+          {{- if .Values.config.datasource.userSecret }}
+          - name: DATA_SOURCE_USER
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.config.datasource.userSecret.name }}
+                key: {{ .Values.config.datasource.userSecret.key }}
+          {{- else }}
           - name: DATA_SOURCE_USER
             value: {{ .Values.config.datasource.user }}
+          {{- end }}
           {{- if .Values.config.datasource.pgpassfile }}
           - name: PGPASSFILE
             value: {{ .Values.config.datasource.pgpassfile }}

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -133,6 +133,11 @@ config:
     # Specify one of both datasource or datasourceSecret
     host:
     user: postgres
+    userSecret: {}
+    # Secret name
+    #  name:
+    # User key inside secret
+    #  key:
     # Only one of password, passwordFile, passwordSecret and pgpassfile can be specified
     password:
     # Specify passwordFile if DB password is stored in a file.


### PR DESCRIPTION
#### What this PR does / why we need it
The PR enables the prometheus-postgres-exporter to read the username from a Kubernetes secret.

In my use case, I store Postgres credentials inside vault secrets. On the basis of these vault secrets an external-secret operator instance automatically creates kubernetes secrets with the needed credentials. My deployment infrastructure itself does not have access to the vault. Thus I cannot dynamically add the value to the chart while rolling it out. In order to not loose my vault as a single point of truth for my complete credential set, I depend on that feature.

#### Which issue this PR fixes

No related issue.

#### Special notes for your reviewer

Since there is a reasonable default value for the user name, I decided to not validate that the username is only set once. It differs from the password validation approach since otherwise user would have been set to null in case of using secret as a source. This seemed pretty counterintuitive to me.

I tested:
- reading the username from a secret with successful authentication to a Postgres DB
- if the chart would default to user in case no secret is defined

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
