### PR TITLE
[prometheus-rabbitmq-exporter] Allows reading User from secret

### DIFF
--- a/charts/prometheus-rabbitmq-exporter/Chart.yaml
+++ b/charts/prometheus-rabbitmq-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Rabbitmq metrics exporter for prometheus
 name: prometheus-rabbitmq-exporter
-version: 1.10.0
+version: 1.11.0
 appVersion: v0.29.0
 home: https://github.com/kbudde/rabbitmq_exporter
 sources:

--- a/charts/prometheus-rabbitmq-exporter/templates/deployment.yaml
+++ b/charts/prometheus-rabbitmq-exporter/templates/deployment.yaml
@@ -59,8 +59,13 @@ spec:
               - name: RABBIT_PASSWORD
                 value: {{ .Values.rabbitmq.password }}
            {{- end }}
-
-           {{- if .Values.rabbitmq.user }}
+           {{- if .Values.rabbitmq.existingUserSecret }}
+              - name: RABBIT_USER
+                valueFrom:
+                  secretKeyRef:
+                    name: "{{ .Values.rabbitmq.existingUserSecret }}"
+                    key: "{{ .Values.rabbitmq.existingUserSecretKey }}"
+           {{- else if .Values.rabbitmq.user }}
               - name: RABBIT_USER
                 value: {{ .Values.rabbitmq.user }}
            {{- end }}

--- a/charts/prometheus-rabbitmq-exporter/values.yaml
+++ b/charts/prometheus-rabbitmq-exporter/values.yaml
@@ -39,6 +39,9 @@ rabbitmq:
   url: http://myrabbit:15672
   user: guest
   password: guest
+  # If existingUserSecret is set then user is ignored
+  existingUserSecret: ~
+  existingUserSecretKey: username
   # If existingPasswordSecret is set then password is ignored
   existingPasswordSecret: ~
   existingPasswordSecretKey: password


### PR DESCRIPTION
Currently the exporter allows using password from secret. This patch allows users to read username from secret as well. This is used in cases where automated username is created during install process of rabbitmq service.

Signed-off-by: Sulochan Acharya <sulochan@gmail.com>