### PR TITLE
[prometheus] updates  Prometheus image to 2.45.0(LTS)

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
-appVersion: v2.44.0
-version: 22.6.6
+appVersion: v2.45.0
+version: 22.7.0
 kubeVersion: ">=1.16.0-0"
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: v2.45.0
-version: 22.7.0
+version: 22.6.7
 kubeVersion: ">=1.16.0-0"
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/


### PR DESCRIPTION
#### What this PR does / why we need it

- Updates [Prometheus  image(to v2.45.0)](https://github.com/prometheus/prometheus/releases/tag/v2.45.0)
  - https://github.com/prometheus/prometheus/compare/v2.44.0...v2.45.0
  - maintenance, This version is a LTS (Long-Term Support) release of Upstream

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- none.

#### Special notes for your reviewer

- May include in #3422, @zeritti

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
  - it is minor, update image version 
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
