### PR TITLE
[kube-prometheus-stack] Updates thanos image to v0.32.1

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 49.0.0
+version: 49.1.0
 appVersion: v0.67.1
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -2385,7 +2385,7 @@ prometheusOperator:
   thanosImage:
     registry: quay.io
     repository: thanos/thanos
-    tag: v0.32.0
+    tag: v0.32.1
     sha: ""
 
   ## Set a Label Selector to filter watched prometheus and prometheusAgent
@@ -3806,7 +3806,7 @@ thanosRuler:
     image:
       registry: quay.io
       repository: thanos/thanos
-      tag: v0.32.0
+      tag: v0.32.1
       sha: ""
 
     ## Namespaces to be selected for PrometheusRules discovery.


### PR DESCRIPTION
#### What this PR does / why we need it

- Updates [thanos image to v0.32.1](https://quay.io/repository/thanos/thanos?tab=tags&tag=v0.32.1)
  - maintainance.
  - upstream: https://github.com/thanos-io/thanos/compare/v0.32.0...v0.32.1

| Package | Update | Change |
|---|---|---|
| quay.io/thanos/thanos | patch | `v0.32.0` -> `v0.32.1` |

#### Which issue this PR fixes

- none.

#### Special notes for your reviewer


```
kind create cluster
install prom oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack --version 49.0.0 -n kube-system --set prometheus.thanosService.enabled=true --set thanosRuler.enabled=true
helm upgrade prom ./ -n kube-system --set prometheus.thanosService.enabled=true --set thanosRuler.enabled=true
```

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
