### PR TITLE
[kube-prometheus-stack] Bump minimun kubeVersion to ">=1.19.0-0"

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 48.6.0
+version: 49.0.0
 appVersion: v0.66.0
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ sources:
   - https://github.com/prometheus-operator/kube-prometheus
 version: 48.6.0
 appVersion: v0.66.0
-kubeVersion: ">=1.16.0-0"
+kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus
 keywords:
   - operator

--- a/charts/kube-prometheus-stack/README.md
+++ b/charts/kube-prometheus-stack/README.md
@@ -8,7 +8,7 @@ _Note: This chart was formerly named `prometheus-operator` chart, now renamed to
 
 ## Prerequisites
 
-- Kubernetes 1.16+
+- Kubernetes 1.19+
 - Helm 3+
 
 ## Get Helm Repository Info
@@ -81,6 +81,12 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 ### Upgrading an existing Release to a new major version
 
 A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an incompatible breaking change needing manual actions.
+
+### From 48.x to 49.x
+
+This version requires Kubernetes 1.19+.
+
+We do not expect any breaking changes in this version.
 
 ### From 47.x to 48.x
 

--- a/charts/kube-prometheus-stack/templates/NOTES.txt
+++ b/charts/kube-prometheus-stack/templates/NOTES.txt
@@ -2,3 +2,11 @@
   kubectl --namespace {{ template "kube-prometheus-stack.namespace" . }} get pods -l "release={{ $.Release.Name }}"
 
 Visit https://github.com/prometheus-operator/kube-prometheus for instructions on how to create & configure Alertmanager and Prometheus instances using the Operator.
+
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1"}}
+#################################################################################
+######   WARNING: The networking.k8s.io/v1beta1 API versions of Ingress is  #####
+######            no longer served as of k8s v1.22+.                        #####
+######            use networking.k8s.io/v1 API.                             #####
+#################################################################################
+{{- end -}}

--- a/charts/kube-prometheus-stack/templates/NOTES.txt
+++ b/charts/kube-prometheus-stack/templates/NOTES.txt
@@ -2,11 +2,3 @@
   kubectl --namespace {{ template "kube-prometheus-stack.namespace" . }} get pods -l "release={{ $.Release.Name }}"
 
 Visit https://github.com/prometheus-operator/kube-prometheus for instructions on how to create & configure Alertmanager and Prometheus instances using the Operator.
-
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1"}}
-#################################################################################
-######   WARNING: The networking.k8s.io/v1beta1 API versions of Ingress is  #####
-######            no longer served as of k8s v1.22+.                        #####
-######            use networking.k8s.io/v1 API.                             #####
-#################################################################################
-{{- end -}}

--- a/charts/kube-prometheus-stack/unittests/alertmanager/ingress_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/alertmanager/ingress_test.yaml
@@ -16,43 +16,13 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
-  - it: should have apiVersion extensions/v1beta1 for k8s < 1.16
-    set:
-      alertmanager.enabled: true
-      alertmanager.ingress.enabled: true
-    capabilities:
-      majorVersion: 1
-      minorVersion: 15
-    asserts:
-      - hasDocuments:
-          count: 1
-      - isKind:
-          of: Ingress
-      - isAPIVersion:
-          of: extensions/v1beta1
-  - it: should have apiVersion networking.k8s.io/v1beta1 for k8s >= 1.16 < 1.19
-    set:
-      alertmanager.enabled: true
-      alertmanager.ingress.enabled: true
-    capabilities:
-      majorVersion: 1
-      minorVersion: 16
-      apiVersions:
-        - networking.k8s.io/v1beta1
-    asserts:
-      - hasDocuments:
-          count: 1
-      - isKind:
-          of: Ingress
-      - isAPIVersion:
-          of: networking.k8s.io/v1beta1
   - it: should have apiVersion networking.k8s.io/v1 for k8s >= 1.19 < 1.22
     set:
       alertmanager.enabled: true
       alertmanager.ingress.enabled: true
     capabilities:
       majorVersion: 1
-      minorVersion: 10
+      minorVersion: 19
       apiVersions:
         - networking.k8s.io/v1
         - networking.k8s.io/v1beta1

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -10,7 +10,7 @@ nameOverride: ""
 ##
 namespaceOverride: ""
 
-## Provide a k8s version to auto dashboard import script example: kubeTargetVersionOverride: 1.16.6
+## Provide a k8s version to auto dashboard import script example: kubeTargetVersionOverride: 1.26.6
 ##
 kubeTargetVersionOverride: ""
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

- Bump minimun kubeVersion to ">=1.19.0-0"
  - Clarify that this chart does not work with kubernetes 1.18 anymore.
- Add Deprecation warning if using networking.k8s.io/v1betav1

#### Which issue this PR fixes

- fixes #3605

#### Special notes for your reviewer

- Note that already 1.18 does not work.
  - see #3605

- `networking.k8s.io/v1beta1` not yet deleted here.
  - kubernetes ~1.24 is already EOL.
  - Will you be discontinuing support to ~1.21 or ~1.24 in the near future?
  -  Warning note removed. I have decided that a warning to those still using kubernetes 1.21 is not necessary.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
  - [x]  Major upgrade. provide release notes
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
