### PR TITLE
fix(kube-state-metrics): skip imagePullSecrets when no override provided

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 5.15.2
+version: 5.15.3
 appVersion: 2.10.1
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/serviceaccount.yaml
+++ b/charts/kube-state-metrics/templates/serviceaccount.yaml
@@ -10,6 +10,8 @@ metadata:
   annotations:
 {{ toYaml .Values.serviceAccount.annotations | indent 4 }}
 {{- end }}
+{{- if .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:
   {{- include "kube-state-metrics.imagePullSecrets" (dict "Values" .Values "imagePullSecrets" .Values.serviceAccount.imagePullSecrets) | indent 2 }}
+{{- end }}
 {{- end -}}

--- a/charts/kube-state-metrics/templates/serviceaccount.yaml
+++ b/charts/kube-state-metrics/templates/serviceaccount.yaml
@@ -10,7 +10,7 @@ metadata:
   annotations:
 {{ toYaml .Values.serviceAccount.annotations | indent 4 }}
 {{- end }}
-{{- if .Values.serviceAccount.imagePullSecrets }}
+{{- if or .Values.serviceAccount.imagePullSecrets .Values.global.imagePullSecrets }}
 imagePullSecrets:
   {{- include "kube-state-metrics.imagePullSecrets" (dict "Values" .Values "imagePullSecrets" .Values.serviceAccount.imagePullSecrets) | indent 2 }}
 {{- end }}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Allows to use default values and prevent an empty `imagePullSecrets` in the ServiceAccount generate resource.

#### Which issue this PR fixes

- fixes #4059

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
