### PR TITLE
[kube-prometheus-stack] Unify usage of prometheus pods selectors

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 48.1.2
+version: 48.1.3
 appVersion: v0.66.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 48.2.0
+version: 48.2.1
 appVersion: v0.66.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 48.1.3
+version: 48.1.2
 appVersion: v0.66.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/networkpolicy.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/networkpolicy.yaml
@@ -23,12 +23,12 @@ spec:
     {{- if .Values.prometheus.networkPolicy.podSelector }}
     {{- toYaml .Values.prometheus.networkPolicy.podSelector | nindent 4 }}
     {{- else }}
-    matchExpressions:
+    matchLabels:
       {{- if .Values.prometheus.agentMode }}
-      - {key: app.kubernetes.io/name, operator: In, values: [prometheus-agent]}
+      app.kubernetes.io/name: prometheus-agent
       {{- else }}
-      - {key: app.kubernetes.io/name, operator: In, values: [prometheus]}
+      app.kubernetes.io/name: prometheus
       {{- end }}
-      - {key: operator.prometheus.io/name, operator: In, values: [{{ template "kube-prometheus-stack.prometheus.crname" . }}]}
+      operator.prometheus.io/name: {{ template "kube-prometheus-stack.prometheus.crname" . }}
     {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/podDisruptionBudget.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/podDisruptionBudget.yaml
@@ -16,6 +16,10 @@ spec:
   {{- end  }}
   selector:
     matchLabels:
+      {{- if .Values.prometheus.agentMode }}
+      app.kubernetes.io/name: prometheus-agent
+      {{- else }}
       app.kubernetes.io/name: prometheus
-      prometheus: {{ template "kube-prometheus-stack.prometheus.crname" . }}
+      {{- end }}
+      operator.prometheus.io/name: {{ template "kube-prometheus-stack.prometheus.crname" . }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/service.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/service.yaml
@@ -58,13 +58,12 @@ spec:
 {{- end }}
   publishNotReadyAddresses: {{ .Values.prometheus.service.publishNotReadyAddresses }}
   selector:
-{{- if .Values.prometheus.agentMode }}
+    {{- if .Values.prometheus.agentMode }}
     app.kubernetes.io/name: prometheus-agent
-    app.kubernetes.io/instance: {{ template "kube-prometheus-stack.fullname" . }}-prometheus
-{{- else }}
+    {{- else }}
     app.kubernetes.io/name: prometheus
-    prometheus: {{ template "kube-prometheus-stack.prometheus.crname" . }}
-{{- end }}
+    {{- end }}
+    operator.prometheus.io/name: {{ template "kube-prometheus-stack.prometheus.crname" . }}
 {{- if .Values.prometheus.service.sessionAffinity }}
   sessionAffinity: {{ .Values.prometheus.service.sessionAffinity }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/serviceThanosSidecar.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/serviceThanosSidecar.yaml
@@ -35,5 +35,5 @@ spec:
     {{- end }}
   selector:
     app.kubernetes.io/name: prometheus
-    prometheus: {{ template "kube-prometheus-stack.prometheus.crname" . }}
+    operator.prometheus.io/name: {{ template "kube-prometheus-stack.prometheus.crname" . }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/serviceThanosSidecarExternal.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/serviceThanosSidecarExternal.yaml
@@ -42,5 +42,5 @@ spec:
     {{- end }}
   selector:
     app.kubernetes.io/name: prometheus
-    prometheus: {{ template "kube-prometheus-stack.prometheus.crname" . }}
+    operator.prometheus.io/name: {{ template "kube-prometheus-stack.prometheus.crname" . }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/serviceperreplica.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/serviceperreplica.yaml
@@ -41,9 +41,14 @@ items:
           port: {{ $serviceValues.port }}
           targetPort: {{ $serviceValues.targetPort }}
       selector:
+        {{- if $.Values.prometheus.agentMode }}
+        app.kubernetes.io/name: prometheus-agent
+        statefulset.kubernetes.io/pod-name: prom-agent-{{ include "kube-prometheus-stack.prometheus.crname" $ }}-{{ $i }}
+        {{- else }}
         app.kubernetes.io/name: prometheus
-        prometheus: {{ include "kube-prometheus-stack.prometheus.crname" $ }}
         statefulset.kubernetes.io/pod-name: prometheus-{{ include "kube-prometheus-stack.prometheus.crname" $ }}-{{ $i }}
+        {{- end }}
+        operator.prometheus.io/name: {{ template "kube-prometheus-stack.prometheus.crname" $ }}
       type: "{{ $serviceValues.type }}"
 {{- end }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it
This PR fixes nonconformity/desync in pod selectors that is appeared after #3520 and #3587 were merged.

#### Which issue this PR fixes
None, but related to #1519.

#### Special notes for your reviewer
As was mentioned in earlier PRs (#3520 and #3587) a prometheus agent pod (that is deployed by operator) doesn't have `prometheus` label. Because of that we were forced to use another labels in pod selectors. But some resources selectors are left out of sync and another still need to be updated with introduced selectors.
Here is a description of the changes made:
- #3520 and #3587 introduced different selectors in `service.yaml` vs `networkpolicy.yaml`. They use `app.kubernetes.io/instance` vs `operator.prometheus.io/name` labels for the same pod selection. Usage of `operator.prometheus.io/name` label is taken as a basis here and in other changes of this PR.
- `networkpolicy.yaml` uses complicated `matchExpressions` selection without any reason instead of simple `matchLabels` and it also uses inlined json that is hard to read by humans. Proposed changes make the networkpolicy selectors identical to other resources.
- `podDisruptionBudget.yaml` and `serviceperreplica.yaml` need to be updated with the introduced earlier selectors.
- `serviceThanosSidecar.yaml` and `serviceThanosSidecarExternal.yaml` do not require any changes by themself (because thanos doesn't make sense in agent mode, as far as i know), but the changes are done just to keep them in sync with other resources.

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)