### PR TITLE
[jiralert] add envFrom config

### DIFF
--- a/charts/jiralert/Chart.yaml
+++ b/charts/jiralert/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jiralert
 description: A Helm chart for Kubernetes to install jiralert
 type: application
-version: 1.6.1
+version: 1.7.0
 appVersion: "v1.3.0"
 home: "https://github.com/prometheus-community/jiralert"
 keywords:

--- a/charts/jiralert/templates/deployment.yaml
+++ b/charts/jiralert/templates/deployment.yaml
@@ -72,6 +72,10 @@ spec:
               value: {{ $value | quote }}
           {{- end }}
         {{- end }}
+        {{- with .Values.envFrom }}
+          envFrom:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
       serviceAccountName: {{ include "jiralert.serviceAccountName" . }}
       {{- with .Values.podSecurityContext }}
       securityContext:

--- a/charts/jiralert/values.yaml
+++ b/charts/jiralert/values.yaml
@@ -29,6 +29,9 @@ extraVolumeMounts: []
 # -- Additional Volumes
 extraVolumes: []
 
+# -- Additional envFrom for jiralert pods
+envFrom: {}
+
 # Number of pod replicas
 replicaCount: 1
 


### PR DESCRIPTION
#### What this PR does / why we need it

This PR adds the envFrom config for jiralert pods. We need it to include a secret created outside the helm chart as an environment variable, as we want to use environment variables in the jiralert config.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
