### PR TITLE
[prometheus-nginx-exporter] Fix Annotation Use in Chart

### DIFF
--- a/charts/prometheus-nginx-exporter/Chart.yaml
+++ b/charts/prometheus-nginx-exporter/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for the Prometheus NGINX Exporter
 name: prometheus-nginx-exporter
-version: 0.2.0
+version: 0.2.1
 appVersion: 0.11.0
 home: https://github.com/nginxinc/nginx-prometheus-exporter
 sources:

--- a/charts/prometheus-nginx-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-nginx-exporter/templates/_helpers.tpl
@@ -77,3 +77,27 @@ Selector labels
 app.kubernetes.io/name: {{ include "prometheus-nginx-exporter.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Pod annotations
+*/}}
+{{- define "prometheus-nginx-exporter.podAnnotations" }}
+{{- if .Values.additionalAnnotations }}
+{{ toYaml .Values.additionalAnnotations }}
+{{- end }}
+{{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations }}
+{{- end }}
+{{- end }}
+
+{{/*
+Service annotations
+*/}}
+{{- define "prometheus-nginx-exporter.serviceAnnotations" }}
+{{- if .Values.additionalAnnotations }}
+{{ toYaml .Values.additionalAnnotations }}
+{{- end }}
+{{- if .Values.service.annotations }}
+{{ toYaml .Values.service.annotations }}
+{{- end }}
+{{- end }}

--- a/charts/prometheus-nginx-exporter/templates/deployment.yaml
+++ b/charts/prometheus-nginx-exporter/templates/deployment.yaml
@@ -25,9 +25,7 @@ spec:
       labels:
         {{- include "prometheus-nginx-exporter.labels" . | indent 8 }}
       annotations:
-      {{- with .Values.additionalAnnotations }}
-      {{ toYaml . | indent 6 }}
-      {{- end }}
+        {{- include "prometheus-nginx-exporter.podAnnotations" . | indent 8 }}
     spec:
       serviceAccountName: {{ template "prometheus-nginx-exporter.serviceAccountName" . }}
       {{- with .Values.initContainers }}

--- a/charts/prometheus-nginx-exporter/templates/deployment.yaml
+++ b/charts/prometheus-nginx-exporter/templates/deployment.yaml
@@ -4,10 +4,7 @@ kind: Deployment
 metadata:
   name: {{ include "prometheus-nginx-exporter.fullname" . }}
   namespace: {{ template "prometheus-nginx-exporter.namespace" . }}
-  {{- with .Values.additionalAnnotations }}
-  annotations:
-  {{ toYaml . | indent 4 }}
-  {{- end }}
+  annotations: {{ toYaml .Values.additionalAnnotations | nindent 4 }}
   labels:
     {{- include "prometheus-nginx-exporter.labels" . | indent 4 }}
 spec:

--- a/charts/prometheus-nginx-exporter/templates/role.yaml
+++ b/charts/prometheus-nginx-exporter/templates/role.yaml
@@ -5,10 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "prometheus-nginx-exporter.fullname" . }}
   namespace: {{ template "prometheus-nginx-exporter.namespace" . }}
-  {{- if .Values.additionalAnnotations }}
-  annotations:
-  {{ toYaml .Values.additionalAnnotations | indent 4 }}
-  {{- end }}
+  annotations: {{ toYaml .Values.additionalAnnotations | nindent 4 }}
   labels:
     {{- include "prometheus-nginx-exporter.labels" . | indent 4 }}
 rules:

--- a/charts/prometheus-nginx-exporter/templates/rolebinding.yaml
+++ b/charts/prometheus-nginx-exporter/templates/rolebinding.yaml
@@ -5,10 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "prometheus-nginx-exporter.fullname" . }}
   namespace: {{ template "prometheus-nginx-exporter.namespace" . }}
-  {{- if .Values.additionalAnnotations }}
-  annotations:
-  {{ toYaml .Values.additionalAnnotations | indent 4 }}
-  {{- end }}
+  annotations: {{ toYaml .Values.additionalAnnotations | nindent 4 }}
   labels:
     {{- include "prometheus-nginx-exporter.labels" . | indent 4 }}
 subjects:

--- a/charts/prometheus-nginx-exporter/templates/service.yaml
+++ b/charts/prometheus-nginx-exporter/templates/service.yaml
@@ -4,13 +4,8 @@ kind: Service
 metadata:
   name: {{ include "prometheus-nginx-exporter.fullname" . }}
   namespace: {{ template "prometheus-nginx-exporter.namespace" . }}
-  {{- if or .Values.service.annotations .Values.additionalAnnotations }}
   annotations:
-  {{ toYaml .Values.service.annotations | indent 4 }}
-  {{- with .Values.additionalAnnotations }}
-  {{ toYaml . | indent 4 }}
-  {{- end }}
-  {{- end }}
+    {{- include "prometheus-nginx-exporter.serviceAnnotations" . | indent 4 }}
   labels:
     {{- include "prometheus-nginx-exporter.labels" . | indent 4 }}
 spec:

--- a/charts/prometheus-nginx-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-nginx-exporter/templates/serviceaccount.yaml
@@ -3,10 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  {{- if .Values.additionalAnnotations }}
-  annotations:
-  {{ toYaml .Values.additionalAnnotations | indent 4 }}
-  {{- end }}
+  annotations: {{ toYaml .Values.additionalAnnotations | nindent 4 }}
   labels:
     {{- include "prometheus-nginx-exporter.labels" . | indent 4 }}
   name: {{ template "prometheus-nginx-exporter.serviceAccountName" . }}

--- a/charts/prometheus-nginx-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-nginx-exporter/templates/servicemonitor.yaml
@@ -5,10 +5,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-nginx-exporter.fullname" .  }}
   namespace: {{ template "prometheus-nginx-exporter.namespace" . }}
-  {{- if .Values.additionalAnnotations }}
-  annotations:
-  {{ toYaml .Values.additionalAnnotations | indent 4 }}
-  {{- end }}
+  annotations: {{ toYaml .Values.additionalAnnotations | nindent 4 }}
   labels:
     {{- include "prometheus-nginx-exporter.labels" . | indent 4 }}
     {{- if .Values.serviceMonitor.additionalLabels }}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
The prometheus-nginx-exporter has two ways to add additional annotations to the resources created by it, the `additionalAnnotations` field and the `podAnnotations` field. Using them in the current version of the chart either breaks the templating or - in the case of the `podAnnotations` field - has no effect.

This PR unifies the use of the `additionalAnnotations` field across the different resources and integrates the `podAnnotations` field into a new helper so that annotations added in this field have an effect.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
