### PR TITLE
[prometheus-json-exporter] feat: add annotations for Deployment

### DIFF
--- a/charts/prometheus-json-exporter/Chart.yaml
+++ b/charts/prometheus-json-exporter/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.0
+version: 0.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/prometheus-json-exporter/ci/default-values.yaml
+++ b/charts/prometheus-json-exporter/ci/default-values.yaml
@@ -1,0 +1,2 @@
+annotations:
+  test-annotation: "true"

--- a/charts/prometheus-json-exporter/ci/default-values.yaml
+++ b/charts/prometheus-json-exporter/ci/default-values.yaml
@@ -1,2 +1,2 @@
-annotations:
+deploymentAnnotations:
   test-annotation: "true"

--- a/charts/prometheus-json-exporter/templates/deployment.yaml
+++ b/charts/prometheus-json-exporter/templates/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ include "prometheus-json-exporter.namespace" . }}
   labels:
     {{- include "prometheus-json-exporter.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/prometheus-json-exporter/templates/deployment.yaml
+++ b/charts/prometheus-json-exporter/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ include "prometheus-json-exporter.namespace" . }}
   labels:
     {{- include "prometheus-json-exporter.labels" . | nindent 4 }}
-  {{- with .Values.annotations }}
+  {{- with .Values.deploymentAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/prometheus-json-exporter/values.yaml
+++ b/charts/prometheus-json-exporter/values.yaml
@@ -25,7 +25,7 @@ serviceAccount:
   name: ""
 
 # Annotations for the Deployment
-annotations: {}
+deploymentAnnotations: {}
 
 podAnnotations: {}
 

--- a/charts/prometheus-json-exporter/values.yaml
+++ b/charts/prometheus-json-exporter/values.yaml
@@ -24,6 +24,9 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+# Annotations for the Deployment
+annotations: {}
+
 podAnnotations: {}
 
 podSecurityContext: {}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
This enables the user to specify annotations for the deployment.

@schmiddim, @zanhsieh, @xiu, mentioning you as per the PR template.
#### Which issue this PR fixes

_No issue_

Annotations can't be set for the deployment

#### Special notes for your reviewer

_None_

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
