### PR TITLE
[kube-prometheus-stack] Updates Alertmanager image to v0.26.0

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 48.3.6
+version: 48.3.7
 appVersion: v0.66.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -575,7 +575,7 @@ alertmanager:
     image:
       registry: quay.io
       repository: prometheus/alertmanager
-      tag: v0.25.0
+      tag: v0.26.0
       sha: ""
 
     ## If true then the user will be responsible to provide a secret with alertmanager configuration


### PR DESCRIPTION
#### What this PR does / why we need it

- Updates Alertmanager image to [v0.26.0](https://quay.io/repository/prometheus/alertmanager?tab=tags&tag=v0.26.0) 
  - maintenance. upstream: https://github.com/prometheus/alertmanager/releases/tag/v0.26.0

#### Which issue this PR fixes

- none.

#### Special notes for your reviewer

- The following tests were passed

```
kind create cluster
helm install prom oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack --version 48.3.6 -n kube-system
helm upgrade prom ./ -n kube-system
```

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
