### PR TITLE
[prometheus-elasticsearch-exporter]: Fix preStop command

### DIFF
--- a/charts/prometheus-elasticsearch-exporter/Chart.yaml
+++ b/charts/prometheus-elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: prometheus-elasticsearch-exporter
-version: 5.3.0
+version: 5.3.1
 kubeVersion: ">=1.10.0-0"
 appVersion: "v1.6.0"
 home: https://github.com/prometheus-community/elasticsearch_exporter

--- a/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
+++ b/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
@@ -161,7 +161,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/bash", "-c", "sleep 20"]
+                command: ["/bin/sleep", "20"]
           volumeMounts:
             {{- if and .Values.es.ssl.enabled (eq .Values.es.ssl.useExistingSecrets false) }}
             - mountPath: /ssl


### PR DESCRIPTION
#### What this PR does / why we need it

This PR fixes the `preStop` command for the elasticsearch-exporter deployment. Right now, it's using `/bin/bash sleep 20`, but bash does not exist in the container image. Thusly, the fix is to use the existing `/bin/sleep` command to sleep 20 seconds.

#### Checklist

- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
