### PR TITLE
[prometheus-node-exporter] updates Node Exporter image to 1.6.0

### DIFF
--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -6,8 +6,8 @@ keywords:
   - prometheus
   - exporter
 type: application
-version: 4.17.5
-appVersion: 1.5.0
+version: 4.18.0
+appVersion: 1.6.0
 home: https://github.com/prometheus/node_exporter/
 sources:
   - https://github.com/prometheus/node_exporter/
@@ -18,3 +18,8 @@ maintainers:
     name: zanhsieh
   - email: rootsandtrees@posteo.de
     name: zeritti
+annotations:
+  "artifacthub.io/license": Apache-2.0
+  "artifacthub.io/links": |
+    - name: Chart Source
+      url: https://github.com/prometheus-community/helm-charts


### PR DESCRIPTION
#### What this PR does / why we need it

- Updates [Prometheus Node Exporter image(to 1.6.0)](https://github.com/prometheus/node_exporter/releases/tag/v1.6.0)
  -  https://github.com/prometheus/node_exporter/compare/v1.5.0...v1.6.0#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6
  - maintenance, reduced vulnerability detection
- add [license annotations](https://artifacthub.io/docs/topics/annotations/helm/)

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- none.

#### Special notes for your reviewer

- none.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
  - it is minor, update image version 
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
