### PR TITLE
[kube-prometheus-stack] bumping chart version to allow updated dependent chart versions to be updated

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 48.1.1
+version: 48.1.2
 appVersion: v0.66.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Bumps the chart version in Charts.yaml to force the dependent charts to fetch updated version when the chart is published.

This specifically is to fetch the latest Grafana Helm chart grafana-6.58.4 (https://github.com/grafana/helm-charts/releases/tag/grafana-6.58.4) which correct a bug with pulling dashboards via the sidecar container.

Without a Chart.lock which was removed in a previous commit this seems like the best method for updating dependent chart versions.
#### Which issue this PR fixes

N/A

#### Special notes for your reviewer
Without a Chart.lock which was removed in a previous commit this seems like the best method for updating dependent chart versions. If there is another preferred method I'm happy to follow that process.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
