### PR TITLE
[prometheus-elasticsearch-exporter] Support ILM metrics

### DIFF
--- a/charts/prometheus-elasticsearch-exporter/Chart.yaml
+++ b/charts/prometheus-elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: prometheus-elasticsearch-exporter
-version: 5.4.0
+version: 5.5.0
 kubeVersion: ">=1.10.0-0"
 appVersion: "v1.7.0"
 home: https://github.com/prometheus-community/elasticsearch_exporter

--- a/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
+++ b/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
@@ -117,6 +117,9 @@ spec:
                     {{- if .Values.es.data_stream }}
                     "--es.data_stream",
                     {{- end }}
+                    {{- if .Values.es.ilm }}
+                    "--es.ilm",
+                    {{- end }}
                     "--es.timeout={{ .Values.es.timeout }}",
                     {{- if .Values.es.sslSkipVerify }}
                     "--es.ssl-skip-verify",

--- a/charts/prometheus-elasticsearch-exporter/values.yaml
+++ b/charts/prometheus-elasticsearch-exporter/values.yaml
@@ -48,7 +48,8 @@ log:
   format: logfmt
   level: info
 
-resources: {}
+resources:
+  {}
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
@@ -182,6 +183,10 @@ es:
   ##
   data_stream: false
 
+  ## If true, query stats for Index Lifecycle Management.
+  ##
+  ilm: false
+
   ## Timeout for trying to get stats from Elasticsearch. (ex: 20s)
   ##
   timeout: 30s
@@ -254,7 +259,8 @@ prometheusRule:
   enabled: false
   #  namespace: monitoring
   labels: {}
-  rules: []
+  rules:
+    []
     # - record: elasticsearch_filesystem_data_used_percent
     #   expr: |
     #     100 * (elasticsearch_filesystem_data_size_bytes{service="{{ template "elasticsearch-exporter.fullname" . }}"} - elasticsearch_filesystem_data_free_bytes{service="{{ template "elasticsearch-exporter.fullname" . }}"})

--- a/charts/prometheus-elasticsearch-exporter/values.yaml
+++ b/charts/prometheus-elasticsearch-exporter/values.yaml
@@ -48,8 +48,7 @@ log:
   format: logfmt
   level: info
 
-resources:
-  {}
+resources: {}
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
@@ -259,8 +258,7 @@ prometheusRule:
   enabled: false
   #  namespace: monitoring
   labels: {}
-  rules:
-    []
+  rules: []
     # - record: elasticsearch_filesystem_data_used_percent
     #   expr: |
     #     100 * (elasticsearch_filesystem_data_size_bytes{service="{{ template "elasticsearch-exporter.fullname" . }}"} - elasticsearch_filesystem_data_free_bytes{service="{{ template "elasticsearch-exporter.fullname" . }}"})


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Elasticsearch Exporter supports exposing metrics related to Index Lifecycle Management since 1.6.0.
While this is actually missing from the exporter README, [release notes](https://github.com/prometheus-community/elasticsearch_exporter/releases/tag/v1.6.0) and the [code](https://github.com/prometheus-community/elasticsearch_exporter/blob/master/main.go#L80) shows that it is actually available.
Lets allow chart users to configure it through the values.

#### Which issue this PR fixes

No opened issues

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
