### PR TITLE
[prometheus-redis-exporter] Allow `REDIS_ADDR` environment variable to be configured through a secret

### DIFF
--- a/charts/prometheus-redis-exporter/Chart.yaml
+++ b/charts/prometheus-redis-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.54.0
 description: Prometheus exporter for Redis metrics
 name: prometheus-redis-exporter
-version: 5.6.0
+version: 6.0.0
 home: https://github.com/oliver006/redis_exporter
 sources:
   - https://github.com/oliver006/redis_exporter

--- a/charts/prometheus-redis-exporter/templates/deployment.yaml
+++ b/charts/prometheus-redis-exporter/templates/deployment.yaml
@@ -55,9 +55,13 @@ spec:
             - name: REDIS_ADDR
             {{- if .Values.redisAddressConfig.enabled }}
               valueFrom:
+              {{- if .Values.redisAddressConfig.isASecret }}
+                secretKeyRef:
+              {{- else }}
                 configMapKeyRef:
-                  name: {{ .Values.redisAddressConfig.configmap.name }}
-                  key: {{ .Values.redisAddressConfig.configmap.key }}
+              {{- end }}
+                  name: {{ .Values.redisAddressConfig.source.name }}
+                  key: {{ .Values.redisAddressConfig.source.key }}
             {{- else }}
               value: {{ .Values.redisAddress }}
             {{- end }}

--- a/charts/prometheus-redis-exporter/templates/deployment.yaml
+++ b/charts/prometheus-redis-exporter/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - name: REDIS_ADDR
             {{- if .Values.redisAddressConfig.enabled }}
               valueFrom:
-              {{- if .Values.redisAddressConfig.isASecret }}
+              {{- if .Values.redisAddressConfig.isSecret }}
                 secretKeyRef:
               {{- else }}
                 configMapKeyRef:

--- a/charts/prometheus-redis-exporter/values.yaml
+++ b/charts/prometheus-redis-exporter/values.yaml
@@ -65,7 +65,7 @@ redisAddressConfig:
   enabled: false
   # if `true` the `REDIS_ADDR` is sourced on a secret instead of a configmap
   isSecret: false
-  # Use existing configmap (ignores redisAddress)
+  # Use an existing configmap or secret will ignore redisAddress
   source:
     name: ""
     key: ""

--- a/charts/prometheus-redis-exporter/values.yaml
+++ b/charts/prometheus-redis-exporter/values.yaml
@@ -61,10 +61,12 @@ labels: {}
 #  prometheus.io/scrape: "true"
 
 redisAddressConfig:
-  # Use config from configmap
+  # configure `REDIS_ADDR` from a configmap
   enabled: false
+  # if `true` the `REDIS_ADDR` is sourced on a secret instead of a configmap
+  isASecret: false
   # Use existing configmap (ignores redisAddress)
-  configmap:
+  source:
     name: ""
     key: ""
 

--- a/charts/prometheus-redis-exporter/values.yaml
+++ b/charts/prometheus-redis-exporter/values.yaml
@@ -64,7 +64,7 @@ redisAddressConfig:
   # configure `REDIS_ADDR` from a configmap
   enabled: false
   # if `true` the `REDIS_ADDR` is sourced on a secret instead of a configmap
-  isASecret: false
+  isSecret: false
   # Use existing configmap (ignores redisAddress)
   source:
     name: ""


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This pr adds support for (prometheus-redis-exporter)[./charts/prometheus-redis-exporter/] redis address environment variable to be configured from a secret.
It would unlock for redis address to be fetched though eg: [external-secrets](https://external-secrets.io/).

#### Which issue this PR fixes

There is no issue linked to this change (that I know of).

#### Special notes for your reviewer

I've performed some sanity checks locally to verify the chart configuration stays as is and the new configuration also works.
Since changes are all around deployment's configuration I'm using `helm` + `yq` to focus on that part of the rendered template.

This is the specific used command:
```bash
helm template . -f values.yaml |yq 'select(.kind == "Deployment").spec.template.spec.containers[0].env'
```

##### using redisAddressConfig.enabled = false

No diff, it's literally `values.yaml` by default, renders as:

```yaml
- name: REDIS_ADDR
  value: redis://myredis:6379
```

##### using redisAddressConfig.enabled = true + redisAddressConfig.isASecret = false

```diff
 redisAddressConfig:
   # configure `REDIS_ADDR` from a configmap
-  enabled: false
+  enabled: true
   # if `true` the `REDIS_ADDR` is sourced on a secret instead of a configmap
   isASecret: false
   # Use existing configmap (ignores redisAddress)
   source:
-    name: ""
-    key: ""
+    name: "testName"
+    key: "testKey"
```
Renders as:
```yaml
- name: REDIS_ADDR
  valueFrom:
    configMapKeyRef:
      name: testName
      key: testKey
```
##### using redisAddressConfig.enabled = true + redisAddressConfig.isASecret = true

```diff
 redisAddressConfig:
   # configure `REDIS_ADDR` from a configmap
-  enabled: false
+  enabled: true
   # if `true` the `REDIS_ADDR` is sourced on a secret instead of a configmap
-  isASecret: false
+  isASecret: true
   # Use existing configmap (ignores redisAddress)
   source:
-    name: ""
-    key: ""
+    name: "testName"
+    key: "testKey"
```
renders as:
```yaml
- name: REDIS_ADDR
  valueFrom:
    secretKeyRef:
      name: testName
      key: testKey
```

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
