### PR TITLE
[prometheus] Apply templating to remote_read & remote_write config

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: v2.47.0
-version: 24.5.0
+version: 25.0.0
 kubeVersion: ">=1.19.0-0"
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/README.md
+++ b/charts/prometheus/README.md
@@ -65,6 +65,12 @@ helm upgrade [RELEASE_NAME] prometheus-community/prometheus --install
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
+### To 25.0
+
+The `server.remoteRead` and `server.remoteWrite` fields now support templating.
+
+Any entries in these which previously included `{{` or `}}` must be escaped with `{{ "{{" }}` and `{{ "}}" }}` respectively.
+
 ### To 24.0
 
 Require Kubernetes 1.19+

--- a/charts/prometheus/README.md
+++ b/charts/prometheus/README.md
@@ -67,9 +67,9 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 
 ### To 25.0
 
-The `server.remoteRead` and `server.remoteWrite` fields now support templating.
+The `server.remoteRead[].url` and `server.remoteWrite[].url` fields now support templating. Allowing for `url` values such as `https://{{ .Release.Name }}.example.com`.
 
-Any entries in these which previously included `{{` or `}}` must be escaped with `{{ "{{" }}` and `{{ "}}" }}` respectively.
+Any entries in these which previously included `{{` or `}}` must be escaped with `{{ "{{" }}` and `{{ "}}" }}` respectively. Entries which did not previously include the template-like syntax will not be affected.
 
 ### To 24.0
 

--- a/charts/prometheus/templates/_helpers.tpl
+++ b/charts/prometheus/templates/_helpers.tpl
@@ -211,3 +211,26 @@ Define template prometheus.namespaces producing a list of namespaces to monitor
 {{- end -}}
 {{ mustToJson $namespaces }}
 {{- end -}}
+
+{{/*
+Define prometheus.server.remoteWrite producing a list of remoteWrite configurations with URL templating
+*/}}
+{{- define "prometheus.server.remoteWrite" -}}
+{{- $remoteWrites := list }}
+{{- range $remoteWrite := .Values.server.remoteWrite }}
+  {{- $remoteWrites = tpl $remoteWrite.url $ | set $remoteWrite "url" | append $remoteWrites }}
+{{- end -}}
+{{ toYaml $remoteWrites }}
+{{- end -}}
+
+{{/*
+Define prometheus.server.remoteRead producing a list of remoteRead configurations with URL templating
+*/}}
+{{- define "prometheus.server.remoteRead" -}}
+{{- $remoteReads := list }}
+{{- range $remoteRead := .Values.server.remoteRead }}
+  {{- $remoteReads = tpl $remoteRead.url $ | set $remoteRead "url" | append $remoteReads }}
+{{- end -}}
+{{ toYaml $remoteReads }}
+{{- end -}}
+

--- a/charts/prometheus/templates/cm.yaml
+++ b/charts/prometheus/templates/cm.yaml
@@ -56,7 +56,7 @@ data:
 {{- end }}
 {{- if eq $key "prometheus.yml" -}}
 {{- if $root.Values.extraScrapeConfigs }}
-{{ tpl $root.Values.extraScrapeConfigs $root |  indent 4 }}
+{{ tpl $root.Values.extraScrapeConfigs $root | indent 4 }}
 {{- end -}}
 {{- if or ($root.Values.alertmanager.enabled) ($root.Values.server.alertmanagers) }}
     alerting:

--- a/charts/prometheus/templates/cm.yaml
+++ b/charts/prometheus/templates/cm.yaml
@@ -22,15 +22,11 @@ data:
 {{ $root.Values.server.global | toYaml | trimSuffix "\n" | indent 6 }}
 {{- if $root.Values.server.remoteWrite }}
     remote_write:
-{{- range $root.Values.server.remoteWrite }}
-{{- tpl . $root | toYaml | cat "-" | nindent 4 }}
-{{- end }}
+{{- include "prometheus.server.remoteWrite" $root | nindent 4 }}
 {{- end }}
 {{- if $root.Values.server.remoteRead }}
     remote_read:
-{{- range $root.Values.server.remoteRead }}
-{{- tpl . $root | toYaml | cat "-" | nindent 4 }}
-{{- end }}
+{{- include "prometheus.server.remoteRead" $root | nindent 4 }}
 {{- end }}
 {{- if or $root.Values.server.tsdb $root.Values.server.exemplars }}
     storage:
@@ -60,7 +56,7 @@ data:
 {{- end }}
 {{- if eq $key "prometheus.yml" -}}
 {{- if $root.Values.extraScrapeConfigs }}
-{{ tpl $root.Values.extraScrapeConfigs $root | indent 4 }}
+{{ tpl $root.Values.extraScrapeConfigs $root |  indent 4 }}
 {{- end -}}
 {{- if or ($root.Values.alertmanager.enabled) ($root.Values.server.alertmanagers) }}
     alerting:

--- a/charts/prometheus/templates/cm.yaml
+++ b/charts/prometheus/templates/cm.yaml
@@ -22,11 +22,15 @@ data:
 {{ $root.Values.server.global | toYaml | trimSuffix "\n" | indent 6 }}
 {{- if $root.Values.server.remoteWrite }}
     remote_write:
-{{ $root.Values.server.remoteWrite | toYaml | indent 4 }}
+{{- range $root.Values.server.remoteWrite }}
+{{- tpl . $root | toYaml | cat "-" | nindent 4 }}
+{{- end }}
 {{- end }}
 {{- if $root.Values.server.remoteRead }}
     remote_read:
-{{ $root.Values.server.remoteRead | toYaml | indent 4 }}
+{{- range $root.Values.server.remoteRead }}
+{{- tpl . $root | toYaml | cat "-" | nindent 4 }}
+{{- end }}
 {{- end }}
 {{- if or $root.Values.server.tsdb $root.Values.server.exemplars }}
     storage:


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Adds template evaluation (via the `tpl` function) to the `remoteRead` & `remoteWrite` fields in the `ConfigMap`. This allows users of the chart to substitute values at templating time. This is especially useful if the services which a user wishes to write to are deployed as part of an adjacent sub-chart where their name includes the deployment name.

#### Special notes for your reviewer

N/A

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
