### PR TITLE
[prometheus-pushgateway] move registry to quay.io

### DIFF
--- a/charts/prometheus-pushgateway/Chart.yaml
+++ b/charts/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v1.6.0"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 2.3.0
+version: 2.4.0
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/charts/prometheus-pushgateway/values.yaml
+++ b/charts/prometheus-pushgateway/values.yaml
@@ -12,7 +12,7 @@ fullnameOverride: ""
 namespaceOverride: ""
 
 image:
-  repository: prom/pushgateway
+  repository: quay.io/prometheus/pushgateway
   # if not set appVersion field from Chart.yaml is used
   tag: ""
   pullPolicy: IfNotPresent


### PR DESCRIPTION
#### What this PR does / why we need it

- Using quary.io image instead of the docker hub image. This change is already done in the prometheus, alertmanager, node-exporter helm chart:
  - see #928

#### Which issue this PR fixes

- fixes #3562

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
