### PR TITLE
[prometheus-snmp-exporter] add action=replace to metricsRelabelings

### DIFF
--- a/charts/prometheus-snmp-exporter/Chart.yaml
+++ b/charts/prometheus-snmp-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus SNMP Exporter
 name: prometheus-snmp-exporter
-version: 1.8.0
+version: 1.8.1
 appVersion: v0.21.0
 home: https://github.com/prometheus/snmp_exporter
 sources:

--- a/charts/prometheus-snmp-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-snmp-exporter/templates/servicemonitor.yaml
@@ -30,12 +30,15 @@ spec:
       - sourceLabels: [instance]
         targetLabel: instance
         replacement: {{ .target }}
+        action: replace
       - sourceLabels: [target]
         targetLabel: target
         replacement: {{ .name }}
+        action: replace
         {{- range $targetLabel, $replacement := .additionalMetricsRelabels | default $.Values.serviceMonitor.additionalMetricsRelabels }}
       - targetLabel: {{ $targetLabel }}
         replacement: {{ $replacement }}
+        action: replace
         {{- end }}
     {{- if (or .relabelings $.Values.serviceMonitor.relabelings) }}
     relabelings:


### PR DESCRIPTION
#### What this PR does / why we need it

This (default) parameter is automatically added by k8s, causing the in-cluster object to differ from the manifest created by this chart. This discrepancy causes GitOps tooling to consider the resource out of date.

#### Which issue this PR fixes
- fixes #3626

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)