### PR TITLE
[kube-state-metrics] Make liveness and readiness probes customizable

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 5.15.3
+version: 5.16.0
 appVersion: 2.10.1
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/kube-state-metrics/templates/deployment.yaml
@@ -49,10 +49,10 @@ spec:
       {{- toYaml . | nindent 6 }}
       {{- end }}
       containers:
-      {{- $httpPort := ternary 9090 (.Values.service.port | default 8080) .Values.kubeRBACProxy.enabled}}
+      {{- $servicePort := ternary 9090 (.Values.service.port | default 8080) .Values.kubeRBACProxy.enabled}}
       {{- $telemetryPort := ternary 9091 (.Values.selfMonitor.telemetryPort | default 8081) .Values.kubeRBACProxy.enabled}}
       - name: {{ template "kube-state-metrics.name" . }}
-        {{- if .Values.autosharding.enabled }}
+        {{- if  .Values.autosharding.enabled }}
         env:
         - name: POD_NAME
           valueFrom:
@@ -67,7 +67,7 @@ spec:
         {{-  if .Values.extraArgs  }}
         {{- .Values.extraArgs | toYaml | nindent 8 }}
         {{-  end  }}
-        - --port={{ $httpPort }}
+        - --port={{ $servicePort }}
         {{-  if .Values.collectors  }}
         - --resources={{ .Values.collectors | join "," }}
         {{-  end  }}
@@ -147,17 +147,41 @@ spec:
         {{- end }}
         {{- end }}
         livenessProbe:
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           httpGet:
+            {{- if .Values.kubeRBACProxy.enabled }}
+            host: 127.0.0.1
+            {{- end }}
+            httpHeaders:
+            {{- range $_, $header := .Values.livenessProbe.httpGet.httpHeaders }}
+            - name: {{ $header.name }}
+              value: {{ $header.value }}
+            {{- end }}
             path: /healthz
-            port: {{ $httpPort }}
-          initialDelaySeconds: 5
-          timeoutSeconds: 5
+            port: {{ $servicePort }}
+            scheme: {{ upper .Values.livenessProbe.httpGet.scheme }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
         readinessProbe:
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           httpGet:
+            {{- if .Values.kubeRBACProxy.enabled }}
+            host: 127.0.0.1
+            {{- end }}
+            httpHeaders:
+            {{- range $_, $header := .Values.readinessProbe.httpGet.httpHeaders }}
+            - name: {{ $header.name }}
+              value: {{ $header.value }}
+            {{- end }}
             path: /
-            port: {{ $httpPort }}
-          initialDelaySeconds: 5
-          timeoutSeconds: 5
+            port: {{ $servicePort }}
+            scheme: {{ upper .Values.readinessProbe.httpGet.scheme }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
         {{- if .Values.resources }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
@@ -173,7 +197,7 @@ spec:
         {{- .Values.kubeRBACProxy.extraArgs | toYaml | nindent 8 }}
         {{-  end  }}
         - --secure-listen-address=:{{ .Values.service.port | default 8080}}
-        - --upstream=http://127.0.0.1:{{ $httpPort }}/
+        - --upstream=http://127.0.0.1:{{ $servicePort }}/
         - --proxy-endpoints-port=8888
         - --config-file=/etc/kube-rbac-proxy-config/config-file.yaml
         volumeMounts:

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -454,3 +454,27 @@ containers: []
 initContainers: []
   # - name: crd-sidecar
   #   image: kiwigrid/k8s-sidecar:latest
+
+## Liveness probe
+##
+livenessProbe:
+  failureThreshold: 3
+  httpGet:
+    httpHeaders: []
+    scheme: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 5
+
+## Readiness probe
+##
+readinessProbe:
+  failureThreshold: 3
+  httpGet:
+    httpHeaders: []
+    scheme: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 5


### PR DESCRIPTION
#### What this PR does / why we need it
I made liveness and readiness probes customizable to make kube-state-metrics features like TLS and Basic-Auth fully available for chart users without requiring kube-rbac-proxy. When you enable those features in kube-state-metrics configuration then probes crash. To use TLS, we need to change httpGet.scheme to HTTPS and for Basic-Auth we need to add httpHeaders in httpGet.

I've also renamed `httpPort` to `servicePort` to bring it in-line with node-exporter.

#### Special notes for your reviewer

This code was borrowed from #2053 

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
