### PR TITLE
OpenCost 1.109.0, which moved the default container registry to GHCR.io

### DIFF
--- a/charts/prometheus-opencost-exporter/Chart.yaml
+++ b/charts/prometheus-opencost-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 appVersion: 1.109.0
-version: 0.1.2
+version: 0.2.0
 description: Prometheus OpenCost Exporter
 home: https://github.com/opencost/opencost
 name: prometheus-opencost-exporter

--- a/charts/prometheus-opencost-exporter/Chart.yaml
+++ b/charts/prometheus-opencost-exporter/Chart.yaml
@@ -1,5 +1,5 @@
-appVersion: 1.108.0
-version: 0.1.1
+appVersion: 1.109.0
+version: 0.1.2
 description: Prometheus OpenCost Exporter
 home: https://github.com/opencost/opencost
 name: prometheus-opencost-exporter
@@ -11,6 +11,7 @@ keywords:
 - opencost
 - prometheus
 - exporter
+- finops
 maintainers:
 - email: mattray@kubecost.com
   name: mattray

--- a/charts/prometheus-opencost-exporter/README.md
+++ b/charts/prometheus-opencost-exporter/README.md
@@ -1,4 +1,4 @@
-# Prometheus Opencost Exporter
+# Prometheus OpenCost Exporter
 
 Prometheus exporter for [OpenCost](https://www.opencost.io) Kubernetes cost monitoring data.
 

--- a/charts/prometheus-opencost-exporter/templates/deployment.yaml
+++ b/charts/prometheus-opencost-exporter/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ include "prometheus-opencost-exporter.fullname" . }}
-          image: "{{ .Values.opencost.exporter.image.registry }}/{{ .Values.opencost.exporter.image.repository }}:{{ .Values.opencost.exporter.image.tag | default (printf "prod-%s" .Chart.AppVersion) }}"
+          image: "{{ .Values.opencost.exporter.image.registry }}/{{ .Values.opencost.exporter.image.repository }}:{{ .Values.opencost.exporter.image.tag | default (printf "%s" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.opencost.exporter.image.pullPolicy }}
           ports:
             - containerPort: 9003

--- a/charts/prometheus-opencost-exporter/values.yaml
+++ b/charts/prometheus-opencost-exporter/values.yaml
@@ -53,9 +53,9 @@ opencost:
     defaultClusterId: 'default-cluster'
     image:
       # -- Exporter container image registry
-      registry: quay.io
+      registry: ghcr.io
       # -- Exporter container image name
-      repository: kubecost1/kubecost-cost-model
+      repository: opencost/opencost
       # -- Exporter container image tag
       # @default -- `""` (use appVersion in Chart.yaml)
       tag: ""
@@ -170,8 +170,8 @@ opencost:
       # -- Use in-cluster Prometheus
       enabled: true
       # -- Service name of in-cluster Prometheus
-      serviceName: my-prometheus
+      serviceName: prometheus-server
       # -- Namespace of in-cluster Prometheus
-      namespaceName: opencost
+      namespaceName: prometheus-system
       # -- Service port of in-cluster Prometheus
-      port: 9090
+      port: 80


### PR DESCRIPTION
#### What this PR does / why we need it
appVersion bump to 1.109.0, version bump to 0.2.0
Registry moved from quay.io -> ghcr.io
Renamed container to "opencost" from legacy "kubecost-cost-model" Removed "prod-" tag prefix, no longer used in ghcr.io 
Synced the internal Prometheus defaults to match the documentation defaults

#### Which issue this PR fixes
n/a

#### Special notes for your reviewer
Tested locally with Kind and k3s

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
