### PR TITLE
[prometheus-blackbox-exporter] Removing whitespace chomping for blackbox deployment extraContainers

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 8.4.0
+version: 8.4.1
 appVersion: v0.24.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/charts/prometheus-blackbox-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-blackbox-exporter/templates/_helpers.tpl
@@ -154,7 +154,7 @@ initContainers:
 {{- end }}
 containers:
 {{- with .Values.extraContainers }}
-  {{- toYaml . }}
+{{ toYaml . }}
 {{- end }}
 - name: blackbox-exporter
   image: {{ include "prometheus-blackbox-exporter.image" . }}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Removing whitespace chomping for blackbox deployment extraContainers.

Currently upgrading from blackbox helm chart 7.x to 8.x with `extraContainers` results in this error.

```
Error: YAML parse error on prometheus-blackbox-exporter/templates/deployment.yaml: error converting YAML to JSON: yaml: line 50: did not find expected '-' indicator
```

This is due to generating the following broken yaml.

```
      containers:- args:
        - |
          echo "starting up..."
          apk add -q jq;
```

Since we don't need to indent here I've pulled the output back to the start of the line and removed the chomping which results in successful yaml.

```
      containers:
      - args:
        - |
          echo "starting up..."
          apk add -q jq;
```

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
