### PR TITLE
[kube-prometheus-stack] add maximumStartupDurationSeconds optional value

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 56.2.1
+version: 56.2.2
 appVersion: v0.71.2
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 56.2.2
+version: 56.3.0
 appVersion: v0.71.2
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -449,6 +449,9 @@ spec:
 {{- if .Values.prometheus.prometheusSpec.minReadySeconds }}
   minReadySeconds: {{ .Values.prometheus.prometheusSpec.minReadySeconds }}
 {{- end }}
+{{- if .Values.prometheus.prometheusSpec.maximumStartupDurationSeconds }}
+  maximumStartupDurationSeconds: {{ .Values.prometheus.prometheusSpec.maximumStartupDurationSeconds }}
+{{- end }}
   hostNetwork: {{ .Values.prometheus.prometheusSpec.hostNetwork }}
 {{- if .Values.prometheus.prometheusSpec.hostAliases }}
   hostAliases:

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -3878,7 +3878,7 @@ prometheus:
     ## success after the WAL replay is complete. If set, the value should be
     ## greater than 60 (seconds). Otherwise it will be equal to 600 seconds (15
     ## minutes).
-    # maximumStartupDurationSeconds: 120
+    maximumStartupDurationSeconds: 0
 
   additionalRulesForClusterRole: []
   #  - apiGroups: [ "" ]

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -3873,6 +3873,13 @@ prometheus:
     ## Otherwise, use prometheus.prometheusSpec.additionalConfig (passed through tpl)
     additionalConfigString: ""
 
+    ## Defines the maximum time that the `prometheus` container's startup probe
+    ## will wait before being considered failed. The startup probe will return
+    ## success after the WAL replay is complete. If set, the value should be
+    ## greater than 60 (seconds). Otherwise it will be equal to 600 seconds (15
+    ## minutes).
+    # maximumStartupDurationSeconds: 120
+
   additionalRulesForClusterRole: []
   #  - apiGroups: [ "" ]
   #    resources:


### PR DESCRIPTION

#### What this PR does / why we need it

This PR allows tuning startupTime in operated prometheus. Should be valuable for the installations with big TSDB

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)

@zeritti @gianrubio @zanhsieh