### PR TITLE
[kube-prometheus-stack] Allow minReplicas to be set for VPA

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 47.5.0
+version: 47.5.1
 appVersion: v0.66.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/verticalpodautoscaler.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/verticalpodautoscaler.yaml
@@ -14,6 +14,9 @@ spec:
       {{- if .Values.prometheusOperator.verticalPodAutoscaler.controlledResources }}
       controlledResources: {{ .Values.prometheusOperator.verticalPodAutoscaler.controlledResources }}
       {{- end }}
+      {{- if .Values.prometheusOperator.verticalPodAutoscaler.controlledValues }}
+      controlledValues: {{ .Values.prometheusOperator.verticalPodAutoscaler.controlledValues }}
+      {{- end }}
       {{- if .Values.prometheusOperator.verticalPodAutoscaler.maxAllowed }}
       maxAllowed:
         {{- toYaml .Values.prometheusOperator.verticalPodAutoscaler.maxAllowed | nindent 8 }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/verticalpodautoscaler.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/verticalpodautoscaler.yaml
@@ -26,10 +26,8 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ template "kube-prometheus-stack.fullname" . }}-operator
-  {{- if .Values.prometheusOperator.verticalPodAutoscaler.updatePolicy }}
+  {{- with .Values.prometheusOperator.verticalPodAutoscaler.updatePolicy }}
   updatePolicy:
-    {{- if .Values.prometheusOperator.verticalPodAutoscaler.updatePolicy.updateMode }}
-    updateMode: {{ .Values.prometheusOperator.verticalPodAutoscaler.updatePolicy.updateMode  }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -2294,6 +2294,8 @@ prometheusOperator:
     enabled: false
     # List of resources that the vertical pod autoscaler can control. Defaults to cpu and memory
     controlledResources: []
+    # Specifies which resource values should be controlled: RequestsOnly or RequestsAndLimits.
+    # controlledValues: RequestsAndLimits
 
     # Define the max allowed resources for the pod
     maxAllowed: {}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -2305,6 +2305,8 @@ prometheusOperator:
     # memory: 100Mi
 
     updatePolicy:
+      # Specifies minimal number of replicas which need to be alive for VPA Updater to attempt pod eviction
+      # minReplicas: 1
       # Specifies whether recommended updates are applied when a Pod is started and whether recommended updates
       # are applied during the life of a Pod. Possible values are "Off", "Initial", "Recreate", and "Auto".
       updateMode: Auto


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
By default, VPA Updater triggers eviction only with 2+ replicas. With single replica deployment, [`minReplicas`](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml#L382) is required to be set to `1` be updated by VPA Updater.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
