### PR TITLE
[prometheus-node-exporter] updates Prometheus Node Exporter image to 1.6.0

### DIFF
--- a/charts/prometheus-couchdb-exporter/Chart.yaml
+++ b/charts/prometheus-couchdb-exporter/Chart.yaml
@@ -1,9 +1,9 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart to export the metrics from couchdb in Prometheus format.
 name: prometheus-couchdb-exporter
 home: https://github.com/gesellix/couchdb-prometheus-exporter
-version: 0.2.1
+version: 1.0.0
 keywords:
 - couchdb-exporter
 sources:
@@ -11,4 +11,3 @@ sources:
 maintainers:
 - name: gkarthiks
   email: github.gkarthiks@gmail.com
-engine: gotpl

--- a/charts/prometheus-couchdb-exporter/README.md
+++ b/charts/prometheus-couchdb-exporter/README.md
@@ -6,25 +6,23 @@ This chart bootstraps a [CouchDB Exporter](https://github.com/gesellix/couchdb-p
 
 ## Prerequisites
 
-- Kubernetes 1.8+ with Beta APIs enabled
+- Helm 3.7+
 
-## Get Repo Info
+Helm v2 was no longer supported from chart version 1.0.0.
+
+## Get repository Info
 
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update
 ```
 
-_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
+_See [`helm repo`](https://helm.sh/docs/helm/helm_repo/) for command documentation._
 
 ## Install Chart
 
 ```console
-# Helm 3
-$ helm install [RELEASE_NAME] prometheus-community/prometheus-couchdb-exporter
-
-# Helm 2
-$ helm install --name [RELEASE_NAME] prometheus-community/prometheus-couchdb-exporter
+helm install [RELEASE_NAME] prometheus-community/prometheus-couchdb-exporter
 ```
 
 _See [configuration](#configuration) below._
@@ -34,11 +32,7 @@ _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documen
 ## Uninstall Chart
 
 ```console
-# Helm 3
-$ helm uninstall [RELEASE_NAME]
-
-# Helm 2
-# helm delete --purge [RELEASE_NAME]
+helm uninstall [RELEASE_NAME]
 ```
 
 This removes all the Kubernetes components associated with the chart and deletes the release.
@@ -48,20 +42,21 @@ _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command doc
 ## Upgrading Chart
 
 ```console
-# Helm 3 or 2
-$ helm upgrade [RELEASE_NAME] [CHART] --install
+helm upgrade [RELEASE_NAME] [CHART] --install
 ```
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+### To 1.0.0
+
+Helm v2 was no longer supported from chart version 1.0.0.
+
+_See [Migrating Helm v2 to v3](https://helm.sh/docs/topics/v2_v3_migration/) guide._
 
 ## Configuration
 
 See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
 
 ```console
-# Helm 2
-$ helm inspect values prometheus-community/prometheus-couchdb-exporter
-
-# Helm 3
-$ helm show values prometheus-community/prometheus-couchdb-exporter
+helm show values prometheus-community/prometheus-couchdb-exporter
 ```

--- a/charts/prometheus-couchdb-exporter/templates/NOTES.txt
+++ b/charts/prometheus-couchdb-exporter/templates/NOTES.txt
@@ -17,3 +17,16 @@
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl port-forward $POD_NAME 8080:80
 {{- end }}
+{{- if .Values.rbac.pspEnabled }}
+#################################################################################
+######   WARNING: Pod Security Policy has been disabled by default since    #####
+######            it deprecated after k8s 1.25+.                            #####
+#################################################################################
+{{- end }}
+{{- if .Values.ingress.enabled }}
+#################################################################################
+######   WARNING: The extensions/v1beta1 API versions of Ingress is         #####
+######            no longer served as of k8s v1.22+.                        #####
+######            use networking.k8s.io/v1 API.                             #####
+#################################################################################
+{{- end }}

--- a/charts/prometheus-couchdb-exporter/templates/ingress.yaml
+++ b/charts/prometheus-couchdb-exporter/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if and .Values.ingress.enabled (.Capabilities.APIVersions.Has "extensions/v1beta1/Ingress") }}
 {{- $fullName := include "prometheus-couchdb-exporter.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
 apiVersion: extensions/v1beta1

--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -6,8 +6,8 @@ keywords:
   - prometheus
   - exporter
 type: application
-version: 4.15.0
-appVersion: 1.5.0
+version: 4.16.0
+appVersion: 1.6.0
 home: https://github.com/prometheus/node_exporter/
 sources:
   - https://github.com/prometheus/node_exporter/
@@ -16,3 +16,8 @@ maintainers:
     name: gianrubio
   - email: zanhsieh@gmail.com
     name: zanhsieh
+annotations:
+  "artifacthub.io/license": Apache-2.0
+  "artifacthub.io/links": |
+    - name: Chart Source
+      url: https://github.com/prometheus-community/helm-charts


### PR DESCRIPTION
#### What this PR does / why we need it

- Updates [Prometheus Node Exporter image(to 1.6.0)](https://github.com/prometheus/node_exporter/releases/tag/v1.6.0)
  -  https://github.com/prometheus/node_exporter/compare/v1.5.0...v1.6.0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6
  - maintenance, reduced vulnerability detection

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- none.

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
  - it is minor, update image version 
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
