### PR TITLE
[prometheus-pushgateway] Add config for hard/soft podAntiAffinity

### DIFF
--- a/charts/prometheus-pushgateway/Chart.yaml
+++ b/charts/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v1.7.0"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 2.7.1
+version: 2.8.0
 home: https://github.com/prometheus/pushgateway
 sources:
   - https://github.com/prometheus/pushgateway

--- a/charts/prometheus-pushgateway/templates/_helpers.tpl
+++ b/charts/prometheus-pushgateway/templates/_helpers.tpl
@@ -182,10 +182,29 @@ nodeSelector:
 tolerations:
   {{- toYaml . | nindent 2 }}
 {{- end }}
-{{- with .Values.affinity }}
+{{- if or .Values.podAntiAffinity .Values.affinity }}
 affinity:
-  {{- toYaml . | nindent 2 }}
 {{- end }}
+  {{- with .Values.affinity }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- if eq .Values.podAntiAffinity "hard" }}
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: {{ .Values.podAntiAffinityTopologyKey }}
+        labelSelector:
+          matchExpressions:
+            - {key: app.kubernetes.io/name, operator: In, values: [{{ include "prometheus-pushgateway.name" . }}]}
+  {{- else if eq .Values.podAntiAffinity "soft" }}
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          topologyKey: {{ .Values.podAntiAffinityTopologyKey }}
+          labelSelector:
+            matchExpressions:
+              - {key: app.kubernetes.io/name, operator: In, values: [{{ include "prometheus-pushgateway.name" . }}]}
+  {{- end }}
 {{- with .Values.topologySpreadConstraints }}
 topologySpreadConstraints:
   {{- toYaml . | nindent 2 }}

--- a/charts/prometheus-pushgateway/values.yaml
+++ b/charts/prometheus-pushgateway/values.yaml
@@ -213,6 +213,18 @@ containerSecurityContext: {}
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}
 
+## Pod anti-affinity can prevent the scheduler from placing push-gateway replicas on the same node.
+## The default value "soft" means that the scheduler should *prefer* to not schedule two replica pods onto the same node but no guarantee is provided.
+## The value "hard" means that the scheduler is *required* to not schedule two replica pods onto the same node.
+## The value "" will disable pod anti-affinity so that no anti-affinity rules will be configured.
+##
+podAntiAffinity: ""
+
+## If anti-affinity is enabled sets the topologyKey to use for anti-affinity.
+## This can be changed to, for example, failure-domain.beta.kubernetes.io/zone
+##
+podAntiAffinityTopologyKey: kubernetes.io/hostname
+
 ## Topology spread constraints for pods
 ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
 topologySpreadConstraints: []

--- a/charts/prometheus-pushgateway/values.yaml
+++ b/charts/prometheus-pushgateway/values.yaml
@@ -213,10 +213,10 @@ containerSecurityContext: {}
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}
 
-## Pod anti-affinity can prevent the scheduler from placing push-gateway replicas on the same node.
-## The default value "soft" means that the scheduler should *prefer* to not schedule two replica pods onto the same node but no guarantee is provided.
+## Pod anti-affinity can prevent the scheduler from placing pushgateway replicas on the same node.
+## The value "soft" means that the scheduler should *prefer* to not schedule two replica pods onto the same node but no guarantee is provided.
 ## The value "hard" means that the scheduler is *required* to not schedule two replica pods onto the same node.
-## The value "" will disable pod anti-affinity so that no anti-affinity rules will be configured.
+## The default value "" will disable pod anti-affinity so that no anti-affinity rules will be configured (unless set in `affinity`).
 ##
 podAntiAffinity: ""
 


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR adds simple configuration for hard/soft podAntiAffinity for prometheus-pushgateway. The implementation is based on the existing pattern in [alertmanager](https://github.com/prometheus-community/helm-charts/blob/f00193179b8d083e8b609ef587c72d66c633072e/charts/alertmanager/templates/statefulset.yaml#L58)

It is already possible to configure podAntiAffinity using the `affinity` config field, however you need to provide the entire podAntiAffinity YAML object. Notably, this includes a selector which matches on Pod labels, therefore requires the developer writing this configuration to know how Pod labels will be rendered. Adding a simple hard/soft `podAntiAffinity` configuration option therefore simplifies a common configuration requirement and provides some extra backwards compatibility for developers' configuration if the Pod labels do change in future.

#### Which issue this PR fixes

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
