### PR TITLE
[kube-prometheus-stack] reduce severity of 'KubeHpaMaxedOut' to 'info'

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 56.6.2
+version: 56.7.0
 appVersion: v0.71.2
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-apps.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-apps.yaml
@@ -555,7 +555,7 @@ spec:
       keep_firing_for: "{{ . }}"
       {{- end }}
       labels:
-        severity: warning
+        severity: info
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
         {{- with .Values.defaultRules.additionalRuleLabels }}
           {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
#### What this PR does / why we need it

The KubeHpaMaxedOut alerts when an HPA is running at maximum replicas for a given amount of time. I would claim there isn't necessarily application impact therefore the severity should be `info` instead of warning `warning`.
This is good to know to tune the HPA, and can be used to add context when paired with a highLatency or longQueue alert but on its own it doesn't require any action. In addition, there are legitimate cases where one may want to prevent an application to scale past a certain point, for example to avoid rate limiting. Therefore, I propose to reduce its severity to `info` and profit from the built-in `InfoInhibitor` alert and inhibition rule to forward with only together with higher severity alerts. 

I am conscious this is a breaking change and I am open for feedback. If my reasoning is contentious we could make it configurable.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
