### PR TITLE
[kube-prometheus-stack] remove default cpu and memory requests and li…

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 51.0.3
+version: 51.1.0
 appVersion: v0.68.0
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -91,26 +91,10 @@ spec:
             {{- else }}
             - --prometheus-config-reloader={{ $configReloaderRegistry }}/{{ .Values.prometheusOperator.prometheusConfigReloader.image.repository }}:{{ .Values.prometheusOperator.prometheusConfigReloader.image.tag | default .Chart.AppVersion }}
             {{- end }}
-            {{- if (((.Values.prometheusOperator.prometheusConfigReloader.resources).requests).cpu) }}
-            - --config-reloader-cpu-request={{ .Values.prometheusOperator.prometheusConfigReloader.resources.requests.cpu }}
-            {{- else }}
-            - --config-reloader-cpu-request=0
-            {{- end }}
-            {{- if (((.Values.prometheusOperator.prometheusConfigReloader.resources).limits).cpu) }}
-            - --config-reloader-cpu-limit={{ .Values.prometheusOperator.prometheusConfigReloader.resources.limits.cpu }}
-            {{- else }}
-            - --config-reloader-cpu-limit=0
-            {{- end }}
-            {{- if (((.Values.prometheusOperator.prometheusConfigReloader.resources).requests).memory) }}
-            - --config-reloader-memory-request={{ .Values.prometheusOperator.prometheusConfigReloader.resources.requests.memory }}
-            {{- else }}
-            - --config-reloader-memory-request=0
-            {{- end }}
-            {{- if (((.Values.prometheusOperator.prometheusConfigReloader.resources).limits).memory) }}            
-            - --config-reloader-memory-limit={{ .Values.prometheusOperator.prometheusConfigReloader.resources.limits.memory }}
-            {{- else }}
-            - --config-reloader-memory-limit=0
-            {{- end }}
+            - --config-reloader-cpu-request={{ (((.Values.prometheusOperator.prometheusConfigReloader.resources).requests).cpu) | default 0 }}
+            - --config-reloader-cpu-limit={{ (((.Values.prometheusOperator.prometheusConfigReloader.resources).limits).cpu) | default 0 }}
+            - --config-reloader-memory-request={{ (((.Values.prometheusOperator.prometheusConfigReloader.resources).requests).memory) | default 0 }}
+            - --config-reloader-memory-limit={{ (((.Values.prometheusOperator.prometheusConfigReloader.resources).limits).memory) | default 0 }}
             {{- if .Values.prometheusOperator.prometheusConfigReloader.enableProbe }}
             - --enable-config-reloader-probes=true
             {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -91,22 +91,22 @@ spec:
             {{- else }}
             - --prometheus-config-reloader={{ $configReloaderRegistry }}/{{ .Values.prometheusOperator.prometheusConfigReloader.image.repository }}:{{ .Values.prometheusOperator.prometheusConfigReloader.image.tag | default .Chart.AppVersion }}
             {{- end }}
-            {{- if .Values.prometheusOperator.prometheusConfigReloader.resources.requests.cpu }}
+            {{- if (((.Values.prometheusOperator.prometheusConfigReloader.resources).requests).cpu) }}
             - --config-reloader-cpu-request={{ .Values.prometheusOperator.prometheusConfigReloader.resources.requests.cpu }}
             {{- else }}
             - --config-reloader-cpu-request=0
             {{- end }}
-            {{- if .Values.prometheusOperator.prometheusConfigReloader.resources.limits.cpu }}
+            {{- if (((.Values.prometheusOperator.prometheusConfigReloader.resources).limits).cpu) }}
             - --config-reloader-cpu-limit={{ .Values.prometheusOperator.prometheusConfigReloader.resources.limits.cpu }}
             {{- else }}
             - --config-reloader-cpu-limit=0
             {{- end }}
-            {{- if .Values.prometheusOperator.prometheusConfigReloader.resources.requests.memory }}
+            {{- if (((.Values.prometheusOperator.prometheusConfigReloader.resources).requests).memory) }}
             - --config-reloader-memory-request={{ .Values.prometheusOperator.prometheusConfigReloader.resources.requests.memory }}
             {{- else }}
             - --config-reloader-memory-request=0
             {{- end }}
-            {{- if .Values.prometheusOperator.prometheusConfigReloader.resources.limits.memory }}            
+            {{- if (((.Values.prometheusOperator.prometheusConfigReloader.resources).limits).memory) }}            
             - --config-reloader-memory-limit={{ .Values.prometheusOperator.prometheusConfigReloader.resources.limits.memory }}
             {{- else }}
             - --config-reloader-memory-limit=0

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -91,10 +91,26 @@ spec:
             {{- else }}
             - --prometheus-config-reloader={{ $configReloaderRegistry }}/{{ .Values.prometheusOperator.prometheusConfigReloader.image.repository }}:{{ .Values.prometheusOperator.prometheusConfigReloader.image.tag | default .Chart.AppVersion }}
             {{- end }}
+            {{- if .Values.prometheusOperator.prometheusConfigReloader.resources.requests.cpu }}
             - --config-reloader-cpu-request={{ .Values.prometheusOperator.prometheusConfigReloader.resources.requests.cpu }}
+            {{- else }}
+            - --config-reloader-cpu-request=0
+            {{- end }}
+            {{- if .Values.prometheusOperator.prometheusConfigReloader.resources.limits.cpu }}
             - --config-reloader-cpu-limit={{ .Values.prometheusOperator.prometheusConfigReloader.resources.limits.cpu }}
+            {{- else }}
+            - --config-reloader-cpu-limit=0
+            {{- end }}
+            {{- if .Values.prometheusOperator.prometheusConfigReloader.resources.requests.memory }}
             - --config-reloader-memory-request={{ .Values.prometheusOperator.prometheusConfigReloader.resources.requests.memory }}
+            {{- else }}
+            - --config-reloader-memory-request=0
+            {{- end }}
+            {{- if .Values.prometheusOperator.prometheusConfigReloader.resources.limits.memory }}            
             - --config-reloader-memory-limit={{ .Values.prometheusOperator.prometheusConfigReloader.resources.limits.memory }}
+            {{- else }}
+            - --config-reloader-memory-limit=0
+            {{- end }}
             {{- if .Values.prometheusOperator.prometheusConfigReloader.enableProbe }}
             - --enable-config-reloader-probes=true
             {{- end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -2377,13 +2377,13 @@ prometheusOperator:
     enableProbe: false
 
     # resource config for prometheusConfigReloader
-    resources:
-      requests:
-        cpu: 200m
-        memory: 50Mi
-      limits:
-        cpu: 200m
-        memory: 50Mi
+    resources: {}
+      # requests:
+      #   cpu: 200m
+      #   memory: 50Mi
+      # limits:
+      #   cpu: 200m
+      #   memory: 50Mi
 
   ## Thanos side-car image when configured
   ##


### PR DESCRIPTION
…mits from prometheus config reloader (#3812)

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.


Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

#### Which issue this PR fixes
@QuentinBisson fixes #3812 

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
