### PR TITLE
[kube-state-metrics] Fix the customResourceState.enabled args conditional

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 5.16.0
+version: 5.16.1
 appVersion: 2.10.1
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/kube-state-metrics/templates/deployment.yaml
@@ -115,9 +115,9 @@ spec:
         {{- if .Values.selfMonitor.telemetryPort }}
         - --telemetry-port={{ $telemetryPort }}
         {{- end }}
+        {{- end }}
         {{- if .Values.customResourceState.enabled }}
         - --custom-resource-state-config-file=/etc/customresourcestate/config.yaml
-        {{- end }}
         {{- end }}
         {{- if or (.Values.kubeconfig.enabled) (.Values.customResourceState.enabled) (.Values.volumeMounts) }}
         volumeMounts:


### PR DESCRIPTION
#### What this PR does / why we need it

The conditional for including the custom resource state configmap is errantly included inside the conditional for kubeRBACProxy

#### Which issue this PR fixes

n/a

#### Special notes for your reviewer

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
