### PR TITLE
[kube-prometheus-stack] Fix indentation multiple imagePullSecrets

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 48.2.3
+version: 48.2.4
 appVersion: v0.66.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -40,7 +40,7 @@ spec:
     {{- end }}
     {{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
-      {{ include "kube-prometheus-stack.imagePullSecrets" . | trim | indent 2 }}
+      {{- include "kube-prometheus-stack.imagePullSecrets" . | indent 8 }}
     {{- end }}
       containers:
         - name: {{ template "kube-prometheus-stack.name" . }}


### PR DESCRIPTION
#### What this PR does / why we need it
Change the indentation for multiple imagePullSecrets and trim the whitespace to fix YAML parse error.

#### Which issue this PR fixes

Error: YAML parse error on kube-prometheus-stack/templates/prometheus-operator/deployment.yaml: error converting YAML to JSON: yaml: line 36: did not find expected key

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
