### PR TITLE
[prometheus-fastly-exporter]: Add security context to fastly-exporter

### DIFF
--- a/charts/prometheus-fastly-exporter/Chart.yaml
+++ b/charts/prometheus-fastly-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "7.2.4"
 description: A Helm chart for the Prometheus Fastly Exporter
 name: prometheus-fastly-exporter
-version: 0.1.2
+version: 0.2.0
 keywords:
   - metrics
   - fastly

--- a/charts/prometheus-fastly-exporter/templates/deployment.yaml
+++ b/charts/prometheus-fastly-exporter/templates/deployment.yaml
@@ -22,6 +22,10 @@ spec:
       {{- with .Values.initContainers }}
       initContainers: {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+       {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -54,6 +58,10 @@ spec:
             timeoutSeconds: 10
           {{- with .Values.resources }}
           resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.extraVolumeMounts }}
           volumeMounts: {{ toYaml . | nindent 12 }}


### PR DESCRIPTION
#### What this PR does / why we need it
Add ability to pass in SecurityContext and PodSecurityContext

#### Which issue this PR fixes

I don't think there is an issue.

#### Special notes for your reviewer

Tested in my cluster with the following:
```yaml
prometheus-fastly-exporter:                                   
  securityContext:                 
    allowPrivilegeEscalation: false
    capabilities:                  
      drop: ["ALL"]                
                                   
  podSecurityContext:              
    seccompProfile:                
      type: RuntimeDefault         
    runAsNonRoot: true             
    runAsUser: 10001               
    runAsGroup: 10001              
```

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
