### PR TITLE
[alertmanager] Updates Alertmanager image to v0.26.0 

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -7,7 +7,7 @@ sources:
   - https://github.com/prometheus/alertmanager
 type: application
 version: 1.5.0
-appVersion: v0.25.0
+appVersion: v0.26.0
 kubeVersion: ">=1.19.0-0"
 keywords:
   - monitoring

--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 1.5.0
+version: 1.5.1
 appVersion: v0.26.0
 kubeVersion: ">=1.19.0-0"
 keywords:

--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 1.5.1
+version: 1.6.0
 appVersion: v0.26.0
 kubeVersion: ">=1.19.0-0"
 keywords:


### PR DESCRIPTION
#### What this PR does / why we need it

- Updates Alertmanager image to [v0.26.0](https://quay.io/repository/prometheus/alertmanager?tab=tags&tag=v0.26.0) 
  - maintenance. upstream: https://github.com/prometheus/alertmanager/releases/tag/v0.26.0

#### Which issue this PR fixes

- none.

#### Special notes for your reviewer

- The following tests were passed

```
kind create cluster
helm install prom oci://ghcr.io/prometheus-community/charts/alertmanager --version 1.5.0 -n kube-system
helm upgrade prom ./ -n kube-system
```

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
