### PR TITLE
[prometheus-systemd-exporter]: add maxime1907 as chart maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -49,5 +49,6 @@
 /charts/prometheus-stackdriver-exporter/ @apenney @rpahli
 /charts/prometheus-statsd-exporter/ @scDisorder
 /charts/prometheus-systemd-exporter/ @capuche2412
+/charts/prometheus-systemd-exporter/ @maxime1907
 /charts/prometheus-to-sd/ @acondrat
 /charts/prometheus-windows-exporter/ @jkroepke

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,7 +48,6 @@
 /charts/prometheus-snmp-exporter/ @miouge1 @xiu
 /charts/prometheus-stackdriver-exporter/ @apenney @rpahli
 /charts/prometheus-statsd-exporter/ @scDisorder
-/charts/prometheus-systemd-exporter/ @capuche2412
-/charts/prometheus-systemd-exporter/ @maxime1907
+/charts/prometheus-systemd-exporter/ @capuche2412 @maxime1907
 /charts/prometheus-to-sd/ @acondrat
 /charts/prometheus-windows-exporter/ @jkroepke

--- a/charts/prometheus-systemd-exporter/Chart.yaml
+++ b/charts/prometheus-systemd-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-systemd-exporter
 description: A Helm chart for prometheus systemd-exporter
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.6.0"
 home: https://github.com/prometheus-community/systemd_exporter
 sources:
@@ -10,3 +10,5 @@ sources:
 maintainers:
 - name: capuche2412
   email: aleroux@wiremind.io
+- name: maxime1907
+  email: 19607336+maxime1907@users.noreply.github.com


### PR DESCRIPTION
#### What this PR does / why we need it
This PR adds @maxime1907 as a maintainer of the chart. I have been contributing to various [open source chart projects](https://github.com/maxime1907?tab=repositories&q=charts&type=&language=&sort=) and will be happy to support the community's work further as a chart maintainer.

#### Which issue this PR fixes

- fixes #1656

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
