### PR TITLE
[prometheus-opencost-exporter] OpenCost 1.108.0 has been released

### DIFF
--- a/charts/prometheus-opencost-exporter/Chart.yaml
+++ b/charts/prometheus-opencost-exporter/Chart.yaml
@@ -1,5 +1,5 @@
-appVersion: 1.107.1
-version: 0.1.0
+appVersion: 1.108.0
+version: 0.1.1
 description: Prometheus OpenCost Exporter
 home: https://github.com/opencost/opencost
 name: prometheus-opencost-exporter


### PR DESCRIPTION
https://github.com/opencost/opencost/releases/tag/v1.108.0

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
