### PR TITLE
[prometheus-snmp-exporter] Move to newest version (v0.24.1)

### DIFF
--- a/charts/prometheus-snmp-exporter/Chart.yaml
+++ b/charts/prometheus-snmp-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Prometheus SNMP Exporter
 name: prometheus-snmp-exporter
 version: 1.8.0
-appVersion: v0.21.0
+appVersion: v0.24.1
 home: https://github.com/prometheus/snmp_exporter
 sources:
   - https://github.com/prometheus/snmp_exporter

--- a/charts/prometheus-snmp-exporter/Chart.yaml
+++ b/charts/prometheus-snmp-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus SNMP Exporter
 name: prometheus-snmp-exporter
-version: 1.8.0
+version: 2.0.0
 appVersion: v0.24.1
 home: https://github.com/prometheus/snmp_exporter
 sources:

--- a/charts/prometheus-snmp-exporter/README.md
+++ b/charts/prometheus-snmp-exporter/README.md
@@ -45,6 +45,14 @@ helm upgrade [RELEASE_NAME] [CHART] --install
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
+### To 2.0.0
+
+BREAKING CHANGES:
+
+This version of the exporter introduces a new configuration file format. This new format separates the walk and metric mappings from the connection and authentication settings. This allows for easier configuration of different auth params without having to duplicate the full walk and metric mapping.
+
+See [auth-split-migration.md](https://github.com/prometheus/snmp_exporter/blob/main/auth-split-migration.md) for more details.
+
 ### To 1.0.0
 
 This version allows multiple Targets to be specified when using ServiceMonitor. When you use ServiceMonitor, please rewrite below:


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Upgrades to stable 0.24.1 and increments to 2.0.0 due to the breaking changes
#### Which issue this PR fixes

upgrade of helm and snmp exporter

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
