### PR TITLE
[prometheus] Add a releaseNamespace option

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: v2.46.0
-version: 23.5.0
+version: 24.1.0
 kubeVersion: ">=1.16.0-0"
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: v2.46.0
-version: 23.4.0
+version: 23.5.0
 kubeVersion: ">=1.16.0-0"
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/templates/_helpers.tpl
+++ b/charts/prometheus/templates/_helpers.tpl
@@ -193,3 +193,21 @@ Define the prometheus.namespace template if set with forceNamespace or .Release.
 {{- define "prometheus.namespace" -}}
   {{- default .Release.Namespace .Values.forceNamespace -}}
 {{- end }}
+
+{{/*
+Define template prometheus.namespaces producing a list of namespaces to monitor
+*/}}
+{{- define "prometheus.namespaces" -}}
+{{- $namespaces := list }}
+{{- if and .Values.rbac.create .Values.server.useExistingClusterRoleName }}
+  {{- if .Values.server.namespaces -}}
+    {{- range $ns := join "," .Values.server.namespaces | split "," }}
+      {{- $namespaces = append $namespaces (tpl $ns $) }}
+    {{- end -}}
+  {{- end -}}
+  {{- if .Values.server.releaseNamespace -}}
+    {{- $namespaces = append $namespaces (include "prometheus.namespace" .) }}
+  {{- end -}}
+{{- end -}}
+{{ mustToJson $namespaces }}
+{{- end -}}

--- a/charts/prometheus/templates/rolebinding.yaml
+++ b/charts/prometheus/templates/rolebinding.yaml
@@ -1,13 +1,4 @@
-{{- $namespaces := list }}
-{{- if and .Values.rbac.create .Values.server.useExistingClusterRoleName .Values.server.namespaces -}}
-{{- range $ns := join "," .Values.server.namespaces | split "," }}
-{{- $namespaces = append $namespaces (tpl $ns $)}}
-{{ end -}}
-{{ end -}}
-{{- if and .Values.rbac.create .Values.server.useExistingClusterRoleName .Values.server.releaseNamespace -}}
-{{- $namespaces = append $namespaces .Release.Namespace }}
-{{ end -}}
-{{- range $namespaces }}
+{{- range include "prometheus.namespaces" . | fromJsonArray }}
 ---
 apiVersion: {{ template "rbac.apiVersion" $ }}
 kind: RoleBinding

--- a/charts/prometheus/templates/rolebinding.yaml
+++ b/charts/prometheus/templates/rolebinding.yaml
@@ -1,5 +1,13 @@
+{{- $namespaces := list }}
 {{- if and .Values.rbac.create .Values.server.useExistingClusterRoleName .Values.server.namespaces -}}
-{{ range $.Values.server.namespaces -}}
+{{- range $ns := join "," .Values.server.namespaces | split "," }}
+{{- $namespaces = append $namespaces (tpl $ns $)}}
+{{ end -}}
+{{ end -}}
+{{- if and .Values.rbac.create .Values.server.useExistingClusterRoleName .Values.server.releaseNamespace -}}
+{{- $namespaces = append $namespaces .Release.Namespace }}
+{{ end -}}
+{{- range $namespaces }}
 ---
 apiVersion: {{ template "rbac.apiVersion" $ }}
 kind: RoleBinding
@@ -16,5 +24,4 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ $.Values.server.useExistingClusterRoleName }}
-{{ end -}}
 {{ end -}}

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -103,6 +103,10 @@ server:
   ##
   clusterRoleNameOverride: ""
 
+  # Enable only the release namespace for monitoring. By default all namespaces are monitored.
+  # If releaseNamespace and namespaces are both set a merged list will be monitored.
+  releaseNamespace: false
+
   ## namespaces to monitor (instead of monitoring all - clusterwide). Needed if you want to run without Cluster-admin privileges.
   # namespaces:
   #   - yournamespace


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Adds a `releaseNamespace` field that allows monitoring only the namespace in which Prometheus is deployed, without having to provide the namespace via the `namespaces` field explicitly. If both the `releaseNamespace` and `namespaces` fields are set, a joined list of namespaces will be monitored.

#### Which issue this PR fixes

- fixes #3552 

#### Special notes for your reviewer
This has been implemented in `kube-state-metrics` already; I took over most of this from the [releaseNamespace implementation](https://github.com/prometheus-community/helm-charts/blob/db2bd5d5f6a2af310b3b6a89c090bc9b9b5decf6/charts/kube-state-metrics/values.yaml#L287-L289) there.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
