### PR TITLE
[kube-state-metrics] Add option to attach sidecar container

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 5.13.0
+version: 5.14.0
 appVersion: 2.10.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/kube-state-metrics/templates/deployment.yaml
@@ -240,6 +240,9 @@ spec:
 {{- end }}
       {{- end }}
       {{- end }}
+      {{- if .Values.sidecars }}
+      {{- tpl (toYaml .Values.sidecars) $ | nindent 6 }}
+      {{- end }}
 {{- if or .Values.imagePullSecrets .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- include "kube-state-metrics.imagePullSecrets" (dict "Values" .Values "imagePullSecrets" .Values.imagePullSecrets) | indent 8 }}
@@ -278,6 +281,6 @@ spec:
             name: {{ template "kube-state-metrics.fullname" . }}-customresourcestate-config
       {{- end }}
       {{- if .Values.volumes }}
-{{ toYaml .Values.volumes | indent 8 }}
+      {{- tpl (toYaml .Values.volumes) $ | nindent 8 }}
       {{- end }}
       {{- end }}

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -442,3 +442,9 @@ extraManifests: []
   #     name: prometheus-extra
   #   data:
   #     extra-data: "value"
+
+# Additional sidecar containers to the kube-state-metrics pod(s)
+sidecars: []
+#   - name: your-image-name
+#     image: your-image
+#     imagePullPolicy: Always


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Support to attach a sidecar container(s), to the kube state metrics pod.

#### Which issue this PR fixes
This is primarily useful for having a [standalone elastic agent run as sidecar container](https://github.com/elastic/elastic-agent/tree/main/docs/manifests/kustomize-autosharding).

- fixes #3759

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
