### PR TITLE
[prometheus-node-exporter] Remove toYaml function in extraManifests template

### DIFF
--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - prometheus
   - exporter
 type: application
-version: 4.23.0
+version: 4.23.1
 appVersion: 1.6.1
 home: https://github.com/prometheus/node_exporter/
 sources:

--- a/charts/prometheus-node-exporter/templates/extra-manifests.yaml
+++ b/charts/prometheus-node-exporter/templates/extra-manifests.yaml
@@ -1,4 +1,4 @@
 {{ range .Values.extraManifests }}
 ---
-{{ tpl (toYaml .) $ }}
+{{ tpl . $ }}
 {{ end }}

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -471,7 +471,8 @@ verticalPodAutoscaler:
 
 # Extra manifests to deploy as an array
 extraManifests: []
-  # - apiVersion: v1
+  # - |
+  #   apiVersion: v1
   #   kind: ConfigMap
   #   metadata:
   #     name: prometheus-extra


### PR DESCRIPTION
@gianrubio @zanhsieh @zeritti 

Analogous to https://github.com/prometheus-community/helm-charts/pull/3287/ made for `prometheus` chart

#### What this PR does / why we need it

Trying to add an extra manifest 

```
extraManifests:
  - |
      apiVersion: v1
      kind: ConfigMap
      metadata:
        namespace: prometheus-node-exporter
        name: configmap-prometheus-node-exporter-web-yaml
      data:
        prometheus-node-exporter-web.yaml: |
          # https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md
          basic_auth_users:
            admin: $aa$hashedpassword
```

getting `helm install` error:
```
Error: UPGRADE FAILED: YAML parse error on prometheus-node-exporter/templates/extra-manifests.yaml: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type releaseutil.SimpleHead
```

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed 
- [x] Chart Version bumped 
- [x] Title of the PR starts with chart name 
