### PR TITLE
[kube-prometheus-stack] extraVolumes and extraVolumeMounts

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 56.12.0
+version: 56.13.0
 appVersion: v0.71.2
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -168,7 +168,7 @@ spec:
             secretName: {{ template "kube-prometheus-stack.fullname" . }}-admission
         {{- end }}
         {{- with .Values.prometheusOperator.extraVolumes }}
-        {{ toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
     {{- with .Values.prometheusOperator.dnsConfig }}
       dnsConfig:

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -151,16 +151,25 @@ spec:
 {{ toYaml .Values.prometheusOperator.resources | indent 12 }}
           securityContext:
 {{ toYaml .Values.prometheusOperator.containerSecurityContext | indent 12 }}
-{{- if .Values.prometheusOperator.tls.enabled }}
           volumeMounts:
+          {{- if .Values.prometheusOperator.tls.enabled }}
             - name: tls-secret
               mountPath: /cert
               readOnly: true
+          {{- end }}
+          {{- with .Values.prometheusOperator.extraVolumeMounts }}
+          {{ toYaml . | nindent 12 }}
+          {{- end }}
       volumes:
+        {{- if .Values.prometheusOperator.tls.enabled }}
         - name: tls-secret
           secret:
             defaultMode: 420
             secretName: {{ template "kube-prometheus-stack.fullname" . }}-admission
+        {{- end }}
+        {{- with .Values.prometheusOperator.extraVolumes }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
 {{- end }}
     {{- with .Values.prometheusOperator.dnsConfig }}
       dnsConfig:

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -170,7 +170,6 @@ spec:
         {{- with .Values.prometheusOperator.extraVolumes }}
         {{ toYaml . | nindent 8 }}
         {{- end }}
-{{- end }}
     {{- with .Values.prometheusOperator.dnsConfig }}
       dnsConfig:
 {{ toYaml . | indent 8 }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -158,7 +158,7 @@ spec:
               readOnly: true
           {{- end }}
           {{- with .Values.prometheusOperator.extraVolumeMounts }}
-          {{ toYaml . | nindent 12 }}
+          {{- toYaml . | nindent 12 }}
           {{- end }}
       volumes:
         {{- if .Values.prometheusOperator.tls.enabled }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -2756,6 +2756,14 @@ prometheusOperator:
   ##
   automountServiceAccountToken: true
 
+  ## Additional volumes
+  ##
+  extraVolumes: []
+
+  ## Additional volume mounts
+  ##
+  extraVolumeMounts: []
+
 ## Deploy a Prometheus instance
 ##
 prometheus:


### PR DESCRIPTION
[kube-prometheus-stack] Add extraVolumes and extraVolumeMounts to prometheus-operator deployment.

This is required to manually mount service account token, related to #4285.

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name
