### PR TITLE
[prometheus-adapter] Use full duration format for default certificate values

### DIFF
--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 4.7.0
+version: 4.7.1
 appVersion: v0.11.1
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/kubernetes-sigs/prometheus-adapter

--- a/charts/prometheus-adapter/values.yaml
+++ b/charts/prometheus-adapter/values.yaml
@@ -277,5 +277,5 @@ podDisruptionBudget:
 
 certManager:
   enabled: false
-  caCertDuration: 43800h
-  certDuration: 8760h
+  caCertDuration: 43800h0m0s
+  certDuration: 8760h0m0s


### PR DESCRIPTION
#### What this PR does / why we need it

Cert-Manager converts simple duration values to their full format: `1h` ends up as `1h0m0s`

GitOps tools like Argo CD keep seeing this as a change and never reach a 'synced' state because they see this as a diff: `1h0m0s != 1h`. Using the full format fixes that.


#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
