### PR TITLE
[prometheus] update prometheus-pushgateway chart to 2.4.0

### DIFF
--- a/charts/prometheus/Chart.lock
+++ b/charts/prometheus/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 0.33.1
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
-  version: 5.8.1
+  version: 5.8.2
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 4.18.1
 - name: prometheus-pushgateway
   repository: https://prometheus-community.github.io/helm-charts
-  version: 2.3.0
-digest: sha256:8d4f6a9def838e338d9abf528e3e45a35ea87ae2bf9d4cc8d96e4df6832c4278
-generated: "2023-06-27T10:44:03.318233083Z"
+  version: 2.4.0
+digest: sha256:4c9532cc9070f769288379a49748d5a03291ec689e058f32bc9f03ffdd8c8835
+generated: "2023-07-10T22:40:16.1594561+09:00"

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -38,7 +38,7 @@ dependencies:
     repository: https://prometheus-community.github.io/helm-charts
     condition: prometheus-node-exporter.enabled
   - name: prometheus-pushgateway
-    version: "2.3.*"
+    version: "2.4.*"
     repository: https://prometheus-community.github.io/helm-charts
     condition: prometheus-pushgateway.enabled
 keywords:

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: v2.45.0
-version: 23.0.0
+version: 23.1.0
 kubeVersion: ">=1.16.0-0"
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/


### PR DESCRIPTION
#### What this PR does / why we need it

- update prometheus-pushgateway chart to 2.4.0
  - see #3563

#### Which issue this PR fixes
- none.

#### Special notes for your reviewer

passed

```
kind create cluster
helm install prom oci://ghcr.io/prometheus-community/charts/prometheus --version 23.0.0 -n kube-system
helm dependency update
helm upgrade prom ./ -n kube-system
```

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
