### PR TITLE
[prom-label-proxy] Add svc annotations support

### DIFF
--- a/charts/prom-label-proxy/Chart.yaml
+++ b/charts/prom-label-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prom-label-proxy
 description: A proxy that enforces a given label in a given PromQL query.
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "v0.6.0"
 home: "https://github.com/prometheus-community/prom-label-proxy"
 keywords:

--- a/charts/prom-label-proxy/Chart.yaml
+++ b/charts/prom-label-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prom-label-proxy
 description: A proxy that enforces a given label in a given PromQL query.
 type: application
-version: 0.3.1
+version: 0.4.0
 appVersion: "v0.6.0"
 home: "https://github.com/prometheus-community/prom-label-proxy"
 keywords:

--- a/charts/prom-label-proxy/templates/service.yaml
+++ b/charts/prom-label-proxy/templates/service.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ template "prom-label-proxy.namespace" . }}
   labels:
     {{- include "prom-label-proxy.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   ports:


### PR DESCRIPTION
#### What this PR does / why we need it

#### Which issue this PR fixes

- Add prom-label-proxy service annotations support mentioned in default values.yaml

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
