### PR TITLE
[prometheus-json-exporter] defaults and service labels/annotations support

### DIFF
--- a/charts/prometheus-json-exporter/Chart.yaml
+++ b/charts/prometheus-json-exporter/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.1
+version: 0.7.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/prometheus-json-exporter/templates/ingress.yaml
+++ b/charts/prometheus-json-exporter/templates/ingress.yaml
@@ -18,6 +18,9 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "prometheus-json-exporter.labels" . | nindent 4 }}
+    {{- with .Values.ingress.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/prometheus-json-exporter/templates/service.yaml
+++ b/charts/prometheus-json-exporter/templates/service.yaml
@@ -4,6 +4,13 @@ metadata:
   name: {{ include "prometheus-json-exporter.fullname" . }}
   labels:
     {{- include "prometheus-json-exporter.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.service.annotations }}
+  annotations:
+      {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/prometheus-json-exporter/values.yaml
+++ b/charts/prometheus-json-exporter/values.yaml
@@ -1,3 +1,4 @@
+---
 # Default values for prometheus-json-exporter.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
@@ -18,18 +19,17 @@ serviceAccount:
   # Specifies whether a service account should be created
   create: true
   # Annotations to add to the service account
-  annotations: []
+  annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-podAnnotations: []
+podAnnotations: {}
 
 podSecurityContext: {}
 # fsGroup: 2000
 
-# podLabels:
-  # Custom labels for the pod
+podLabels: {}
 
 securityContext: {}
 # capabilities:
@@ -73,7 +73,7 @@ serviceMonitor:
 ingress:
   enabled: false
   className: ""
-  annotations: []
+  annotations: {}
   # kubernetes.io/ingress.class: nginx
   # kubernetes.io/tls-acme: "true"
   hosts:

--- a/charts/prometheus-json-exporter/values.yaml
+++ b/charts/prometheus-json-exporter/values.yaml
@@ -75,6 +75,7 @@ serviceMonitor:
 ingress:
   enabled: false
   className: ""
+  labels: {}
   annotations: {}
   # kubernetes.io/ingress.class: nginx
   # kubernetes.io/tls-acme: "true"

--- a/charts/prometheus-json-exporter/values.yaml
+++ b/charts/prometheus-json-exporter/values.yaml
@@ -44,6 +44,8 @@ service:
   port: 7979
   targetPort: http
   name: http
+  labels: {}
+  annotations: {}
 
 serviceMonitor:
   ## If true, a ServiceMonitor CRD is created for a prometheus operator


### PR DESCRIPTION
#### What this PR does / why we need it

Fixes some default values from `[]` to `{}` and adds support for setting service labels and annotations.

@schmiddim @zanhsieh @xiu 

#### Checklist

- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
