### PR TITLE
[prometheus-adapter] Update prometheus adapter version and drop deprecated arg

### DIFF
--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 4.2.0
-appVersion: v0.10.0
+version: 4.3.0
+appVersion: v0.11.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/kubernetes-sigs/prometheus-adapter
 keywords:

--- a/charts/prometheus-adapter/templates/deployment.yaml
+++ b/charts/prometheus-adapter/templates/deployment.yaml
@@ -60,7 +60,6 @@ spec:
         - --tls-private-key-file=/var/run/serving-cert/tls.key
         {{- end }}
         - --cert-dir=/tmp/cert
-        - --logtostderr=true
         - --prometheus-url={{ tpl .Values.prometheus.url . }}{{ if .Values.prometheus.port }}:{{ .Values.prometheus.port }}{{end}}{{ .Values.prometheus.path }}
         - --metrics-relist-interval={{ .Values.metricsRelistInterval }}
         - --v={{ .Values.logLevel }}

--- a/charts/prometheus-adapter/values.yaml
+++ b/charts/prometheus-adapter/values.yaml
@@ -4,7 +4,7 @@ topologySpreadConstraints: []
 
 image:
   repository: registry.k8s.io/prometheus-adapter/prometheus-adapter
-  tag: v0.10.0
+  tag: v0.11.0
   pullPolicy: IfNotPresent
 
 logLevel: 4


### PR DESCRIPTION
Bump prometheus-adapter version to v0.11.0 and remove deprecated (and now unsupported) arg.

Fixes: #3642 

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
