### PR TITLE
[alertmanager] Remove old ingress version, Switch config map reloader

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,9 +6,9 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 0.33.1
+version: 1.0.0
 appVersion: v0.25.0
-kubeVersion: ">=1.16.0-0"
+kubeVersion: ">=1.19.0-0"
 keywords:
   - monitoring
 maintainers:
@@ -17,6 +17,7 @@ maintainers:
   - name: naseemkullah
     email: naseem@transit.app
 annotations:
+  "artifacthub.io/license": Apache-2.0
   "artifacthub.io/links": |
     - name: Chart Source
       url: https://github.com/prometheus-community/helm-charts

--- a/charts/alertmanager/README.md
+++ b/charts/alertmanager/README.md
@@ -47,6 +47,12 @@ helm upgrade [RELEASE_NAME] [CHART] --install
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
+### To 1.0
+
+The [configmap-reload](https://github.com/jimmidyson/configmap-reload) container was replaced by the [prometheus-config-reloader](https://github.com/prometheus-operator/prometheus-operator/tree/main/cmd/prometheus-config-reloader).
+Extra command-line arguments specified via configmapReload.prometheus.extraArgs are not compatible and will break with the new prometheus-config-reloader, refer to the [sources](https://github.com/prometheus-operator/prometheus-operator/blob/main/cmd/prometheus-config-reloader/main.go) in order to make the appropriate adjustment to the extea command-line arguments.
+The `networking.k8s.io/v1beta1` is no longer supported. use [`networking.k8s.io/v1`](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingressclass-v122).
+
 ## Configuration
 
 See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:

--- a/charts/alertmanager/templates/_helpers.tpl
+++ b/charts/alertmanager/templates/_helpers.tpl
@@ -66,13 +66,7 @@ Create the name of the service account to use
 Define Ingress apiVersion
 */}}
 {{- define "alertmanager.ingress.apiVersion" -}}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
 {{- printf "networking.k8s.io/v1" }}
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
-{{- printf "networking.k8s.io/v1beta1" }}
-{{- else }}
-{{- printf "extensions/v1beta1" }}
-{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/alertmanager/templates/ingress.yaml
+++ b/charts/alertmanager/templates/ingress.yaml
@@ -1,11 +1,6 @@
 {{- if .Values.ingress.enabled }}
 {{- $fullName := include "alertmanager.fullname" . }}
 {{- $svcPort := .Values.service.port }}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-{{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-{{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-{{- end }}
-{{- end }}
 apiVersion: {{ include "alertmanager.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
@@ -18,9 +13,7 @@ metadata:
   {{- end }}
   namespace: {{ include "alertmanager.namespace" . }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
@@ -38,19 +31,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
             pathType: {{ .pathType }}
-            {{- end }}
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -98,8 +98,8 @@ spec:
           image: "{{ .Values.configmapReload.image.repository }}:{{ .Values.configmapReload.image.tag }}"
           imagePullPolicy: "{{ .Values.configmapReload.image.pullPolicy }}"
           args:
-            - --volume-dir=/etc/alertmanager
-            - --webhook-url=http://127.0.0.1:9093/-/reload
+            - --watched-dir=/etc/alertmanager
+            - --reload-url=http://127.0.0.1:9093/-/reload
           resources:
             {{- toYaml .Values.configmapReload.resources | nindent 12 }}
           {{- with .Values.configmapReload.containerPort }}

--- a/charts/alertmanager/unittests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/alertmanager/unittests/__snapshot__/ingress_test.yaml.snap
@@ -23,26 +23,3 @@ should match snapshot of default values:
                   number: 9093
             path: /
             pathType: ImplementationSpecific
-should match snapshot of default values with old kubernetes ingress:
-  1: |
-    apiVersion: networking.k8s.io/v1beta1
-    kind: Ingress
-    metadata:
-      annotations:
-        kubernetes.io/ingress.class: nginx-test
-      labels:
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: alertmanager
-        app.kubernetes.io/version: 1.0.0
-        helm.sh/chart: alertmanager-1.0.0
-      name: RELEASE-NAME-alertmanager
-    spec:
-      rules:
-      - host: alertmanager.domain.com
-        http:
-          paths:
-          - backend:
-              serviceName: RELEASE-NAME-alertmanager
-              servicePort: 9093
-            path: /

--- a/charts/alertmanager/unittests/ingress_test.yaml
+++ b/charts/alertmanager/unittests/ingress_test.yaml
@@ -6,32 +6,6 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
-  - it: should have apiVersion extensions/v1beta1 for k8s < 1.14
-    set:
-      ingress.enabled: true
-    capabilities:
-      majorVersion: 1
-      minorVersion: 13
-    asserts:
-      - hasDocuments:
-          count: 1
-      - isKind:
-          of: Ingress
-      - isAPIVersion:
-          of: extensions/v1beta1
-  - it: should have apiVersion networking.k8s.io/v1beta1 for k8s < 1.19
-    set:
-      ingress.enabled: true
-    capabilities:
-      majorVersion: 1
-      minorVersion: 18
-    asserts:
-      - hasDocuments:
-          count: 1
-      - isKind:
-          of: Ingress
-      - isAPIVersion:
-          of: networking.k8s.io/v1beta1
   - it: should have apiVersion networking.k8s.io/v1 for k8s >= 1.19
     set:
       ingress.enabled: true
@@ -62,18 +36,6 @@ tests:
     set:
       ingress.enabled: true
       ingress.className: nginx-test
-    chart:
-      version: 1.0.0
-      appVersion: 1.0.0
-    asserts:
-      - matchSnapshot: { }
-  - it: should match snapshot of default values with old kubernetes ingress
-    set:
-      ingress.enabled: true
-      ingress.className: nginx-test
-    capabilities:
-      majorVersion: 1
-      minorVersion: 17
     chart:
       version: 1.0.0
       appVersion: 1.0.0

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -219,7 +219,7 @@ config:
     repeat_interval: 3h
 
 ## Monitors ConfigMap changes and POSTs to a URL
-## Ref: https://github.com/jimmidyson/configmap-reload
+## Ref: https://github.com/prometheus-operator/prometheus-operator/tree/main/cmd/prometheus-config-reloader
 ##
 configmapReload:
   ## If false, the configmap-reload container will not be deployed
@@ -233,8 +233,8 @@ configmapReload:
   ## configmap-reload container image
   ##
   image:
-    repository: jimmidyson/configmap-reload
-    tag: v0.8.0
+    repository: quay.io/prometheus-operator/prometheus-config-reloader
+    tag: v0.66.0
     pullPolicy: IfNotPresent
 
   # containerPort: 9533


### PR DESCRIPTION
#### What this PR does / why we need it

- Switch to use a different config map reloader
  - see: #3133
  - prometheus now uses prometheus-operator/prometheus-config-reloader
- Remove old ingress version
  - kubernetes 1.18 is old enough to deserve removal of support
  - Simplify the chart
  - required kubernetes 1.19 
- chore: add license identifer

#### Which issue this PR fixes

- none.

#### Special notes for your reviewer

- Need more additional notes?
- test with:

```
kind create cluster
helm install traefik traefik/traefik --version 21.1.0 --set hostNetwork=true --set ports.traefik.expose=true -n kube-system
helm install prom oci://ghcr.io/prometheus-community/charts/alertmanager --version 0.33.1 -n kube-system --set configmapReload.enabled=true --set configmapReload.containerPort=9533 --set ingress.enabled=true --set ingress.className=traefik
helm upgrade prom ./ -n kube-system --set configmapReload.enabled=true --set configmapReload.containerPort=9533 --set ingress.enabled=true --set ingress.className=traefik
```

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
  - [x]  Major upgrade. provide release notes
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
