### PR TITLE
[CI] Group chart-tester logs

### DIFF
--- a/.github/linters/ct.yaml
+++ b/.github/linters/ct.yaml
@@ -7,6 +7,7 @@ chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
   - grafana=https://grafana.github.io/helm-charts
   - prometheus-community=https://prometheus-community.github.io/helm-charts
+github-groups: true
 helm-extra-args: --timeout 600s
 excluded-charts:
   # If not running on GCE, will error: "Failed to get GCE config"


### PR DESCRIPTION
#### What this PR does / why we need it

Makes chart-testing logs easier to read. Feature createad on https://github.com/helm/chart-testing/pull/556.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
