### PR TITLE
[prometheus-statsd-exporter] - add conditional for hpa apiVersion

### DIFF
--- a/charts/prometheus-statsd-exporter/Chart.yaml
+++ b/charts/prometheus-statsd-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus-statsd-exporter
 description: A Helm chart for prometheus stats-exporter
-version: 0.9.0
+version: 0.9.1
 appVersion: v0.22.8
 home: https://github.com/prometheus/statsd_exporter
 sources:

--- a/charts/prometheus-statsd-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-statsd-exporter/templates/_helpers.tpl
@@ -74,3 +74,16 @@ Check if there is any mappings available
 {{- template "prometheus-statsd-exporter.fullname" . -}}
 {{- end }}
 {{- end }}
+
+{{/*
+Define apiVersion of HorizontalPodAutoscaler
+*/}}
+{{- define "prometheus-statsd-exporter.hpa.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "autoscaling/v2" -}}
+{{- print "autoscaling/v2" -}}
+{{- else if .Capabilities.APIVersions.Has "autoscaling/v2beta2" -}}
+{{- print "autoscaling/v2beta2" -}}
+{{- else -}}
+{{- print "autoscaling/v2beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/prometheus-statsd-exporter/templates/hpa.yaml
+++ b/charts/prometheus-statsd-exporter/templates/hpa.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.autoscaling.enabled }}
+{{- if semverCompare ">=1.25-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: autoscaling/v2
+{{- else -}}
 apiVersion: autoscaling/v2beta1
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "prometheus-statsd-exporter.fullname" . }}

--- a/charts/prometheus-statsd-exporter/templates/hpa.yaml
+++ b/charts/prometheus-statsd-exporter/templates/hpa.yaml
@@ -1,9 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-{{- if semverCompare ">=1.25-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: autoscaling/v2
-{{- else -}}
-apiVersion: autoscaling/v2beta1
-{{- end }}
+apiVersion: {{ include "prometheus-statsd-exporter.hpa.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "prometheus-statsd-exporter.fullname" . }}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
autoscaling/v2beta1 api for horizontalPodAutoscalers was [removed in k8s 1.25](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v125)
This PR adds a conditional to use autoscaling/v2 API version if the k8s version of your cluster is 1.25 or greater.
#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer
@scDisorder - @-mentioning you per the instructions above. Please review when you have the time, thank you!
#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
