### PR TITLE
[prometheus-node-exporter] Add Termination Msg Params to Daemonset

### DIFF
--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - prometheus
   - exporter
 type: application
-version: 4.27.1
+version: 4.27.0
 appVersion: 1.7.0
 home: https://github.com/prometheus/node_exporter/
 sources:

--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - prometheus
   - exporter
 type: application
-version: 4.26.1
+version: 4.27.1
 appVersion: 1.7.0
 home: https://github.com/prometheus/node_exporter/
 sources:

--- a/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -40,6 +40,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "prometheus-node-exporter.serviceAccountName" . }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       containers:
         {{- $servicePort := ternary .Values.kubeRBACProxy.port .Values.service.port .Values.kubeRBACProxy.enabled }}
         - name: node-exporter
@@ -124,12 +125,25 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+
+          # CHANGED
+          {{- if eq .Values.configureTerminationMessagePath true }}
+          terminationMessagePath: {{ .Values.terminationMessagePath }}
+          terminationMessagePolicy: {{ .Values.terminationMessagePolicy }}
+          {{- end }}
+
           volumeMounts:
             - name: proc
               mountPath: /host/proc
+              {{- if .Values.hostProcFsMount.enabled }}
+              mountPropagation: {{ .Values.hostProcFsMount.mountPropagation }}
+              {{- end }}
               readOnly:  true
             - name: sys
               mountPath: /host/sys
+              {{- if .Values.hostProcFsMount.enabled }}
+              mountPropagation: {{ .Values.hostSysFsMount.mountPropagation }}
+              {{- end }}
               readOnly: true
             {{- if .Values.hostRootFsMount.enabled }}
             - name: root
@@ -146,6 +160,7 @@ spec:
               {{- with $mount.mountPropagation }}
               mountPropagation: {{ . }}
               {{- end }}
+              type: {{ $mount.type}}
             {{- end }}
             {{- range $_, $mount := .Values.sidecarVolumeMount }}
             - name: {{ $mount.name }}
@@ -196,6 +211,9 @@ spec:
               {{- if .Values.kubeRBACProxy.enableHostPort }}
               hostPort: {{ .Values.service.port }}
               {{- end }}
+
+              # CHANGED
+              protocol: {{ .Values.kubeRBACProxy.portProtocol }}
             - containerPort: 8888
               name: "http-healthz"
           readinessProbe:
@@ -207,8 +225,22 @@ spec:
             timeoutSeconds: 5
           {{- if .Values.kubeRBACProxy.resources }}
           resources:
-          {{ toYaml .Values.kubeRBACProxy.resources | nindent 12 }}
+          {{- toYaml .Values.kubeRBACProxy.resources | nindent 12 }}
           {{- end }}
+
+          # CHANGED
+          env:
+            {{- range $key, $value := .Values.kubeRBACProxy.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+
+          # CHANGED
+          {{- if eq .Values.kubeRBACProxy.configureTerminationMessagePath true }}
+          terminationMessagePath: {{ .Values.kubeRBACProxy.terminationMessagePath  }}
+          terminationMessagePolicy: {{ .Values.kubeRBACProxy.terminationMessagePolicy }}
+          {{- end }}
+
           {{- if .Values.kubeRBACProxy.containerSecurityContext }}
           securityContext:
           {{ toYaml .Values.kubeRBACProxy.containerSecurityContext | nindent 12 }}
@@ -228,6 +260,7 @@ spec:
       dnsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      restartPolicy: {{ .Values.restartPolicy }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -40,7 +40,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "prometheus-node-exporter.serviceAccountName" . }}
-      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- with .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
       containers:
         {{- $servicePort := ternary .Values.kubeRBACProxy.port .Values.service.port .Values.kubeRBACProxy.enabled }}
         - name: node-exporter

--- a/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -220,7 +220,7 @@ spec:
             timeoutSeconds: 5
           {{- if .Values.kubeRBACProxy.resources }}
           resources:
-          {{- toYaml .Values.kubeRBACProxy.resources | nindent 12 }}
+          {{ toYaml .Values.kubeRBACProxy.resources | nindent 12 }}
           {{- end }}
           {{-  if .Values.kubeRBACProxy.env }}
           env:

--- a/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -214,13 +214,6 @@ spec:
           resources:
           {{ toYaml .Values.kubeRBACProxy.resources | nindent 12 }}
           {{- end }}
-          {{-  if .Values.kubeRBACProxy.env }}
-          env:
-            {{- range $key, $value := .Values.kubeRBACProxy.env }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
-          {{- end }}
           {{- if eq .Values.kubeRBACProxy.configureTerminationMessagePath true }}
           terminationMessagePath: {{ .Values.kubeRBACProxy.terminationMessagePath  }}
           terminationMessagePolicy: {{ .Values.kubeRBACProxy.terminationMessagePolicy }}

--- a/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -125,13 +125,10 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-
-          # CHANGED
           {{- if eq .Values.configureTerminationMessagePath true }}
           terminationMessagePath: {{ .Values.terminationMessagePath }}
           terminationMessagePolicy: {{ .Values.terminationMessagePolicy }}
           {{- end }}
-
           volumeMounts:
             - name: proc
               mountPath: /host/proc
@@ -211,8 +208,6 @@ spec:
               {{- if .Values.kubeRBACProxy.enableHostPort }}
               hostPort: {{ .Values.service.port }}
               {{- end }}
-
-              # CHANGED
               protocol: {{ .Values.kubeRBACProxy.portProtocol }}
             - containerPort: 8888
               name: "http-healthz"
@@ -227,20 +222,17 @@ spec:
           resources:
           {{- toYaml .Values.kubeRBACProxy.resources | nindent 12 }}
           {{- end }}
-
-          # CHANGED
+          {{-  if .Values.kubeRBACProxy.env }}
           env:
             {{- range $key, $value := .Values.kubeRBACProxy.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
-
-          # CHANGED
+          {{- end }}
           {{- if eq .Values.kubeRBACProxy.configureTerminationMessagePath true }}
           terminationMessagePath: {{ .Values.kubeRBACProxy.terminationMessagePath  }}
           terminationMessagePolicy: {{ .Values.kubeRBACProxy.terminationMessagePolicy }}
           {{- end }}
-
           {{- if .Values.kubeRBACProxy.containerSecurityContext }}
           securityContext:
           {{ toYaml .Values.kubeRBACProxy.containerSecurityContext | nindent 12 }}

--- a/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -132,15 +132,9 @@ spec:
           volumeMounts:
             - name: proc
               mountPath: /host/proc
-              {{- if .Values.hostProcFsMount.enabled }}
-              mountPropagation: {{ .Values.hostProcFsMount.mountPropagation }}
-              {{- end }}
               readOnly:  true
             - name: sys
               mountPath: /host/sys
-              {{- if .Values.hostProcFsMount.enabled }}
-              mountPropagation: {{ .Values.hostSysFsMount.mountPropagation }}
-              {{- end }}
               readOnly: true
             {{- if .Values.hostRootFsMount.enabled }}
             - name: root
@@ -157,7 +151,6 @@ spec:
               {{- with $mount.mountPropagation }}
               mountPropagation: {{ . }}
               {{- end }}
-              type: {{ $mount.type}}
             {{- end }}
             {{- range $_, $mount := .Values.sidecarVolumeMount }}
             - name: {{ $mount.name }}
@@ -208,7 +201,6 @@ spec:
               {{- if .Values.kubeRBACProxy.enableHostPort }}
               hostPort: {{ .Values.service.port }}
               {{- end }}
-              protocol: {{ .Values.kubeRBACProxy.portProtocol }}
             - containerPort: 8888
               name: "http-healthz"
           readinessProbe:
@@ -252,7 +244,6 @@ spec:
       dnsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      restartPolicy: {{ .Values.restartPolicy }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -125,9 +125,11 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if eq .Values.configureTerminationMessagePath true }}
-          terminationMessagePath: {{ .Values.terminationMessagePath }}
-          terminationMessagePolicy: {{ .Values.terminationMessagePolicy }}
+          {{- if .Values.terminationMessageParams.enabled }}
+          {{- with .Values.terminationMessageParams }}
+          terminationMessagePath: {{ .terminationMessagePath }}
+          terminationMessagePolicy: {{ .terminationMessagePolicy }}
+          {{- end }}
           {{- end }}
           volumeMounts:
             - name: proc
@@ -214,9 +216,11 @@ spec:
           resources:
           {{ toYaml .Values.kubeRBACProxy.resources | nindent 12 }}
           {{- end }}
-          {{- if eq .Values.kubeRBACProxy.configureTerminationMessagePath true }}
-          terminationMessagePath: {{ .Values.kubeRBACProxy.terminationMessagePath  }}
-          terminationMessagePolicy: {{ .Values.kubeRBACProxy.terminationMessagePolicy }}
+          {{- if .Values.terminationMessageParams.enabled }}
+          {{- with .Values.terminationMessageParams }}
+          terminationMessagePath: {{ .terminationMessagePath }}
+          terminationMessagePolicy: {{ .terminationMessagePolicy }}
+          {{- end }}
           {{- end }}
           {{- if .Values.kubeRBACProxy.containerSecurityContext }}
           securityContext:

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -40,6 +40,8 @@ global:
 kubeRBACProxy:
   enabled: false
   env: {}
+  ##  env:
+  ##    VARIABLE: value
   image:
     registry: quay.io
     repository: brancz/kube-rbac-proxy
@@ -47,7 +49,7 @@ kubeRBACProxy:
     sha: ""
     pullPolicy: IfNotPresent
 
-  # List of additional cli arguments to configure kube-rbac-prxy
+  # List of additional cli arguments to configure kube-rbac-proxy
   # for example: --tls-cipher-suites, --log-file, etc.
   # all the possible args can be found here: https://github.com/brancz/kube-rbac-proxy#usage
   extraArgs: []
@@ -276,7 +278,8 @@ resources: {}
   #   cpu: 100m
   #   memory: 30Mi
 
-# CHANGED
+# Specify the container restart policy passed to the Node Export container
+# Possible Values: Always (default)|OnFailure|Never
 restartPolicy: Always
 
 serviceAccount:

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -38,7 +38,7 @@ global:
 # Configure kube-rbac-proxy. When enabled, creates a kube-rbac-proxy to protect the node-exporter http endpoint.
 # The requests are served through the same service but requests are HTTPS.
 kubeRBACProxy:
-  enabled: false
+  enabled: true
   image:
     registry: quay.io
     repository: brancz/kube-rbac-proxy
@@ -62,13 +62,6 @@ kubeRBACProxy:
   portName: http
   # Configure a hostPort. If true, hostPort will be enabled in the container and set to service.port.
   enableHostPort: false
-
-  # Enable or disable container termination messages for KubeRBACProxy container
-  configureTerminationMessagePath: true
-  # If configureTerminationMessagePath is enabled, specify the path for termination messages for KubeRBACProxy container
-  terminationMessagePath: /dev/termination-log
-  # If configureTerminationMessagePath is enabled, specify the Policy for termination messages for KubeRBACProxy container
-  terminationMessagePolicy: File
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
@@ -375,12 +368,15 @@ tolerations:
   - effect: NoSchedule
     operator: Exists
 
-# Enable or disable container termination messages for Node Exporter container
-configureTerminationMessagePath: true
-# If configureTerminationMessagePath is enabled, specify the path for termination messages for Node Exporter container
-terminationMessagePath: /dev/termination-log
-# If configureTerminationMessagePath is enabled, specify the Policy for termination messages for Node Exporter container
-terminationMessagePolicy: File
+# Enable or disable container termination message settings
+# https://kubernetes.io/docs/tasks/debug/debug-application/determine-reason-pod-failure/
+terminationMessageParams:
+  enabled: true
+  # If enabled, specify the path for termination messages
+  terminationMessagePath: /dev/termination-log
+  # If enabled, specify the policy for termination messages
+  terminationMessagePolicy: File
+
 
 ## Assign a PriorityClassName to pods if set
 # priorityClassName: ""

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -83,9 +83,9 @@ kubeRBACProxy:
     # limits:
     #  cpu: 100m
     #  memory: 64Mi
-  #   requests:
-  #    cpu: 10m
-  #    memory: 32Mi
+  # requests:
+  #  cpu: 10m
+  #  memory: 32Mi
 
 service:
   enabled: true
@@ -417,6 +417,7 @@ extraHostVolumeMounts: []
 #    hostPath: <hostPath>
 #    mountPath: <mountPath>
 #    readOnly: true|false
+#    type: "" (Default)|DirectoryOrCreate|Directory|FileOrCreate|File|Socket|CharDevice|BlockDevice
 #    mountPropagation: None|HostToContainer|Bidirectional
 
 

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -371,7 +371,7 @@ tolerations:
 # Enable or disable container termination message settings
 # https://kubernetes.io/docs/tasks/debug/debug-application/determine-reason-pod-failure/
 terminationMessageParams:
-  enabled: true
+  enabled: false
   # If enabled, specify the path for termination messages
   terminationMessagePath: /dev/termination-log
   # If enabled, specify the policy for termination messages

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -39,9 +39,6 @@ global:
 # The requests are served through the same service but requests are HTTPS.
 kubeRBACProxy:
   enabled: false
-  env: {}
-  ##  env:
-  ##    VARIABLE: value
   image:
     registry: quay.io
     repository: brancz/kube-rbac-proxy
@@ -65,8 +62,6 @@ kubeRBACProxy:
   portName: http
   # Configure a hostPort. If true, hostPort will be enabled in the container and set to service.port.
   enableHostPort: false
-  # Configure the protocol for the container port
-  portProtocol: TCP
 
   # Enable or disable container termination messages for KubeRBACProxy container
   configureTerminationMessagePath: true
@@ -278,10 +273,6 @@ resources: {}
   #   cpu: 100m
   #   memory: 30Mi
 
-# Specify the container restart policy passed to the Node Export container
-# Possible Values: Always (default)|OnFailure|Never
-restartPolicy: Always
-
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true
@@ -331,16 +322,6 @@ hostRootFsMount:
   # None, HostToContainer, and Bidirectional. If this field is omitted, then
   # None is used. More information on:
   # https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation
-  mountPropagation: HostToContainer
-
-# Mount the node's proc file system (/) at /host/proc in the container
-hostProcFsMount:
-  enabled: false
-  mountPropagation: HostToContainer
-
-# Mount the node's sys file system (/) at /host/sys in the container
-hostSysFsMount:
-  enabled: true
   mountPropagation: HostToContainer
 
 ## Assign a group of affinity scheduling rules
@@ -417,7 +398,6 @@ extraHostVolumeMounts: []
 #    hostPath: <hostPath>
 #    mountPath: <mountPath>
 #    readOnly: true|false
-#    type: "" (Default)|DirectoryOrCreate|Directory|FileOrCreate|File|Socket|CharDevice|BlockDevice
 #    mountPropagation: None|HostToContainer|Bidirectional
 
 

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -361,7 +361,7 @@ nodeSelector:
   kubernetes.io/os: linux
   #  kubernetes.io/arch: amd64
 
-# Specify grace period for graceful termination of pods. Defaults to 30
+# Specify grace period for graceful termination of pods. Defaults to 30 if null or not specified
 terminationGracePeriodSeconds: null
 
 tolerations:

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -361,8 +361,8 @@ nodeSelector:
   kubernetes.io/os: linux
   #  kubernetes.io/arch: amd64
 
-# Specify grace period for graceful termination of pods
-terminationGracePeriodSeconds: 30
+# Specify grace period for graceful termination of pods. Defaults to 30
+terminationGracePeriodSeconds: null
 
 tolerations:
   - effect: NoSchedule
@@ -371,7 +371,7 @@ tolerations:
 # Enable or disable container termination message settings
 # https://kubernetes.io/docs/tasks/debug/debug-application/determine-reason-pod-failure/
 terminationMessageParams:
-  enabled: false
+  enabled: true
   # If enabled, specify the path for termination messages
   terminationMessagePath: /dev/termination-log
   # If enabled, specify the policy for termination messages

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -38,7 +38,7 @@ global:
 # Configure kube-rbac-proxy. When enabled, creates a kube-rbac-proxy to protect the node-exporter http endpoint.
 # The requests are served through the same service but requests are HTTPS.
 kubeRBACProxy:
-  enabled: true
+  enabled: false
   image:
     registry: quay.io
     repository: brancz/kube-rbac-proxy
@@ -371,7 +371,7 @@ tolerations:
 # Enable or disable container termination message settings
 # https://kubernetes.io/docs/tasks/debug/debug-application/determine-reason-pod-failure/
 terminationMessageParams:
-  enabled: true
+  enabled: false
   # If enabled, specify the path for termination messages
   terminationMessagePath: /dev/termination-log
   # If enabled, specify the policy for termination messages

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -400,7 +400,6 @@ extraHostVolumeMounts: []
 #    readOnly: true|false
 #    mountPropagation: None|HostToContainer|Bidirectional
 
-
 ## Additional configmaps to be mounted.
 ##
 configmaps: []

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -38,7 +38,9 @@ global:
 # Configure kube-rbac-proxy. When enabled, creates a kube-rbac-proxy to protect the node-exporter http endpoint.
 # The requests are served through the same service but requests are HTTPS.
 kubeRBACProxy:
-  enabled: false
+  enabled: true  # CHANGED
+  env:
+    create_key: true  # SET TO {}
   image:
     registry: quay.io
     repository: brancz/kube-rbac-proxy
@@ -63,6 +65,13 @@ kubeRBACProxy:
   # Configure a hostPort. If true, hostPort will be enabled in the container and set to service.port.
   enableHostPort: false
 
+  # CHANGED
+  portProtocol: TCP
+
+  configureTerminationMessagePath: true
+  terminationMessagePath: /dev/termination-log
+  terminationMessagePolicy: File
+
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
@@ -71,9 +80,9 @@ kubeRBACProxy:
     # limits:
     #  cpu: 100m
     #  memory: 64Mi
-  # requests:
-  #  cpu: 10m
-  #  memory: 32Mi
+  #   requests:
+  #    cpu: 10m
+  #    memory: 32Mi
 
 service:
   enabled: true
@@ -266,6 +275,9 @@ resources: {}
   #   cpu: 100m
   #   memory: 30Mi
 
+# CHANGED
+restartPolicy: Always
+
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true
@@ -309,6 +321,26 @@ hostPID: true
 
 # Mount the node's root file system (/) at /host/root in the container
 hostRootFsMount:
+  enabled: true
+  # Defines how new mounts in existing mounts on the node or in the container
+  # are propagated to the container or node, respectively. Possible values are
+  # None, HostToContainer, and Bidirectional. If this field is omitted, then
+  # None is used. More information on:
+  # https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation
+  mountPropagation: HostToContainer
+
+# Mount the node's root file system (/) at /host/root in the container
+hostProcFsMount:
+  enabled: false
+  # Defines how new mounts in existing mounts on the node or in the container
+  # are propagated to the container or node, respectively. Possible values are
+  # None, HostToContainer, and Bidirectional. If this field is omitted, then
+  # None is used. More information on:
+  # https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation
+  mountPropagation: HostToContainer
+
+# Mount the node's root file system (/) at /host/root in the container
+hostSysFsMount:
   enabled: true
   # Defines how new mounts in existing mounts on the node or in the container
   # are propagated to the container or node, respectively. Possible values are
@@ -361,9 +393,16 @@ nodeSelector:
   kubernetes.io/os: linux
   #  kubernetes.io/arch: amd64
 
+# CHANGED
+terminationGracePeriodSeconds: 30
+
 tolerations:
   - effect: NoSchedule
     operator: Exists
+
+configureTerminationMessagePath: true
+terminationMessagePath: /dev/termination-log
+terminationMessagePolicy: File
 
 ## Assign a PriorityClassName to pods if set
 # priorityClassName: ""
@@ -376,11 +415,19 @@ extraArgs: []
 
 ## Additional mounts from the host to node-exporter container
 ##
-extraHostVolumeMounts: []
+extraHostVolumeMounts:
+  - name: node-exporter-volume
+    mountPath: /run/node-exporter/textfile_collector
+    readOnly: true
+    hostPath: /run/node-exporter/textfile_collector
+    mountPropagation: HostToContainer
+
+#extraHostVolumeMounts: []
 #  - name: <mountName>
 #    hostPath: <hostPath>
 #    mountPath: <mountPath>
 #    readOnly: true|false
+#    type: ""|DirectoryOrCreate|Directory|FileOrCreate|File|Socket|CharDevice|BlockDevice
 #    mountPropagation: None|HostToContainer|Bidirectional
 
 ## Additional configmaps to be mounted.

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -39,8 +39,7 @@ global:
 # The requests are served through the same service but requests are HTTPS.
 kubeRBACProxy:
   enabled: true  # CHANGED
-  env:
-    create_key: true  # SET TO {}
+  env: {}
   image:
     registry: quay.io
     repository: brancz/kube-rbac-proxy
@@ -64,12 +63,14 @@ kubeRBACProxy:
   portName: http
   # Configure a hostPort. If true, hostPort will be enabled in the container and set to service.port.
   enableHostPort: false
-
-  # CHANGED
+  # Configure the protocol for the container port
   portProtocol: TCP
 
+  # Enable or disable container termination messages for KubeRBACProxy container
   configureTerminationMessagePath: true
+  # If configureTerminationMessagePath is enabled, specify the path for termination messages for KubeRBACProxy container
   terminationMessagePath: /dev/termination-log
+  # If configureTerminationMessagePath is enabled, specify the Policy for termination messages for KubeRBACProxy container
   terminationMessagePolicy: File
 
   resources: {}
@@ -329,24 +330,14 @@ hostRootFsMount:
   # https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation
   mountPropagation: HostToContainer
 
-# Mount the node's root file system (/) at /host/root in the container
+# Mount the node's proc file system (/) at /host/proc in the container
 hostProcFsMount:
   enabled: false
-  # Defines how new mounts in existing mounts on the node or in the container
-  # are propagated to the container or node, respectively. Possible values are
-  # None, HostToContainer, and Bidirectional. If this field is omitted, then
-  # None is used. More information on:
-  # https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation
   mountPropagation: HostToContainer
 
-# Mount the node's root file system (/) at /host/root in the container
+# Mount the node's sys file system (/) at /host/sys in the container
 hostSysFsMount:
   enabled: true
-  # Defines how new mounts in existing mounts on the node or in the container
-  # are propagated to the container or node, respectively. Possible values are
-  # None, HostToContainer, and Bidirectional. If this field is omitted, then
-  # None is used. More information on:
-  # https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation
   mountPropagation: HostToContainer
 
 ## Assign a group of affinity scheduling rules
@@ -393,15 +384,18 @@ nodeSelector:
   kubernetes.io/os: linux
   #  kubernetes.io/arch: amd64
 
-# CHANGED
+# Specify grace period for graceful termination of pods
 terminationGracePeriodSeconds: 30
 
 tolerations:
   - effect: NoSchedule
     operator: Exists
 
+# Enable or disable container termination messages for Node Exporter container
 configureTerminationMessagePath: true
+# If configureTerminationMessagePath is enabled, specify the path for termination messages for Node Exporter container
 terminationMessagePath: /dev/termination-log
+# If configureTerminationMessagePath is enabled, specify the Policy for termination messages for Node Exporter container
 terminationMessagePolicy: File
 
 ## Assign a PriorityClassName to pods if set
@@ -415,20 +409,13 @@ extraArgs: []
 
 ## Additional mounts from the host to node-exporter container
 ##
-extraHostVolumeMounts:
-  - name: node-exporter-volume
-    mountPath: /run/node-exporter/textfile_collector
-    readOnly: true
-    hostPath: /run/node-exporter/textfile_collector
-    mountPropagation: HostToContainer
-
-#extraHostVolumeMounts: []
+extraHostVolumeMounts: []
 #  - name: <mountName>
 #    hostPath: <hostPath>
 #    mountPath: <mountPath>
 #    readOnly: true|false
-#    type: ""|DirectoryOrCreate|Directory|FileOrCreate|File|Socket|CharDevice|BlockDevice
 #    mountPropagation: None|HostToContainer|Bidirectional
+
 
 ## Additional configmaps to be mounted.
 ##

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -38,7 +38,7 @@ global:
 # Configure kube-rbac-proxy. When enabled, creates a kube-rbac-proxy to protect the node-exporter http endpoint.
 # The requests are served through the same service but requests are HTTPS.
 kubeRBACProxy:
-  enabled: true  # CHANGED
+  enabled: false
   env: {}
   image:
     registry: quay.io


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

For our purposes of this chart, we would like to be able to customize the node-exporter daemonset with the following variables:

- For both the Node Exporter and KubeRBACProxy containers, variables have been added to configure `terminationMessagePath` and `terminationMessagePolicy`
- A variable was added to configure the `terminationGracePeriodSeconds`

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)

@zeritti @gianrubio @zanhsieh 