### PR TITLE
[kube-prometheus-stack] :bug: Duplicate Prometheus Rule

### DIFF
--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-availability.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-availability.rules.yaml
@@ -226,40 +226,7 @@ spec:
         {{- end }}
       {{- end }}
       record: code_resource:apiserver_request_total:rate5m
-    - expr: sum by (cluster, code, verb) (increase(apiserver_request_total{job="apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"2.."}[1h]))
-      record: code_verb:apiserver_request_total:increase1h
-      {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
-      labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
-      {{- end }}
-    - expr: sum by (cluster, code, verb) (increase(apiserver_request_total{job="apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"3.."}[1h]))
-      record: code_verb:apiserver_request_total:increase1h
-      {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
-      labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
-      {{- end }}
-    - expr: sum by (cluster, code, verb) (increase(apiserver_request_total{job="apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"4.."}[1h]))
-      record: code_verb:apiserver_request_total:increase1h
-      {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
-      labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
-      {{- end }}
-    - expr: sum by (cluster, code, verb) (increase(apiserver_request_total{job="apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"5.."}[1h]))
+    - expr: sum by (cluster, code, verb) (increase(apiserver_request_total{job="apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"2..|3..|4..|5.."}[1h]))
       record: code_verb:apiserver_request_total:increase1h
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
       labels:


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR remove few duplicates Prometheus Rules in the kube-apiserver-availability rules group. 

It's easy to verify, using `promtool check rules <my_rule_file.yaml>`

*BEFORE* : 
``` bash
$ promtool check rules tmp/rules/test-kube-apiserver-availability.rules.yaml
Checking /tmp/rules/test-kube-apiserver-availability.rules.yaml
  FAILED:
lint error 1 duplicate rule(s) found.
Metric: code_verb:apiserver_request_total:increase1h
Label(s):
Might cause inconsistency while recording expressions
``` 

*AFTER* : 
``` bash
$ promtool check rules tmp/rules/test-kube-apiserver-availability.rules.yaml
Checking /tmp/rules/test-kube-apiserver-availability.rules.yaml
  SUCCESS: 13 rules found
``` 

#### Which issue this PR fixes

N/A, i have not open any issue for this and don't found one already open.

#### Special notes for your reviewer

That my first PR and i'm not really sure about how to proceed.. feel free to adjust or commit into

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
