### PR TITLE
[alertmanager] Add common meta labels

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,8 +6,8 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 1.6.0
-appVersion: v0.27.0
+version: 1.7.0
+appVersion: v0.26.0
 kubeVersion: ">=1.19.0-0"
 keywords:
   - monitoring

--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 1.5.0
+version: 1.5.1
 appVersion: v0.25.0
 kubeVersion: ">=1.19.0-0"
 keywords:

--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 1.5.1
+version: 1.6.0
 appVersion: v0.25.0
 kubeVersion: ">=1.19.0-0"
 keywords:

--- a/charts/alertmanager/templates/_helpers.tpl
+++ b/charts/alertmanager/templates/_helpers.tpl
@@ -41,6 +41,9 @@ helm.sh/chart: {{ include "alertmanager.chart" . }}
 app.kubernetes.io/version: {{ . | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonMetaLabels}}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/alertmanager/templates/_helpers.tpl
+++ b/charts/alertmanager/templates/_helpers.tpl
@@ -41,7 +41,7 @@ helm.sh/chart: {{ include "alertmanager.chart" . }}
 app.kubernetes.io/version: {{ . | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- with .Values.commonMetaLabels}}
+{{- with .Values.extraLabels }}
 {{ toYaml . }}
 {{- end }}
 {{- end }}

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -228,6 +228,8 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: storage
+        labels:
+          {{- include "alertmanager.labels" . | nindent 10 }}
       spec:
         accessModes:
           {{- toYaml .Values.persistence.accessModes | nindent 10 }}

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -229,6 +229,9 @@ spec:
     - metadata:
         name: storage
         labels:
+          {{- if .Values.extraLabels }}
+          {{- toYaml .Values.extraLabels | nindent 10 }}
+          {{- end }}
           {{- if .Values.persistence.labels }}
           {{- toYaml .Values.persistence.labels | nindent 10 }}
           {{- end }}

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -229,7 +229,9 @@ spec:
     - metadata:
         name: storage
         labels:
-          {{- include "alertmanager.labels" . | nindent 10 }}
+          {{- if .Values.persistence.labels }}
+          {{- toYaml .Values.persistence.labels | nindent 10 }}
+          {{- end }}
       spec:
         accessModes:
           {{- toYaml .Values.persistence.accessModes | nindent 10 }}

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -17,6 +17,10 @@ image:
 
 extraArgs: {}
 
+## Additional labels to add to all Kubernetes objects managed by this Helm chart.
+##
+extraLabels: {}
+
 ## Additional Alertmanager Secret mounts
 # Defines additional mounts with secrets. Secrets must be manually created in the namespace.
 extraSecretMounts: []

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -199,6 +199,8 @@ persistence:
   accessModes:
     - ReadWriteOnce
   size: 50Mi
+  ## Alertmanager Persistent Volume labels
+  labels: {}
 
 configAnnotations: {}
   ## For example if you want to provide private data from a secret vault


### PR DESCRIPTION
#### What this PR does / why we need it

This PR adds the ability to add custom labels to the Kubernetes objects defined by this Helm chart. It does this by 

1) adding `extraLabels` to the `alertmanager.labels` template (and to the `values.yaml`); and 
2) adding `alertmanager.labels` to the PVC defined by the sts.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
