### PR TITLE
[CI] Run shellcheck on custom lint file

### DIFF
--- a/.github/linters/ct.yaml
+++ b/.github/linters/ct.yaml
@@ -12,5 +12,5 @@ excluded-charts:
   # If not running on GCE, will error: "Failed to get GCE config"
   - prometheus-to-sd
 additional-commands:
-  - sh -c "if [ -f '{{ .Path }}/ci/lint.sh' ]; then exec bash '{{ .Path }}/ci/lint.sh'; fi"
+  - sh -ec "if [ -f '{{ .Path }}/ci/lint.sh' ]; then shellcheck '{{ .Path }}/ci/lint.sh'; bash '{{ .Path }}/ci/lint.sh'; fi"
   # - helm unittest --helm3 --strict --file unittests/*.yaml --file 'unittests/**/*.yaml' {{ .Path }}


### PR DESCRIPTION
#### What this PR does / why we need it

- Following https://github.com/prometheus-community/helm-charts/pull/3987#discussion_r1420446414
- Run shellcheck on custom lint file
- Causes https://github.com/prometheus-community/helm-charts/pull/4073

#### Testing

```sh
→ for DIR in ./charts/*; do
    echo "==> Working on $DIR"
    export DIR
    sh -ec "if [ -f '${DIR}/ci/lint.sh' ]; then shellcheck '${DIR}/ci/lint.sh'; bash '${DIR}/ci/lint.sh'; fi"
done
```

<details>
  <summary>Click to expand result.</summary>
  
  ```sh
==> Working on ./charts/alertmanager
==> Working on ./charts/alertmanager-snmp-notifier
==> Working on ./charts/jiralert
==> Working on ./charts/kube-prometheus-stack

In ./charts/kube-prometheus-stack/ci/lint.sh line 16:
source venv/bin/activate
       ^---------------^ SC1091 (info): Not following: venv/bin/activate was not specified as input (see shellcheck -x).


In ./charts/kube-prometheus-stack/ci/lint.sh line 20:
export PATH="$(go env GOPATH)/bin:$PATH"
       ^--^ SC2155 (warning): Declare and assign separately to avoid masking return values.

For more information:
  https://www.shellcheck.net/wiki/SC2155 -- Declare and assign separately to ...
  https://www.shellcheck.net/wiki/SC1091 -- Not following: venv/bin/activate ...
==> Working on ./charts/kube-state-metrics
==> Working on ./charts/prom-label-proxy
==> Working on ./charts/prometheus
==> Working on ./charts/prometheus-adapter
==> Working on ./charts/prometheus-blackbox-exporter
==> Working on ./charts/prometheus-cloudwatch-exporter
==> Working on ./charts/prometheus-conntrack-stats-exporter
==> Working on ./charts/prometheus-consul-exporter
==> Working on ./charts/prometheus-couchdb-exporter
==> Working on ./charts/prometheus-druid-exporter
==> Working on ./charts/prometheus-elasticsearch-exporter
==> Working on ./charts/prometheus-fastly-exporter
==> Working on ./charts/prometheus-ipmi-exporter
==> Working on ./charts/prometheus-json-exporter
==> Working on ./charts/prometheus-kafka-exporter
==> Working on ./charts/prometheus-memcached-exporter
==> Working on ./charts/prometheus-modbus-exporter
==> Working on ./charts/prometheus-mongodb-exporter
==> Working on ./charts/prometheus-mysql-exporter
==> Working on ./charts/prometheus-nats-exporter
==> Working on ./charts/prometheus-nginx-exporter
==> Working on ./charts/prometheus-node-exporter
==> Working on ./charts/prometheus-opencost-exporter
==> Working on ./charts/prometheus-operator-admission-webhook
==> Working on ./charts/prometheus-operator-crds
==> Working on ./charts/prometheus-pgbouncer-exporter
==> Working on ./charts/prometheus-pingdom-exporter
==> Working on ./charts/prometheus-pingmesh-exporter
==> Working on ./charts/prometheus-postgres-exporter
==> Working on ./charts/prometheus-pushgateway
==> Working on ./charts/prometheus-rabbitmq-exporter
==> Working on ./charts/prometheus-redis-exporter
==> Working on ./charts/prometheus-smartctl-exporter
==> Working on ./charts/prometheus-snmp-exporter
==> Working on ./charts/prometheus-stackdriver-exporter
==> Working on ./charts/prometheus-statsd-exporter
==> Working on ./charts/prometheus-to-sd
==> Working on ./charts/prometheus-windows-exporter
  ```

</details>

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
