### PR TITLE
[kube-prometheus-stack] fix reloader-web's app protocol

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 50.3.1
+version: 50.3.2
 appVersion: v0.67.1
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/alertmanager/service.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/service.yaml
@@ -43,7 +43,8 @@ spec:
     port: {{ .Values.alertmanager.service.port }}
     targetPort: {{ .Values.alertmanager.service.targetPort }}
     protocol: TCP
-  - name: reloader-web
+  - appProtocol: http
+    name: reloader-web
     port: 8080
     targetPort: reloader-web
 {{- if .Values.alertmanager.service.additionalPorts }}

--- a/charts/kube-prometheus-stack/templates/alertmanager/service.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/service.yaml
@@ -43,8 +43,11 @@ spec:
     port: {{ .Values.alertmanager.service.port }}
     targetPort: {{ .Values.alertmanager.service.targetPort }}
     protocol: TCP
-  - appProtocol: http
-    name: reloader-web
+  - name: reloader-web
+    {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
+    {{- if semverCompare ">=1.20.0-0" $kubeTargetVersion }}
+    appProtocol: http
+    {{- end }}
     port: 8080
     targetPort: reloader-web
 {{- if .Values.alertmanager.service.additionalPorts }}

--- a/charts/kube-prometheus-stack/templates/alertmanager/service.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/service.yaml
@@ -1,3 +1,4 @@
+{{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if .Values.alertmanager.enabled }}
 apiVersion: v1
 kind: Service
@@ -44,7 +45,6 @@ spec:
     targetPort: {{ .Values.alertmanager.service.targetPort }}
     protocol: TCP
   - name: reloader-web
-    {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
     {{- if semverCompare ">=1.20.0-0" $kubeTargetVersion }}
     appProtocol: http
     {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/service.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/service.yaml
@@ -42,8 +42,11 @@ spec:
     {{- end }}
     port: {{ .Values.prometheus.service.port }}
     targetPort: {{ .Values.prometheus.service.targetPort }}
-  - appProtocol: http
-    name: reloader-web
+  - name: reloader-web
+    {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
+    {{- if semverCompare "> 1.20.0-0" $kubeTargetVersion }}
+    appProtocol: http
+    {{- end }}
     port: 8080
     targetPort: reloader-web
   {{- if .Values.prometheus.thanosIngress.enabled }}

--- a/charts/kube-prometheus-stack/templates/prometheus/service.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/service.yaml
@@ -1,3 +1,4 @@
+{{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if .Values.prometheus.enabled }}
 apiVersion: v1
 kind: Service
@@ -43,7 +44,6 @@ spec:
     port: {{ .Values.prometheus.service.port }}
     targetPort: {{ .Values.prometheus.service.targetPort }}
   - name: reloader-web
-    {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
     {{- if semverCompare "> 1.20.0-0" $kubeTargetVersion }}
     appProtocol: http
     {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/service.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/service.yaml
@@ -42,7 +42,8 @@ spec:
     {{- end }}
     port: {{ .Values.prometheus.service.port }}
     targetPort: {{ .Values.prometheus.service.targetPort }}
-  - name: reloader-web
+  - appProtocol: http
+    name: reloader-web
     port: 8080
     targetPort: reloader-web
   {{- if .Values.prometheus.thanosIngress.enabled }}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

To integrate this port with applications such as istio the applicationProtocol should be set explicitly.
One solution to enable this integration is to add an `appProtocol` attribute to the port as explained in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol) and implemented in this PR. Another alternative is to prefix the port with `http-`.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
