### PR TITLE
[kube-prometheus-stack] Shellcheck linter file

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 55.1.0
+version: 55.1.1
 appVersion: v0.70.0
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 55.0.1
+version: 55.0.2
 appVersion: v0.70.0
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/ci/lint.sh
+++ b/charts/kube-prometheus-stack/ci/lint.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 
 cd "${SCRIPT_DIR}/../"
 
@@ -13,11 +13,13 @@ if ! git diff --exit-code; then
 fi
 
 python3 -m venv venv
+# shellcheck disable=SC1091
 source venv/bin/activate
 pip3 install -r hack/requirements.txt
 
 go install -a github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
-export PATH="$(go env GOPATH)/bin:$PATH"
+PATH="$(go env GOPATH)/bin:$PATH"
+export PATH
 
 ./hack/sync_prometheus_rules.py
 if ! git diff --exit-code; then


### PR DESCRIPTION
#### What this PR does / why we need it

- Required due to https://github.com/prometheus-community/helm-charts/pull/4072
- Shellcheck linter file

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
