### PR TITLE
[prometheus] Add config for hard/soft podAntiAffinity and bump chart deps

### DIFF
--- a/charts/prometheus/Chart.lock
+++ b/charts/prometheus/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 1.9.0
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
-  version: 5.16.2
+  version: 5.16.4
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 4.30.3
 - name: prometheus-pushgateway
   repository: https://prometheus-community.github.io/helm-charts
-  version: 2.7.1
-digest: sha256:5ed0b00e1cc49009ca45133136a02c38f311f040b063914c04864983f6df5721
-generated: "2024-03-01T05:51:36.909838+02:00"
+  version: 2.8.0
+digest: sha256:23062baabef57dc60e08aaec1882cdde4f84ec9d2807573368b7e86ec1fa89f0
+generated: "2024-03-08T09:36:45.247714358Z"

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: v2.50.1
-version: 25.16.0
+version: 25.17.0
 kubeVersion: ">=1.19.0-0"
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -38,7 +38,7 @@ dependencies:
     repository: https://prometheus-community.github.io/helm-charts
     condition: prometheus-node-exporter.enabled
   - name: prometheus-pushgateway
-    version: "2.7.*"
+    version: "2.8.*"
     repository: https://prometheus-community.github.io/helm-charts
     condition: prometheus-pushgateway.enabled
 keywords:

--- a/charts/prometheus/templates/deploy.yaml
+++ b/charts/prometheus/templates/deploy.yaml
@@ -300,7 +300,7 @@ spec:
       affinity:
     {{- end }}
       {{- with .Values.server.affinity }}
-{{ toYaml . | indent 8 }}
+      {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if eq .Values.server.podAntiAffinity "hard" }}
         podAntiAffinity:

--- a/charts/prometheus/templates/deploy.yaml
+++ b/charts/prometheus/templates/deploy.yaml
@@ -296,10 +296,29 @@ spec:
       tolerations:
 {{ toYaml .Values.server.tolerations | indent 8 }}
     {{- end }}
-    {{- if .Values.server.affinity }}
+    {{- if or .Values.server.affinity .Values.server.podAntiAffinity }}
       affinity:
-{{ toYaml .Values.server.affinity | indent 8 }}
     {{- end }}
+      {{- with .Values.server.affinity }}
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- if eq .Values.server.podAntiAffinity "hard" }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: {{ .Values.server.podAntiAffinityTopologyKey }}
+              labelSelector:
+                matchExpressions:
+                  - {key: app.kubernetes.io/name, operator: In, values: [{{ template "prometheus.name" . }}]}
+      {{- else if eq .Values.server.podAntiAffinity "soft" }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: {{ .Values.server.podAntiAffinityTopologyKey }}
+                labelSelector:
+                  matchExpressions:
+                    - {key: app.kubernetes.io/name, operator: In, values: [{{ template "prometheus.name" . }}]}
+      {{- end }}
     {{- with .Values.server.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}

--- a/charts/prometheus/templates/sts.yaml
+++ b/charts/prometheus/templates/sts.yaml
@@ -303,7 +303,7 @@ spec:
       affinity:
     {{- end }}
       {{- with .Values.server.affinity }}
-{{ toYaml . | indent 8 }}
+      {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if eq .Values.server.podAntiAffinity "hard" }}
         podAntiAffinity:

--- a/charts/prometheus/templates/sts.yaml
+++ b/charts/prometheus/templates/sts.yaml
@@ -299,10 +299,29 @@ spec:
       tolerations:
 {{ toYaml .Values.server.tolerations | indent 8 }}
     {{- end }}
-    {{- if .Values.server.affinity }}
+    {{- if or .Values.server.affinity .Values.server.podAntiAffinity }}
       affinity:
-{{ toYaml .Values.server.affinity | indent 8 }}
     {{- end }}
+      {{- with .Values.server.affinity }}
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- if eq .Values.server.podAntiAffinity "hard" }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: {{ .Values.server.podAntiAffinityTopologyKey }}
+              labelSelector:
+                matchExpressions:
+                  - {key: app.kubernetes.io/name, operator: In, values: [{{ template "prometheus.name" . }}]}
+      {{- else if eq .Values.server.podAntiAffinity "soft" }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: {{ .Values.server.podAntiAffinityTopologyKey }}
+                labelSelector:
+                  matchExpressions:
+                    - {key: app.kubernetes.io/name, operator: In, values: [{{ template "prometheus.name" . }}]}
+      {{- end }}
     {{- with .Values.server.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}

--- a/charts/prometheus/values.schema.json
+++ b/charts/prometheus/values.schema.json
@@ -396,6 +396,14 @@
                 "podAnnotations": {
                     "type": "object"
                 },
+                "podAntiAffinity": {
+                    "type": "string",
+                    "enum": ["", "soft", "hard"],
+                    "default": ""
+                },
+                "podAntiAffinityTopologyKey": {
+                    "type": "string"
+                },
                 "podDisruptionBudget": {
                     "type": "object",
                     "properties": {

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -397,6 +397,18 @@ server:
   ##
   affinity: {}
 
+  ## Pod anti-affinity can prevent the scheduler from placing Prometheus server replicas on the same node.
+  ## The value "soft" means that the scheduler should *prefer* to not schedule two replica pods onto the same node but no guarantee is provided.
+  ## The value "hard" means that the scheduler is *required* to not schedule two replica pods onto the same node.
+  ## The default value "" will disable pod anti-affinity so that no anti-affinity rules will be configured (unless set in `server.affinity`).
+  ##
+  podAntiAffinity: ""
+
+  ## If anti-affinity is enabled sets the topologyKey to use for anti-affinity.
+  ## This can be changed to, for example, failure-domain.beta.kubernetes.io/zone
+  ##
+  podAntiAffinityTopologyKey: kubernetes.io/hostname
+
   ## Pod topology spread constraints
   ## ref. https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
   topologySpreadConstraints: []


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Follows !4340

This PR adds simple configuration for hard/soft podAntiAffinity for prometheus. The implementation is based on the existing pattern in [alertmanager](https://github.com/prometheus-community/helm-charts/blob/f00193179b8d083e8b609ef587c72d66c633072e/charts/alertmanager/templates/statefulset.yaml#L58)

It is already possible to configure podAntiAffinity using the `server.affinity` config field, however you need to provide the entire podAntiAffinity YAML object. Notably, this includes a selector which matches on Pod labels, therefore requires the developer writing this configuration to know how Pod labels will be rendered. Adding a simple hard/soft `server.podAntiAffinity` configuration option therefore simplifies a common configuration requirement and provides some extra backwards compatibility for developers' configuration if the Pod labels do change in future.

#### Which issue this PR fixes

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
