### PR TITLE
Populating dynamic honorLabels and honorTimestamps in kubelet ServiceMonitor

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 52.0.1
+version: 52.10.1
 appVersion: v0.68.0
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 52.10.1
+version: 52.1.1
 appVersion: v0.68.0
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 51.10.0
+version: 51.11.0
 appVersion: v0.68.0
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 52.1.1
+version: 52.1.0
 appVersion: v0.68.0
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/exporters/kubelet/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kubelet/servicemonitor.yaml
@@ -33,7 +33,8 @@ spec:
       caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
       insecureSkipVerify: true
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    honorLabels: true
+    honorLabels: {{ .Values.kubelet.serviceMonitor.honorLabels }}
+    honorTimestamps: {{ .Values.kubelet.serviceMonitor.honorTimestamps }}
 {{- if .Values.kubelet.serviceMonitor.metricRelabelings }}
     metricRelabelings:
 {{ tpl (toYaml .Values.kubelet.serviceMonitor.metricRelabelings | indent 4) . }}
@@ -55,7 +56,8 @@ spec:
     {{- if .Values.kubelet.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.kubelet.serviceMonitor.scrapeTimeout }}
     {{- end }}
-    honorLabels: true
+    honorLabels: {{ .Values.kubelet.serviceMonitor.honorLabels }}
+    honorTimestamps: {{ .Values.kubelet.serviceMonitor.honorTimestamps }}
     tlsConfig:
       caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
       insecureSkipVerify: true
@@ -82,7 +84,8 @@ spec:
     {{- if .Values.kubelet.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.kubelet.serviceMonitor.scrapeTimeout }}
     {{- end }}
-    honorLabels: true
+    honorLabels: {{ .Values.kubelet.serviceMonitor.honorLabels }}
+    honorTimestamps: {{ .Values.kubelet.serviceMonitor.honorTimestamps }}
     tlsConfig:
       caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
       insecureSkipVerify: true
@@ -109,7 +112,8 @@ spec:
     {{- if .Values.kubelet.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.kubelet.serviceMonitor.scrapeTimeout }}
     {{- end }}
-    honorLabels: true
+    honorLabels: {{ .Values.kubelet.serviceMonitor.honorLabels }}
+    honorTimestamps: {{ .Values.kubelet.serviceMonitor.honorTimestamps }}
     tlsConfig:
       caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
       insecureSkipVerify: true
@@ -134,7 +138,8 @@ spec:
     {{- if .Values.kubelet.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.kubelet.serviceMonitor.scrapeTimeout }}
     {{- end }}
-    honorLabels: true
+    honorLabels: {{ .Values.kubelet.serviceMonitor.honorLabels }}
+    honorTimestamps: {{ .Values.kubelet.serviceMonitor.honorTimestamps }}
 {{- if .Values.kubelet.serviceMonitor.metricRelabelings }}
     metricRelabelings:
 {{ tpl (toYaml .Values.kubelet.serviceMonitor.metricRelabelings | indent 4) . }}
@@ -155,7 +160,8 @@ spec:
     {{- if .Values.kubelet.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.kubelet.serviceMonitor.scrapeTimeout }}
     {{- end }}
-    honorLabels: true
+    honorLabels: {{ .Values.kubelet.serviceMonitor.honorLabels }}
+    honorTimestamps: {{ .Values.kubelet.serviceMonitor.honorTimestamps }}
 {{- if .Values.kubelet.serviceMonitor.cAdvisorMetricRelabelings }}
     metricRelabelings:
 {{ tpl (toYaml .Values.kubelet.serviceMonitor.cAdvisorMetricRelabelings | indent 4) . }}
@@ -176,7 +182,8 @@ spec:
     {{- if .Values.kubelet.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.kubelet.serviceMonitor.scrapeTimeout }}
     {{- end }}
-    honorLabels: true
+    honorLabels: {{ .Values.kubelet.serviceMonitor.honorLabels }}
+    honorTimestamps: {{ .Values.kubelet.serviceMonitor.honorTimestamps }}
 {{- if .Values.kubelet.serviceMonitor.probesMetricRelabelings }}
     metricRelabelings:
 {{ tpl (toYaml .Values.kubelet.serviceMonitor.probesMetricRelabelings | indent 4) . }}
@@ -198,7 +205,8 @@ spec:
     {{- if .Values.kubelet.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.kubelet.serviceMonitor.scrapeTimeout }}
     {{- end }}
-    honorLabels: true
+    honorLabels: {{ .Values.kubelet.serviceMonitor.honorLabels }}
+    honorTimestamps: {{ .Values.kubelet.serviceMonitor.honorTimestamps }}
 {{- if .Values.kubelet.serviceMonitor.resourceMetricRelabelings }}
     metricRelabelings:
 {{ tpl (toYaml .Values.kubelet.serviceMonitor.resourceMetricRelabelings | indent 4) . }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1186,7 +1186,7 @@ kubelet:
     ## If true, Prometheus use (respect) labels provided by exporter.
     ##
     honorLabels: true
-    
+
     ## If true, Prometheus ingests metrics with timestamp provided by exporter. If false, Prometheus ingests metrics with timestamp of scrape.
     ##
     honorTimestamps: true

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1183,6 +1183,14 @@ kubelet:
     ##
     interval: ""
 
+    ## If true, Prometheus use (respect) labels provided by exporter.
+    ##
+    honorLabels: true
+    
+    ## If true, Prometheus ingests metrics with timestamp provided by exporter. If false, Prometheus ingests metrics with timestamp of scrape.
+    ##
+    honorTimestamps: true
+
     ## SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.
     ##
     sampleLimit: 0


### PR DESCRIPTION
Hello, 

I have faced an issue, when due to circumstances, cadvisor metric timestamp is from the past. Due to this, prometheus rejects metrics with reason "Error on ingesting out-of-order samples". 
I don't see any advantage in using exporters timestamp over prometheus timestamp, therefore I want to try to reject honor labels. 
Unfortunately, I found it is impossible within kube-prometheus-stack helm chart. 
This PR gives an opportunity to set honorLabels/Timestamps without creating separate ServiceMonitor. 