### PR TITLE
[kube-prometheus-stack] fix typo in scrapeConfigNamespaceSelector

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 48.3.2
+version: 48.3.3
 appVersion: v0.66.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -3099,7 +3099,7 @@ prometheus:
     ## If nil, select own namespace. Namespaces to be selected for scrapeConfig discovery.
     scrapeConfigNamespaceSelector: {}
     ## Example which selects scrapeConfig in namespaces with label "prometheus" set to "somelabel"
-    # scrapeConfigsNamespaceSelector:
+    # scrapeConfigNamespaceSelector:
     #   matchLabels:
     #     prometheus: somelabel
 


### PR DESCRIPTION
#### What this PR does / why we need it:
A simple fix for the typo happened in kube-prometheus-stack values.yaml. I encountered an error while using the commented scrapeConfigNamespaceSelector field and tried to fix this in the official chart.

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)