### PR TITLE
[prometheus-adapter] Updates chart for v0.11.0

### DIFF
--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 4.2.0
-appVersion: v0.10.0
+version: 4.3.0
+appVersion: v0.11.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/kubernetes-sigs/prometheus-adapter
 keywords:

--- a/charts/prometheus-adapter/templates/deployment.yaml
+++ b/charts/prometheus-adapter/templates/deployment.yaml
@@ -60,7 +60,6 @@ spec:
         - --tls-private-key-file=/var/run/serving-cert/tls.key
         {{- end }}
         - --cert-dir=/tmp/cert
-        - --logtostderr=true
         - --prometheus-url={{ tpl .Values.prometheus.url . }}{{ if .Values.prometheus.port }}:{{ .Values.prometheus.port }}{{end}}{{ .Values.prometheus.path }}
         - --metrics-relist-interval={{ .Values.metricsRelistInterval }}
         - --v={{ .Values.logLevel }}


### PR DESCRIPTION
This PR updates the chart to support the latest release of Prometheus Adapter, v0.11.0, by removing a deprecated arg. This fixes #3642.