### PR TITLE
[prometheus-snmp-exporter] Allow setting environment variables via envFrom

### DIFF
--- a/charts/prometheus-snmp-exporter/Chart.yaml
+++ b/charts/prometheus-snmp-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus SNMP Exporter
 name: prometheus-snmp-exporter
-version: 5.1.0
+version: 5.1.1
 appVersion: v0.25.0
 home: https://github.com/prometheus/snmp_exporter
 sources:

--- a/charts/prometheus-snmp-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-snmp-exporter/templates/daemonset.yaml
@@ -46,6 +46,10 @@ spec:
         {{- if .Values.extraArgs }}
 {{ toYaml .Values.extraArgs | indent 12 }}
         {{- end }}
+          {{- if .Values.envFrom }}
+          envFrom:
+            {{- toYaml .Values.envFrom | nindent 12 }}
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           ports:

--- a/charts/prometheus-snmp-exporter/templates/deployment.yaml
+++ b/charts/prometheus-snmp-exporter/templates/deployment.yaml
@@ -53,6 +53,10 @@ spec:
         {{- if .Values.extraArgs }}
 {{ toYaml .Values.extraArgs | indent 12 }}
         {{- end }}
+          {{- if .Values.envFrom }}
+          envFrom:
+            {{- toYaml .Values.envFrom | nindent 12 }}
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           ports:

--- a/charts/prometheus-snmp-exporter/values.yaml
+++ b/charts/prometheus-snmp-exporter/values.yaml
@@ -128,6 +128,8 @@ extraArgs: []
 #  --history.limit=1000
 
 envFrom: []
+#  - secretRef:
+#      name: name-of-secret
 
 replicas: 1
 ## Monitors ConfigMap changes and POSTs to a URL

--- a/charts/prometheus-snmp-exporter/values.yaml
+++ b/charts/prometheus-snmp-exporter/values.yaml
@@ -127,6 +127,8 @@ podAnnotations: {}
 extraArgs: []
 #  --history.limit=1000
 
+envFrom: []
+
 replicas: 1
 ## Monitors ConfigMap changes and POSTs to a URL
 ## Ref: https://github.com/jimmidyson/configmap-reload


### PR DESCRIPTION
- Add optional envFrom sections to DaemonSet and Deployment

@Miouge1 @xiu @walker-tom 

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Allow setting an optional `envFrom` section in DaemonSet or Deployment in order to be able to inject secrets as environment variables to be expanded by the exporter.

#### Which issue this PR fixes

- fixes #4438

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
