### PR TITLE
[alertmanager] Add securityContext to configmap reload

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 1.4.0
+version: 1.5.0
 appVersion: v0.25.0
 kubeVersion: ">=1.19.0-0"
 keywords:

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -118,8 +118,10 @@ spec:
           ports:
             - containerPort: {{ . }}
           {{- end }}
+          {{- with .Values.configmapReload.securityContext }}
           securityContext:
-            {{- toYaml .Values.configmapReload.securityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: /etc/alertmanager

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -115,11 +115,11 @@ spec:
           resources:
             {{- toYaml .Values.configmapReload.resources | nindent 12 }}
           {{- with .Values.configmapReload.containerPort }}
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
           ports:
             - containerPort: {{ . }}
           {{- end }}
+          securityContext:
+            {{- toYaml .Values.configmapReload.securityContext | nindent 12 }}
           volumeMounts:
             - name: config
               mountPath: /etc/alertmanager

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -115,6 +115,8 @@ spec:
           resources:
             {{- toYaml .Values.configmapReload.resources | nindent 12 }}
           {{- with .Values.configmapReload.containerPort }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           ports:
             - containerPort: {{ . }}
           {{- end }}

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -266,6 +266,15 @@ configmapReload:
     # - name: FOO
     #   value: BAR
 
+  securityContext:
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    runAsUser: 65534
+    runAsNonRoot: true
+    runAsGroup: 65534
+
 templates: {}
 #   alertmanager.tmpl: |-
 

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -266,14 +266,14 @@ configmapReload:
     # - name: FOO
     #   value: BAR
 
-  securityContext:
+  securityContext: {}
     # capabilities:
     #   drop:
     #   - ALL
     # readOnlyRootFilesystem: true
-    runAsUser: 65534
-    runAsNonRoot: true
-    runAsGroup: 65534
+    # runAsUser: 65534
+    # runAsNonRoot: true
+    # runAsGroup: 65534
 
 templates: {}
 #   alertmanager.tmpl: |-


### PR DESCRIPTION
#### What this PR does / why we need it

When adding the sidecar container via helm values, our policies complain about the container not having security context set.
This sets the `securityContext` of the configmap reloader to the same values as the main container, to prevent it from running as root.

#### Which issue this PR fixes
#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
