### PR TITLE
[kube-prometheus-stack] Add automountServiceAccountToken option

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 56.9.0
+version: 56.10.0
 appVersion: v0.71.2
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/alertmanager/alertmanager.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/alertmanager.yaml
@@ -31,6 +31,7 @@ spec:
   replicas: {{ .Values.alertmanager.alertmanagerSpec.replicas }}
   listenLocal: {{ .Values.alertmanager.alertmanagerSpec.listenLocal }}
   serviceAccountName: {{ template "kube-prometheus-stack.alertmanager.serviceAccountName" . }}
+  automountServiceAccountToken: {{ .Values.alertmanager.alertmanagerSpec.automountServiceAccountToken }}
 {{- if .Values.alertmanager.alertmanagerSpec.externalUrl }}
   externalUrl: "{{ tpl .Values.alertmanager.alertmanagerSpec.externalUrl . }}"
 {{- else if and .Values.alertmanager.ingress.enabled .Values.alertmanager.ingress.hosts }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/deployment/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/deployment/deployment.yaml
@@ -119,6 +119,7 @@ spec:
 {{ toYaml .Values.prometheusOperator.admissionWebhooks.deployment.securityContext | indent 8 }}
 {{- end }}
       serviceAccountName: {{ template "kube-prometheus-stack.operator.serviceAccountName" . }}-webhook
+      automountServiceAccountToken: {{ .Values.prometheusOperator.admissionWebhooks.deployment.automountServiceAccountToken }}
 {{- if .Values.prometheusOperator.admissionWebhooks.deployment.hostNetwork }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -171,6 +171,7 @@ spec:
 {{ toYaml .Values.prometheusOperator.securityContext | indent 8 }}
 {{- end }}
       serviceAccountName: {{ template "kube-prometheus-stack.operator.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.prometheusOperator.automountServiceAccountToken }}
 {{- if .Values.prometheusOperator.hostNetwork }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/serviceaccount.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/serviceaccount.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     {{- include "kube-prometheus-stack.prometheus-operator.labels" . | nindent 4 }}
+automountServiceAccountToken: {{ .Values.prometheusOperator.serviceAccount.automountServiceAccountToken }}
 {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets:
 {{ include "kube-prometheus-stack.imagePullSecrets" . | trim | indent 2 }}

--- a/charts/kube-prometheus-stack/templates/prometheus/serviceaccount.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/serviceaccount.yaml
@@ -13,6 +13,7 @@ metadata:
   annotations:
 {{ toYaml .Values.prometheus.serviceAccount.annotations | indent 4 }}
 {{- end }}
+automountServiceAccountToken: {{ .Values.prometheus.serviceAccount.automountServiceAccountToken }}
 {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets:
 {{ include "kube-prometheus-stack.imagePullSecrets" . | trim | indent 2 }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -658,6 +658,10 @@ alertmanager:
     ##
     secrets: []
 
+    ## If false then the user will opt out of automounting API credentials.
+    ##
+    automountServiceAccountToken: true
+
     ## ConfigMaps is a list of ConfigMaps in the same namespace as the Alertmanager object, which shall be mounted into the Alertmanager Pods.
     ## The ConfigMaps are mounted into /etc/alertmanager/configmaps/.
     ##
@@ -2739,6 +2743,10 @@ prometheusOperator:
   ## Set a Field Selector to filter watched secrets
   ##
   secretFieldSelector: "type!=kubernetes.io/dockercfg,type!=kubernetes.io/service-account-token,type!=helm.sh/release.v1"
+
+  ## If false then the user will opt out of automounting API credentials.
+  ##
+  automountServiceAccountToken: true
 
 ## Deploy a Prometheus instance
 ##

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -2330,6 +2330,10 @@ prometheusOperator:
           drop:
             - ALL
 
+      ## If false then the user will opt out of automounting API credentials.
+      ##
+      automountServiceAccountToken: true
+
     patch:
       enabled: true
       image:

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -2435,6 +2435,7 @@ prometheusOperator:
   serviceAccount:
     create: true
     name: ""
+    automountServiceAccountToken: true
 
   ## Configuration for Prometheus operator service
   ##
@@ -2784,6 +2785,7 @@ prometheus:
     create: true
     name: ""
     annotations: {}
+    automountServiceAccountToken: true
 
   # Service for thanos service discovery on sidecar
   # Enable this can make Thanos Query can use


### PR DESCRIPTION
#### What this PR does / why we need it

Add automountServiceAccountToken option to prometheus and prometheus-operator. It is needed as Azure's security recommendation suggests disabling automounting of API credentials.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name
