### PR TITLE
[kube-state-metrics] Add endpointslices to ClusterRole/Role

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 5.9.0
+version: 5.8.1
 appVersion: 2.9.2
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 5.8.0
+version: 5.9.0
 appVersion: 2.9.2
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/role.yaml
+++ b/charts/kube-state-metrics/templates/role.yaml
@@ -51,6 +51,12 @@ rules:
   - endpoints
   verbs: ["list", "watch"]
 {{ end -}}
+{{ if has "endpointslices" $.Values.collectors }}
+- apiGroups: ["discovery.k8s.io"]
+  resources:
+  - endpointslices
+  verbs: ["list", "watch"]
+{{ end -}}
 {{ if has "horizontalpodautoscalers" $.Values.collectors }}
 - apiGroups: ["autoscaling"]
   resources:


### PR DESCRIPTION
#### What this PR does / why we need it

When `endpointslices` are enabled in collectors (not the default), `kube-state-metrics` logs the following error:
```
2023-06-20T17:51:58.346283983-05:00 E0620 22:51:58.346134       1 reflector.go:140] pkg/mod/k8s.io/client-go@v0.26.1/tools/cache/reflector.go:169: Failed to watch *v1.EndpointSlice: failed to list *v1.EndpointSlice: endpointslices.discovery.k8s.io is forbidden: User "system:serviceaccount:monitoring:prometheus-kube-state-metrics" cannot list resource "endpointslices" in API group "discovery.k8s.io" at the cluster scope
```

And no `kube_endpointslice_` metrics are collected.

Reviewers: @tariq1890 @mrueg @dotdc 

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
