### PR TITLE
[kube-prometheus-stack] Fix network policy for agent mode

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 48.0.0
+version: 48.0.1
 appVersion: v0.66.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/networkpolicy.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/networkpolicy.yaml
@@ -24,7 +24,11 @@ spec:
     {{- toYaml .Values.prometheus.networkPolicy.podSelector | nindent 4 }}
     {{- else }}
     matchExpressions:
+      {{- if .Values.prometheus.agentMode }}
+      - {key: app.kubernetes.io/name, operator: In, values: [prometheus-agent]}
+      {{- else }}
       - {key: app.kubernetes.io/name, operator: In, values: [prometheus]}
-      - {key: prometheus, operator: In, values: [{{ template "kube-prometheus-stack.prometheus.crname" . }}]}
+      {{- end }}
+      - {key: operator.prometheus.io/name, operator: In, values: [{{ template "kube-prometheus-stack.prometheus.crname" . }}]}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR fixes Prometheus network policy for Prometheus Agent mode (introduced in #3520).

The selectors are updated to
1. conditionally match pods with `prometheus-agent` (instead of `prometheus`) label,
2. use `operator.prometheus.io/name` instead of short `prometheus` label to match Prometheus name, which is not set for pods in Agent mode.

#### Which issue this PR fixes

No issue.

#### Special notes for your reviewer

See Prometheus Operator code for missing `prometheus` label in Agent mode:

- Prometheus Server has label `prometheus` set
 
https://github.com/prometheus-operator/prometheus-operator/blob/45a45f9737ae33b5d0eb4dddfbb6ee5444c3dfbd/pkg/prometheus/server/statefulset.go#L351

- Prometheus Agent doesn't have label `prometheus` set

https://github.com/prometheus-operator/prometheus-operator/blob/45a45f9737ae33b5d0eb4dddfbb6ee5444c3dfbd/pkg/prometheus/agent/statefulset.go#L274-L280

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
