### PR TITLE
Add 'release' label to prometheus-pushgateway service monitor

### DIFF
--- a/charts/prometheus-pushgateway/templates/_helpers.tpl
+++ b/charts/prometheus-pushgateway/templates/_helpers.tpl
@@ -74,6 +74,7 @@ Selector labels
 {{- define "prometheus-pushgateway.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "prometheus-pushgateway.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+release: {{ .Release.Name }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
'release' label is required for integrating with kube-prometheus-stack

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Adds 'release' label to prometheus-pushgateway ServiceMonitor.
This label is used by prometheus from kube-prometheus-stack for collecting metrics.

I cannot use {{ .Release.Name }} as value in values.yaml. So I've add it to template.

Also, I don't understand why kube-prometheus-stack uses 'release' label, but not 'app.kubernetes.io/instance' label.
But I am not good in k8s.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
