### PR TITLE
[kube-prometheus-stack] update helm release grafana to 6.59.* 

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 48.4.0
+version: 48.5.0
 appVersion: v0.66.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -51,7 +51,7 @@ dependencies:
     repository: https://prometheus-community.github.io/helm-charts
     condition: nodeExporter.enabled
   - name: grafana
-    version: "6.58.*"
+    version: "6.59.*"
     repository: https://grafana.github.io/helm-charts
     condition: grafana.enabled
   - name: prometheus-windows-exporter


### PR DESCRIPTION
#### What this PR does / why we need it

- update helm release grafana to 6.59.* 
  - maintainance.
  - upstream: 

| Package | Update | Change |
|---|---|---|
| [grafana](https://grafana.net) ([source](https://github.com/grafana/helm-charts)) | minor | `6.58.*` -> `6.59.*` |

#### Which issue this PR fixes

- none.

#### Special notes for your reviewer

passed(kind 1.27.3)

```
kind create cluster
helm install prom oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack --version 48.4.0 -n kube-system
helm upgrade prom ./ -n kube-system
```

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
