### PR TITLE
[prometheus-adapter] - Added pod security policy specific annotations

### DIFF
--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 4.8.3
+version: 4.8.4
 appVersion: v0.11.2
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/kubernetes-sigs/prometheus-adapter

--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 4.8.4
+version: 4.9.0
 appVersion: v0.11.2
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/kubernetes-sigs/prometheus-adapter

--- a/charts/prometheus-adapter/templates/psp.yaml
+++ b/charts/prometheus-adapter/templates/psp.yaml
@@ -4,14 +4,9 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "k8s-prometheus-adapter.fullname" . }}
-  {{- if or .Values.customAnnotations .Values.pspAnnotations }}
+  {{- with (merge .Values.customAnnotations .Values.psp.annotations }}
   annotations:
-    {{- with .Values.customAnnotations }}
     {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- with .Values.pspAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
   {{- end }}
   labels:
     {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}

--- a/charts/prometheus-adapter/templates/psp.yaml
+++ b/charts/prometheus-adapter/templates/psp.yaml
@@ -4,7 +4,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "k8s-prometheus-adapter.fullname" . }}
-  {{- with (merge .Values.customAnnotations .Values.psp.annotations }}
+  {{- with (merge .Values.customAnnotations .Values.psp.annotations) }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/prometheus-adapter/templates/psp.yaml
+++ b/charts/prometheus-adapter/templates/psp.yaml
@@ -4,9 +4,14 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "k8s-prometheus-adapter.fullname" . }}
-  {{- if .Values.customAnnotations }}
+  {{- if or .Values.customAnnotations .Values.pspAnnotations }}
   annotations:
-  {{- toYaml .Values.customAnnotations | nindent 4 }}
+    {{- with .Values.customAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.pspAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
   labels:
     {{- include "k8s-prometheus-adapter.labels" . | indent 4 }}

--- a/charts/prometheus-adapter/values.yaml
+++ b/charts/prometheus-adapter/values.yaml
@@ -254,6 +254,12 @@ podAnnotations: {}
 # Annotations added to the deployment
 deploymentAnnotations: {}
 
+# Annotations added to the pod security policy
+pspAnnotations: {}
+## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
+## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
+## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#sysctl
+
 hostNetwork:
   # Specifies if prometheus-adapter should be started in hostNetwork mode.
   #

--- a/charts/prometheus-adapter/values.yaml
+++ b/charts/prometheus-adapter/values.yaml
@@ -66,6 +66,11 @@ rbac:
 psp:
   # Specifies whether PSP resources should be created
   create: false
+  # Annotations added to the pod security policy
+  annotations: {}
+  ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
+  ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
+  ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#sysctl
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -253,12 +258,6 @@ podAnnotations: {}
 
 # Annotations added to the deployment
 deploymentAnnotations: {}
-
-# Annotations added to the pod security policy
-pspAnnotations: {}
-## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
-## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
-## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#sysctl
 
 hostNetwork:
   # Specifies if prometheus-adapter should be started in hostNetwork mode.


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Prometheus adapter is missing pod security annotations, current workaround is to apply them as custom annotations but then they apply to all objects, copying the approach taken in kube-prometheus-stack and adding support for specific pod security policy annotations

#### Which issue this PR fixes

Didn't bother raising one

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
