### PR TITLE
[prometheus-snmp-exporter] Add extraVolumes support and passing auth param

### DIFF
--- a/charts/prometheus-snmp-exporter/Chart.yaml
+++ b/charts/prometheus-snmp-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus SNMP Exporter
 name: prometheus-snmp-exporter
-version: 2.1.0
+version: 3.0.0
 appVersion: v0.21.0
 home: https://github.com/prometheus/snmp_exporter
 sources:

--- a/charts/prometheus-snmp-exporter/Chart.yaml
+++ b/charts/prometheus-snmp-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Prometheus SNMP Exporter
 name: prometheus-snmp-exporter
 version: 3.0.0
-appVersion: v0.21.0
+appVersion: v0.24.1
 home: https://github.com/prometheus/snmp_exporter
 sources:
   - https://github.com/prometheus/snmp_exporter

--- a/charts/prometheus-snmp-exporter/README.md
+++ b/charts/prometheus-snmp-exporter/README.md
@@ -81,6 +81,11 @@ serviceMonitor:
 
 This version changes the `serviceMonitor.namespace` value from `monitoring` to the namespace the release is deployed to.
 
+### To 3.0.0
+
+This version upgrades snmp-exporter version to 0.24.1, which introduces breaking change to configuration format.
+See [Module and Auth Split Migration](https://github.com/prometheus/snmp_exporter/blob/main/auth-split-migration.md) for more details.
+
 ## Configuration
 
 See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:

--- a/charts/prometheus-snmp-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-snmp-exporter/templates/daemonset.yaml
@@ -72,6 +72,9 @@ spec:
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
           {{- end }}
+          {{- with .Values.extraVolumeMounts }}
+          {{ toYaml . | nindent 12 }}
+          {{- end }}
       {{- if .Values.config }}
         - name: configmap-reload
           image: "{{ .Values.configmapReload.image.repository }}:{{ .Values.configmapReload.image.tag }}"
@@ -111,5 +114,8 @@ spec:
           secret:
             secretName: {{ .secretName }}
             defaultMode: {{ .defaultMode }}
+      {{- end }}
+      {{- with .Values.extraVolumes }}
+      {{ toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/prometheus-snmp-exporter/templates/deployment.yaml
+++ b/charts/prometheus-snmp-exporter/templates/deployment.yaml
@@ -79,6 +79,9 @@ spec:
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
           {{- end }}
+          {{- with .Values.extraVolumeMounts }}
+          {{ toYaml . | nindent 12 }}
+          {{- end }}
       {{- if .Values.config }}
         - name: configmap-reload
           image: "{{ .Values.configmapReload.image.repository }}:{{ .Values.configmapReload.image.tag }}"
@@ -118,5 +121,8 @@ spec:
           secret:
             secretName: {{ .secretName }}
             defaultMode: {{ .defaultMode }}
+      {{- end }}
+      {{- with .Values.extraVolumes }}
+      {{ toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/prometheus-snmp-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-snmp-exporter/templates/servicemonitor.yaml
@@ -24,6 +24,9 @@ spec:
       module: {{ .module | default $.Values.serviceMonitor.module }}
       target:
       - {{ .target }}
+      {{ if .auth }}
+      auth: {{ .auth }}
+      {{- end }}
     metricRelabelings:
       - sourceLabels: [instance]
         targetLabel: instance

--- a/charts/prometheus-snmp-exporter/values.yaml
+++ b/charts/prometheus-snmp-exporter/values.yaml
@@ -193,6 +193,8 @@ serviceMonitor:
     # Module used for scraping. Overrides value set in serviceMonitor.module
     #   module:
     #     - if_mib
+    # Auth used for scraping.
+    # auth: test-auth
     # Map of labels for ServiceMonitor. Overrides value set in serviceMonitor.selector
     #   labels: {}
           # release: kube-prometheus-stack

--- a/charts/prometheus-snmp-exporter/values.yaml
+++ b/charts/prometheus-snmp-exporter/values.yaml
@@ -194,7 +194,8 @@ serviceMonitor:
     #   module:
     #     - if_mib
     # Auth used for scraping.
-    # auth: test-auth
+    #   auth:
+    #     - test-auth
     # Map of labels for ServiceMonitor. Overrides value set in serviceMonitor.selector
     #   labels: {}
           # release: kube-prometheus-stack

--- a/charts/prometheus-snmp-exporter/values.yaml
+++ b/charts/prometheus-snmp-exporter/values.yaml
@@ -58,6 +58,12 @@ extraSecretMounts: []
   #   readOnly: true
   #   defaultMode: 420
 
+# Additional volumes, e.g. for secrets used in an extraContainer
+extraVolumes: []
+
+# Additional volume mounts for snmp-exporter container
+extraVolumeMounts: []
+
 ## For RBAC support:
 rbac:
   # Specifies whether RBAC resources should be created


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR upgrades snmp exporter to version 0.24.1 which supports submitting config as multiple files (see https://github.com/prometheus/snmp_exporter/issues/628). This provides the ability to move the auth part into a separate file and load it separately as a secret (from Vault for example).

This PR also introduces support for extraVolumes and extraVolumeMounts to support this feature.

My use case for this feature:
I have an init container that is responsible for getting the auth part of the config from the vault and needs to pass it to snmp-exporter, for this, I need to create an emptyDir volume and mount it to both containers. 
Also, it is quite a common feature to have for helm-charts with a lot of use cases in general.

Finally, this PR adds ability to specify auth query param to be passed to exporter via service monitor configuration (see https://github.com/prometheus/snmp_exporter/issues/619)

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
