### PR TITLE
[prometheus-kafka-exporter]: Add relabelings and metricRelabeling…

### DIFF
--- a/charts/prometheus-kafka-exporter/Chart.yaml
+++ b/charts/prometheus-kafka-exporter/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v1.6.0"
 description: A Helm chart to export the metrics from Kafka in Prometheus format using the kafka-exporter from https://github.com/danielqsj/kafka_exporter
 name: prometheus-kafka-exporter
 home: https://github.com/danielqsj/kafka_exporter
-version: 2.2.0
+version: 2.3.0
 kubeVersion: ">=1.19.0-0"
 sources:
   - https://gkarthiks.github.io/helm-charts/charts/prometheus-kafka-exporter

--- a/charts/prometheus-kafka-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-kafka-exporter/templates/servicemonitor.yaml
@@ -35,4 +35,12 @@ spec:
     {{- if .Values.prometheus.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.prometheus.serviceMonitor.scrapeTimeout }}
     {{- end }}
+    {{- if .Values.prometheus.serviceMonitor.relabelings }}
+    relabelings:
+    {{- toYaml .Values.prometheus.serviceMonitor.relabelings | nindent 6 }}
+    {{- end }}
+    {{- if .Values.prometheus.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+    {{- toYaml .Values.prometheus.serviceMonitor.metricRelabelings | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/charts/prometheus-kafka-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-kafka-exporter/templates/servicemonitor.yaml
@@ -39,8 +39,8 @@ spec:
     relabelings:
     {{- toYaml .Values.prometheus.serviceMonitor.relabelings | nindent 6 }}
     {{- end }}
-    {{- if .Values.prometheus.serviceMonitor.metricRelabelings }}
+    {{- with .Values.prometheus.serviceMonitor.metricRelabelings }}
     metricRelabelings:
-    {{- toYaml .Values.prometheus.serviceMonitor.metricRelabelings | nindent 6 }}
+    {{- toYaml . | nindent 6 }}
     {{- end }}
 {{- end }}

--- a/charts/prometheus-kafka-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-kafka-exporter/templates/servicemonitor.yaml
@@ -35,9 +35,9 @@ spec:
     {{- if .Values.prometheus.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.prometheus.serviceMonitor.scrapeTimeout }}
     {{- end }}
-    {{- if .Values.prometheus.serviceMonitor.relabelings }}
+    {{- with .Values.prometheus.serviceMonitor.relabelings }}
     relabelings:
-    {{- toYaml .Values.prometheus.serviceMonitor.relabelings | nindent 6 }}
+    {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- with .Values.prometheus.serviceMonitor.metricRelabelings }}
     metricRelabelings:

--- a/charts/prometheus-kafka-exporter/values.yaml
+++ b/charts/prometheus-kafka-exporter/values.yaml
@@ -91,7 +91,7 @@ prometheus:
     additionalLabels: {}
     targetLabels: []
     # Relabel configs to apply to target's labelset before the target gets scraped.
-    ## [Relabeling](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config)
+    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.RelabelConfig
     relabelings: null
     # - sourceLabels: [__meta_kubernetes_pod_node_name]
     #   separator: ;

--- a/charts/prometheus-kafka-exporter/values.yaml
+++ b/charts/prometheus-kafka-exporter/values.yaml
@@ -90,7 +90,7 @@ prometheus:
     #   release: kube-prometheus
     additionalLabels: {}
     targetLabels: []
-    ## Relabel configs to apply to samples before ingestion.
+    # Relabel configs to apply to target's labelset before the target gets scraped.
     ## [Relabeling](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config)
     relabelings: null
     # - sourceLabels: [__meta_kubernetes_pod_node_name]

--- a/charts/prometheus-kafka-exporter/values.yaml
+++ b/charts/prometheus-kafka-exporter/values.yaml
@@ -90,6 +90,24 @@ prometheus:
     #   release: kube-prometheus
     additionalLabels: {}
     targetLabels: []
+    ## Relabel configs to apply to samples before ingestion.
+    ## [Relabeling](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config)
+    relabelings: null
+    # - sourceLabels: [__meta_kubernetes_pod_node_name]
+    #   separator: ;
+    #   regex: ^(.*)$
+    #   targetLabel: nodename
+    #   replacement: $1
+    #   action: replace
+    # Metric relabeling is applied to samples as the last step before ingestion 
+    # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
+    metricRelabelings: null
+    # - sourceLabels: [__meta_kubernetes_pod_node_name]
+    #   separator: ;
+    #   regex: ^(.*)$
+    #   targetLabel: nodename
+    #   replacement: $1
+    #   action: replace
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/prometheus-kafka-exporter/values.yaml
+++ b/charts/prometheus-kafka-exporter/values.yaml
@@ -100,7 +100,7 @@ prometheus:
     #   replacement: $1
     #   action: replace
     # Metric relabeling is applied to samples as the last step before ingestion 
-    # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
+    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.RelabelConfig
     metricRelabelings: null
     # - sourceLabels: [__meta_kubernetes_pod_node_name]
     #   separator: ;

--- a/charts/prometheus-kafka-exporter/values.yaml
+++ b/charts/prometheus-kafka-exporter/values.yaml
@@ -99,7 +99,7 @@ prometheus:
     #   targetLabel: nodename
     #   replacement: $1
     #   action: replace
-    # Metric relabeling is applied to samples as the last step before ingestion 
+    # Metric relabeling is applied to samples as the last step before ingestion
     # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.RelabelConfig
     metricRelabelings: null
     # - sourceLabels: [__meta_kubernetes_pod_node_name]


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Add `relabelings` and `metricRelabelings` in prometheus-kafka-exporter.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #3639

#### Special notes for your reviewer

Validated with values:

```yaml
prometheus:
  serviceMonitor:
    enabled: true

    additionalLabels:
      kube-prometheus-stack: platform
    metricRelabelings:
    # Get spaceid from topic
      - sourceLabels: [ consumergroup ]
        regex: .*([0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}).*
        targetLabel: customerid
        replacement: $1
    # Get spaceid from consumergroup
      - sourceLabels: [ topic ]
        regex: .*([0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}).*
        targetLabel: customerid
        replacement: $1
```

Result:

```yaml
# Source: prometheus-kafka-exporter/templates/servicemonitor.yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: release-name-prometheus-kafka-exporter
  namespace: monitoring
  labels:
    app.kubernetes.io/name: prometheus-kafka-exporter
    helm.sh/chart: prometheus-kafka-exporter-2.3.0
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    kube-prometheus-stack: platform
spec:
  jobLabel: jobLabel
  selector:
    matchLabels:
      app: prometheus-kafka-exporter
      release: release-name
  namespaceSelector:
    matchNames:
    - prometheus-kafka-exporter
  endpoints:
  - port: exporter-port
    interval: 30s
    metricRelabelings:
      - regex: .*([0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}).*
        replacement: $1
        sourceLabels:
        - consumergroup
        targetLabel: customerid
      - regex: .*([0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}).*
        replacement: $1
        sourceLabels:
        - topic
        targetLabel: customerid
```

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
