### PR TITLE
[kube-prometheus-stack] Allow changing port name of built-in ServiceMonitors

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 56.15.0
+version: 56.16.0
 appVersion: v0.71.2
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/ci/03-non-defaults-values.yaml
+++ b/charts/kube-prometheus-stack/ci/03-non-defaults-values.yaml
@@ -52,6 +52,7 @@ coreDns:
   service:
     enabled: false
   serviceMonitor:
+    port: metrics
     selector:
       matchLabels:
         k8s-app: '{{ $.Release.Name }}'

--- a/charts/kube-prometheus-stack/templates/exporters/core-dns/service.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/core-dns/service.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   clusterIP: None
   ports:
-    - name: http-metrics
+    - name: {{ .Values.coreDns.serviceMonitor.port }}
       port: {{ .Values.coreDns.service.port }}
       protocol: TCP
       targetPort: {{ .Values.coreDns.service.targetPort }}

--- a/charts/kube-prometheus-stack/templates/exporters/core-dns/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/core-dns/servicemonitor.yaml
@@ -29,7 +29,7 @@ spec:
     matchNames:
       - "kube-system"
   endpoints:
-  - port: http-metrics
+  - port: {{ .Values.coreDns.serviceMonitor.port }}
     {{- if .Values.coreDns.serviceMonitor.interval}}
     interval: {{ .Values.coreDns.serviceMonitor.interval }}
     {{- end }}

--- a/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/endpoints.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/endpoints.yaml
@@ -14,7 +14,7 @@ subsets:
       - ip: {{ . }}
       {{- end }}
     ports:
-      - name: http-metrics
+      - name: {{ .Values.kubeControllerManager.serviceMonitor.port }}
         {{- $kubeControllerManagerDefaultInsecurePort := 10252 }}
         {{- $kubeControllerManagerDefaultSecurePort := 10257 }}
         port: {{ include "kube-prometheus-stack.kubeControllerManager.insecureScrape" (list . $kubeControllerManagerDefaultInsecurePort $kubeControllerManagerDefaultSecurePort .Values.kubeControllerManager.service.port) }}

--- a/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/service.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/service.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   clusterIP: None
   ports:
-    - name: http-metrics
+    - name: {{ .Values.kubeControllerManager.serviceMonitor.port }}
       {{- $kubeControllerManagerDefaultInsecurePort := 10252 }}
       {{- $kubeControllerManagerDefaultSecurePort := 10257 }}
       port: {{ include "kube-prometheus-stack.kubeControllerManager.insecureScrape" (list . $kubeControllerManagerDefaultInsecurePort $kubeControllerManagerDefaultSecurePort .Values.kubeControllerManager.service.port) }}

--- a/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/servicemonitor.yaml
@@ -29,7 +29,7 @@ spec:
     matchNames:
       - "kube-system"
   endpoints:
-  - port: http-metrics
+  - port: {{ .Values.kubeControllerManager.serviceMonitor.port }}
     {{- if .Values.kubeControllerManager.serviceMonitor.interval }}
     interval: {{ .Values.kubeControllerManager.serviceMonitor.interval }}
     {{- end }}

--- a/charts/kube-prometheus-stack/templates/exporters/kube-etcd/endpoints.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-etcd/endpoints.yaml
@@ -14,7 +14,7 @@ subsets:
       - ip: {{ . }}
       {{- end }}
     ports:
-      - name: http-metrics
+      - name: {{ .Values.kubeEtcd.serviceMonitor.port }}
         port: {{ .Values.kubeEtcd.service.port }}
         protocol: TCP
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/exporters/kube-etcd/service.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-etcd/service.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   clusterIP: None
   ports:
-    - name: http-metrics
+    - name: {{ .Values.kubeEtcd.serviceMonitor.port }}
       port: {{ .Values.kubeEtcd.service.port }}
       protocol: TCP
       targetPort: {{ .Values.kubeEtcd.service.targetPort }}

--- a/charts/kube-prometheus-stack/templates/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-etcd/servicemonitor.yaml
@@ -29,7 +29,7 @@ spec:
     matchNames:
       - "kube-system"
   endpoints:
-  - port: http-metrics
+  - port: {{ .Values.kubeEtcd.serviceMonitor.port }}
     {{- if .Values.kubeEtcd.serviceMonitor.interval }}
     interval: {{ .Values.kubeEtcd.serviceMonitor.interval }}
     {{- end }}

--- a/charts/kube-prometheus-stack/templates/exporters/kube-proxy/endpoints.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-proxy/endpoints.yaml
@@ -14,7 +14,7 @@ subsets:
       - ip: {{ . }}
       {{- end }}
     ports:
-      - name: http-metrics
+      - name: {{ .Values.kubeProxy.serviceMonitor.port }}
         port: {{ .Values.kubeProxy.service.port }}
         protocol: TCP
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/exporters/kube-proxy/service.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-proxy/service.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   clusterIP: None
   ports:
-    - name: http-metrics
+    - name: {{ .Values.kubeProxy.serviceMonitor.port }}
       port: {{ .Values.kubeProxy.service.port }}
       protocol: TCP
       targetPort: {{ .Values.kubeProxy.service.targetPort }}

--- a/charts/kube-prometheus-stack/templates/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-proxy/servicemonitor.yaml
@@ -29,7 +29,7 @@ spec:
     matchNames:
       - "kube-system"
   endpoints:
-  - port: http-metrics
+  - port: {{ .Values.kubeProxy.serviceMonitor.port }}
     {{- if .Values.kubeProxy.serviceMonitor.interval }}
     interval: {{ .Values.kubeProxy.serviceMonitor.interval }}
     {{- end }}

--- a/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/endpoints.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/endpoints.yaml
@@ -14,7 +14,7 @@ subsets:
       - ip: {{ . }}
       {{- end }}
     ports:
-      - name: http-metrics
+      - name: {{ .Values.kubeScheduler.serviceMonitor.port }}
         {{- $kubeSchedulerDefaultInsecurePort := 10251 }}
         {{- $kubeSchedulerDefaultSecurePort := 10259 }}
         port: {{ include "kube-prometheus-stack.kubeScheduler.insecureScrape" (list . $kubeSchedulerDefaultInsecurePort $kubeSchedulerDefaultSecurePort .Values.kubeScheduler.service.port)  }}

--- a/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/service.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/service.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   clusterIP: None
   ports:
-    - name: http-metrics
+    - name: {{ .Values.kubeScheduler.serviceMonitor.port }}
       {{- $kubeSchedulerDefaultInsecurePort := 10251 }}
       {{- $kubeSchedulerDefaultSecurePort := 10259 }}
       port: {{ include "kube-prometheus-stack.kubeScheduler.insecureScrape" (list . $kubeSchedulerDefaultInsecurePort $kubeSchedulerDefaultSecurePort .Values.kubeScheduler.service.port)  }}

--- a/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -29,7 +29,7 @@ spec:
     matchNames:
       - "kube-system"
   endpoints:
-  - port: http-metrics
+  - port: {{ .Values.kubeScheduler.serviceMonitor.port }}
     {{- if .Values.kubeScheduler.serviceMonitor.interval }}
     interval: {{ .Values.kubeScheduler.serviceMonitor.interval }}
     {{- end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1486,6 +1486,10 @@ kubeControllerManager:
     ##
     proxyUrl: ""
 
+    ## port: Name of the port the metrics will be scraped from
+    ##
+    port: http-metrics
+
     jobLabel: jobLabel
     selector: {}
     #  matchLabels:
@@ -1566,6 +1570,10 @@ coreDns:
     ## proxyUrl: URL of a proxy that should be used for scraping.
     ##
     proxyUrl: ""
+
+    ## port: Name of the port the metrics will be scraped from
+    ##
+    port: http-metrics
 
     jobLabel: jobLabel
     selector: {}
@@ -1754,6 +1762,10 @@ kubeEtcd:
     certFile: ""
     keyFile: ""
 
+    ## port: Name of the port the metrics will be scraped from
+    ##
+    port: http-metrics
+
     jobLabel: jobLabel
     selector: {}
     #  matchLabels:
@@ -1842,6 +1854,10 @@ kubeScheduler:
     ##
     https: null
 
+    ## port: Name of the port the metrics will be scraped from
+    ##
+    port: http-metrics
+
     jobLabel: jobLabel
     selector: {}
     #  matchLabels:
@@ -1925,6 +1941,10 @@ kubeProxy:
     ## proxyUrl: URL of a proxy that should be used for scraping.
     ##
     proxyUrl: ""
+
+    ## port: Name of the port the metrics will be scraped from
+    ##
+    port: http-metrics
 
     jobLabel: jobLabel
     selector: {}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Following on from #4312, I found while trying to use the built-in kube-dns service instead of just a custom externally-managed one for scraping metrics that the default configuration calls the metrics port `metrics`, not `http-metrics` like the chart expects.

This change allows overriding this value for all the built-in ServiceMonitors that create Services, and setting it will change the port name for the Helm managed services to ensure setting it without using custom Services continues to work.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
