### PR TITLE
[kube-prometheus-stack] Allow setting selectors for built-in ServiceMonitors

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 56.13.1
+version: 56.14.0
 appVersion: v0.71.2
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/ci/03-non-defaults-values.yaml
+++ b/charts/kube-prometheus-stack/ci/03-non-defaults-values.yaml
@@ -54,7 +54,7 @@ coreDns:
   serviceMonitor:
     selector:
       matchLabels:
-        k8s-app: kube-dns
+        k8s-app: '{{ $.Release.Name }}'
 kubeEtcd:
   service:
     enabled: false

--- a/charts/kube-prometheus-stack/ci/03-non-defaults-values.yaml
+++ b/charts/kube-prometheus-stack/ci/03-non-defaults-values.yaml
@@ -40,3 +40,39 @@ customRules:
   AlertmanagerMembersInconsistent:
     for: 5m
     severity: "warning"
+
+kubeControllerManager:
+  service:
+    enabled: false
+  serviceMonitor:
+    selector:
+      matchLabels:
+        component: kube-controller-manager
+coreDns:
+  service:
+    enabled: false
+  serviceMonitor:
+    selector:
+      matchLabels:
+        k8s-app: kube-dns
+kubeEtcd:
+  service:
+    enabled: false
+  serviceMonitor:
+    selector:
+      matchLabels:
+        component: etcd
+kubeScheduler:
+  service:
+    enabled: false
+  serviceMonitor:
+    selector:
+      matchLabels:
+        component: kube-scheduler
+kubeProxy:
+  service:
+    enabled: false
+  serviceMonitor:
+    selector:
+      matchLabels:
+        k8s-app: kube-proxy

--- a/charts/kube-prometheus-stack/templates/exporters/core-dns/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/core-dns/servicemonitor.yaml
@@ -15,12 +15,16 @@ metadata:
   {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
-  jobLabel: jobLabel
+  jobLabel: {{ .Values.coreDns.serviceMonitor.jobLabel }}
   {{- include "servicemonitor.scrapeLimits" .Values.coreDns.serviceMonitor | nindent 2 }}
   selector:
+    {{- if .Values.coreDns.serviceMonitor.selector }}
+    {{ tpl (toYaml .Values.coreDns.serviceMonitor.selector | nindent 4) . }}
+    {{- else }}
     matchLabels:
       app: {{ template "kube-prometheus-stack.name" . }}-coredns
       release: {{ $.Release.Name | quote }}
+    {{- end }}
   namespaceSelector:
     matchNames:
       - "kube-system"

--- a/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/servicemonitor.yaml
@@ -15,12 +15,16 @@ metadata:
   {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
-  jobLabel: jobLabel
+  jobLabel: {{ .Values.kubeControllerManager.serviceMonitor.jobLabel }}
   {{- include "servicemonitor.scrapeLimits" .Values.kubeControllerManager.serviceMonitor | nindent 2 }}
   selector:
+    {{- if .Values.kubeControllerManager.serviceMonitor.selector }}
+    {{ tpl (toYaml .Values.kubeControllerManager.serviceMonitor.selector | nindent 4) . }}
+    {{- else }}
     matchLabels:
       app: {{ template "kube-prometheus-stack.name" . }}-kube-controller-manager
       release: {{ $.Release.Name | quote }}
+    {{- end }}
   namespaceSelector:
     matchNames:
       - "kube-system"

--- a/charts/kube-prometheus-stack/templates/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-dns/servicemonitor.yaml
@@ -15,12 +15,16 @@ metadata:
   {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
-  jobLabel: jobLabel
+  jobLabel: {{ .Values.kubeDns.serviceMonitor.jobLabel }}
   {{- include "servicemonitor.scrapeLimits" .Values.kubeDns.serviceMonitor | nindent 2 }}
   selector:
+    {{- if .Values.kubeDns.serviceMonitor.selector }}
+    {{ tpl (toYaml .Values.kubeDns.serviceMonitor.selector | nindent 4) . }}
+    {{- else }}
     matchLabels:
       app: {{ template "kube-prometheus-stack.name" . }}-kube-dns
       release: {{ $.Release.Name | quote }}
+    {{- end }}
   namespaceSelector:
     matchNames:
       - "kube-system"

--- a/charts/kube-prometheus-stack/templates/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-etcd/servicemonitor.yaml
@@ -15,12 +15,16 @@ metadata:
   {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
-  jobLabel: jobLabel
+  jobLabel: {{ .Values.kubeEtcd.serviceMonitor.jobLabel }}
   {{- include "servicemonitor.scrapeLimits" .Values.kubeEtcd.serviceMonitor | nindent 4 }}
   selector:
+    {{- if .Values.kubeEtcd.serviceMonitor.selector }}
+    {{ tpl (toYaml .Values.kubeEtcd.serviceMonitor.selector | nindent 4) . }}
+    {{- else }}
     matchLabels:
       app: {{ template "kube-prometheus-stack.name" . }}-kube-etcd
       release: {{ $.Release.Name | quote }}
+    {{- end }}
   namespaceSelector:
     matchNames:
       - "kube-system"

--- a/charts/kube-prometheus-stack/templates/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-proxy/servicemonitor.yaml
@@ -15,12 +15,16 @@ metadata:
   {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
-  jobLabel: jobLabel
+  jobLabel: {{ .Values.kubeProxy.serviceMonitor.jobLabel }}
   {{- include "servicemonitor.scrapeLimits" .Values.kubeProxy.serviceMonitor | nindent 2 }}
   selector:
+    {{- if .Values.kubeProxy.serviceMonitor.selector }}
+    {{ tpl (toYaml .Values.kubeProxy.serviceMonitor.selector | nindent 4) . }}
+    {{- else }}
     matchLabels:
       app: {{ template "kube-prometheus-stack.name" . }}-kube-proxy
       release: {{ $.Release.Name | quote }}
+    {{- end }}
   namespaceSelector:
     matchNames:
       - "kube-system"

--- a/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -15,12 +15,16 @@ metadata:
   {{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
-  jobLabel: jobLabel
+  jobLabel: {{ .Values.kubeScheduler.serviceMonitor.jobLabel }}
   {{- include "servicemonitor.scrapeLimits" .Values.kubeScheduler.serviceMonitor | nindent 2 }}
   selector:
+    {{- if .Values.kubeScheduler.serviceMonitor.selector }}
+    {{ tpl (toYaml .Values.kubeScheduler.serviceMonitor.selector | nindent 4) . }}
+    {{- else }}
     matchLabels:
       app: {{ template "kube-prometheus-stack.name" . }}-kube-scheduler
       release: {{ $.Release.Name | quote }}
+    {{- end }}
   namespaceSelector:
     matchNames:
       - "kube-system"

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1486,6 +1486,11 @@ kubeControllerManager:
     ##
     proxyUrl: ""
 
+    jobLabel: jobLabel
+    selector: {}
+    #  matchLabels:
+    #    component: kube-controller-manager
+
     ## Enable scraping kube-controller-manager over https.
     ## Requires proper certs (not self-signed) and delegated authentication/authorization checks.
     ## If null or unset, the value is determined dynamically based on target Kubernetes version.
@@ -1562,6 +1567,11 @@ coreDns:
     ##
     proxyUrl: ""
 
+    jobLabel: jobLabel
+    selector: {}
+    #  matchLabels:
+    #    k8s-app: kube-dns
+
     ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
     ##
@@ -1627,6 +1637,11 @@ kubeDns:
     ## proxyUrl: URL of a proxy that should be used for scraping.
     ##
     proxyUrl: ""
+
+    jobLabel: jobLabel
+    selector: {}
+    #  matchLabels:
+    #    k8s-app: kube-dns
 
     ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
@@ -1739,6 +1754,11 @@ kubeEtcd:
     certFile: ""
     keyFile: ""
 
+    jobLabel: jobLabel
+    selector: {}
+    #  matchLabels:
+    #    component: etcd
+
     ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
     ##
@@ -1822,6 +1842,11 @@ kubeScheduler:
     ##
     https: null
 
+    jobLabel: jobLabel
+    selector: {}
+    #  matchLabels:
+    #    component: kube-scheduler
+
     ## Skip TLS certificate validation when scraping
     insecureSkipVerify: null
 
@@ -1900,6 +1925,11 @@ kubeProxy:
     ## proxyUrl: URL of a proxy that should be used for scraping.
     ##
     proxyUrl: ""
+
+    jobLabel: jobLabel
+    selector: {}
+    #  matchLabels:
+    #    k8s-app: kube-proxy
 
     ## Enable scraping kube-proxy over https.
     ## Requires proper certs (not self-signed) and delegated authentication/authorization checks


### PR DESCRIPTION

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This will make it easier to install the chart in environments where resources cannot be created in the kube-system namespace, such as a tightly scoped ArgoCD AppProject.

Without this change, to use the built-in ServiceMonitors with service.enabled=false, the cluster operator is expected to create services in the kube-system namespace that have labels that exactly match what the chart is expecting.

With this change, I can create these service resources with my own naming conventions and labels before installing the helm chart, and inform the ServiceMonitor on how to select them.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
