### PR TITLE
[prometheus-smartctl-exporter] Fix typo in (prometheus)-rules.txt

### DIFF
--- a/charts/prometheus-smartctl-exporter/Chart.yaml
+++ b/charts/prometheus-smartctl-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/prometheus-smartctl-exporter/rules/rules.txt
+++ b/charts/prometheus-smartctl-exporter/rules/rules.txt
@@ -13,10 +13,10 @@ rules:
   for: 1m
   labels:
     severity: warning
-- alert: SmartCTLDeviceAvailableSpareUnderThreadhold
+- alert: SmartCTLDeviceAvailableSpareUnderThreshold
   expr: smartctl_device_available_spare_threshold > smartctl_device_available_spare
   annotations:
-    message: Device {{ $labels.device }} on instance {{ $labels.instance }} is under available spare threashold.
+    message: Device {{ $labels.device }} on instance {{ $labels.instance }} is under available spare threshold.
   for: 1m
   labels:
     severity: warning


### PR DESCRIPTION

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
It fixes a typo that i noticed while reviewing prometheusRules

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
