### PR TITLE
[prometheus-stackdriver-exporter] make deployment env value configurable

### DIFF
--- a/charts/prometheus-stackdriver-exporter/Chart.yaml
+++ b/charts/prometheus-stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: prometheus-stackdriver-exporter
-version: 4.3.0
+version: 4.3.1
 appVersion: 0.13.0
 home: https://www.stackdriver.com/
 sources:

--- a/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
@@ -97,10 +97,16 @@ spec:
             {{- end }}
           {{- end }}
           {{- end }}
-          {{- if or .Values.stackdriver.serviceAccountSecret .Values.stackdriver.serviceAccountKey }}
           env:
+          {{- if or .Values.stackdriver.serviceAccountSecret .Values.stackdriver.serviceAccountKey }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/secrets/service-account/credentials.json
+          {{- end }}
+          {{- range $key, $value := .Values.extraEnvs }}
+            {{- if $value }}
+            - name: {{ $key | quote }}
+              value: {{ $value |quote }}
+            {{- end }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/prometheus-stackdriver-exporter/values.yaml
+++ b/charts/prometheus-stackdriver-exporter/values.yaml
@@ -102,6 +102,11 @@ annotations: {}
 ##
 extraArgs: {}
 
+## Pod extra Environment vars
+## Ex: GOMAXPROCS=1
+##
+extraEnvs: {}
+
 ## Node labels for stackdriver-exporter pod assignment
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

So far, Golang apps deployed in Kubernetes start with a `GOMAXPROCS` defined to the total number of cores/CPU on the node.

This leads to high throttling and under-performance by creating too many goroutines.

This PR adds a way to configure the `env` portion of the deployment so we can set any env variable, inclusing the `GOMAXPROCS` one.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes none

#### Special notes for your reviewer

From a prod GKE cluster, here's the `stackdriver-exporter` deployed using `100m` request CPU on a 8 node server: 25% of the request is used:

![image](https://github.com/prometheus-community/helm-charts/assets/1110398/c10ec464-30d6-4754-b092-b894bb43c350)

After adding the `GOMAXPROCS=1` env variable, CPU usage is down to 16%:

![image](https://github.com/prometheus-community/helm-charts/assets/1110398/6842fbf3-4628-4bdc-8a1b-e1bf5f98e057)

Another solution would be to use https://github.com/uber-go/automaxprocs in the `stackdriver-exporter`, but it's not a bad idea to make the `env` configurable anyways.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
