### PR TITLE
[prometheus-kafka-exporter] add support for valueFrom in env variables

### DIFF
--- a/charts/prometheus-kafka-exporter/Chart.yaml
+++ b/charts/prometheus-kafka-exporter/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v1.6.0"
 description: A Helm chart to export the metrics from Kafka in Prometheus format using the kafka-exporter from https://github.com/danielqsj/kafka_exporter
 name: prometheus-kafka-exporter
 home: https://github.com/danielqsj/kafka_exporter
-version: 2.3.0
+version: 2.4.0
 kubeVersion: ">=1.19.0-0"
 sources:
   - https://gkarthiks.github.io/helm-charts/charts/prometheus-kafka-exporter

--- a/charts/prometheus-kafka-exporter/templates/deployment.yaml
+++ b/charts/prometheus-kafka-exporter/templates/deployment.yaml
@@ -81,9 +81,8 @@ spec:
           {{- end }}
           {{- end }}
           env:
-          {{- range $env := .Values.env }}
-            - name: {{ $env.name }}
-              value: {{ $env.value }}
+          {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if .Values.sasl.scram.enabled }}
             - name: SCRAM_USERNAME

--- a/charts/prometheus-kafka-exporter/values.yaml
+++ b/charts/prometheus-kafka-exporter/values.yaml
@@ -48,9 +48,18 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
+# Specifies environment variables to be added to the kafka-exporter container.
+# Environment variables can be defined as a list of either key-value pairs or
+# using valueFrom to reference a secret or config map.
 env: []
-# - name: <ENV_VAR_NAME>
-#   value: <value>
+  # - name: <ENV_VAR_NAME>
+  #   value: <value>
+  # - name: PASSWORD
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: mysecret
+  #       key: password
+  #       optional: false
 
 # List of additional cli arguments to configure kafka-exporter
 # for example: --log.enable-sarama, --log.level=debug, etc.


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Adds support for non key-value environment variables to the prometheus-kafka-exporter chart. This makes it possible mount keys Secrets/ConfigMaps into the container and use the values in the args.

This makes it possible to e.g. use `kafkaServers` from a ConfigMap:

```yaml
env:
  - name: KAFKA_SERVER
    valueFrom:
      configMapKeyRef:
        name: kafka-server
        key: endpoint
kafkaServer:
  - $(KAFKA_SERVER)
```

#### Special notes for your reviewer

@gkarthiks @golgoth31 @zeritti 

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
