### PR TITLE
[prometheus]changing arguments as old ones changed at jimmidyson/configmap-reload

### DIFF
--- a/charts/prometheus/templates/deploy.yaml
+++ b/charts/prometheus/templates/deploy.yaml
@@ -64,17 +64,17 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           args:
-            - --watched-dir=/etc/config
+            - --volume-dir=/etc/config
           {{- $default_url := "http://127.0.0.1:9090/-/reload" }}
           {{- with .Values.server.prefixURL }}
           {{- $default_url = printf "http://127.0.0.1:9090%s/-/reload" . }}
           {{- end }}
-            - --reload-url={{ default $default_url .Values.configmapReload.reloadUrl }}
+            - --webhook-url={{ default $default_url .Values.configmapReload.reloadUrl }}
           {{- range $key, $value := .Values.configmapReload.prometheus.extraArgs }}
             - --{{ $key }}={{ $value }}
           {{- end }}
           {{- range .Values.configmapReload.prometheus.extraVolumeDirs }}
-            - --watched-dir={{ . }}
+            - --volume-dir={{ . }}
           {{- end }}
           {{- with .Values.configmapReload.env }}
           env:

--- a/charts/prometheus/templates/sts.yaml
+++ b/charts/prometheus/templates/sts.yaml
@@ -64,17 +64,17 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           args:
-            - --watched-dir=/etc/config
+            - --volume-dir=/etc/config
           {{- $default_url := "http://127.0.0.1:9090/-/reload" }}
           {{- with .Values.server.prefixURL }}
           {{- $default_url = printf "http://127.0.0.1:9090%s/-/reload" . }}
           {{- end }}
-            - --reload-url={{ default $default_url .Values.configmapReload.reloadUrl }}
+            - --webhook-url={{ default $default_url .Values.configmapReload.reloadUrl }}
           {{- range $key, $value := .Values.configmapReload.prometheus.extraArgs }}
             - --{{ $key }}={{ $value }}
           {{- end }}
           {{- range .Values.configmapReload.prometheus.extraVolumeDirs }}
-            - --watched-dir={{ . }}
+            - --volume-dir={{ . }}
           {{- end }}
           {{- with .Values.configmapReload.env }}
           env:


### PR DESCRIPTION

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
 arguments are no longer supported in https://github.com/jimmidyson/configmap-reload, being replaced by volume-dir and webhook-url
#### Which issue this PR fixes
flag provided but not defined: -watched-dir in configmap-reload
flag provided but not defined: -reload-url in configmap-reload
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
