### PR TITLE
[kube-prometheus-stack] let additionalRuleGroupLabels override additionalRuleLabels

### DIFF
--- a/charts/kube-prometheus-stack/hack/sync_prometheus_rules.py
+++ b/charts/kube-prometheus-stack/hack/sync_prometheus_rules.py
@@ -319,11 +319,15 @@ def add_custom_labels(rules_str, group, indent=4, label_indent=2):
     rule_group_labels = get_rule_group_condition(condition_map.get(group['name'], ''), 'additionalRuleGroupLabels')
 
     additional_rule_labels = textwrap.indent("""
-{{- with .Values.defaultRules.additionalRuleLabels }}
-  {{- toYaml . | nindent 8 }}
+{{- range $k, $v := mergeOverwrite
+      (.Values.defaultRules.additionalRuleLabels | default (dict))
+      (%s | default (dict))
+    }}
+
+{{- if $v }}
+{{ $k | quote }}: {{ $v | quote }}
 {{- end }}
-{{- with %s }}
-  {{- toYaml . | nindent 8 }}
+
 {{- end }}""" % (rule_group_labels,), " " * (indent + label_indent * 2))
 
     additional_rule_labels_condition_start = "\n" + " " * (indent + label_indent) + '{{- if or .Values.defaultRules.additionalRuleLabels %s }}' % (rule_group_labels,)
@@ -374,13 +378,24 @@ def add_custom_labels(rules_str, group, indent=4, label_indent=2):
 
 def add_custom_annotations(rules, group, indent=4):
     """Add if wrapper for additional rules annotations"""
-    rule_condition = '{{- if .Values.defaultRules.additionalRuleAnnotations }}\n{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}\n{{- end }}'
-    rule_group_labels = get_rule_group_condition(condition_map.get(group['name'], ''), 'additionalRuleGroupAnnotations')
-    rule_group_condition = '\n{{- if %s }}\n{{ toYaml %s | indent 8 }}\n{{- end }}' % (rule_group_labels, rule_group_labels)
+
+    rule_group_annotations = get_rule_group_condition(condition_map.get(group['name'], ''), 'additionalRuleGroupAnnotations')
+
+    annotations_body = textwrap.indent("""
+{{- range $k, $v := mergeOverwrite
+      (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+      (%s | default (dict))
+    }}
+
+{{- if $v }}
+{{ $k | quote }}: {{ $v | quote }}
+{{- end }}
+
+{{- end }}""" % (rule_group_annotations,), " " * (indent * 2))
+
     annotations = "      annotations:"
     annotations_len = len(annotations) + 1
-    rule_condition_len = len(rule_condition) + 1
-    rule_group_condition_len = len(rule_group_condition)
+    annotations_body_len = len(annotations_body) + 1
 
     separator = " " * indent + "- alert:.*"
     alerts_positions = re.finditer(separator,rules)
@@ -388,8 +403,8 @@ def add_custom_annotations(rules, group, indent=4):
 
     for alert_position in alerts_positions:
         # Add rule_condition after 'annotations:' statement
-        index = alert_position.end() + annotations_len + (rule_condition_len + rule_group_condition_len) * alert
-        rules = rules[:index] + "\n" + rule_condition + rule_group_condition +  rules[index:]
+        index = alert_position.end() + annotations_len + annotations_body_len * alert
+        rules = rules[:index] + "\n" + annotations_body + rules[index:]
         alert += 1
 
     return rules

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/alertmanager.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/alertmanager.rules.yaml
@@ -29,12 +29,17 @@ spec:
 {{- if not (.Values.defaultRules.disabled.AlertmanagerFailedReload | default false) }}
     - alert: AlertmanagerFailedReload
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.alertmanager }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.alertmanager | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.alertmanager | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Configuration has failed to load for {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod{{`}}`}}.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/alertmanager/alertmanagerfailedreload
         summary: Reloading an Alertmanager configuration has failed.
@@ -49,23 +54,32 @@ spec:
       labels:
         severity: {{ dig "AlertmanagerFailedReload" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.alertmanager }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.alertmanager | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.alertmanager }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.AlertmanagerMembersInconsistent | default false) }}
     - alert: AlertmanagerMembersInconsistent
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.alertmanager }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.alertmanager | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.alertmanager | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Alertmanager {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod{{`}}`}} has only found {{`{{`}} $value {{`}}`}} members of the {{`{{`}}$labels.job{{`}}`}} cluster.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/alertmanager/alertmanagermembersinconsistent
         summary: A member of an Alertmanager cluster has not found all other cluster members.
@@ -82,23 +96,32 @@ spec:
       labels:
         severity: {{ dig "AlertmanagerMembersInconsistent" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.alertmanager }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.alertmanager | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.alertmanager }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.AlertmanagerFailedToSendAlerts | default false) }}
     - alert: AlertmanagerFailedToSendAlerts
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.alertmanager }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.alertmanager | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.alertmanager | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Alertmanager {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod{{`}}`}} failed to send {{`{{`}} $value | humanizePercentage {{`}}`}} of notifications to {{`{{`}} $labels.integration {{`}}`}}.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/alertmanager/alertmanagerfailedtosendalerts
         summary: An Alertmanager instance failed to send notifications.
@@ -116,23 +139,32 @@ spec:
       labels:
         severity: {{ dig "AlertmanagerFailedToSendAlerts" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.alertmanager }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.alertmanager | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.alertmanager }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.AlertmanagerClusterFailedToSendAlerts | default false) }}
     - alert: AlertmanagerClusterFailedToSendAlerts
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.alertmanager }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.alertmanager | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.alertmanager | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: The minimum notification failure rate to {{`{{`}} $labels.integration {{`}}`}} sent from any instance in the {{`{{`}}$labels.job{{`}}`}} cluster is {{`{{`}} $value | humanizePercentage {{`}}`}}.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/alertmanager/alertmanagerclusterfailedtosendalerts
         summary: All Alertmanager instances in a cluster failed to send notifications to a critical integration.
@@ -150,23 +182,32 @@ spec:
       labels:
         severity: {{ dig "AlertmanagerClusterFailedToSendAlerts" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.alertmanager }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.alertmanager | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.alertmanager }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.AlertmanagerClusterFailedToSendAlerts | default false) }}
     - alert: AlertmanagerClusterFailedToSendAlerts
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.alertmanager }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.alertmanager | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.alertmanager | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: The minimum notification failure rate to {{`{{`}} $labels.integration {{`}}`}} sent from any instance in the {{`{{`}}$labels.job{{`}}`}} cluster is {{`{{`}} $value | humanizePercentage {{`}}`}}.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/alertmanager/alertmanagerclusterfailedtosendalerts
         summary: All Alertmanager instances in a cluster failed to send notifications to a non-critical integration.
@@ -184,23 +225,32 @@ spec:
       labels:
         severity: {{ dig "AlertmanagerClusterFailedToSendAlerts" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.alertmanager }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.alertmanager | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.alertmanager }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.AlertmanagerConfigInconsistent | default false) }}
     - alert: AlertmanagerConfigInconsistent
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.alertmanager }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.alertmanager | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.alertmanager | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Alertmanager instances within the {{`{{`}}$labels.job{{`}}`}} cluster have different configurations.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/alertmanager/alertmanagerconfiginconsistent
         summary: Alertmanager instances within the same cluster have different configurations.
@@ -216,23 +266,32 @@ spec:
       labels:
         severity: {{ dig "AlertmanagerConfigInconsistent" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.alertmanager }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.alertmanager | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.alertmanager }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.AlertmanagerClusterDown | default false) }}
     - alert: AlertmanagerClusterDown
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.alertmanager }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.alertmanager | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.alertmanager | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: '{{`{{`}} $value | humanizePercentage {{`}}`}} of Alertmanager instances within the {{`{{`}}$labels.job{{`}}`}} cluster have been up for less than half of the last 5m.'
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/alertmanager/alertmanagerclusterdown
         summary: Half or more of the Alertmanager instances within the same cluster are down.
@@ -254,23 +313,32 @@ spec:
       labels:
         severity: {{ dig "AlertmanagerClusterDown" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.alertmanager }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.alertmanager | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.alertmanager }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.AlertmanagerClusterCrashlooping | default false) }}
     - alert: AlertmanagerClusterCrashlooping
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.alertmanager }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.alertmanager | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.alertmanager | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: '{{`{{`}} $value | humanizePercentage {{`}}`}} of Alertmanager instances within the {{`{{`}}$labels.job{{`}}`}} cluster have restarted at least 5 times in the last 10m.'
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/alertmanager/alertmanagerclustercrashlooping
         summary: Half or more of the Alertmanager instances within the same cluster are crashlooping.
@@ -292,11 +360,15 @@ spec:
       labels:
         severity: {{ dig "AlertmanagerClusterCrashlooping" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.alertmanager }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.alertmanager | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.alertmanager }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/config-reloaders.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/config-reloaders.yaml
@@ -27,12 +27,17 @@ spec:
 {{- if not (.Values.defaultRules.disabled.ConfigReloaderSidecarErrors | default false) }}
     - alert: ConfigReloaderSidecarErrors
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.configReloaders }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.configReloaders | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.configReloaders | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: 'Errors encountered while the {{`{{`}}$labels.pod{{`}}`}} config-reloader sidecar attempts to sync config in {{`{{`}}$labels.namespace{{`}}`}} namespace.
 
           As a result, configuration for service running in {{`{{`}}$labels.pod{{`}}`}} may be stale and cannot be updated anymore.'
@@ -46,11 +51,15 @@ spec:
       labels:
         severity: {{ dig "ConfigReloaderSidecarErrors" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.configReloaders }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.configReloaders | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.configReloaders }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/etcd.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/etcd.yaml
@@ -27,12 +27,17 @@ spec:
 {{- if not (.Values.defaultRules.disabled.etcdMembersDown | default false) }}
     - alert: etcdMembersDown
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.etcd }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.etcd | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.etcd | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: 'etcd cluster "{{`{{`}} $labels.job {{`}}`}}": members are down ({{`{{`}} $value {{`}}`}}).'
         summary: etcd cluster members are down.
       expr: |-
@@ -51,23 +56,32 @@ spec:
       labels:
         severity: {{ dig "etcdMembersDown" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.etcd }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.etcd | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.etcd }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.etcdInsufficientMembers | default false) }}
     - alert: etcdInsufficientMembers
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.etcd }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.etcd | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.etcd | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: 'etcd cluster "{{`{{`}} $labels.job {{`}}`}}": insufficient members ({{`{{`}} $value {{`}}`}}).'
         summary: etcd cluster has insufficient number of members.
       expr: sum(up{job=~".*etcd.*"} == bool 1) without (instance) < ((count(up{job=~".*etcd.*"}) without (instance) + 1) / 2)
@@ -78,23 +92,32 @@ spec:
       labels:
         severity: {{ dig "etcdInsufficientMembers" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.etcd }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.etcd | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.etcd }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.etcdNoLeader | default false) }}
     - alert: etcdNoLeader
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.etcd }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.etcd | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.etcd | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: 'etcd cluster "{{`{{`}} $labels.job {{`}}`}}": member {{`{{`}} $labels.instance {{`}}`}} has no leader.'
         summary: etcd cluster has no leader.
       expr: etcd_server_has_leader{job=~".*etcd.*"} == 0
@@ -105,23 +128,32 @@ spec:
       labels:
         severity: {{ dig "etcdNoLeader" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.etcd }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.etcd | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.etcd }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.etcdHighNumberOfLeaderChanges | default false) }}
     - alert: etcdHighNumberOfLeaderChanges
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.etcd }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.etcd | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.etcd | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: 'etcd cluster "{{`{{`}} $labels.job {{`}}`}}": {{`{{`}} $value {{`}}`}} leader changes within the last 15 minutes. Frequent elections may be a sign of insufficient resources, high network latency, or disruptions by other components and should be investigated.'
         summary: etcd cluster has high number of leader changes.
       expr: increase((max without (instance) (etcd_server_leader_changes_seen_total{job=~".*etcd.*"}) or 0*absent(etcd_server_leader_changes_seen_total{job=~".*etcd.*"}))[15m:1m]) >= 4
@@ -132,23 +164,32 @@ spec:
       labels:
         severity: {{ dig "etcdHighNumberOfLeaderChanges" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.etcd }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.etcd | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.etcd }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.etcdHighNumberOfFailedGRPCRequests | default false) }}
     - alert: etcdHighNumberOfFailedGRPCRequests
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.etcd }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.etcd | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.etcd | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: 'etcd cluster "{{`{{`}} $labels.job {{`}}`}}": {{`{{`}} $value {{`}}`}}% of requests for {{`{{`}} $labels.grpc_method {{`}}`}} failed on etcd instance {{`{{`}} $labels.instance {{`}}`}}.'
         summary: etcd cluster has high number of failed grpc requests.
       expr: |-
@@ -163,23 +204,32 @@ spec:
       labels:
         severity: {{ dig "etcdHighNumberOfFailedGRPCRequests" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.etcd }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.etcd | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.etcd }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.etcdHighNumberOfFailedGRPCRequests | default false) }}
     - alert: etcdHighNumberOfFailedGRPCRequests
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.etcd }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.etcd | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.etcd | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: 'etcd cluster "{{`{{`}} $labels.job {{`}}`}}": {{`{{`}} $value {{`}}`}}% of requests for {{`{{`}} $labels.grpc_method {{`}}`}} failed on etcd instance {{`{{`}} $labels.instance {{`}}`}}.'
         summary: etcd cluster has high number of failed grpc requests.
       expr: |-
@@ -194,23 +244,32 @@ spec:
       labels:
         severity: {{ dig "etcdHighNumberOfFailedGRPCRequests" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.etcd }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.etcd | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.etcd }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.etcdGRPCRequestsSlow | default false) }}
     - alert: etcdGRPCRequestsSlow
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.etcd }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.etcd | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.etcd | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: 'etcd cluster "{{`{{`}} $labels.job {{`}}`}}": 99th percentile of gRPC requests is {{`{{`}} $value {{`}}`}}s on etcd instance {{`{{`}} $labels.instance {{`}}`}} for {{`{{`}} $labels.grpc_method {{`}}`}} method.'
         summary: etcd grpc requests are slow
       expr: |-
@@ -223,23 +282,32 @@ spec:
       labels:
         severity: {{ dig "etcdGRPCRequestsSlow" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.etcd }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.etcd | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.etcd }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.etcdMemberCommunicationSlow | default false) }}
     - alert: etcdMemberCommunicationSlow
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.etcd }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.etcd | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.etcd | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: 'etcd cluster "{{`{{`}} $labels.job {{`}}`}}": member communication with {{`{{`}} $labels.To {{`}}`}} is taking {{`{{`}} $value {{`}}`}}s on etcd instance {{`{{`}} $labels.instance {{`}}`}}.'
         summary: etcd cluster member communication is slow.
       expr: |-
@@ -252,23 +320,32 @@ spec:
       labels:
         severity: {{ dig "etcdMemberCommunicationSlow" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.etcd }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.etcd | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.etcd }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.etcdHighNumberOfFailedProposals | default false) }}
     - alert: etcdHighNumberOfFailedProposals
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.etcd }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.etcd | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.etcd | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: 'etcd cluster "{{`{{`}} $labels.job {{`}}`}}": {{`{{`}} $value {{`}}`}} proposal failures within the last 30 minutes on etcd instance {{`{{`}} $labels.instance {{`}}`}}.'
         summary: etcd cluster has high number of proposal failures.
       expr: rate(etcd_server_proposals_failed_total{job=~".*etcd.*"}[15m]) > 5
@@ -279,23 +356,32 @@ spec:
       labels:
         severity: {{ dig "etcdHighNumberOfFailedProposals" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.etcd }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.etcd | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.etcd }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.etcdHighFsyncDurations | default false) }}
     - alert: etcdHighFsyncDurations
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.etcd }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.etcd | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.etcd | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: 'etcd cluster "{{`{{`}} $labels.job {{`}}`}}": 99th percentile fsync durations are {{`{{`}} $value {{`}}`}}s on etcd instance {{`{{`}} $labels.instance {{`}}`}}.'
         summary: etcd cluster 99th percentile fsync durations are too high.
       expr: |-
@@ -308,23 +394,32 @@ spec:
       labels:
         severity: {{ dig "etcdHighFsyncDurations" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.etcd }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.etcd | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.etcd }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.etcdHighFsyncDurations | default false) }}
     - alert: etcdHighFsyncDurations
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.etcd }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.etcd | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.etcd | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: 'etcd cluster "{{`{{`}} $labels.job {{`}}`}}": 99th percentile fsync durations are {{`{{`}} $value {{`}}`}}s on etcd instance {{`{{`}} $labels.instance {{`}}`}}.'
         summary: etcd cluster 99th percentile fsync durations are too high.
       expr: |-
@@ -337,23 +432,32 @@ spec:
       labels:
         severity: {{ dig "etcdHighFsyncDurations" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.etcd }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.etcd | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.etcd }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.etcdHighCommitDurations | default false) }}
     - alert: etcdHighCommitDurations
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.etcd }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.etcd | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.etcd | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: 'etcd cluster "{{`{{`}} $labels.job {{`}}`}}": 99th percentile commit durations {{`{{`}} $value {{`}}`}}s on etcd instance {{`{{`}} $labels.instance {{`}}`}}.'
         summary: etcd cluster 99th percentile commit durations are too high.
       expr: |-
@@ -366,23 +470,32 @@ spec:
       labels:
         severity: {{ dig "etcdHighCommitDurations" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.etcd }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.etcd | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.etcd }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.etcdDatabaseQuotaLowSpace | default false) }}
     - alert: etcdDatabaseQuotaLowSpace
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.etcd }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.etcd | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.etcd | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: 'etcd cluster "{{`{{`}} $labels.job {{`}}`}}": database size exceeds the defined quota on etcd instance {{`{{`}} $labels.instance {{`}}`}}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
         summary: etcd cluster database is running full.
       expr: (last_over_time(etcd_mvcc_db_total_size_in_bytes{job=~".*etcd.*"}[5m]) / last_over_time(etcd_server_quota_backend_bytes{job=~".*etcd.*"}[5m]))*100 > 95
@@ -393,23 +506,32 @@ spec:
       labels:
         severity: {{ dig "etcdDatabaseQuotaLowSpace" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.etcd }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.etcd | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.etcd }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.etcdExcessiveDatabaseGrowth | default false) }}
     - alert: etcdExcessiveDatabaseGrowth
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.etcd }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.etcd | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.etcd | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: 'etcd cluster "{{`{{`}} $labels.job {{`}}`}}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{`{{`}} $labels.instance {{`}}`}}, please check as it might be disruptive.'
         summary: etcd cluster database growing very fast.
       expr: predict_linear(etcd_mvcc_db_total_size_in_bytes{job=~".*etcd.*"}[4h], 4*60*60) > etcd_server_quota_backend_bytes{job=~".*etcd.*"}
@@ -420,23 +542,32 @@ spec:
       labels:
         severity: {{ dig "etcdExcessiveDatabaseGrowth" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.etcd }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.etcd | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.etcd }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.etcdDatabaseHighFragmentationRatio | default false) }}
     - alert: etcdDatabaseHighFragmentationRatio
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.etcd }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.etcd | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.etcd | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: 'etcd cluster "{{`{{`}} $labels.job {{`}}`}}": database size in use on instance {{`{{`}} $labels.instance {{`}}`}} is {{`{{`}} $value | humanizePercentage {{`}}`}} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
         runbook_url: https://etcd.io/docs/v3.5/op-guide/maintenance/#defragmentation
         summary: etcd database size in use is less than 50% of the actual allocated storage.
@@ -448,11 +579,15 @@ spec:
       labels:
         severity: {{ dig "etcdDatabaseHighFragmentationRatio" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.etcd }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.etcd | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.etcd }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/general.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/general.rules.yaml
@@ -27,12 +27,17 @@ spec:
 {{- if not (.Values.defaultRules.disabled.TargetDown | default false) }}
     - alert: TargetDown
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.general }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.general | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.general | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: '{{`{{`}} printf "%.4g" $value {{`}}`}}% of the {{`{{`}} $labels.job {{`}}`}}/{{`{{`}} $labels.service {{`}}`}} targets in {{`{{`}} $labels.namespace {{`}}`}} namespace are down.'
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/general/targetdown
         summary: One or more targets are unreachable.
@@ -44,23 +49,32 @@ spec:
       labels:
         severity: {{ dig "TargetDown" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.general }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.general | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.general }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.Watchdog | default false) }}
     - alert: Watchdog
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.general }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.general | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.general | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: 'This is an alert meant to ensure that the entire alerting pipeline is functional.
 
           This alert is always firing, therefore it should always be firing in Alertmanager
@@ -78,23 +92,32 @@ spec:
       labels:
         severity: {{ dig "Watchdog" "severity" "none" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.general }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.general | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.general }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.InfoInhibitor | default false) }}
     - alert: InfoInhibitor
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.general }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.general | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.general | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: 'This is an alert that is used to inhibit info alerts.
 
           By themselves, the info-level alerts are sometimes very noisy, but they are relevant when combined with
@@ -114,11 +137,15 @@ spec:
       labels:
         severity: {{ dig "InfoInhibitor" "severity" "none" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.general }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.general | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.general }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/k8s.rules.container_cpu_usage_seconds_total.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/k8s.rules.container_cpu_usage_seconds_total.yaml
@@ -33,11 +33,15 @@ spec:
       record: node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.k8sContainerCpuUsageSecondsTotal }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.k8sContainerCpuUsageSecondsTotal | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.k8sContainerCpuUsageSecondsTotal }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/k8s.rules.container_memory_cache.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/k8s.rules.container_memory_cache.yaml
@@ -32,11 +32,15 @@ spec:
       record: node_namespace_pod_container:container_memory_cache
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.k8sContainerMemoryCache }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.k8sContainerMemoryCache | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.k8sContainerMemoryCache }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/k8s.rules.container_memory_rss.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/k8s.rules.container_memory_rss.yaml
@@ -32,11 +32,15 @@ spec:
       record: node_namespace_pod_container:container_memory_rss
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.k8sContainerMemoryRss }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.k8sContainerMemoryRss | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.k8sContainerMemoryRss }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/k8s.rules.container_memory_swap.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/k8s.rules.container_memory_swap.yaml
@@ -32,11 +32,15 @@ spec:
       record: node_namespace_pod_container:container_memory_swap
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.k8sContainerMemorySwap }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.k8sContainerMemorySwap | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.k8sContainerMemorySwap }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/k8s.rules.container_memory_working_set_bytes.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/k8s.rules.container_memory_working_set_bytes.yaml
@@ -32,11 +32,15 @@ spec:
       record: node_namespace_pod_container:container_memory_working_set_bytes
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.k8sContainerMemoryWorkingSetBytes }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.k8sContainerMemoryWorkingSetBytes | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.k8sContainerMemoryWorkingSetBytes }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/k8s.rules.container_resource.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/k8s.rules.container_resource.yaml
@@ -33,11 +33,15 @@ spec:
       record: cluster:namespace:pod_memory:active:kube_pod_container_resource_requests
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.k8sContainerResource }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.k8sContainerResource | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.k8sContainerResource }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -53,11 +57,15 @@ spec:
       record: namespace_memory:kube_pod_container_resource_requests:sum
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.k8sContainerResource }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.k8sContainerResource | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.k8sContainerResource }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -68,11 +76,15 @@ spec:
       record: cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.k8sContainerResource }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.k8sContainerResource | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.k8sContainerResource }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -88,11 +100,15 @@ spec:
       record: namespace_cpu:kube_pod_container_resource_requests:sum
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.k8sContainerResource }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.k8sContainerResource | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.k8sContainerResource }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -103,11 +119,15 @@ spec:
       record: cluster:namespace:pod_memory:active:kube_pod_container_resource_limits
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.k8sContainerResource }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.k8sContainerResource | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.k8sContainerResource }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -123,11 +143,15 @@ spec:
       record: namespace_memory:kube_pod_container_resource_limits:sum
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.k8sContainerResource }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.k8sContainerResource | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.k8sContainerResource }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -138,11 +162,15 @@ spec:
       record: cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.k8sContainerResource }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.k8sContainerResource | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.k8sContainerResource }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -158,11 +186,15 @@ spec:
       record: namespace_cpu:kube_pod_container_resource_limits:sum
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.k8sContainerResource }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.k8sContainerResource | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.k8sContainerResource }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/k8s.rules.pod_owner.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/k8s.rules.pod_owner.yaml
@@ -42,11 +42,15 @@ spec:
       labels:
         workload_type: deployment
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.k8sPodOwner }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.k8sPodOwner | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.k8sPodOwner }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: namespace_workload_pod:kube_pod_owner:relabel
@@ -60,11 +64,15 @@ spec:
       labels:
         workload_type: daemonset
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.k8sPodOwner }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.k8sPodOwner | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.k8sPodOwner }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: namespace_workload_pod:kube_pod_owner:relabel
@@ -78,11 +86,15 @@ spec:
       labels:
         workload_type: statefulset
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.k8sPodOwner }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.k8sPodOwner | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.k8sPodOwner }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: namespace_workload_pod:kube_pod_owner:relabel
@@ -96,11 +108,15 @@ spec:
       labels:
         workload_type: job
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.k8sPodOwner }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.k8sPodOwner | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.k8sPodOwner }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: namespace_workload_pod:kube_pod_owner:relabel

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-availability.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-availability.rules.yaml
@@ -29,22 +29,30 @@ spec:
       record: code_verb:apiserver_request_total:increase30d
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: sum by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, code) (code_verb:apiserver_request_total:increase30d{verb=~"LIST|GET"})
       labels:
         verb: read
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: code:apiserver_request_total:increase30d
@@ -52,11 +60,15 @@ spec:
       labels:
         verb: write
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: code:apiserver_request_total:increase30d
@@ -64,44 +76,60 @@ spec:
       record: cluster_verb_scope:apiserver_request_sli_duration_seconds_count:increase1h
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: sum by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, verb, scope) (avg_over_time(cluster_verb_scope:apiserver_request_sli_duration_seconds_count:increase1h[30d]) * 24 * 30)
       record: cluster_verb_scope:apiserver_request_sli_duration_seconds_count:increase30d
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: sum by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, verb, scope, le) (increase(apiserver_request_sli_duration_seconds_bucket[1h]))
       record: cluster_verb_scope_le:apiserver_request_sli_duration_seconds_bucket:increase1h
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: sum by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, verb, scope, le) (avg_over_time(cluster_verb_scope_le:apiserver_request_sli_duration_seconds_bucket:increase1h[30d]) * 24 * 30)
       record: cluster_verb_scope_le:apiserver_request_sli_duration_seconds_bucket:increase30d
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -136,11 +164,15 @@ spec:
       labels:
         verb: all
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: apiserver_request:availability30d
@@ -169,11 +201,15 @@ spec:
       labels:
         verb: read
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: apiserver_request:availability30d
@@ -194,11 +230,15 @@ spec:
       labels:
         verb: write
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: apiserver_request:availability30d
@@ -206,11 +246,15 @@ spec:
       labels:
         verb: read
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: code_resource:apiserver_request_total:rate5m
@@ -218,11 +262,15 @@ spec:
       labels:
         verb: write
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: code_resource:apiserver_request_total:rate5m
@@ -230,44 +278,60 @@ spec:
       record: code_verb:apiserver_request_total:increase1h
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: sum by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, code, verb) (increase(apiserver_request_total{job="apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"3.."}[1h]))
       record: code_verb:apiserver_request_total:increase1h
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: sum by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, code, verb) (increase(apiserver_request_total{job="apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"4.."}[1h]))
       record: code_verb:apiserver_request_total:increase1h
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: sum by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, code, verb) (increase(apiserver_request_total{job="apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"5.."}[1h]))
       record: code_verb:apiserver_request_total:increase1h
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverAvailability }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-burnrate.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-burnrate.rules.yaml
@@ -51,11 +51,15 @@ spec:
       labels:
         verb: read
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: apiserver_request:burnrate1d
@@ -86,11 +90,15 @@ spec:
       labels:
         verb: read
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: apiserver_request:burnrate1h
@@ -121,11 +129,15 @@ spec:
       labels:
         verb: read
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: apiserver_request:burnrate2h
@@ -156,11 +168,15 @@ spec:
       labels:
         verb: read
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: apiserver_request:burnrate30m
@@ -191,11 +207,15 @@ spec:
       labels:
         verb: read
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: apiserver_request:burnrate3d
@@ -226,11 +246,15 @@ spec:
       labels:
         verb: read
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: apiserver_request:burnrate5m
@@ -261,11 +285,15 @@ spec:
       labels:
         verb: read
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: apiserver_request:burnrate6h
@@ -285,11 +313,15 @@ spec:
       labels:
         verb: write
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: apiserver_request:burnrate1d
@@ -309,11 +341,15 @@ spec:
       labels:
         verb: write
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: apiserver_request:burnrate1h
@@ -333,11 +369,15 @@ spec:
       labels:
         verb: write
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: apiserver_request:burnrate2h
@@ -357,11 +397,15 @@ spec:
       labels:
         verb: write
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: apiserver_request:burnrate30m
@@ -381,11 +425,15 @@ spec:
       labels:
         verb: write
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: apiserver_request:burnrate3d
@@ -405,11 +453,15 @@ spec:
       labels:
         verb: write
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: apiserver_request:burnrate5m
@@ -429,11 +481,15 @@ spec:
       labels:
         verb: write
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverBurnrate }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: apiserver_request:burnrate6h

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-histogram.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-histogram.rules.yaml
@@ -29,11 +29,15 @@ spec:
         quantile: '0.99'
         verb: read
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverHistogram }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverHistogram | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverHistogram }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: cluster_quantile:apiserver_request_sli_duration_seconds:histogram_quantile
@@ -42,11 +46,15 @@ spec:
         quantile: '0.99'
         verb: write
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverHistogram }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverHistogram | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverHistogram }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: cluster_quantile:apiserver_request_sli_duration_seconds:histogram_quantile

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-slos.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-apiserver-slos.yaml
@@ -27,12 +27,17 @@ spec:
 {{- if not (.Values.defaultRules.disabled.KubeAPIErrorBudgetBurn | default false) }}
     - alert: KubeAPIErrorBudgetBurn
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubeApiserverSlos }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubeApiserverSlos | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubeApiserverSlos | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: The API server is burning too much error budget.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubeapierrorbudgetburn
         summary: The API server is burning too much error budget.
@@ -49,23 +54,32 @@ spec:
         severity: {{ dig "KubeAPIErrorBudgetBurn" "severity" "critical" .Values.customRules }}
         short: 5m
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverSlos }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverSlos | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverSlos }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeAPIErrorBudgetBurn | default false) }}
     - alert: KubeAPIErrorBudgetBurn
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubeApiserverSlos }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubeApiserverSlos | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubeApiserverSlos | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: The API server is burning too much error budget.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubeapierrorbudgetburn
         summary: The API server is burning too much error budget.
@@ -82,23 +96,32 @@ spec:
         severity: {{ dig "KubeAPIErrorBudgetBurn" "severity" "critical" .Values.customRules }}
         short: 30m
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverSlos }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverSlos | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverSlos }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeAPIErrorBudgetBurn | default false) }}
     - alert: KubeAPIErrorBudgetBurn
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubeApiserverSlos }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubeApiserverSlos | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubeApiserverSlos | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: The API server is burning too much error budget.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubeapierrorbudgetburn
         summary: The API server is burning too much error budget.
@@ -115,23 +138,32 @@ spec:
         severity: {{ dig "KubeAPIErrorBudgetBurn" "severity" "warning" .Values.customRules }}
         short: 2h
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverSlos }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverSlos | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverSlos }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeAPIErrorBudgetBurn | default false) }}
     - alert: KubeAPIErrorBudgetBurn
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubeApiserverSlos }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubeApiserverSlos | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubeApiserverSlos | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: The API server is burning too much error budget.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubeapierrorbudgetburn
         summary: The API server is burning too much error budget.
@@ -148,11 +180,15 @@ spec:
         severity: {{ dig "KubeAPIErrorBudgetBurn" "severity" "warning" .Values.customRules }}
         short: 6h
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverSlos }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeApiserverSlos | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeApiserverSlos }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-prometheus-general.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-prometheus-general.rules.yaml
@@ -28,22 +28,30 @@ spec:
       record: count:up1
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubePrometheusGeneral }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubePrometheusGeneral | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubePrometheusGeneral }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: count without(instance, pod, node) (up == 0)
       record: count:up0
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubePrometheusGeneral }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubePrometheusGeneral | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubePrometheusGeneral }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-prometheus-node-recording.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-prometheus-node-recording.rules.yaml
@@ -28,66 +28,90 @@ spec:
       record: instance:node_cpu:rate:sum
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubePrometheusNodeRecording }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubePrometheusNodeRecording | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubePrometheusNodeRecording }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: sum(rate(node_network_receive_bytes_total[3m])) BY (instance)
       record: instance:node_network_receive_bytes:rate:sum
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubePrometheusNodeRecording }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubePrometheusNodeRecording | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubePrometheusNodeRecording }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: sum(rate(node_network_transmit_bytes_total[3m])) BY (instance)
       record: instance:node_network_transmit_bytes:rate:sum
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubePrometheusNodeRecording }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubePrometheusNodeRecording | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubePrometheusNodeRecording }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[5m])) WITHOUT (cpu, mode) / ON(instance) GROUP_LEFT() count(sum(node_cpu_seconds_total) BY (instance, cpu)) BY (instance)
       record: instance:node_cpu:ratio
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubePrometheusNodeRecording }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubePrometheusNodeRecording | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubePrometheusNodeRecording }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[5m]))
       record: cluster:node_cpu:sum_rate5m
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubePrometheusNodeRecording }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubePrometheusNodeRecording | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubePrometheusNodeRecording }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: cluster:node_cpu:sum_rate5m / count(sum(node_cpu_seconds_total) BY (instance, cpu))
       record: cluster:node_cpu:ratio
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubePrometheusNodeRecording }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubePrometheusNodeRecording | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubePrometheusNodeRecording }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-scheduler.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-scheduler.rules.yaml
@@ -28,11 +28,15 @@ spec:
       labels:
         quantile: '0.99'
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeSchedulerRecording }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeSchedulerRecording | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeSchedulerRecording }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
@@ -40,11 +44,15 @@ spec:
       labels:
         quantile: '0.99'
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeSchedulerRecording }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeSchedulerRecording | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeSchedulerRecording }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
@@ -52,11 +60,15 @@ spec:
       labels:
         quantile: '0.99'
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeSchedulerRecording }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeSchedulerRecording | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeSchedulerRecording }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
@@ -64,11 +76,15 @@ spec:
       labels:
         quantile: '0.9'
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeSchedulerRecording }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeSchedulerRecording | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeSchedulerRecording }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
@@ -76,11 +92,15 @@ spec:
       labels:
         quantile: '0.9'
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeSchedulerRecording }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeSchedulerRecording | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeSchedulerRecording }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
@@ -88,11 +108,15 @@ spec:
       labels:
         quantile: '0.9'
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeSchedulerRecording }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeSchedulerRecording | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeSchedulerRecording }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
@@ -100,11 +124,15 @@ spec:
       labels:
         quantile: '0.5'
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeSchedulerRecording }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeSchedulerRecording | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeSchedulerRecording }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
@@ -112,11 +140,15 @@ spec:
       labels:
         quantile: '0.5'
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeSchedulerRecording }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeSchedulerRecording | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeSchedulerRecording }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
@@ -124,11 +156,15 @@ spec:
       labels:
         quantile: '0.5'
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeSchedulerRecording }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeSchedulerRecording | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeSchedulerRecording }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-state-metrics.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kube-state-metrics.yaml
@@ -28,12 +28,17 @@ spec:
 {{- if not (.Values.defaultRules.disabled.KubeStateMetricsListErrors | default false) }}
     - alert: KubeStateMetricsListErrors
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubeStateMetrics }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubeStateMetrics | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubeStateMetrics | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: kube-state-metrics is experiencing errors at an elevated rate in list operations. This is likely causing it to not be able to expose metrics about Kubernetes objects correctly or at all.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kube-state-metrics/kubestatemetricslisterrors
         summary: kube-state-metrics is experiencing errors in list operations.
@@ -49,23 +54,32 @@ spec:
       labels:
         severity: {{ dig "KubeStateMetricsListErrors" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeStateMetrics }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeStateMetrics | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeStateMetrics }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeStateMetricsWatchErrors | default false) }}
     - alert: KubeStateMetricsWatchErrors
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubeStateMetrics }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubeStateMetrics | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubeStateMetrics | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: kube-state-metrics is experiencing errors at an elevated rate in watch operations. This is likely causing it to not be able to expose metrics about Kubernetes objects correctly or at all.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kube-state-metrics/kubestatemetricswatcherrors
         summary: kube-state-metrics is experiencing errors in watch operations.
@@ -81,23 +95,32 @@ spec:
       labels:
         severity: {{ dig "KubeStateMetricsWatchErrors" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeStateMetrics }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeStateMetrics | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeStateMetrics }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeStateMetricsShardingMismatch | default false) }}
     - alert: KubeStateMetricsShardingMismatch
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubeStateMetrics }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubeStateMetrics | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubeStateMetrics | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: kube-state-metrics pods are running with different --total-shards configuration, some Kubernetes objects may be exposed multiple times or not exposed at all.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kube-state-metrics/kubestatemetricsshardingmismatch
         summary: kube-state-metrics sharding is misconfigured.
@@ -109,23 +132,32 @@ spec:
       labels:
         severity: {{ dig "KubeStateMetricsShardingMismatch" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeStateMetrics }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeStateMetrics | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeStateMetrics }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeStateMetricsShardsMissing | default false) }}
     - alert: KubeStateMetricsShardsMissing
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubeStateMetrics }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubeStateMetrics | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubeStateMetrics | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: kube-state-metrics shards are missing, some Kubernetes objects are not being exposed.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kube-state-metrics/kubestatemetricsshardsmissing
         summary: kube-state-metrics shards are missing.
@@ -141,11 +173,15 @@ spec:
       labels:
         severity: {{ dig "KubeStateMetricsShardsMissing" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeStateMetrics }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeStateMetrics | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeStateMetrics }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubelet.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubelet.rules.yaml
@@ -28,11 +28,15 @@ spec:
       labels:
         quantile: '0.99'
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubelet }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubelet | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubelet }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile
@@ -40,11 +44,15 @@ spec:
       labels:
         quantile: '0.9'
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubelet }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubelet | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubelet }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile
@@ -52,11 +60,15 @@ spec:
       labels:
         quantile: '0.5'
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubelet }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubelet | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubelet }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
       record: node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-apps.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-apps.yaml
@@ -29,12 +29,17 @@ spec:
 {{- if not (.Values.defaultRules.disabled.KubePodCrashLooping | default false) }}
     - alert: KubePodCrashLooping
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: 'Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}} ({{`{{`}} $labels.container {{`}}`}}) is in waiting state (reason: "CrashLoopBackOff").'
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubepodcrashlooping
         summary: Pod is crash looping.
@@ -46,23 +51,32 @@ spec:
       labels:
         severity: {{ dig "KubePodCrashLooping" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubePodNotReady | default false) }}
     - alert: KubePodNotReady
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}} has been in a non-ready state for longer than 15 minutes.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubepodnotready
         summary: Pod has been in a non-ready state for more than 15 minutes.
@@ -81,23 +95,32 @@ spec:
       labels:
         severity: {{ dig "KubePodNotReady" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeDeploymentGenerationMismatch | default false) }}
     - alert: KubeDeploymentGenerationMismatch
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Deployment generation for {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.deployment {{`}}`}} does not match, this indicates that the Deployment has failed but has not been rolled back.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubedeploymentgenerationmismatch
         summary: Deployment generation mismatch due to possible roll-back
@@ -112,23 +135,32 @@ spec:
       labels:
         severity: {{ dig "KubeDeploymentGenerationMismatch" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeDeploymentReplicasMismatch | default false) }}
     - alert: KubeDeploymentReplicasMismatch
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Deployment {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.deployment {{`}}`}} has not matched the expected number of replicas for longer than 15 minutes.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubedeploymentreplicasmismatch
         summary: Deployment has not matched the expected number of replicas.
@@ -149,23 +181,32 @@ spec:
       labels:
         severity: {{ dig "KubeDeploymentReplicasMismatch" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeDeploymentRolloutStuck | default false) }}
     - alert: KubeDeploymentRolloutStuck
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Rollout of deployment {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.deployment {{`}}`}} is not progressing for longer than 15 minutes.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubedeploymentrolloutstuck
         summary: Deployment rollout is not progressing.
@@ -179,23 +220,32 @@ spec:
       labels:
         severity: {{ dig "KubeDeploymentRolloutStuck" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeStatefulSetReplicasMismatch | default false) }}
     - alert: KubeStatefulSetReplicasMismatch
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: StatefulSet {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.statefulset {{`}}`}} has not matched the expected number of replicas for longer than 15 minutes.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubestatefulsetreplicasmismatch
         summary: StatefulSet has not matched the expected number of replicas.
@@ -216,23 +266,32 @@ spec:
       labels:
         severity: {{ dig "KubeStatefulSetReplicasMismatch" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeStatefulSetGenerationMismatch | default false) }}
     - alert: KubeStatefulSetGenerationMismatch
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: StatefulSet generation for {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.statefulset {{`}}`}} does not match, this indicates that the StatefulSet has failed but has not been rolled back.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubestatefulsetgenerationmismatch
         summary: StatefulSet generation mismatch due to possible roll-back
@@ -247,23 +306,32 @@ spec:
       labels:
         severity: {{ dig "KubeStatefulSetGenerationMismatch" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeStatefulSetUpdateNotRolledOut | default false) }}
     - alert: KubeStatefulSetUpdateNotRolledOut
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: StatefulSet {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.statefulset {{`}}`}} update has not been rolled out.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubestatefulsetupdatenotrolledout
         summary: StatefulSet update has not been rolled out.
@@ -292,23 +360,32 @@ spec:
       labels:
         severity: {{ dig "KubeStatefulSetUpdateNotRolledOut" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeDaemonSetRolloutStuck | default false) }}
     - alert: KubeDaemonSetRolloutStuck
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: DaemonSet {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.daemonset {{`}}`}} has not finished or progressed for at least 15 minutes.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubedaemonsetrolloutstuck
         summary: DaemonSet rollout is stuck.
@@ -343,23 +420,32 @@ spec:
       labels:
         severity: {{ dig "KubeDaemonSetRolloutStuck" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeContainerWaiting | default false) }}
     - alert: KubeContainerWaiting
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: pod/{{`{{`}} $labels.pod {{`}}`}} in namespace {{`{{`}} $labels.namespace {{`}}`}} on container {{`{{`}} $labels.container{{`}}`}} has been in waiting state for longer than 1 hour.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubecontainerwaiting
         summary: Pod container waiting longer than 1 hour
@@ -371,23 +457,32 @@ spec:
       labels:
         severity: {{ dig "KubeContainerWaiting" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeDaemonSetNotScheduled | default false) }}
     - alert: KubeDaemonSetNotScheduled
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: '{{`{{`}} $value {{`}}`}} Pods of DaemonSet {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.daemonset {{`}}`}} are not scheduled.'
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubedaemonsetnotscheduled
         summary: DaemonSet pods are not scheduled.
@@ -402,23 +497,32 @@ spec:
       labels:
         severity: {{ dig "KubeDaemonSetNotScheduled" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeDaemonSetMisScheduled | default false) }}
     - alert: KubeDaemonSetMisScheduled
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: '{{`{{`}} $value {{`}}`}} Pods of DaemonSet {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.daemonset {{`}}`}} are running where they are not supposed to run.'
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubedaemonsetmisscheduled
         summary: DaemonSet pods are misscheduled.
@@ -430,23 +534,32 @@ spec:
       labels:
         severity: {{ dig "KubeDaemonSetMisScheduled" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeJobNotCompleted | default false) }}
     - alert: KubeJobNotCompleted
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Job {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.job_name {{`}}`}} is taking more than {{`{{`}} "43200" | humanizeDuration {{`}}`}} to complete.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubejobnotcompleted
         summary: Job did not complete in time
@@ -457,23 +570,32 @@ spec:
       labels:
         severity: {{ dig "KubeJobNotCompleted" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeJobFailed | default false) }}
     - alert: KubeJobFailed
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Job {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.job_name {{`}}`}} failed to complete. Removing failed job after investigation should clear this alert.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubejobfailed
         summary: Job failed to complete.
@@ -485,23 +607,32 @@ spec:
       labels:
         severity: {{ dig "KubeJobFailed" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeHpaReplicasMismatch | default false) }}
     - alert: KubeHpaReplicasMismatch
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: HPA {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.horizontalpodautoscaler  {{`}}`}} has not matched the desired number of replicas for longer than 15 minutes.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubehpareplicasmismatch
         summary: HPA has not matched desired number of replicas.
@@ -526,23 +657,32 @@ spec:
       labels:
         severity: {{ dig "KubeHpaReplicasMismatch" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeHpaMaxedOut | default false) }}
     - alert: KubeHpaMaxedOut
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: HPA {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.horizontalpodautoscaler  {{`}}`}} has been running at max replicas for longer than 15 minutes.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubehpamaxedout
         summary: HPA is running at max replicas
@@ -557,11 +697,15 @@ spec:
       labels:
         severity: {{ dig "KubeHpaMaxedOut" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesApps | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesApps }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-resources.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-resources.yaml
@@ -28,12 +28,17 @@ spec:
 {{- if not (.Values.defaultRules.disabled.KubeCPUOvercommit | default false) }}
     - alert: KubeCPUOvercommit
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesResources }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesResources | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesResources | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Cluster {{`{{`}} $labels.cluster {{`}}`}} has overcommitted CPU resource requests for Pods by {{`{{`}} $value {{`}}`}} CPU shares and cannot tolerate node failure.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubecpuovercommit
         summary: Cluster has overcommitted CPU resource requests.
@@ -48,23 +53,32 @@ spec:
       labels:
         severity: {{ dig "KubeCPUOvercommit" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesResources }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesResources | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesResources }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeMemoryOvercommit | default false) }}
     - alert: KubeMemoryOvercommit
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesResources }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesResources | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesResources | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Cluster {{`{{`}} $labels.cluster {{`}}`}} has overcommitted memory resource requests for Pods by {{`{{`}} $value | humanize {{`}}`}} bytes and cannot tolerate node failure.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubememoryovercommit
         summary: Cluster has overcommitted memory resource requests.
@@ -79,23 +93,32 @@ spec:
       labels:
         severity: {{ dig "KubeMemoryOvercommit" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesResources }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesResources | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesResources }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeCPUQuotaOvercommit | default false) }}
     - alert: KubeCPUQuotaOvercommit
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesResources }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesResources | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesResources | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Cluster {{`{{`}} $labels.cluster {{`}}`}}  has overcommitted CPU resource requests for Namespaces.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubecpuquotaovercommit
         summary: Cluster has overcommitted CPU resource requests.
@@ -111,23 +134,32 @@ spec:
       labels:
         severity: {{ dig "KubeCPUQuotaOvercommit" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesResources }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesResources | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesResources }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeMemoryQuotaOvercommit | default false) }}
     - alert: KubeMemoryQuotaOvercommit
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesResources }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesResources | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesResources | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Cluster {{`{{`}} $labels.cluster {{`}}`}}  has overcommitted memory resource requests for Namespaces.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubememoryquotaovercommit
         summary: Cluster has overcommitted memory resource requests.
@@ -143,23 +175,32 @@ spec:
       labels:
         severity: {{ dig "KubeMemoryQuotaOvercommit" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesResources }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesResources | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesResources }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeQuotaAlmostFull | default false) }}
     - alert: KubeQuotaAlmostFull
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesResources }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesResources | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesResources | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Namespace {{`{{`}} $labels.namespace {{`}}`}} is using {{`{{`}} $value | humanizePercentage {{`}}`}} of its {{`{{`}} $labels.resource {{`}}`}} quota.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubequotaalmostfull
         summary: Namespace quota is going to be full.
@@ -175,23 +216,32 @@ spec:
       labels:
         severity: {{ dig "KubeQuotaAlmostFull" "severity" "info" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesResources }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesResources | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesResources }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeQuotaFullyUsed | default false) }}
     - alert: KubeQuotaFullyUsed
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesResources }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesResources | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesResources | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Namespace {{`{{`}} $labels.namespace {{`}}`}} is using {{`{{`}} $value | humanizePercentage {{`}}`}} of its {{`{{`}} $labels.resource {{`}}`}} quota.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubequotafullyused
         summary: Namespace quota is fully used.
@@ -207,23 +257,32 @@ spec:
       labels:
         severity: {{ dig "KubeQuotaFullyUsed" "severity" "info" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesResources }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesResources | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesResources }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeQuotaExceeded | default false) }}
     - alert: KubeQuotaExceeded
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesResources }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesResources | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesResources | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Namespace {{`{{`}} $labels.namespace {{`}}`}} is using {{`{{`}} $value | humanizePercentage {{`}}`}} of its {{`{{`}} $labels.resource {{`}}`}} quota.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubequotaexceeded
         summary: Namespace quota has exceeded the limits.
@@ -239,23 +298,32 @@ spec:
       labels:
         severity: {{ dig "KubeQuotaExceeded" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesResources }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesResources | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesResources }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.CPUThrottlingHigh | default false) }}
     - alert: CPUThrottlingHigh
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesResources }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesResources | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesResources | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: '{{`{{`}} $value | humanizePercentage {{`}}`}} throttling of CPU in namespace {{`{{`}} $labels.namespace {{`}}`}} for container {{`{{`}} $labels.container {{`}}`}} in pod {{`{{`}} $labels.pod {{`}}`}}.'
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/cputhrottlinghigh
         summary: Processes experience elevated CPU throttling.
@@ -271,11 +339,15 @@ spec:
       labels:
         severity: {{ dig "CPUThrottlingHigh" "severity" "info" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesResources }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesResources | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesResources }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-storage.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-storage.yaml
@@ -29,12 +29,17 @@ spec:
 {{- if not (.Values.defaultRules.disabled.KubePersistentVolumeFillingUp | default false) }}
     - alert: KubePersistentVolumeFillingUp
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesStorage }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesStorage | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesStorage | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: The PersistentVolume claimed by {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in Namespace {{`{{`}} $labels.namespace {{`}}`}} {{`{{`}} with $labels.cluster -{{`}}`}} on Cluster {{`{{`}} . {{`}}`}} {{`{{`}}- end {{`}}`}} is only {{`{{`}} $value | humanizePercentage {{`}}`}} free.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubepersistentvolumefillingup
         summary: PersistentVolume is filling up.
@@ -57,23 +62,32 @@ spec:
       labels:
         severity: {{ dig "KubePersistentVolumeFillingUp" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesStorage }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesStorage | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesStorage }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubePersistentVolumeFillingUp | default false) }}
     - alert: KubePersistentVolumeFillingUp
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesStorage }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesStorage | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesStorage | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Based on recent sampling, the PersistentVolume claimed by {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in Namespace {{`{{`}} $labels.namespace {{`}}`}} {{`{{`}} with $labels.cluster -{{`}}`}} on Cluster {{`{{`}} . {{`}}`}} {{`{{`}}- end {{`}}`}} is expected to fill up within four days. Currently {{`{{`}} $value | humanizePercentage {{`}}`}} is available.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubepersistentvolumefillingup
         summary: PersistentVolume is filling up.
@@ -98,23 +112,32 @@ spec:
       labels:
         severity: {{ dig "KubePersistentVolumeFillingUp" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesStorage }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesStorage | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesStorage }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubePersistentVolumeInodesFillingUp | default false) }}
     - alert: KubePersistentVolumeInodesFillingUp
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesStorage }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesStorage | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesStorage | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: The PersistentVolume claimed by {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in Namespace {{`{{`}} $labels.namespace {{`}}`}} {{`{{`}} with $labels.cluster -{{`}}`}} on Cluster {{`{{`}} . {{`}}`}} {{`{{`}}- end {{`}}`}} only has {{`{{`}} $value | humanizePercentage {{`}}`}} free inodes.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubepersistentvolumeinodesfillingup
         summary: PersistentVolumeInodes are filling up.
@@ -137,23 +160,32 @@ spec:
       labels:
         severity: {{ dig "KubePersistentVolumeInodesFillingUp" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesStorage }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesStorage | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesStorage }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubePersistentVolumeInodesFillingUp | default false) }}
     - alert: KubePersistentVolumeInodesFillingUp
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesStorage }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesStorage | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesStorage | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Based on recent sampling, the PersistentVolume claimed by {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in Namespace {{`{{`}} $labels.namespace {{`}}`}} {{`{{`}} with $labels.cluster -{{`}}`}} on Cluster {{`{{`}} . {{`}}`}} {{`{{`}}- end {{`}}`}} is expected to run out of inodes within four days. Currently {{`{{`}} $value | humanizePercentage {{`}}`}} of its inodes are free.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubepersistentvolumeinodesfillingup
         summary: PersistentVolumeInodes are filling up.
@@ -178,23 +210,32 @@ spec:
       labels:
         severity: {{ dig "KubePersistentVolumeInodesFillingUp" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesStorage }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesStorage | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesStorage }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubePersistentVolumeErrors | default false) }}
     - alert: KubePersistentVolumeErrors
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesStorage }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesStorage | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesStorage | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: The persistent volume {{`{{`}} $labels.persistentvolume {{`}}`}} {{`{{`}} with $labels.cluster -{{`}}`}} on Cluster {{`{{`}} . {{`}}`}} {{`{{`}}- end {{`}}`}} has status {{`{{`}} $labels.phase {{`}}`}}.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubepersistentvolumeerrors
         summary: PersistentVolume is having issues with provisioning.
@@ -206,11 +247,15 @@ spec:
       labels:
         severity: {{ dig "KubePersistentVolumeErrors" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesStorage }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesStorage | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesStorage }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-apiserver.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-apiserver.yaml
@@ -27,12 +27,17 @@ spec:
 {{- if not (.Values.defaultRules.disabled.KubeClientCertificateExpiration | default false) }}
     - alert: KubeClientCertificateExpiration
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: A client certificate used to authenticate to kubernetes apiserver is expiring in less than 7.0 days.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubeclientcertificateexpiration
         summary: Client certificate is about to expire.
@@ -44,23 +49,32 @@ spec:
       labels:
         severity: {{ dig "KubeClientCertificateExpiration" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeClientCertificateExpiration | default false) }}
     - alert: KubeClientCertificateExpiration
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: A client certificate used to authenticate to kubernetes apiserver is expiring in less than 24.0 hours.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubeclientcertificateexpiration
         summary: Client certificate is about to expire.
@@ -72,23 +86,32 @@ spec:
       labels:
         severity: {{ dig "KubeClientCertificateExpiration" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeAggregatedAPIErrors | default false) }}
     - alert: KubeAggregatedAPIErrors
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Kubernetes aggregated API {{`{{`}} $labels.name {{`}}`}}/{{`{{`}} $labels.namespace {{`}}`}} has reported errors. It has appeared unavailable {{`{{`}} $value | humanize {{`}}`}} times averaged over the past 10m.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubeaggregatedapierrors
         summary: Kubernetes aggregated API has reported errors.
@@ -96,23 +119,32 @@ spec:
       labels:
         severity: {{ dig "KubeAggregatedAPIErrors" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeAggregatedAPIDown | default false) }}
     - alert: KubeAggregatedAPIDown
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Kubernetes aggregated API {{`{{`}} $labels.name {{`}}`}}/{{`{{`}} $labels.namespace {{`}}`}} has been only {{`{{`}} $value | humanize {{`}}`}}% available over the last 10m.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubeaggregatedapidown
         summary: Kubernetes aggregated API is down.
@@ -124,11 +156,15 @@ spec:
       labels:
         severity: {{ dig "KubeAggregatedAPIDown" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
@@ -136,12 +172,17 @@ spec:
 {{- if not (.Values.defaultRules.disabled.KubeAPIDown | default false) }}
     - alert: KubeAPIDown
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: KubeAPI has disappeared from Prometheus target discovery.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubeapidown
         summary: Target disappeared from Prometheus target discovery.
@@ -153,11 +194,15 @@ spec:
       labels:
         severity: {{ dig "KubeAPIDown" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
@@ -165,12 +210,17 @@ spec:
 {{- if not (.Values.defaultRules.disabled.KubeAPITerminatedRequests | default false) }}
     - alert: KubeAPITerminatedRequests
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: The kubernetes apiserver has terminated {{`{{`}} $value | humanizePercentage {{`}}`}} of its incoming requests.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubeapiterminatedrequests
         summary: The kubernetes apiserver has terminated {{`{{`}} $value | humanizePercentage {{`}}`}} of its incoming requests.
@@ -182,11 +232,15 @@ spec:
       labels:
         severity: {{ dig "KubeAPITerminatedRequests" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-controller-manager.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-controller-manager.yaml
@@ -28,12 +28,17 @@ spec:
 {{- if not (.Values.defaultRules.disabled.KubeControllerManagerDown | default false) }}
     - alert: KubeControllerManagerDown
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubeControllerManager }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubeControllerManager | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubeControllerManager | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: KubeControllerManager has disappeared from Prometheus target discovery.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubecontrollermanagerdown
         summary: Target disappeared from Prometheus target discovery.
@@ -45,11 +50,15 @@ spec:
       labels:
         severity: {{ dig "KubeControllerManagerDown" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeControllerManager }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeControllerManager | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeControllerManager }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-kubelet.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-kubelet.yaml
@@ -28,12 +28,17 @@ spec:
 {{- if not (.Values.defaultRules.disabled.KubeNodeNotReady | default false) }}
     - alert: KubeNodeNotReady
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: '{{`{{`}} $labels.node {{`}}`}} has been unready for more than 15 minutes.'
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubenodenotready
         summary: Node is not ready.
@@ -45,23 +50,32 @@ spec:
       labels:
         severity: {{ dig "KubeNodeNotReady" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeNodeUnreachable | default false) }}
     - alert: KubeNodeUnreachable
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: '{{`{{`}} $labels.node {{`}}`}} is unreachable and some workloads may be rescheduled.'
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubenodeunreachable
         summary: Node is unreachable.
@@ -73,23 +87,32 @@ spec:
       labels:
         severity: {{ dig "KubeNodeUnreachable" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeletTooManyPods | default false) }}
     - alert: KubeletTooManyPods
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Kubelet '{{`{{`}} $labels.node {{`}}`}}' is running at {{`{{`}} $value | humanizePercentage {{`}}`}} of its Pod capacity.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubelettoomanypods
         summary: Kubelet is running at capacity.
@@ -108,23 +131,32 @@ spec:
       labels:
         severity: {{ dig "KubeletTooManyPods" "severity" "info" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeNodeReadinessFlapping | default false) }}
     - alert: KubeNodeReadinessFlapping
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: The readiness status of node {{`{{`}} $labels.node {{`}}`}} has changed {{`{{`}} $value {{`}}`}} times in the last 15 minutes.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubenodereadinessflapping
         summary: Node readiness status is flapping.
@@ -136,23 +168,32 @@ spec:
       labels:
         severity: {{ dig "KubeNodeReadinessFlapping" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeletPlegDurationHigh | default false) }}
     - alert: KubeletPlegDurationHigh
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: The Kubelet Pod Lifecycle Event Generator has a 99th percentile duration of {{`{{`}} $value {{`}}`}} seconds on node {{`{{`}} $labels.node {{`}}`}}.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubeletplegdurationhigh
         summary: Kubelet Pod Lifecycle Event Generator is taking too long to relist.
@@ -164,23 +205,32 @@ spec:
       labels:
         severity: {{ dig "KubeletPlegDurationHigh" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeletPodStartUpLatencyHigh | default false) }}
     - alert: KubeletPodStartUpLatencyHigh
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Kubelet Pod startup 99th percentile latency is {{`{{`}} $value {{`}}`}} seconds on node {{`{{`}} $labels.node {{`}}`}}.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubeletpodstartuplatencyhigh
         summary: Kubelet Pod startup latency is too high.
@@ -192,23 +242,32 @@ spec:
       labels:
         severity: {{ dig "KubeletPodStartUpLatencyHigh" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeletClientCertificateExpiration | default false) }}
     - alert: KubeletClientCertificateExpiration
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Client certificate for Kubelet on node {{`{{`}} $labels.node {{`}}`}} expires in {{`{{`}} $value | humanizeDuration {{`}}`}}.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubeletclientcertificateexpiration
         summary: Kubelet client certificate is about to expire.
@@ -216,23 +275,32 @@ spec:
       labels:
         severity: {{ dig "KubeletClientCertificateExpiration" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeletClientCertificateExpiration | default false) }}
     - alert: KubeletClientCertificateExpiration
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Client certificate for Kubelet on node {{`{{`}} $labels.node {{`}}`}} expires in {{`{{`}} $value | humanizeDuration {{`}}`}}.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubeletclientcertificateexpiration
         summary: Kubelet client certificate is about to expire.
@@ -240,23 +308,32 @@ spec:
       labels:
         severity: {{ dig "KubeletClientCertificateExpiration" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeletServerCertificateExpiration | default false) }}
     - alert: KubeletServerCertificateExpiration
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Server certificate for Kubelet on node {{`{{`}} $labels.node {{`}}`}} expires in {{`{{`}} $value | humanizeDuration {{`}}`}}.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubeletservercertificateexpiration
         summary: Kubelet server certificate is about to expire.
@@ -264,23 +341,32 @@ spec:
       labels:
         severity: {{ dig "KubeletServerCertificateExpiration" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeletServerCertificateExpiration | default false) }}
     - alert: KubeletServerCertificateExpiration
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Server certificate for Kubelet on node {{`{{`}} $labels.node {{`}}`}} expires in {{`{{`}} $value | humanizeDuration {{`}}`}}.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubeletservercertificateexpiration
         summary: Kubelet server certificate is about to expire.
@@ -288,23 +374,32 @@ spec:
       labels:
         severity: {{ dig "KubeletServerCertificateExpiration" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeletClientCertificateRenewalErrors | default false) }}
     - alert: KubeletClientCertificateRenewalErrors
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Kubelet on node {{`{{`}} $labels.node {{`}}`}} has failed to renew its client certificate ({{`{{`}} $value | humanize {{`}}`}} errors in the last 5 minutes).
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubeletclientcertificaterenewalerrors
         summary: Kubelet has failed to renew its client certificate.
@@ -316,23 +411,32 @@ spec:
       labels:
         severity: {{ dig "KubeletClientCertificateRenewalErrors" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeletServerCertificateRenewalErrors | default false) }}
     - alert: KubeletServerCertificateRenewalErrors
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Kubelet on node {{`{{`}} $labels.node {{`}}`}} has failed to renew its server certificate ({{`{{`}} $value | humanize {{`}}`}} errors in the last 5 minutes).
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubeletservercertificaterenewalerrors
         summary: Kubelet has failed to renew its server certificate.
@@ -344,11 +448,15 @@ spec:
       labels:
         severity: {{ dig "KubeletServerCertificateRenewalErrors" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
@@ -356,12 +464,17 @@ spec:
 {{- if not (.Values.defaultRules.disabled.KubeletDown | default false) }}
     - alert: KubeletDown
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Kubelet has disappeared from Prometheus target discovery.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubeletdown
         summary: Target disappeared from Prometheus target discovery.
@@ -373,11 +486,15 @@ spec:
       labels:
         severity: {{ dig "KubeletDown" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-scheduler.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-scheduler.yaml
@@ -28,12 +28,17 @@ spec:
 {{- if not (.Values.defaultRules.disabled.KubeSchedulerDown | default false) }}
     - alert: KubeSchedulerDown
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubeSchedulerAlerting }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubeSchedulerAlerting | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubeSchedulerAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: KubeScheduler has disappeared from Prometheus target discovery.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubeschedulerdown
         summary: Target disappeared from Prometheus target discovery.
@@ -45,11 +50,15 @@ spec:
       labels:
         severity: {{ dig "KubeSchedulerDown" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubeSchedulerAlerting }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubeSchedulerAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubeSchedulerAlerting }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system.yaml
@@ -27,12 +27,17 @@ spec:
 {{- if not (.Values.defaultRules.disabled.KubeVersionMismatch | default false) }}
     - alert: KubeVersionMismatch
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: There are {{`{{`}} $value {{`}}`}} different semantic versions of Kubernetes components running.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubeversionmismatch
         summary: Different semantic versions of Kubernetes components running.
@@ -44,23 +49,32 @@ spec:
       labels:
         severity: {{ dig "KubeVersionMismatch" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.KubeClientErrors | default false) }}
     - alert: KubeClientErrors
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Kubernetes API server client '{{`{{`}} $labels.job {{`}}`}}/{{`{{`}} $labels.instance {{`}}`}}' is experiencing {{`{{`}} $value | humanizePercentage {{`}}`}} errors.'
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/kubernetes/kubeclienterrors
         summary: Kubernetes API server client is experiencing errors.
@@ -76,11 +90,15 @@ spec:
       labels:
         severity: {{ dig "KubeClientErrors" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesSystem }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-exporter.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-exporter.rules.yaml
@@ -31,11 +31,15 @@ spec:
       record: instance:node_num_cpu:sum
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -45,11 +49,15 @@ spec:
       record: instance:node_cpu_utilisation:rate5m
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -61,11 +69,15 @@ spec:
       record: instance:node_load1_per_cpu:ratio
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -89,44 +101,60 @@ spec:
       record: instance:node_memory_utilisation:ratio
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: rate(node_vmstat_pgmajfault{job="node-exporter"}[5m])
       record: instance:node_vmstat_pgmajfault:rate5m
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: rate(node_disk_io_time_seconds_total{job="node-exporter", device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"}[5m])
       record: instance_device:node_disk_io_time_seconds:rate5m
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: rate(node_disk_io_time_weighted_seconds_total{job="node-exporter", device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"}[5m])
       record: instance_device:node_disk_io_time_weighted_seconds:rate5m
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -136,11 +164,15 @@ spec:
       record: instance:node_network_receive_bytes_excluding_lo:rate5m
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -150,11 +182,15 @@ spec:
       record: instance:node_network_transmit_bytes_excluding_lo:rate5m
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -164,11 +200,15 @@ spec:
       record: instance:node_network_receive_drop_excluding_lo:rate5m
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -178,11 +218,15 @@ spec:
       record: instance:node_network_transmit_drop_excluding_lo:rate5m
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterRecording }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-exporter.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-exporter.yaml
@@ -27,12 +27,17 @@ spec:
 {{- if not (.Values.defaultRules.disabled.NodeFilesystemSpaceFillingUp | default false) }}
     - alert: NodeFilesystemSpaceFillingUp
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Filesystem on {{`{{`}} $labels.device {{`}}`}}, mounted on {{`{{`}} $labels.mountpoint {{`}}`}}, at {{`{{`}} $labels.instance {{`}}`}} has only {{`{{`}} printf "%.2f" $value {{`}}`}}% available space left and is filling up.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodefilesystemspacefillingup
         summary: Filesystem is predicted to run out of space within the next 24 hours.
@@ -51,23 +56,32 @@ spec:
       labels:
         severity: {{ dig "NodeFilesystemSpaceFillingUp" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeFilesystemSpaceFillingUp | default false) }}
     - alert: NodeFilesystemSpaceFillingUp
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Filesystem on {{`{{`}} $labels.device {{`}}`}}, mounted on {{`{{`}} $labels.mountpoint {{`}}`}}, at {{`{{`}} $labels.instance {{`}}`}} has only {{`{{`}} printf "%.2f" $value {{`}}`}}% available space left and is filling up fast.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodefilesystemspacefillingup
         summary: Filesystem is predicted to run out of space within the next 4 hours.
@@ -86,23 +100,32 @@ spec:
       labels:
         severity: {{ dig "NodeFilesystemSpaceFillingUp" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeFilesystemAlmostOutOfSpace | default false) }}
     - alert: NodeFilesystemAlmostOutOfSpace
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Filesystem on {{`{{`}} $labels.device {{`}}`}}, mounted on {{`{{`}} $labels.mountpoint {{`}}`}}, at {{`{{`}} $labels.instance {{`}}`}} has only {{`{{`}} printf "%.2f" $value {{`}}`}}% available space left.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodefilesystemalmostoutofspace
         summary: Filesystem has less than 5% space left.
@@ -119,23 +142,32 @@ spec:
       labels:
         severity: {{ dig "NodeFilesystemAlmostOutOfSpace" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeFilesystemAlmostOutOfSpace | default false) }}
     - alert: NodeFilesystemAlmostOutOfSpace
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Filesystem on {{`{{`}} $labels.device {{`}}`}}, mounted on {{`{{`}} $labels.mountpoint {{`}}`}}, at {{`{{`}} $labels.instance {{`}}`}} has only {{`{{`}} printf "%.2f" $value {{`}}`}}% available space left.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodefilesystemalmostoutofspace
         summary: Filesystem has less than 3% space left.
@@ -152,23 +184,32 @@ spec:
       labels:
         severity: {{ dig "NodeFilesystemAlmostOutOfSpace" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeFilesystemFilesFillingUp | default false) }}
     - alert: NodeFilesystemFilesFillingUp
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Filesystem on {{`{{`}} $labels.device {{`}}`}}, mounted on {{`{{`}} $labels.mountpoint {{`}}`}}, at {{`{{`}} $labels.instance {{`}}`}} has only {{`{{`}} printf "%.2f" $value {{`}}`}}% available inodes left and is filling up.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodefilesystemfilesfillingup
         summary: Filesystem is predicted to run out of inodes within the next 24 hours.
@@ -187,23 +228,32 @@ spec:
       labels:
         severity: {{ dig "NodeFilesystemFilesFillingUp" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeFilesystemFilesFillingUp | default false) }}
     - alert: NodeFilesystemFilesFillingUp
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Filesystem on {{`{{`}} $labels.device {{`}}`}}, mounted on {{`{{`}} $labels.mountpoint {{`}}`}}, at {{`{{`}} $labels.instance {{`}}`}} has only {{`{{`}} printf "%.2f" $value {{`}}`}}% available inodes left and is filling up fast.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodefilesystemfilesfillingup
         summary: Filesystem is predicted to run out of inodes within the next 4 hours.
@@ -222,23 +272,32 @@ spec:
       labels:
         severity: {{ dig "NodeFilesystemFilesFillingUp" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeFilesystemAlmostOutOfFiles | default false) }}
     - alert: NodeFilesystemAlmostOutOfFiles
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Filesystem on {{`{{`}} $labels.device {{`}}`}}, mounted on {{`{{`}} $labels.mountpoint {{`}}`}}, at {{`{{`}} $labels.instance {{`}}`}} has only {{`{{`}} printf "%.2f" $value {{`}}`}}% available inodes left.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodefilesystemalmostoutoffiles
         summary: Filesystem has less than 5% inodes left.
@@ -255,23 +314,32 @@ spec:
       labels:
         severity: {{ dig "NodeFilesystemAlmostOutOfFiles" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeFilesystemAlmostOutOfFiles | default false) }}
     - alert: NodeFilesystemAlmostOutOfFiles
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Filesystem on {{`{{`}} $labels.device {{`}}`}}, mounted on {{`{{`}} $labels.mountpoint {{`}}`}}, at {{`{{`}} $labels.instance {{`}}`}} has only {{`{{`}} printf "%.2f" $value {{`}}`}}% available inodes left.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodefilesystemalmostoutoffiles
         summary: Filesystem has less than 3% inodes left.
@@ -288,23 +356,32 @@ spec:
       labels:
         severity: {{ dig "NodeFilesystemAlmostOutOfFiles" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeNetworkReceiveErrs | default false) }}
     - alert: NodeNetworkReceiveErrs
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: '{{`{{`}} $labels.instance {{`}}`}} interface {{`{{`}} $labels.device {{`}}`}} has encountered {{`{{`}} printf "%.0f" $value {{`}}`}} receive errors in the last two minutes.'
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodenetworkreceiveerrs
         summary: Network interface is reporting many receive errors.
@@ -316,23 +393,32 @@ spec:
       labels:
         severity: {{ dig "NodeNetworkReceiveErrs" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeNetworkTransmitErrs | default false) }}
     - alert: NodeNetworkTransmitErrs
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: '{{`{{`}} $labels.instance {{`}}`}} interface {{`{{`}} $labels.device {{`}}`}} has encountered {{`{{`}} printf "%.0f" $value {{`}}`}} transmit errors in the last two minutes.'
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodenetworktransmiterrs
         summary: Network interface is reporting many transmit errors.
@@ -344,23 +430,32 @@ spec:
       labels:
         severity: {{ dig "NodeNetworkTransmitErrs" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeHighNumberConntrackEntriesUsed | default false) }}
     - alert: NodeHighNumberConntrackEntriesUsed
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: '{{`{{`}} $value | humanizePercentage {{`}}`}} of conntrack entries are used.'
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodehighnumberconntrackentriesused
         summary: Number of conntrack are getting close to the limit.
@@ -368,23 +463,32 @@ spec:
       labels:
         severity: {{ dig "NodeHighNumberConntrackEntriesUsed" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeTextFileCollectorScrapeError | default false) }}
     - alert: NodeTextFileCollectorScrapeError
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Node Exporter text file collector on {{`{{`}} $labels.instance {{`}}`}} failed to scrape.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodetextfilecollectorscrapeerror
         summary: Node Exporter text file collector failed to scrape.
@@ -392,23 +496,32 @@ spec:
       labels:
         severity: {{ dig "NodeTextFileCollectorScrapeError" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeClockSkewDetected | default false) }}
     - alert: NodeClockSkewDetected
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Clock at {{`{{`}} $labels.instance {{`}}`}} is out of sync by more than 0.05s. Ensure NTP is configured correctly on this host.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodeclockskewdetected
         summary: Clock skew detected.
@@ -431,23 +544,32 @@ spec:
       labels:
         severity: {{ dig "NodeClockSkewDetected" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeClockNotSynchronising | default false) }}
     - alert: NodeClockNotSynchronising
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Clock at {{`{{`}} $labels.instance {{`}}`}} is not synchronising. Ensure NTP is configured on this host.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodeclocknotsynchronising
         summary: Clock not synchronising.
@@ -462,23 +584,32 @@ spec:
       labels:
         severity: {{ dig "NodeClockNotSynchronising" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeRAIDDegraded | default false) }}
     - alert: NodeRAIDDegraded
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: RAID array '{{`{{`}} $labels.device {{`}}`}}' at {{`{{`}} $labels.instance {{`}}`}} is in degraded state due to one or more disks failures. Number of spare drives is insufficient to fix issue automatically.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/noderaiddegraded
         summary: RAID Array is degraded.
@@ -490,23 +621,32 @@ spec:
       labels:
         severity: {{ dig "NodeRAIDDegraded" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeRAIDDiskFailure | default false) }}
     - alert: NodeRAIDDiskFailure
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: At least one device in RAID array at {{`{{`}} $labels.instance {{`}}`}} failed. Array '{{`{{`}} $labels.device {{`}}`}}' needs attention and possibly a disk swap.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/noderaiddiskfailure
         summary: Failed device in RAID array.
@@ -514,23 +654,32 @@ spec:
       labels:
         severity: {{ dig "NodeRAIDDiskFailure" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeFileDescriptorLimit | default false) }}
     - alert: NodeFileDescriptorLimit
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: File descriptors limit at {{`{{`}} $labels.instance {{`}}`}} is currently at {{`{{`}} printf "%.2f" $value {{`}}`}}%.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodefiledescriptorlimit
         summary: Kernel is predicted to exhaust file descriptors limit soon.
@@ -545,23 +694,32 @@ spec:
       labels:
         severity: {{ dig "NodeFileDescriptorLimit" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeFileDescriptorLimit | default false) }}
     - alert: NodeFileDescriptorLimit
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: File descriptors limit at {{`{{`}} $labels.instance {{`}}`}} is currently at {{`{{`}} printf "%.2f" $value {{`}}`}}%.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodefiledescriptorlimit
         summary: Kernel is predicted to exhaust file descriptors limit soon.
@@ -576,23 +734,32 @@ spec:
       labels:
         severity: {{ dig "NodeFileDescriptorLimit" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeCPUHighUsage | default false) }}
     - alert: NodeCPUHighUsage
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: 'CPU usage at {{`{{`}} $labels.instance {{`}}`}} has been above 90% for the last 15 minutes, is currently at {{`{{`}} printf "%.2f" $value {{`}}`}}%.
 
           '
@@ -606,23 +773,32 @@ spec:
       labels:
         severity: {{ dig "NodeCPUHighUsage" "severity" "info" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeSystemSaturation | default false) }}
     - alert: NodeSystemSaturation
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: 'System load per core at {{`{{`}} $labels.instance {{`}}`}} has been above 2 for the last 15 minutes, is currently at {{`{{`}} printf "%.2f" $value {{`}}`}}.
 
           This might indicate this instance resources saturation and can cause it becoming unresponsive.
@@ -640,23 +816,32 @@ spec:
       labels:
         severity: {{ dig "NodeSystemSaturation" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeMemoryMajorPagesFaults | default false) }}
     - alert: NodeMemoryMajorPagesFaults
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: 'Memory major pages are occurring at very high rate at {{`{{`}} $labels.instance {{`}}`}}, 500 major page faults per second for the last 15 minutes, is currently at {{`{{`}} printf "%.2f" $value {{`}}`}}.
 
           Please check that there is enough memory available at this instance.
@@ -672,23 +857,32 @@ spec:
       labels:
         severity: {{ dig "NodeMemoryMajorPagesFaults" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeMemoryHighUtilization | default false) }}
     - alert: NodeMemoryHighUtilization
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: 'Memory is filling up at {{`{{`}} $labels.instance {{`}}`}}, has been above 90% for the last 15 minutes, is currently at {{`{{`}} printf "%.2f" $value {{`}}`}}%.
 
           '
@@ -702,23 +896,32 @@ spec:
       labels:
         severity: {{ dig "NodeMemoryHighUtilization" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeDiskIOSaturation | default false) }}
     - alert: NodeDiskIOSaturation
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: 'Disk IO queue (aqu-sq) is high on {{`{{`}} $labels.device {{`}}`}} at {{`{{`}} $labels.instance {{`}}`}}, has been above 10 for the last 30 minutes, is currently at {{`{{`}} printf "%.2f" $value {{`}}`}}.
 
           This symptom might indicate disk saturation.
@@ -734,23 +937,32 @@ spec:
       labels:
         severity: {{ dig "NodeDiskIOSaturation" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeSystemdServiceFailed | default false) }}
     - alert: NodeSystemdServiceFailed
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Systemd service {{`{{`}} $labels.name {{`}}`}} has entered failed state at {{`{{`}} $labels.instance {{`}}`}}
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodesystemdservicefailed
         summary: Systemd service has entered failed state.
@@ -762,23 +974,32 @@ spec:
       labels:
         severity: {{ dig "NodeSystemdServiceFailed" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.NodeBondingDegraded | default false) }}
     - alert: NodeBondingDegraded
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Bonding interface {{`{{`}} $labels.master {{`}}`}} on {{`{{`}} $labels.instance {{`}}`}} is in degraded state due to one or more slave failures.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodebondingdegraded
         summary: Bonding interface is degraded
@@ -790,11 +1011,15 @@ spec:
       labels:
         severity: {{ dig "NodeBondingDegraded" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.nodeExporterAlerting }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-network.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-network.yaml
@@ -27,12 +27,17 @@ spec:
 {{- if not (.Values.defaultRules.disabled.NodeNetworkInterfaceFlapping | default false) }}
     - alert: NodeNetworkInterfaceFlapping
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.network }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.network | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.network | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Network interface "{{`{{`}} $labels.device {{`}}`}}" changing its up status often on node-exporter {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}}
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/general/nodenetworkinterfaceflapping
         summary: Network interface is often changing its status
@@ -44,11 +49,15 @@ spec:
       labels:
         severity: {{ dig "NodeNetworkInterfaceFlapping" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.network }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.network | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.network }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node.rules.yaml
@@ -33,11 +33,15 @@ spec:
       record: 'node_namespace_pod:kube_pod_info:'
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.node }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.node | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.node }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -49,11 +53,15 @@ spec:
       record: node:node_num_cpu:sum
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.node }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.node | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.node }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -69,11 +77,15 @@ spec:
       record: :node_memory_MemAvailable_bytes:sum
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.node }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.node | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.node }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -85,11 +97,15 @@ spec:
       record: node:node_cpu_utilization:ratio_rate5m
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.node }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.node | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.node }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -99,11 +115,15 @@ spec:
       record: cluster:node_cpu:ratio_rate5m
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.node }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.node | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.node }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/prometheus-operator.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/prometheus-operator.yaml
@@ -29,12 +29,17 @@ spec:
 {{- if not (.Values.defaultRules.disabled.PrometheusOperatorListErrors | default false) }}
     - alert: PrometheusOperatorListErrors
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.prometheusOperator }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.prometheusOperator | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.prometheusOperator | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Errors while performing List operations in controller {{`{{`}}$labels.controller{{`}}`}} in {{`{{`}}$labels.namespace{{`}}`}} namespace.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus-operator/prometheusoperatorlisterrors
         summary: Errors while performing list operations in controller.
@@ -46,23 +51,32 @@ spec:
       labels:
         severity: {{ dig "PrometheusOperatorListErrors" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.prometheusOperator }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.prometheusOperator | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.prometheusOperator }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusOperatorWatchErrors | default false) }}
     - alert: PrometheusOperatorWatchErrors
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.prometheusOperator }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.prometheusOperator | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.prometheusOperator | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Errors while performing watch operations in controller {{`{{`}}$labels.controller{{`}}`}} in {{`{{`}}$labels.namespace{{`}}`}} namespace.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus-operator/prometheusoperatorwatcherrors
         summary: Errors while performing watch operations in controller.
@@ -74,23 +88,32 @@ spec:
       labels:
         severity: {{ dig "PrometheusOperatorWatchErrors" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.prometheusOperator }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.prometheusOperator | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.prometheusOperator }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusOperatorSyncFailed | default false) }}
     - alert: PrometheusOperatorSyncFailed
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.prometheusOperator }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.prometheusOperator | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.prometheusOperator | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Controller {{`{{`}} $labels.controller {{`}}`}} in {{`{{`}} $labels.namespace {{`}}`}} namespace fails to reconcile {{`{{`}} $value {{`}}`}} objects.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus-operator/prometheusoperatorsyncfailed
         summary: Last controller reconciliation failed
@@ -102,23 +125,32 @@ spec:
       labels:
         severity: {{ dig "PrometheusOperatorSyncFailed" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.prometheusOperator }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.prometheusOperator | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.prometheusOperator }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusOperatorReconcileErrors | default false) }}
     - alert: PrometheusOperatorReconcileErrors
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.prometheusOperator }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.prometheusOperator | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.prometheusOperator | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: '{{`{{`}} $value | humanizePercentage {{`}}`}} of reconciling operations failed for {{`{{`}} $labels.controller {{`}}`}} controller in {{`{{`}} $labels.namespace {{`}}`}} namespace.'
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus-operator/prometheusoperatorreconcileerrors
         summary: Errors while reconciling objects.
@@ -130,23 +162,32 @@ spec:
       labels:
         severity: {{ dig "PrometheusOperatorReconcileErrors" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.prometheusOperator }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.prometheusOperator | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.prometheusOperator }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusOperatorStatusUpdateErrors | default false) }}
     - alert: PrometheusOperatorStatusUpdateErrors
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.prometheusOperator }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.prometheusOperator | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.prometheusOperator | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: '{{`{{`}} $value | humanizePercentage {{`}}`}} of status update operations failed for {{`{{`}} $labels.controller {{`}}`}} controller in {{`{{`}} $labels.namespace {{`}}`}} namespace.'
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus-operator/prometheusoperatorstatusupdateerrors
         summary: Errors while updating objects status.
@@ -158,23 +199,32 @@ spec:
       labels:
         severity: {{ dig "PrometheusOperatorStatusUpdateErrors" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.prometheusOperator }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.prometheusOperator | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.prometheusOperator }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusOperatorNodeLookupErrors | default false) }}
     - alert: PrometheusOperatorNodeLookupErrors
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.prometheusOperator }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.prometheusOperator | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.prometheusOperator | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Errors while reconciling Prometheus in {{`{{`}} $labels.namespace {{`}}`}} Namespace.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus-operator/prometheusoperatornodelookuperrors
         summary: Errors while reconciling Prometheus.
@@ -186,23 +236,32 @@ spec:
       labels:
         severity: {{ dig "PrometheusOperatorNodeLookupErrors" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.prometheusOperator }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.prometheusOperator | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.prometheusOperator }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusOperatorNotReady | default false) }}
     - alert: PrometheusOperatorNotReady
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.prometheusOperator }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.prometheusOperator | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.prometheusOperator | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Prometheus operator in {{`{{`}} $labels.namespace {{`}}`}} namespace isn't ready to reconcile {{`{{`}} $labels.controller {{`}}`}} resources.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus-operator/prometheusoperatornotready
         summary: Prometheus operator not ready
@@ -214,23 +273,32 @@ spec:
       labels:
         severity: {{ dig "PrometheusOperatorNotReady" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.prometheusOperator }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.prometheusOperator | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.prometheusOperator }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusOperatorRejectedResources | default false) }}
     - alert: PrometheusOperatorRejectedResources
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.prometheusOperator }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.prometheusOperator | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.prometheusOperator | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Prometheus operator in {{`{{`}} $labels.namespace {{`}}`}} namespace rejected {{`{{`}} printf "%0.0f" $value {{`}}`}} {{`{{`}} $labels.controller {{`}}`}}/{{`{{`}} $labels.resource {{`}}`}} resources.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus-operator/prometheusoperatorrejectedresources
         summary: Resources rejected by Prometheus operator
@@ -242,11 +310,15 @@ spec:
       labels:
         severity: {{ dig "PrometheusOperatorRejectedResources" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.prometheusOperator }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.prometheusOperator | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.prometheusOperator }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/prometheus.yaml
@@ -29,12 +29,17 @@ spec:
 {{- if not (.Values.defaultRules.disabled.PrometheusBadConfig | default false) }}
     - alert: PrometheusBadConfig
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.prometheus }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.prometheus | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} has failed to reload its configuration.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus/prometheusbadconfig
         summary: Failed Prometheus configuration reload.
@@ -49,23 +54,32 @@ spec:
       labels:
         severity: {{ dig "PrometheusBadConfig" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusSDRefreshFailure | default false) }}
     - alert: PrometheusSDRefreshFailure
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.prometheus }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.prometheus | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} has failed to refresh SD with mechanism {{`{{`}}$labels.mechanism{{`}}`}}.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus/prometheussdrefreshfailure
         summary: Failed Prometheus SD refresh.
@@ -77,23 +91,32 @@ spec:
       labels:
         severity: {{ dig "PrometheusSDRefreshFailure" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusNotificationQueueRunningFull | default false) }}
     - alert: PrometheusNotificationQueueRunningFull
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.prometheus }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.prometheus | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Alert notification queue of Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} is running full.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus/prometheusnotificationqueuerunningfull
         summary: Prometheus alert notification queue predicted to run full in less than 30m.
@@ -112,23 +135,32 @@ spec:
       labels:
         severity: {{ dig "PrometheusNotificationQueueRunningFull" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusErrorSendingAlertsToSomeAlertmanagers | default false) }}
     - alert: PrometheusErrorSendingAlertsToSomeAlertmanagers
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.prometheus }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.prometheus | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: '{{`{{`}} printf "%.1f" $value {{`}}`}}% errors while sending alerts from Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} to Alertmanager {{`{{`}}$labels.alertmanager{{`}}`}}.'
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus/prometheuserrorsendingalertstosomealertmanagers
         summary: Prometheus has encountered more than 1% errors sending alerts to a specific Alertmanager.
@@ -147,23 +179,32 @@ spec:
       labels:
         severity: {{ dig "PrometheusErrorSendingAlertsToSomeAlertmanagers" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusNotConnectedToAlertmanagers | default false) }}
     - alert: PrometheusNotConnectedToAlertmanagers
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.prometheus }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.prometheus | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} is not connected to any Alertmanagers.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus/prometheusnotconnectedtoalertmanagers
         summary: Prometheus is not connected to any Alertmanagers.
@@ -178,23 +219,32 @@ spec:
       labels:
         severity: {{ dig "PrometheusNotConnectedToAlertmanagers" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusTSDBReloadsFailing | default false) }}
     - alert: PrometheusTSDBReloadsFailing
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.prometheus }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.prometheus | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} has detected {{`{{`}}$value | humanize{{`}}`}} reload failures over the last 3h.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus/prometheustsdbreloadsfailing
         summary: Prometheus has issues reloading blocks from disk.
@@ -206,23 +256,32 @@ spec:
       labels:
         severity: {{ dig "PrometheusTSDBReloadsFailing" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusTSDBCompactionsFailing | default false) }}
     - alert: PrometheusTSDBCompactionsFailing
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.prometheus }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.prometheus | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} has detected {{`{{`}}$value | humanize{{`}}`}} compaction failures over the last 3h.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus/prometheustsdbcompactionsfailing
         summary: Prometheus has issues compacting blocks.
@@ -234,23 +293,32 @@ spec:
       labels:
         severity: {{ dig "PrometheusTSDBCompactionsFailing" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusNotIngestingSamples | default false) }}
     - alert: PrometheusNotIngestingSamples
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.prometheus }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.prometheus | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} is not ingesting samples.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus/prometheusnotingestingsamples
         summary: Prometheus is not ingesting samples.
@@ -271,23 +339,32 @@ spec:
       labels:
         severity: {{ dig "PrometheusNotIngestingSamples" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusDuplicateTimestamps | default false) }}
     - alert: PrometheusDuplicateTimestamps
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.prometheus }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.prometheus | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} is dropping {{`{{`}} printf "%.4g" $value  {{`}}`}} samples/s with different values but duplicated timestamp.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus/prometheusduplicatetimestamps
         summary: Prometheus is dropping samples with duplicate timestamps.
@@ -299,23 +376,32 @@ spec:
       labels:
         severity: {{ dig "PrometheusDuplicateTimestamps" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusOutOfOrderTimestamps | default false) }}
     - alert: PrometheusOutOfOrderTimestamps
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.prometheus }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.prometheus | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} is dropping {{`{{`}} printf "%.4g" $value  {{`}}`}} samples/s with timestamps arriving out of order.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus/prometheusoutofordertimestamps
         summary: Prometheus drops samples with out-of-order timestamps.
@@ -327,23 +413,32 @@ spec:
       labels:
         severity: {{ dig "PrometheusOutOfOrderTimestamps" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusRemoteStorageFailures | default false) }}
     - alert: PrometheusRemoteStorageFailures
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.prometheus }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.prometheus | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} failed to send {{`{{`}} printf "%.1f" $value {{`}}`}}% of the samples to {{`{{`}} $labels.remote_name{{`}}`}}:{{`{{`}} $labels.url {{`}}`}}
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus/prometheusremotestoragefailures
         summary: Prometheus fails to send samples to remote storage.
@@ -366,23 +461,32 @@ spec:
       labels:
         severity: {{ dig "PrometheusRemoteStorageFailures" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusRemoteWriteBehind | default false) }}
     - alert: PrometheusRemoteWriteBehind
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.prometheus }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.prometheus | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} remote write is {{`{{`}} printf "%.1f" $value {{`}}`}}s behind for {{`{{`}} $labels.remote_name{{`}}`}}:{{`{{`}} $labels.url {{`}}`}}.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus/prometheusremotewritebehind
         summary: Prometheus remote write is behind.
@@ -402,23 +506,32 @@ spec:
       labels:
         severity: {{ dig "PrometheusRemoteWriteBehind" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusRemoteWriteDesiredShards | default false) }}
     - alert: PrometheusRemoteWriteDesiredShards
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.prometheus }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.prometheus | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} remote write desired shards calculation wants to run {{`{{`}} $value {{`}}`}} shards for queue {{`{{`}} $labels.remote_name{{`}}`}}:{{`{{`}} $labels.url {{`}}`}}, which is more than the max of {{`{{`}} printf `prometheus_remote_storage_shards_max{instance="%s",job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}` $labels.instance | query | first | value {{`}}`}}.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus/prometheusremotewritedesiredshards
         summary: Prometheus remote write desired shards calculation wants to run more than configured max shards.
@@ -437,23 +550,32 @@ spec:
       labels:
         severity: {{ dig "PrometheusRemoteWriteDesiredShards" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusRuleFailures | default false) }}
     - alert: PrometheusRuleFailures
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.prometheus }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.prometheus | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} has failed to evaluate {{`{{`}} printf "%.0f" $value {{`}}`}} rules in the last 5m.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus/prometheusrulefailures
         summary: Prometheus is failing rule evaluations.
@@ -465,23 +587,32 @@ spec:
       labels:
         severity: {{ dig "PrometheusRuleFailures" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusMissingRuleEvaluations | default false) }}
     - alert: PrometheusMissingRuleEvaluations
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.prometheus }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.prometheus | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} has missed {{`{{`}} printf "%.0f" $value {{`}}`}} rule group evaluations in the last 5m.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus/prometheusmissingruleevaluations
         summary: Prometheus is missing rule evaluations due to slow rule group evaluation.
@@ -493,23 +624,32 @@ spec:
       labels:
         severity: {{ dig "PrometheusMissingRuleEvaluations" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusTargetLimitHit | default false) }}
     - alert: PrometheusTargetLimitHit
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.prometheus }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.prometheus | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} has dropped {{`{{`}} printf "%.0f" $value {{`}}`}} targets because the number of targets exceeded the configured target_limit.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus/prometheustargetlimithit
         summary: Prometheus has dropped targets because some scrape configs have exceeded the targets limit.
@@ -521,23 +661,32 @@ spec:
       labels:
         severity: {{ dig "PrometheusTargetLimitHit" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusLabelLimitHit | default false) }}
     - alert: PrometheusLabelLimitHit
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.prometheus }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.prometheus | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} has dropped {{`{{`}} printf "%.0f" $value {{`}}`}} targets because some samples exceeded the configured label_limit, label_name_length_limit or label_value_length_limit.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus/prometheuslabellimithit
         summary: Prometheus has dropped targets because some scrape configs have exceeded the labels limit.
@@ -549,23 +698,32 @@ spec:
       labels:
         severity: {{ dig "PrometheusLabelLimitHit" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusScrapeBodySizeLimitHit | default false) }}
     - alert: PrometheusScrapeBodySizeLimitHit
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.prometheus }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.prometheus | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} has failed {{`{{`}} printf "%.0f" $value {{`}}`}} scrapes in the last 5m because some targets exceeded the configured body_size_limit.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus/prometheusscrapebodysizelimithit
         summary: Prometheus has dropped some targets that exceeded body size limit.
@@ -577,23 +735,32 @@ spec:
       labels:
         severity: {{ dig "PrometheusScrapeBodySizeLimitHit" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusScrapeSampleLimitHit | default false) }}
     - alert: PrometheusScrapeSampleLimitHit
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.prometheus }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.prometheus | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} has failed {{`{{`}} printf "%.0f" $value {{`}}`}} scrapes in the last 5m because some targets exceeded the configured sample_limit.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus/prometheusscrapesamplelimithit
         summary: Prometheus has failed scrapes that have exceeded the configured sample limit.
@@ -605,23 +772,32 @@ spec:
       labels:
         severity: {{ dig "PrometheusScrapeSampleLimitHit" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusTargetSyncFailure | default false) }}
     - alert: PrometheusTargetSyncFailure
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.prometheus }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.prometheus | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: '{{`{{`}} printf "%.0f" $value {{`}}`}} targets in Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} have failed to sync because invalid configuration was supplied.'
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus/prometheustargetsyncfailure
         summary: Prometheus has failed to sync targets.
@@ -633,23 +809,32 @@ spec:
       labels:
         severity: {{ dig "PrometheusTargetSyncFailure" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusHighQueryLoad | default false) }}
     - alert: PrometheusHighQueryLoad
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.prometheus }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.prometheus | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} query API has less than 20% available capacity in its query engine for the last 15 minutes.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus/prometheushighqueryload
         summary: Prometheus is reaching its maximum capacity serving concurrent requests.
@@ -661,23 +846,32 @@ spec:
       labels:
         severity: {{ dig "PrometheusHighQueryLoad" "severity" "warning" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}
 {{- if not (.Values.defaultRules.disabled.PrometheusErrorSendingAlertsToAnyAlertmanager | default false) }}
     - alert: PrometheusErrorSendingAlertsToAnyAlertmanager
       annotations:
-{{- if .Values.defaultRules.additionalRuleAnnotations }}
-{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.defaultRules.additionalRuleGroupAnnotations.prometheus }}
-{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.prometheus | indent 8 }}
-{{- end }}
+
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleAnnotations | default (dict))
+              (.Values.defaultRules.additionalRuleGroupAnnotations.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
+        {{- end }}
+
+        {{- end }}
         description: '{{`{{`}} printf "%.1f" $value {{`}}`}}% minimum errors while sending alerts from Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} to any Alertmanager.'
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus/prometheuserrorsendingalertstoanyalertmanager
         summary: Prometheus encounters more than 3% errors sending alerts to any Alertmanager.
@@ -696,11 +890,15 @@ spec:
       labels:
         severity: {{ dig "PrometheusErrorSendingAlertsToAnyAlertmanager" "severity" "critical" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.prometheus | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.prometheus }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/windows.node.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/windows.node.rules.yaml
@@ -31,11 +31,15 @@ spec:
       record: node:windows_node:sum
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -45,22 +49,30 @@ spec:
       record: node:windows_node_num_cpu:sum
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: 1 - avg by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster) (rate(windows_cpu_time_total{job="windows-exporter",mode="idle"}[1m]))
       record: :windows_node_cpu_utilisation:avg1m
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -70,11 +82,15 @@ spec:
       record: node:windows_node_cpu_utilisation:avg1m
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -85,44 +101,60 @@ spec:
       record: ':windows_node_memory_utilisation:'
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: sum by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster) (windows_memory_available_bytes{job="windows-exporter"} + windows_memory_cache_bytes{job="windows-exporter"})
       record: :windows_node_memory_MemFreeCached_bytes:sum
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: (windows_memory_cache_bytes{job="windows-exporter"} + windows_memory_modified_page_list_bytes{job="windows-exporter"} + windows_memory_standby_cache_core_bytes{job="windows-exporter"} + windows_memory_standby_cache_normal_priority_bytes{job="windows-exporter"} + windows_memory_standby_cache_reserve_bytes{job="windows-exporter"})
       record: node:windows_node_memory_totalCached_bytes:sum
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: sum by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster) (windows_os_visible_memory_bytes{job="windows-exporter"})
       record: :windows_node_memory_MemTotal_bytes:sum
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -132,11 +164,15 @@ spec:
       record: node:windows_node_memory_bytes_available:sum
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -146,11 +182,15 @@ spec:
       record: node:windows_node_memory_bytes_total:sum
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -160,33 +200,45 @@ spec:
       record: node:windows_node_memory_utilisation:ratio
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: 1 - (node:windows_node_memory_bytes_available:sum / node:windows_node_memory_bytes_total:sum)
       record: 'node:windows_node_memory_utilisation:'
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: irate(windows_memory_swap_page_operations_total{job="windows-exporter"}[5m])
       record: node:windows_node_memory_swap_io_pages:irate
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -196,11 +248,15 @@ spec:
       record: :windows_node_disk_utilisation:avg_irate
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -211,11 +267,15 @@ spec:
       record: node:windows_node_disk_utilisation:avg_irate
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -227,33 +287,45 @@ spec:
       record: 'node:windows_node_filesystem_usage:'
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: max by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster, instance, volume) (windows_logical_disk_free_bytes{job="windows-exporter"} / windows_logical_disk_size_bytes{job="windows-exporter"})
       record: 'node:windows_node_filesystem_avail:'
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: sum by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}cluster) (irate(windows_net_bytes_total{job="windows-exporter"}[1m]))
       record: :windows_node_net_utilisation:sum_irate
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -263,11 +335,15 @@ spec:
       record: node:windows_node_net_utilisation:sum_irate
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -276,11 +352,15 @@ spec:
       record: :windows_node_net_saturation:sum_irate
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -291,11 +371,15 @@ spec:
       record: node:windows_node_net_saturation:sum_irate
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/windows.pod.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/windows.pod.rules.yaml
@@ -29,66 +29,90 @@ spec:
       record: windows_pod_container_available
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: windows_container_cpu_usage_seconds_total{job="windows-exporter", container_id != ""} * on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}container_id, cluster) group_left(container, pod, namespace) max(kube_pod_container_info{job="{{ $kubeStateMetricsJob }}", container_id != ""}) by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}container, container_id, pod, namespace, cluster)
       record: windows_container_total_runtime
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: windows_container_memory_usage_commit_bytes{job="windows-exporter", container_id != ""} * on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}container_id, cluster) group_left(container, pod, namespace) max(kube_pod_container_info{job="{{ $kubeStateMetricsJob }}", container_id != ""}) by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}container, container_id, pod, namespace, cluster)
       record: windows_container_memory_usage
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: windows_container_memory_usage_private_working_set_bytes{job="windows-exporter", container_id != ""} * on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}container_id, cluster) group_left(container, pod, namespace) max(kube_pod_container_info{job="{{ $kubeStateMetricsJob }}", container_id != ""}) by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}container, container_id, pod, namespace, cluster)
       record: windows_container_private_working_set_usage
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: windows_container_network_receive_bytes_total{job="windows-exporter", container_id != ""} * on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}container_id, cluster) group_left(container, pod, namespace) max(kube_pod_container_info{job="{{ $kubeStateMetricsJob }}", container_id != ""}) by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}container, container_id, pod, namespace, cluster)
       record: windows_container_network_received_bytes_total
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: windows_container_network_transmit_bytes_total{job="windows-exporter", container_id != ""} * on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}container_id, cluster) group_left(container, pod, namespace) max(kube_pod_container_info{job="{{ $kubeStateMetricsJob }}", container_id != ""}) by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}container, container_id, pod, namespace, cluster)
       record: windows_container_network_transmitted_bytes_total
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -98,22 +122,30 @@ spec:
       record: kube_pod_windows_container_resource_memory_request
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: kube_pod_container_resource_limits{resource="memory",job="{{ $kubeStateMetricsJob }}"} * on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}container,pod,namespace,cluster) (windows_pod_container_available)
       record: kube_pod_windows_container_resource_memory_limit
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -123,22 +155,30 @@ spec:
       record: kube_pod_windows_container_resource_cpu_cores_request
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: kube_pod_container_resource_limits{resource="cpu",job="{{ $kubeStateMetricsJob }}"} * on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}container,pod,namespace,cluster) (windows_pod_container_available)
       record: kube_pod_windows_container_resource_cpu_cores_limit
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
     - expr: |-
@@ -148,11 +188,15 @@ spec:
       record: namespace_pod_container:windows_container_cpu_usage_seconds_total:sum_rate
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.windows }}
       labels:
-        {{- with .Values.defaultRules.additionalRuleLabels }}
-          {{- toYaml . | nindent 8 }}
+        {{- range $k, $v := mergeOverwrite
+              (.Values.defaultRules.additionalRuleLabels | default (dict))
+              (.Values.defaultRules.additionalRuleGroupLabels.windows | default (dict))
+            }}
+
+        {{- if $v }}
+        {{ $k | quote }}: {{ $v | quote }}
         {{- end }}
-        {{- with .Values.defaultRules.additionalRuleGroupLabels.windows }}
-          {{- toYaml . | nindent 8 }}
+
         {{- end }}
       {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR ensures that rule annotations and labels that are specific to a rule group -- i.e., the ones set in `.Values.defaultRules.additionalRuleGroup(Labels|Annotations)` -- will override values set in the global defaults (e.g. `.defaultRules.additionalRuleLabels`). Specifically, this change allows the following configuration, which applies a global label _except_ to rules which would break if such labels were applied.

```yaml
defaultRules:
  additionalRules:
    cluster: cluster-nam

  additionalRuleGroupLabels:
    kubeApiserverAvailability:
      cluster: null
```

This provides a workaround to https://github.com/prometheus-community/helm-charts/issues/3396, where a rule in `kube-apiserver-availability.rules` will fail when labels are applied to it.  

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- mitigates #3396

#### Special notes for your reviewer

I am unsure if releases are performed for every PR, or PRs are held for larger releases. As such I have not bumped the chart version for this PR. Please let me know if I should do so, thanks.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
