### PR TITLE
[kube-state-metrics] Ignore global values for kube-state-metrics

### DIFF
--- a/charts/kube-state-metrics/templates/_helpers.tpl
+++ b/charts/kube-state-metrics/templates/_helpers.tpl
@@ -108,7 +108,15 @@ labelValueLengthLimit: {{ . }}
 Formats imagePullSecrets. Input is (dict "Values" .Values "imagePullSecrets" .{specific imagePullSecrets})
 */}}
 {{- define "kube-state-metrics.imagePullSecrets" -}}
-{{- range (concat .Values.global.imagePullSecrets .imagePullSecrets) }}
+
+{{- $pullSecrets := "" }}
+{{- if .Values.ignoreGlobal }}
+{{- $pullSecrets = .imagePullSecrets }}
+{{- else }}
+{{- $pullSecrets = (concat .Values.global.imagePullSecrets .imagePullSecrets) }}
+{{- end }}
+
+{{- range $pullSecrets }}
   {{- if eq (typeOf .) "map[string]interface {}" }}
 - {{ toYaml . | trim }}
   {{- else }}
@@ -122,13 +130,13 @@ The image to use for kube-state-metrics
 */}}
 {{- define "kube-state-metrics.image" -}}
 {{- if .Values.image.sha }}
-{{- if .Values.global.imageRegistry }}
+{{- if and .Values.global.imageRegistry (not .Values.ignoreGlobal) }}
 {{- printf "%s/%s:%s@%s" .Values.global.imageRegistry .Values.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) .Values.image.sha }}
 {{- else }}
 {{- printf "%s/%s:%s@%s" .Values.image.registry .Values.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) .Values.image.sha }}
 {{- end }}
 {{- else }}
-{{- if .Values.global.imageRegistry }}
+{{- if and .Values.global.imageRegistry (not .Values.ignoreGlobal) }}
 {{- printf "%s/%s:%s" .Values.global.imageRegistry .Values.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) }}
 {{- else }}
 {{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) }}
@@ -141,13 +149,13 @@ The image to use for kubeRBACProxy
 */}}
 {{- define "kubeRBACProxy.image" -}}
 {{- if .Values.kubeRBACProxy.image.sha }}
-{{- if .Values.global.imageRegistry }}
+{{- if and .Values.global.imageRegistry (not .Values.ignoreGlobal) }}
 {{- printf "%s/%s:%s@%s" .Values.global.imageRegistry .Values.kubeRBACProxy.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.kubeRBACProxy.image.tag) .Values.kubeRBACProxy.image.sha }}
 {{- else }}
 {{- printf "%s/%s:%s@%s" .Values.kubeRBACProxy.image.registry .Values.kubeRBACProxy.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.kubeRBACProxy.image.tag) .Values.kubeRBACProxy.image.sha }}
 {{- end }}
 {{- else }}
-{{- if .Values.global.imageRegistry }}
+{{- if and .Values.global.imageRegistry (not .Values.ignoreGlobal) }}
 {{- printf "%s/%s:%s" .Values.global.imageRegistry .Values.kubeRBACProxy.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.kubeRBACProxy.image.tag) }}
 {{- else }}
 {{- printf "%s/%s:%s" .Values.kubeRBACProxy.image.registry .Values.kubeRBACProxy.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.kubeRBACProxy.image.tag) }}

--- a/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/kube-state-metrics/templates/deployment.yaml
@@ -271,7 +271,7 @@ spec:
       {{- with .Values.containers }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
-{{- if or .Values.imagePullSecrets .Values.global.imagePullSecrets }}
+{{- if or .Values.imagePullSecrets (and .Values.global.imagePullSecrets (not .Values.ignoreGlobal)) }}
       imagePullSecrets:
         {{- include "kube-state-metrics.imagePullSecrets" (dict "Values" .Values "imagePullSecrets" .Values.imagePullSecrets) | indent 8 }}
       {{- end }}

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -28,6 +28,9 @@ global:
   # Allow parent charts to override registry hostname
   imageRegistry: ""
 
+# Ignore parent chart overrides
+ignoreGlobal: false
+
 # If set to true, this will deploy kube-state-metrics as a StatefulSet and the data
 # will be automatically sharded across <.Values.replicas> pods using the built-in
 # autodiscovery feature: https://github.com/kubernetes/kube-state-metrics#automated-sharding


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Currently, I can set [`.Values.global.imageRegistry`](https://github.com/prometheus-community/helm-charts/blob/714322e38a04746fec8ec32f362bbdebc33ddbdd/charts/kube-prometheus-stack/values.yaml#L223) in the `kube-prometheus-stack` chart and this value will be used for all images in the chart and subcharts.
So, if I want to use my private registry for all images, I have two options:
1. Override registry for every image in values file (a lot of overrides)
2. Set global registry in values file and replicate all images while keeping original path (`/kube-state-metrics/kube-state-metrics`, `/prometheus/alertmanager`)

Almost all images in the chart are located in the `quay.io` registry, but `kube-state-metrics` image is from `registry.k8s.io`.
Private registries often use pull trough cache, so there is no option to keep original path in the registry. Path must start with the prefix, depending on the source registry.
i.e. `registry.k8s.io/kube-state-metrics/kube-state-metrics` => `private.registry.com/k8s/kube-state-metrics/kube-state-metrics`

I suggest a third option: 
- Set global registry in values file and use `.Values.ignoreGlobal` flag in `kube-state-metrics` chart to ignore it. Then I can safely override registry via `.Values.kube-state-metrics.image.registry` and there will be less overrides in my value file.

#### Special notes for your reviewer

This w/a is kinda janky, please let me know if you have a better w/a for the problem.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
