### PR TITLE
[kube-prometheus-stack] Upgrade Grafana chart to 6.58.*

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 47.4.0
+version: 47.5.0
 appVersion: v0.66.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus


### PR DESCRIPTION
#### What this PR does / why we need it

- Updates [Grafana Chart to 6.58.*](https://github.com/grafana/helm-charts/compare/grafana-6.57.4...grafana-6.58.1)
- maintenance, upstream
  - grafana/helm-charts#2492
  - grafana/helm-charts#2479

#### Which issue this PR fixes

- none

#### Special notes for your reviewer

- The following tests were passed

```
kind create cluster
helm install prom oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack --version 47.4.0 -n kube-system
helm upgrade prom ./ -n kube-system
```

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
