### PR TITLE
[alertmanager] Fix alertmanager's configmapReload schema

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 0.33.0
+version: 0.33.1
 appVersion: v0.25.0
 kubeVersion: ">=1.16.0-0"
 keywords:

--- a/charts/alertmanager/values.schema.json
+++ b/charts/alertmanager/values.schema.json
@@ -840,26 +840,30 @@
             }
         },
         "configmapReload": {
-            "enabled": {
-                "description": "Specifies whether the configmap-reload container should be deployed.",
-                "type": "boolean",
-                "default": false
-            },
-            "name": {
-                "description": "The name of the configmap-reload container.",
-                "type": "string"
-            },
-            "image": {
-                "description": "The container image for the configmap-reload container.",
-                "$ref": "#/definitions/image"
-            },
-            "containerPort": {
-                "description": "Port number for the configmap-reload container.",
-                "type": "integer"
-            },
-            "resources": {
-                "description": "Resource requests and limits for the configmap-reload container.",
-                "$ref": "#/definitions/resources"
+            "description": "Monitors ConfigMap changes and POSTs to a URL.",
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "description": "Specifies whether the configmap-reload container should be deployed.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "name": {
+                    "description": "The name of the configmap-reload container.",
+                    "type": "string"
+                },
+                "image": {
+                    "description": "The container image for the configmap-reload container.",
+                    "$ref": "#/definitions/image"
+                },
+                "containerPort": {
+                    "description": "Port number for the configmap-reload container.",
+                    "type": "integer"
+                },
+                "resources": {
+                    "description": "Resource requests and limits for the configmap-reload container.",
+                    "$ref": "#/definitions/resources"
+                }
             }
         },
         "templates": {

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=values.schema.json
 # Default values for alertmanager.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.


### PR DESCRIPTION
#### What this PR does / why we need it

List of changes:
* fix `configmapReload` - replace properties under the `properties` key;
* add `configmapReload` description;
* add inlined schema on the top of the values.yaml - useful for editing via IDE(e.g. VS Code).
  `The main advantage is that it is available under the hood with all recent IDEs by using the YAML Language Server.`

Sources: 
* <https://github.com/redhat-developer/yaml-language-server#using-inlined-schema>

#### Which issue this PR fixes

None

#### Special notes for your reviewer

None.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name