### PR TITLE
[kube-prometheus-stack] Grafana Datasource CM, Prometheus Replicas and Exemplar Trace Destinations

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 54.1.0
+version: 54.1.1
 appVersion: v0.69.1
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/grafana/configmaps-datasources.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/configmaps-datasources.yaml
@@ -55,8 +55,8 @@ data:
         timeInterval: {{ $scrapeInterval }}
 {{- if $.Values.grafana.sidecar.datasources.exemplarTraceIdDestinations }}
         exemplarTraceIdDestinations:
-        - datasourceUid: {{ .Values.grafana.sidecar.datasources.exemplarTraceIdDestinations.datasourceUid }}
-          name: {{ .Values.grafana.sidecar.datasources.exemplarTraceIdDestinations.traceIdLabelName }}
+        - datasourceUid: {{ $.Values.grafana.sidecar.datasources.exemplarTraceIdDestinations.datasourceUid }}
+          name: {{ $.Values.grafana.sidecar.datasources.exemplarTraceIdDestinations.traceIdLabelName }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it
Fixing Grafana configmaps Datasource when Prometheus Replicas and Exemplar Trace Destinations.  Values that are not specified as part of the range need a `$` to make sure its grabbing the top level value.

#### Which issue this PR fixes
- fixes #4027 

#### Special notes for your reviewer
n/a

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
