### PR TITLE
[prometheus-postgres-exporter] Add tpl functionality to the datasource config of Postgres-exporter

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.11.1"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 4.5.0
+version: 4.6.0
 home: https://github.com/prometheus-community/postgres_exporter
 sources:
 - https://github.com/prometheus-community/postgres_exporter

--- a/charts/prometheus-postgres-exporter/README.md
+++ b/charts/prometheus-postgres-exporter/README.md
@@ -40,6 +40,12 @@ _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command doc
 
 ## Upgrading
 
+### To 4.6.0
+This release adds functionality to template the variables inside `config.datasource` by means of allowing the `tpl` function in the resources that make use of it. This functionality is useful when you want to do sub-charting (e.g. in a postgres chart) and you want to avoid the duplication of variables inside `config.datasource`.
+
+
+Compared to the previous release (4.5.0) the only thing that changed is the fact that you can no longer leave the `config.datasource.host` variable blank. Leaving it blank could cause errors with the `tpl` function. However, the default value was changed to `''` so this error is not expected to happen. 
+
 ### To 4.0.0
 
 This release removes the `pg_database` query from `config.queries` as it has been converted to a built-in collector

--- a/charts/prometheus-postgres-exporter/README.md
+++ b/charts/prometheus-postgres-exporter/README.md
@@ -41,10 +41,10 @@ _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command doc
 ## Upgrading
 
 ### To 4.6.0
+
 This release adds functionality to template the variables inside `config.datasource` by means of allowing the `tpl` function in the resources that make use of it. This functionality is useful when you want to do sub-charting (e.g. in a postgres chart) and you want to avoid the duplication of variables inside `config.datasource`.
 
-
-Compared to the previous release (4.5.0) the only thing that changed is the fact that you can no longer leave the `config.datasource.host` variable blank. Leaving it blank could cause errors with the `tpl` function. However, the default value was changed to `''` so this error is not expected to happen. 
+Compared to the previous release (4.5.0) the only thing that changed is the fact that you can no longer leave the `config.datasource.host` variable blank. Leaving it blank could cause errors with the `tpl` function. However, the default value was changed to `''` so this error is not expected to happen.
 
 ### To 4.0.0
 

--- a/charts/prometheus-postgres-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-postgres-exporter/templates/_helpers.tpl
@@ -48,7 +48,7 @@ Create the name of the service account to use
 Set DATA_SOURCE_URI environment variable
 */}}
 {{- define "prometheus-postgres-exporter.data_source_uri" -}}
-{{ printf "%s:%d/%s?sslmode=%s&%s" .Values.config.datasource.host ( .Values.config.datasource.port | int) .Values.config.datasource.database .Values.config.datasource.sslmode .Values.config.datasource.extraParams | trimSuffix "&" | quote }}
+{{ printf "%s:%d/%s?sslmode=%s&%s" (tpl .Values.config.datasource.host .) (tpl .Values.config.datasource.port . | int) (tpl .Values.config.datasource.database .) (tpl .Values.config.datasource.sslmode .) (tpl .Values.config.datasource.extraParams .) | trimSuffix "&" | quote }}
 {{- end }}
 
 {{/*

--- a/charts/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/charts/prometheus-postgres-exporter/templates/deployment.yaml
@@ -92,8 +92,8 @@ spec:
           - name: DATA_SOURCE_NAME
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.config.datasourceSecret.name }}
-                key: {{ .Values.config.datasourceSecret.key }}
+                name: {{ tpl .Values.config.datasourceSecret.name . }}
+                key: {{ tpl .Values.config.datasourceSecret.key . }}
           {{- else }}
           - name: DATA_SOURCE_URI
             value: {{ template "prometheus-postgres-exporter.data_source_uri" . }}
@@ -101,28 +101,28 @@ spec:
           - name: DATA_SOURCE_USER
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.config.datasource.userSecret.name }}
-                key: {{ .Values.config.datasource.userSecret.key }}
+                name: {{ tpl .Values.config.datasource.userSecret.name . }}
+                key: {{ tpl .Values.config.datasource.userSecret.key . }}
           {{- else }}
           - name: DATA_SOURCE_USER
-            value: {{ .Values.config.datasource.user }}
+            value: {{ tpl .Values.config.datasource.user . }}
           {{- end }}
           {{- if .Values.config.datasource.pgpassfile }}
           - name: PGPASSFILE
-            value: {{ .Values.config.datasource.pgpassfile }}
+            value: {{ tpl .Values.config.datasource.pgpassfile  . }}
           - name: DATA_SOURCE_PASS
             value: ""
           {{- else }}
           {{- if .Values.config.datasource.passwordFile }}
           - name: DATA_SOURCE_PASS_FILE
-            value: {{ .Values.config.datasource.passwordFile }}
+            value: {{ tpl .Values.config.datasource.passwordFile . }}
           {{- else }}
           - name: DATA_SOURCE_PASS
             valueFrom:
               secretKeyRef:
           {{- if .Values.config.datasource.passwordSecret }}
-                name: {{ .Values.config.datasource.passwordSecret.name }}
-                key: {{ .Values.config.datasource.passwordSecret.key }}
+                name: {{ tpl .Values.config.datasource.passwordSecret.name . }}
+                key: {{ tpl .Values.config.datasource.passwordSecret.key . }}
           {{- else }}
                 name: {{ template "prometheus-postgres-exporter.fullname" . }}
                 key: data_source_password

--- a/charts/prometheus-postgres-exporter/templates/secrets.yaml
+++ b/charts/prometheus-postgres-exporter/templates/secrets.yaml
@@ -10,5 +10,5 @@ metadata:
     release: {{ .Release.Name }}
 type: Opaque
 data:
-  data_source_password: {{ .Values.config.datasource.password | default "somepaswword" | b64enc }}
+  data_source_password: {{ tpl (.Values.config.datasource.password | default "somepaswword") . | b64enc }}
 {{- end -}}

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -129,9 +129,11 @@ hostAliases: []
   #   - "bar.local"
 
 config:
+  ## The datasource properties on config are passed through helm tpl function.
+  ## ref: https://helm.sh/docs/developing_charts/#using-the-tpl-function
   datasource:
     # Specify one of both datasource or datasourceSecret
-    host:
+    host: ''
     user: postgres
     userSecret: {}
     # Secret name


### PR DESCRIPTION
What this PR does / why we need it

When we want to do sub-charting (eg. in a postgres chart) we need to duplicate the datasource config code in the values file. We want to avoid duplicating this configuration as the postgresql-chart is used by multiple applications and we want to avoid having to duplicate all these values in each sub-chart using this.

Furthermore the tpl function does not incur any form of regression on the previous setup thus the change is non-breaking.

Checklist
 - [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
 - [x] Chart Version bumped
 - [x] Title of the PR starts with chart name (e.g. [prometheus-couchdb-exporter])