### PR TITLE
[prometheus-adapter] Add a name to the Service object (KIA0601)

### DIFF
--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 4.9.0
+version: 4.9.1
 appVersion: v0.11.2
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/kubernetes-sigs/prometheus-adapter

--- a/charts/prometheus-adapter/templates/service.yaml
+++ b/charts/prometheus-adapter/templates/service.yaml
@@ -21,6 +21,7 @@ spec:
 {{- end }}
   ports:
   - port: {{ .Values.service.port }}
+    name: https
     protocol: TCP
     targetPort: https
   selector:


### PR DESCRIPTION
#### What this PR does / why we need it
Fixes the KIA0601 error

#### Special notes for your reviewer
is just the name of the service

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
