### PR TITLE
[kube-state-metrics] add option to set updateStrategy to Recreate

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 5.12.1
+version: 5.13.0
 appVersion: 2.10.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/kube-state-metrics/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
     matchLabels:
       {{- include "kube-state-metrics.selectorLabels" . | indent 6 }}
   replicas: {{ .Values.replicas }}
+  {{- if not .Values.autosharding.enabled }}
+  strategy:
+    type: {{ .Values.updateStrategy | default "RollingUpdate" }}
+  {{- end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   {{- if .Values.autosharding.enabled }}
   serviceName: {{ template "kube-state-metrics.fullname" . }}

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -37,6 +37,9 @@ autosharding:
 
 replicas: 1
 
+# Change the deployment strategy when autosharding is disabled
+# updateStrategy: Recreate
+
 # Number of old history to retain to allow rollback
 # Default Kubernetes value is set to 10
 revisionHistoryLimit: 10


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR includes changes which will enable us to change the Deployment Strategy for kube-state-metrics when using the `Kind: Deployment`.

#### Which issue this PR fixes

- fixes #3764

#### Special notes for your reviewer
N/A

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
