### PR TITLE
[kube-prometheus-stack] Updates thanos image to v0.32.0 

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 48.5.0
+version: 48.6.0
 appVersion: v0.66.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -2385,7 +2385,7 @@ prometheusOperator:
   thanosImage:
     registry: quay.io
     repository: thanos/thanos
-    tag: v0.31.0
+    tag: v0.32.0
     sha: ""
 
   ## Set a Label Selector to filter watched prometheus and prometheusAgent


### PR DESCRIPTION
#### What this PR does / why we need it

- Updates [thanos image to v0.32.0](https://quay.io/repository/thanos/thanos?tab=tags&tag=v0.32.0)
  - maintainance.
  - upstream: https://github.com/thanos-io/thanos/compare/v0.31.0...v0.32.0

| Package | Update | Change |
|---|---|---|
| quay.io/thanos/thanos | minor | `v0.31.0` -> `v0.32.0` |

#### Which issue this PR fixes

- none.

#### Special notes for your reviewer


```
kind create cluster
helm install prom oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack --version 48.5.0 -n kube-system
helm upgrade prom ./ -n kube-system
```

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
