### PR TITLE
[kube-prometheus-stack] Fixing template inconsistencies in prometheus-operator fullname

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 56.6.0
+version: 56.6.1
 appVersion: v0.71.2
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/deployment/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/deployment/deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "kube-prometheus-stack.fullname" . }}-operator-webhook
+  name: {{ template "kube-prometheus-stack.operator.fullname" . }}-webhook
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}-operator-webhook

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/deployment/pdb.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/deployment/pdb.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy/v1{{ ternary "" "beta1" ($.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget") }}
 kind: PodDisruptionBudget
 metadata:
-  name: {{ template "kube-prometheus-stack.fullname" . }}-operator-webhook
+  name: {{ template "kube-prometheus-stack.operator.fullname" . }}-webhook
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     {{- include "kube-prometheus-stack.prometheus-operator-webhook.labels" . | nindent 4 }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/deployment/service.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/deployment/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "kube-prometheus-stack.fullname" . }}-operator-webhook
+  name: {{ template "kube-prometheus-stack.operator.fullname" . }}-webhook
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}-operator-webhook

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/ciliumnetworkpolicy.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/ciliumnetworkpolicy.yaml
@@ -2,7 +2,7 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: {{ template "kube-prometheus-stack.fullname" . }}-operator
+  name: {{ template "kube-prometheus-stack.operator.fullname" . }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     {{- include "kube-prometheus-stack.prometheus-operator.labels" . | nindent 4 }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/clusterrole.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "kube-prometheus-stack.fullname" . }}-operator
+  name: {{ template "kube-prometheus-stack.operator.fullname" . }}
   labels:
     {{- include "kube-prometheus-stack.prometheus-operator.labels" . | nindent 4 }}
 rules:

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/clusterrolebinding.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/clusterrolebinding.yaml
@@ -2,13 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "kube-prometheus-stack.fullname" . }}-operator
+  name: {{ template "kube-prometheus-stack.operator.fullname" . }}
   labels:
     {{- include "kube-prometheus-stack.prometheus-operator.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "kube-prometheus-stack.fullname" . }}-operator
+  name: {{ template "kube-prometheus-stack.operator.fullname" . }}
 subjects:
 - kind: ServiceAccount
   name: {{ template "kube-prometheus-stack.operator.serviceAccountName" . }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -4,7 +4,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "kube-prometheus-stack.fullname" . }}-operator
+  name: {{ template "kube-prometheus-stack.operator.fullname" . }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     {{- include "kube-prometheus-stack.prometheus-operator.labels" . | nindent 4 }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/networkpolicy.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/networkpolicy.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ template "kube-prometheus-stack.prometheus.networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
 metadata:
-  name: {{ template "kube-prometheus-stack.fullname" . }}-operator
+  name: {{ template "kube-prometheus-stack.operator.fullname" . }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     {{- include "kube-prometheus-stack.prometheus-operator.labels" . | nindent 4 }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/psp-clusterrole.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/psp-clusterrole.yaml
@@ -3,7 +3,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ template "kube-prometheus-stack.fullname" . }}-operator-psp
+  name: {{ template "kube-prometheus-stack.operator.fullname" . }}-psp
   labels:
     {{- include "kube-prometheus-stack.prometheus-operator.labels" . | nindent 4 }}
 rules:
@@ -16,6 +16,6 @@ rules:
   resources: ['podsecuritypolicies']
   verbs:     ['use']
   resourceNames:
-  - {{ template "kube-prometheus-stack.fullname" . }}-operator
+  - {{ template "kube-prometheus-stack.operator.fullname" . }}
 {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/psp-clusterrolebinding.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/psp-clusterrolebinding.yaml
@@ -3,13 +3,13 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ template "kube-prometheus-stack.fullname" . }}-operator-psp
+  name: {{ template "kube-prometheus-stack.operator.fullname" . }}-psp
   labels:
     {{- include "kube-prometheus-stack.prometheus-operator.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "kube-prometheus-stack.fullname" . }}-operator-psp
+  name: {{ template "kube-prometheus-stack.operator.fullname" . }}-psp
 subjects:
   - kind: ServiceAccount
     name: {{ template "kube-prometheus-stack.operator.serviceAccountName" . }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/psp.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/psp.yaml
@@ -3,7 +3,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ template "kube-prometheus-stack.fullname" . }}-operator
+  name: {{ template "kube-prometheus-stack.operator.fullname" . }}
   labels:
     {{- include "kube-prometheus-stack.prometheus-operator.labels" . | nindent 4 }}
 {{- if .Values.global.rbac.pspAnnotations }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/service.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "kube-prometheus-stack.fullname" . }}-operator
+  name: {{ template "kube-prometheus-stack.operator.fullname" . }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     {{- include "kube-prometheus-stack.prometheus-operator.labels" . | nindent 4 }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ template "kube-prometheus-stack.fullname" . }}-operator
+  name: {{ template "kube-prometheus-stack.operator.fullname" . }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     {{- include "kube-prometheus-stack.prometheus-operator.labels" . | nindent 4 }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/verticalpodautoscaler.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/verticalpodautoscaler.yaml
@@ -2,7 +2,7 @@
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
-  name: {{ template "kube-prometheus-stack.fullname" . }}-operator
+  name: {{ template "kube-prometheus-stack.operator.fullname" . }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     {{- include "kube-prometheus-stack.prometheus-operator.labels" . | nindent 4 }}
@@ -32,7 +32,7 @@ spec:
   targetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ template "kube-prometheus-stack.fullname" . }}-operator
+    name: {{ template "kube-prometheus-stack.operator.fullname" . }}
   {{- with .Values.prometheusOperator.verticalPodAutoscaler.updatePolicy }}
   updatePolicy:
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
The prometheus-operator fullname is already defined and suffixed in
https://github.com/prometheus-community/helm-charts/blob/2f3dbddd3ed01e3b5044a9186f064b050dbe9a31/charts/kube-prometheus-stack/templates/_helpers.tpl#L27-L30

However, it's not used globally in the templates. With these changes there will be no inconsistencies between the `_helpers.tpl` and the templates themself.

#### Which issue this PR fixes

- fixes #

#### Special notes for your reviewer
There will be no actual changes in the generated files using `helm template` command after this contribution

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
