### PR TITLE
[kube-prometheus-stack] fix label on admission controller

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 56.0.2
+version: 56.0.3
 appVersion: v0.71.0
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/deployment/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/deployment/deployment.yaml
@@ -26,7 +26,6 @@ spec:
       labels:
         app: {{ template "kube-prometheus-stack.name" . }}-operator-webhook
         {{- include "kube-prometheus-stack.prometheus-operator-webhook.labels" . | nindent 8 }}
-        release: {{ $.Release.Name | quote }}
 {{- if .Values.prometheusOperator.admissionWebhooks.deployment.podLabels }}
 {{ toYaml .Values.prometheusOperator.admissionWebhooks.deployment.podLabels | indent 8 }}
 {{- end }}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR solves an issue that was introduced in version 56.0.1 by the following commit: https://github.com/prometheus-community/helm-charts/commit/120ab8fb11fd0578b14743ffd897eab6cbbf3cc7

Upgrading the chart results in the following error:
```
kube-prometheus-stack           56.0.0                  False           False   Helm upgrade failed for release monitoring/kube-prometheus-stack with chart kube-prometheus-stack@56.0.1: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors: line 40: mapping key "release" already defined at line 36
```

This is because `release` is already included as label [here](https://github.com/prometheus-community/helm-charts/blob/2f3dbddd3ed01e3b5044a9186f064b050dbe9a31/charts/kube-prometheus-stack/templates/_helpers.tpl#L78), which is included in [`kube-prometheus-stack.prometheus-operator-webhook.labels`](https://github.com/prometheus-community/helm-charts/blob/2f3dbddd3ed01e3b5044a9186f064b050dbe9a31/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/_prometheus-operator-webhook.tpl#L3) and finally [applied to the `operator-webhook` deployment](https://github.com/prometheus-community/helm-charts/blob/2f3dbddd3ed01e3b5044a9186f064b050dbe9a31/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/deployment/deployment.yaml#L28).

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
