### PR TITLE
[prometheus-modbus-exporter] fix deployment template

### DIFF
--- a/charts/prometheus-modbus-exporter/Chart.yaml
+++ b/charts/prometheus-modbus-exporter/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
 
 type: application
 
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.4.0"
 
 maintainers:

--- a/charts/prometheus-modbus-exporter/templates/deployment.yaml
+++ b/charts/prometheus-modbus-exporter/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           - "--log.format={{ .Values.log.format }}"
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: metrics
@@ -56,7 +56,7 @@ spec:
             mountPath: /etc/modbus_exporter/
         {{ if .Values.configReloaderSidecar.enable }}
         - name: {{ include "prometheus-modbus-exporter.fullname" . }}-config-reloader-sidecar
-          image: "{{ .Values.configReloaderSidecar.image.repository }}:{{ .Values.configReloaderSidecar.image.tag }}"
+          image: "{{ .Values.configReloaderSidecar.image.registry }}/{{ .Values.configReloaderSidecar.image.repository }}:{{ .Values.configReloaderSidecar.image.tag }}"
           env:
           - name: CONFIG_DIR
             value: /etc/modbus_exporter/


### PR DESCRIPTION
#### What this PR does / why we need it:

Hi, I have discover that the current deployment template for the `prometheus-modbus-exporter` does not handle the overloading of the registry that can be found in the values.

In the values.yaml there is two references for that action:

```yaml
image:
  registry: docker.io
...
configReloaderSidecar:
  enabled: true
  image:
    registry: docker.io
 ```
 
But the actions in the deployment template are:

 ```yaml
      containers:
        - name: {{ include "prometheus-modbus-exporter.fullname" . }}
          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
        ...
         - name: {{ include "prometheus-modbus-exporter.fullname" . }}-config-reloader-sidecar
           image: "{{ .Values.configReloaderSidecar.image.repository }}:{{ .Values.configReloaderSidecar.image.tag }}"
```

The proposed change includes the .values.image.registry in the image address.

 ```yaml
      containers:
        - name: {{ include "prometheus-modbus-exporter.fullname" . }}
          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
        ...
        - name: {{ include "prometheus-modbus-exporter.fullname" . }}-config-reloader-sidecar
          image: "{{ .Values.configReloaderSidecar.image.repository }}:{{ .Values.configReloaderSidecar.image.tag }}"
```

This PR is to fix that and allow the user to use a different registry for the main image and the sidecar.
The chart has also been bumped from `0.1.0` to `0.1.1` to reflect the changes.

#### Which issue this PR fixes:

- fixes # "N/A"

#### Checklist:

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. [prometheus-couchdb-exporter])