### PR TITLE
[prometheus-blackbox-exporter] PodSecurityPolicy is a cluster level r…

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 7.12.0
+version: 7.12.1
 appVersion: v0.24.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/charts/prometheus-blackbox-exporter/templates/podsecuritypolicy.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/podsecuritypolicy.yaml
@@ -3,7 +3,6 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus-blackbox-exporter.fullname" . }}-psp
-  namespace: {{ template "prometheus-blackbox-exporter.namespace" . }}
   labels:
     {{- include "prometheus-blackbox-exporter.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
…esource.

#### What this PR does / why we need it
PodSecurityPolicy is a cluster level resource. It does not use **namespace**.
See https://v1-24.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#podsecuritypolicy-v1beta1-policy

#### Which issue this PR fixes
Namespace field is ignored, so this just removes some possible confusion.

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ X] Chart Version bumped
- [ X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
