### PR TITLE
[prometheus-json-exporter] Fix ConfigMap name inconsistency

### DIFF
--- a/charts/prometheus-json-exporter/templates/configmap.yaml
+++ b/charts/prometheus-json-exporter/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-configmap
+  name: {{ include "prometheus-json-exporter.fullname" . }}
 data:
   allow-snippet-annotations: "false"
   config.yml: |

--- a/charts/prometheus-json-exporter/templates/deployment.yaml
+++ b/charts/prometheus-json-exporter/templates/deployment.yaml
@@ -69,7 +69,7 @@ spec:
       volumes:
       - name: config-configmap-volume
         configMap:
-          name: {{ .Release.Name }}-configmap
+          name: {{ include "prometheus-json-exporter.fullname" . }}
           items:
             - key: config.yml
               path: config.yml


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

ConfigMap's name doesn't follow the same naming pattern as other resources. This PR uses the same fullname template for configmaps.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
