### PR TITLE
[alertmanager] Add support for templated per-replica service annotations

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 1.7.0
+version: 1.7.1
 appVersion: v0.26.0
 kubeVersion: ">=1.19.0-0"
 keywords:

--- a/charts/alertmanager/templates/serviceperreplica.yaml
+++ b/charts/alertmanager/templates/serviceperreplica.yaml
@@ -17,7 +17,7 @@ items:
         {{- include "alertmanager.labels" $ | nindent 8 }}
       {{- if $serviceValues.annotations }}
       annotations:
-{{ toYaml $serviceValues.annotations | indent 8 }}
+        {{- tpl (toYaml $serviceValues.annotations) . | nindent 8 }}
       {{- end }}
     spec:
       {{- if $serviceValues.clusterIP }}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

I would like to be able to modify per-replica service annotations. I am using external-dns to publish domain names in a private DNS zone about ClusterIP services so that I can access it from other clusters in the same VNet.

Adding this simple `tpl` allows me to simply do the following:

```yaml
servicePerReplica:
  annotations:
    external-dns.alpha.kubernetes.io/internal-hostname: '{{ printf "alertmanager-%d.internal.example.com" $count }}'
```

I do not use a LoadBalancer service as it is explicitly discouraged by Prometheus [here](https://prometheus.io/docs/alerting/latest/alertmanager/#high-availability).

#### Special notes for your reviewer

N/A

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
