### PR TITLE
[prometheus] Allow setting scrape_config_files in prometheus config

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: v2.47.0
-version: 25.2.0
+version: 25.3.0
 kubeVersion: ">=1.19.0-0"
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/templates/cm.yaml
+++ b/charts/prometheus/templates/cm.yaml
@@ -39,6 +39,10 @@ data:
 {{ $root.Values.server.exemplars | toYaml | indent 8 }}
 {{- end }}
 {{- end }}
+{{- if $root.Values.scrapeConfigFiles }}
+    scrape_config_files:
+{{ toYaml $root.Values.scrapeConfigFiles | indent 4 }}
+{{- end }}
 {{- end }}
 {{- if eq $key "alerts" }}
 {{- if and (not (empty $value)) (empty $value.groups) }}

--- a/charts/prometheus/values.schema.json
+++ b/charts/prometheus/values.schema.json
@@ -644,6 +644,9 @@
                 }
             }
         },
+        "scrapeConfigFiles": {
+            "type": "array"
+        },
         "serverFiles": {
             "type": "object",
             "properties": {

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -682,6 +682,11 @@ server:
 ## Prometheus server ConfigMap entries for rule files (allow prometheus labels interpolation)
 ruleFiles: {}
 
+## Prometheus server ConfigMap entries for scrape_config_files
+## (allows scrape configs defined in additional files)
+##
+scrapeConfigFiles: []
+
 ## Prometheus server ConfigMap entries
 ##
 serverFiles:


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Allows setting the `scrape_config_files` in the prometheus configuration which was introduced in 2.43.0 https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md#2430--2023-03-21 - this allows splitting up scrape_configs into multiple files (which can be mounted in via `extraConfigmapMounts` or `extraHostPathMounts`, etc) 

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

Thanks for reviewing!

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
