### PR TITLE
[prometheus-operator-admission-webhook] feat: allow changing the default revisionHistoryLimit

### DIFF
--- a/charts/prometheus-operator-admission-webhook/Chart.yaml
+++ b/charts/prometheus-operator-admission-webhook/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: Prometheus Operator Admission Webhook
 name: prometheus-operator-admission-webhook
-version: 0.5.0
+version: 0.6.0
 appVersion: 0.67.0
 home: https://github.com/prometheus-operator/prometheus-operator
 icon: https://github.com/prometheus-operator/prometheus-operator/raw/main/Documentation/logos/prometheus-operator-logo.png

--- a/charts/prometheus-operator-admission-webhook/templates/deployment.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/deployment.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: {{ include "prometheus-operator-admission-webhook.namespace" . }}
 spec:
   replicas: {{ default 1 .Values.replicas }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "prometheus-operator-admission-webhook.selectorLabels" . | nindent 6 }}

--- a/charts/prometheus-operator-admission-webhook/values.yaml
+++ b/charts/prometheus-operator-admission-webhook/values.yaml
@@ -141,6 +141,10 @@ containerPort: 10250
 ## of the webhook, set at least 2.
 replicas: 1
 
+## Number of old history to retain to allow rollback
+## Default Kubernetes value is set to 10
+revisionHistoryLimit: 10
+
 ## restartPolicy
 restartPolicy: Always
 


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
You may want to clean up old ReplicaSets so that these don't appear in metrics, OPA violations, ArgoCD UI and so on.
Therefore you want to overwrite the Kubernetes default revision history limit.

The Prometheus Operator Admission Webhook Depoyment has been adapted to allow the user changing the default revisionHistoryLimit.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer

N/A

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
