### PR TITLE
Fix env for jiralert chart

### DIFF
--- a/charts/jiralert/Chart.yaml
+++ b/charts/jiralert/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jiralert
 description: A Helm chart for Kubernetes to install jiralert
 type: application
-version: 1.7.0
+version: 1.7.1
 appVersion: "v1.3.0"
 home: "https://github.com/prometheus-community/jiralert"
 keywords:

--- a/charts/jiralert/templates/deployment.yaml
+++ b/charts/jiralert/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
           {{- end }}
         {{- with .Values.env }}
           env:
-          {{- range $key, $value := $.Values.env }}
+          {{- range $key, $value := . }}
             - name: {{ $key }}
               value: {{ $value | quote }}
           {{- end }}

--- a/charts/jiralert/templates/deployment.yaml
+++ b/charts/jiralert/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
           {{- end }}
         {{- with .Values.env }}
           env:
-          {{- range $key, $value := .Values.env }}
+          {{- range $key, $value := $.Values.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}
           {{- end }}

--- a/charts/jiralert/values.yaml
+++ b/charts/jiralert/values.yaml
@@ -29,6 +29,9 @@ extraVolumeMounts: []
 # -- Additional Volumes
 extraVolumes: []
 
+# -- Additional env for jiralert pods
+env: {}
+
 # -- Additional envFrom for jiralert pods
 envFrom: {}
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Trying to use `env` gives the following error:

`Error: template: jiralert/templates/deployment.yaml:70:43: executing "jiralert/templates/deployment.yaml" at <.Values.env>: nil pointer evaluating interface {}.env`

Also `values.yaml` doesn't show that `env:` is an option; one needs to check out the `deployment.yaml` to see that it's used