### PR TITLE
[kube-prometheus-stack] fixes thanos ruler object store configs

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 51.9.1
+version: 51.9.2
 appVersion: v0.68.0
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/thanos-ruler/ruler.yaml
+++ b/charts/kube-prometheus-stack/templates/thanos-ruler/ruler.yaml
@@ -101,7 +101,7 @@ spec:
 {{- end }}
 {{- if .Values.thanosRuler.thanosRulerSpec.objectStorageConfig }}
   objectStorageConfig:
-    key: objectstore-configs.yaml
+    key: object-storage-configs.yaml
     name: {{ template "kube-prometheus-stack.thanosRuler.name" . }}
 {{- end }}
 {{- if .Values.thanosRuler.thanosRulerSpec.labels }}

--- a/charts/kube-prometheus-stack/templates/thanos-ruler/ruler.yaml
+++ b/charts/kube-prometheus-stack/templates/thanos-ruler/ruler.yaml
@@ -101,7 +101,8 @@ spec:
 {{- end }}
 {{- if .Values.thanosRuler.thanosRulerSpec.objectStorageConfig }}
   objectStorageConfig:
-{{ toYaml .Values.thanosRuler.thanosRulerSpec.objectStorageConfig | indent 4 }}
+    key: objectstore-configs.yaml
+    name: {{ template "kube-prometheus-stack.thanosRuler.name" . }}
 {{- end }}
 {{- if .Values.thanosRuler.thanosRulerSpec.labels }}
   labels:

--- a/charts/kube-prometheus-stack/templates/thanos-ruler/secret.yaml
+++ b/charts/kube-prometheus-stack/templates/thanos-ruler/secret.yaml
@@ -11,4 +11,7 @@ data:
 {{- if .Values.thanosRuler.thanosRulerSpec.alertmanagersConfig }}
   alertmanager-configs.yaml: {{ toYaml .Values.thanosRuler.thanosRulerSpec.alertmanagersConfig | b64enc | quote }}
 {{- end }}
+{{- if .Values.thanosRuler.thanosRulerSpec.objectStorageConfig }}
+  objectstore-configs.yaml: {{ toYaml .Values.thanosRuler.thanosRulerSpec.objectStorageConfig | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/thanos-ruler/secret.yaml
+++ b/charts/kube-prometheus-stack/templates/thanos-ruler/secret.yaml
@@ -12,6 +12,6 @@ data:
   alertmanager-configs.yaml: {{ toYaml .Values.thanosRuler.thanosRulerSpec.alertmanagersConfig | b64enc | quote }}
 {{- end }}
 {{- if .Values.thanosRuler.thanosRulerSpec.objectStorageConfig }}
-  objectstore-configs.yaml: {{ toYaml .Values.thanosRuler.thanosRulerSpec.objectStorageConfig | b64enc | quote }}
+  object-storage-configs.yaml: {{ toYaml .Values.thanosRuler.thanosRulerSpec.objectStorageConfig | b64enc | quote }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it
Fixes ThanosRuler objectstore configs

#### Which issue this PR fixes
fixes https://github.com/prometheus-community/helm-charts/issues/3912

#### Special notes for your reviewer

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
