### PR TITLE
[prometheus] Bump prometheus, config-reloader and chart deps

### DIFF
--- a/charts/prometheus/Chart.lock
+++ b/charts/prometheus/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 0.33.1
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
-  version: 5.8.2
+  version: 5.10.1
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
-  version: 4.18.1
+  version: 4.21.0
 - name: prometheus-pushgateway
   repository: https://prometheus-community.github.io/helm-charts
   version: 2.4.0
-digest: sha256:4c9532cc9070f769288379a49748d5a03291ec689e058f32bc9f03ffdd8c8835
-generated: "2023-07-10T22:40:16.1594561+09:00"
+digest: sha256:4062158e1b8cf004b8f42feb018340d1d19e8e97cc8db70b5b514e159788c1a1
+generated: "2023-07-28T13:17:20.309944342Z"

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
-appVersion: v2.45.0
-version: 23.1.0
+appVersion: v2.46.0
+version: 23.2.0
 kubeVersion: ">=1.16.0-0"
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -30,11 +30,11 @@ dependencies:
     repository: https://prometheus-community.github.io/helm-charts
     condition: alertmanager.enabled
   - name: kube-state-metrics
-    version: "5.8.*"
+    version: "5.10.*"
     repository: https://prometheus-community.github.io/helm-charts
     condition: kube-state-metrics.enabled
   - name: prometheus-node-exporter
-    version: "4.18.*"
+    version: "4.21.*"
     repository: https://prometheus-community.github.io/helm-charts
     condition: prometheus-node-exporter.enabled
   - name: prometheus-pushgateway

--- a/charts/prometheus/templates/clusterrole.yaml
+++ b/charts/prometheus/templates/clusterrole.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "prometheus.server.labels" . | nindent 4 }}
   name: {{ include "prometheus.clusterRoleName" . }}
 rules:
-{{- if .Values.podSecurityPolicy.enabled }}
+{{- if and .Values.podSecurityPolicy.enabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
   - apiGroups:
     - extensions
     resources:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -48,7 +48,7 @@ configmapReload:
     ##
     image:
       repository: quay.io/prometheus-operator/prometheus-config-reloader
-      tag: v0.66.0
+      tag: v0.67.0
       # When digest is set to a non-empty value, images will be pulled by digest (regardless of tag value).
       digest: ""
       pullPolicy: IfNotPresent


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Releases bumped as follows:
- prometheus [2.46.0](https://github.com/prometheus/prometheus/releases/tag/v2.46.0)
- config-reloader [0.67.0](https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.67.0)
- dependency kube-state-metrics 5.10.1
- dependency prometheus-node-exporter 4.21.0

A minor correction in clusterrole has been made: references to PSP resources should not be created without the required API being supported in the cluster as the resources being referred to are in fact not present.

#### Which issue this PR fixes

None

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
