### PR TITLE
[prometheus] Bump chart dependencies, Bump minimum kubeVersion

### DIFF
--- a/charts/prometheus/Chart.lock
+++ b/charts/prometheus/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: alertmanager
   repository: https://prometheus-community.github.io/helm-charts
-  version: 0.33.1
+  version: 1.6.0
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
-  version: 5.10.1
+  version: 5.11.0
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
-  version: 4.21.0
+  version: 4.22.0
 - name: prometheus-pushgateway
   repository: https://prometheus-community.github.io/helm-charts
   version: 2.4.0
-digest: sha256:4062158e1b8cf004b8f42feb018340d1d19e8e97cc8db70b5b514e159788c1a1
-generated: "2023-07-28T13:17:20.309944342Z"
+digest: sha256:1aa107e6e124974678660600ac0260321e81887a64fb7c0fd85d34a0bbb95e7d
+generated: "2023-08-26T22:57:53.836095+09:00"

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus
 appVersion: v2.46.0
 version: 23.4.0
-kubeVersion: ">=1.16.0-0"
+kubeVersion: ">=1.19.0-0"
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -26,15 +26,15 @@ maintainers:
 type: application
 dependencies:
   - name: alertmanager
-    version: "0.33.*"
+    version: "1.6.*"
     repository: https://prometheus-community.github.io/helm-charts
     condition: alertmanager.enabled
   - name: kube-state-metrics
-    version: "5.10.*"
+    version: "5.11.*"
     repository: https://prometheus-community.github.io/helm-charts
     condition: kube-state-metrics.enabled
   - name: prometheus-node-exporter
-    version: "4.21.*"
+    version: "4.22.*"
     repository: https://prometheus-community.github.io/helm-charts
     condition: prometheus-node-exporter.enabled
   - name: prometheus-pushgateway

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: v2.46.0
-version: 23.4.0
+version: 24.0.0
 kubeVersion: ">=1.19.0-0"
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/README.md
+++ b/charts/prometheus/README.md
@@ -69,8 +69,8 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 
 Require Kubernetes 1.19+
 
-Release 1.0.0 of the _alertmanager_ replaced from [configmap-reload](https://github.com/jimmidyson/configmap-reload) to [prometheus-config-reloader](https://github.com/prometheus-operator/prometheus-operator/tree/main/cmd/prometheus-config-reloader).
-Extra command-line arguments specified via configmapReload.prometheus.extraArgs are not compatible and will break with the new prometheus-config-reloader, refer to the [sources](https://github.com/prometheus-operator/prometheus-operator/blob/main/cmd/prometheus-config-reloader/main.go) in order to make the appropriate adjustment to the extea command-line arguments.
+Release 1.0.0 of the _alertmanager_ replaced [configmap-reload](https://github.com/jimmidyson/configmap-reload) with [prometheus-config-reloader](https://github.com/prometheus-operator/prometheus-operator/tree/main/cmd/prometheus-config-reloader).
+Extra command-line arguments specified via `configmapReload.prometheus.extraArgs` are not compatible and will break with the new prometheus-config-reloader. Please, refer to the [sources](https://github.com/prometheus-operator/prometheus-operator/blob/main/cmd/prometheus-config-reloader/main.go) in order to make the appropriate adjustment to the extra command-line arguments.
 
 ### To 23.0
 

--- a/charts/prometheus/README.md
+++ b/charts/prometheus/README.md
@@ -6,7 +6,7 @@ This chart bootstraps a [Prometheus](https://prometheus.io/) deployment on a [Ku
 
 ## Prerequisites
 
-- Kubernetes 1.16+
+- Kubernetes 1.19+
 - Helm 3.7+
 
 ## Get Repository Info
@@ -65,6 +65,13 @@ helm upgrade [RELEASE_NAME] prometheus-community/prometheus --install
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
+### To 24.0
+
+Require Kubernetes 1.19+
+
+Release 1.0.0 of the _alertmanager_ replaced from [configmap-reload](https://github.com/jimmidyson/configmap-reload) to [prometheus-config-reloader](https://github.com/prometheus-operator/prometheus-operator/tree/main/cmd/prometheus-config-reloader).
+Extra command-line arguments specified via configmapReload.prometheus.extraArgs are not compatible and will break with the new prometheus-config-reloader, refer to the [sources](https://github.com/prometheus-operator/prometheus-operator/blob/main/cmd/prometheus-config-reloader/main.go) in order to make the appropriate adjustment to the extea command-line arguments.
+
 ### To 23.0
 
 Release 5.0.0 of the _kube-state-metrics_ chart introduced a separation of the `image.repository` value in two distinct values:
@@ -73,7 +80,7 @@ Release 5.0.0 of the _kube-state-metrics_ chart introduced a separation of the `
  image:
    registry: registry.k8s.io
    repository: kube-state-metrics/kube-state-metrics
- ```
+```
 
 If a custom values file or CLI flags set `kube-state.metrics.image.repository`, please, set the new values accordingly.
 


### PR DESCRIPTION
#### What this PR does / why we need it

- Bump chart dependencies
- Require Kubernetes 1.19+

| Package | Update | Change |
|---|---|---|
| [alertmanager](https://prometheus.io/) ([source](https://github.com/prometheus-community/helm-charts)) | major | `0.33.*` -> `1.6.*` |
| [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics/) ([source](https://github.com/prometheus-community/helm-charts)) | minor | `5.10.*` -> `5.11.*` |
| [prometheus-node-exporter](https://github.com/prometheus/node_exporter/) ([source](https://github.com/prometheus-community/helm-charts)) | minor | `4.21.*` -> `4.22.*` |

#### Which issue this PR fixes

- none.

#### Special notes for your reviewer

- has major upgrade.
  - kubernetes 1.18 is old enough to deserve removal of support
  - add release notes

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
