### PR TITLE
[kube-prometheus-stack] Quote enums for consistency

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 48.2.3
+version: 48.2.4
 appVersion: v0.66.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/charts/crds/crds/crd-alertmanagerconfigs.yaml
+++ b/charts/kube-prometheus-stack/charts/crds/crds/crd-alertmanagerconfigs.yaml
@@ -70,8 +70,8 @@ spec:
                               if non-empty.
                             enum:
                             - '!='
-                            - =
-                            - =~
+                            - '='
+                            - '=~'
                             - '!~'
                             type: string
                           name:
@@ -103,8 +103,8 @@ spec:
                               if non-empty.
                             enum:
                             - '!='
-                            - =
-                            - =~
+                            - '='
+                            - '=~'
                             - '!~'
                             type: string
                           name:
@@ -4425,8 +4425,8 @@ spec:
                             if non-empty.
                           enum:
                           - '!='
-                          - =
-                          - =~
+                          - '='
+                          - '=~'
                           - '!~'
                           type: string
                         name:


### PR DESCRIPTION
Applying the crds with the k8s module of Ansible failed due to a contructor error. It turned out to be unquoted equal signs. It is also more consistent to quote these signs.

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Quotes are added to the equal signt in crd-alertmanagerconfigs.yaml. This will fix the appliance of the crd using the ansible module kubernetes.core.k8s (which uses PyYAML under the hood) which errors if these equal signs are not quoted.

#### Which issue this PR fixes
No issue reported

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
