### PR TITLE
[prometheus-pushgateway] add support for basic authentication

### DIFF
--- a/charts/prometheus-pushgateway/Chart.yaml
+++ b/charts/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v1.8.0"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 2.12.0
+version: 3.0.0
 home: https://github.com/prometheus/pushgateway
 sources:
   - https://github.com/prometheus/pushgateway

--- a/charts/prometheus-pushgateway/Chart.yaml
+++ b/charts/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v1.8.0"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 3.0.0
+version: 2.12.0
 home: https://github.com/prometheus/pushgateway
 sources:
   - https://github.com/prometheus/pushgateway

--- a/charts/prometheus-pushgateway/Chart.yaml
+++ b/charts/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v1.8.0"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 2.10.0
+version: 2.12.0
 home: https://github.com/prometheus/pushgateway
 sources:
   - https://github.com/prometheus/pushgateway

--- a/charts/prometheus-pushgateway/README.md
+++ b/charts/prometheus-pushgateway/README.md
@@ -1,17 +1,17 @@
 # Prometheus Pushgateway
 
-This chart bootstraps a prometheus [pushgateway](http://github.com/prometheus/pushgateway) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a Prometheus [Pushgateway](http://github.com/prometheus/pushgateway) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
-An optional prometheus `ServiceMonitor` can be enabled, should you wish to use this gateway with a [Prometheus Operator](https://github.com/coreos/prometheus-operator).
+An optional prometheus `ServiceMonitor` can be enabled, should you wish to use this gateway with [Prometheus Operator](https://github.com/coreos/prometheus-operator).
 
 ## Get Repository Info
-
+<!-- textlint-disable terminology -->
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update
 ```
-
-_See [`helm repo`](https://helm.sh/docs/helm/helm_repo/) for command documentation._
+<!-- textlint-enable -->
+_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
 
 ## Install Chart
 
@@ -36,7 +36,7 @@ _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command doc
 ## Upgrading Chart
 
 ```console
-helm upgrade [RELEASE_NAME] [CHART] --install
+helm upgrade [RELEASE_NAME] prometheus-community/prometheus-pushgateway --install
 ```
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._

--- a/charts/prometheus-pushgateway/README.md
+++ b/charts/prometheus-pushgateway/README.md
@@ -10,9 +10,9 @@ An optional prometheus `ServiceMonitor` can be enabled, should you wish to use t
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update
 ```
-<!-- textlint-enable -->
-_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
 
+_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
+<!-- textlint-enable -->
 ## Install Chart
 
 ```console

--- a/charts/prometheus-pushgateway/templates/_helpers.tpl
+++ b/charts/prometheus-pushgateway/templates/_helpers.tpl
@@ -163,12 +163,14 @@ containers:
     env:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- if or .Values.extraArgs .Values.webConfiguration }}
     args:
     {{- with .Values.extraArgs }}
       {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- if .Values.webConfiguration }}
       - --web.config.file=/etc/config/web-config.yaml
+    {{- end }}
     {{- end }}
     ports:
       - name: metrics

--- a/charts/prometheus-pushgateway/templates/_helpers.tpl
+++ b/charts/prometheus-pushgateway/templates/_helpers.tpl
@@ -112,6 +112,26 @@ Define Ingress apiVersion
 {{- end }}
 
 {{/*
+Define webConfiguration
+*/}}
+{{- define "prometheus-pushgateway.webConfiguration" -}}
+basic_auth_users:
+{{- range $k, $v := .Values.webConfiguration.basicAuthUsers }}
+  {{ $k }}: {{ htpasswd "" $v | trimPrefix ":"}}
+{{- end }}
+{{- end }}
+
+{{/*
+Define Authorization
+*/}}
+{{- define "prometheus-pushgateway.Authorization" -}}
+{{- $users := keys .Values.webConfiguration.basicAuthUsers }}
+{{- $user := first $users }}
+{{- $password := index .Values.webConfiguration.basicAuthUsers $user }}
+{{- $user }}:{{ $password }}
+{{- end }}
+
+{{/*
 Returns pod spec
 */}}
 {{- define "prometheus-pushgateway.podSpec" -}}
@@ -143,9 +163,12 @@ containers:
     env:
       {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- with .Values.extraArgs }}
     args:
+    {{- with .Values.extraArgs }}
       {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- if .Values.webConfiguration }}
+      - --web.config.file=/etc/config/web-config.yaml
     {{- end }}
     ports:
       - name: metrics
@@ -153,11 +176,29 @@ containers:
         protocol: TCP
     {{- if .Values.liveness.enabled }}
     livenessProbe:
-      {{- toYaml .Values.liveness.probe | nindent 6 }}
+      httpGet:
+        path: {{ .Values.liveness.probe.httpGet.path }}
+        port: {{ .Values.liveness.probe.httpGet.port }}
+        httpHeaders:
+        {{- if .Values.webConfiguration.basicAuthUsers }}
+          - name: Authorization
+            value: Basic {{ include "prometheus-pushgateway.Authorization" . | b64enc }}
+        {{- end }}
+      initialDelaySeconds: {{ .Values.liveness.probe.initialDelaySeconds }}
+      timeoutSeconds: {{ .Values.liveness.probe.timeoutSeconds }}
     {{- end }}
     {{- if .Values.readiness.enabled }}
     readinessProbe:
-      {{- toYaml .Values.readiness.probe | nindent 6 }}
+      httpGet:
+        path: {{ .Values.readiness.probe.httpGet.path }}
+        port: {{ .Values.readiness.probe.httpGet.port }}
+        httpHeaders:
+        {{- if .Values.webConfiguration.basicAuthUsers }}
+          - name: Authorization
+            value: Basic {{ include "prometheus-pushgateway.Authorization" . | b64enc }}
+        {{- end }}
+      initialDelaySeconds: {{ .Values.readiness.probe.initialDelaySeconds }}
+      timeoutSeconds: {{ .Values.readiness.probe.timeoutSeconds }}
     {{- end }}
     {{- with .Values.resources }}
     resources:
@@ -171,6 +212,10 @@ containers:
       - name: storage-volume
         mountPath: "{{ .Values.persistentVolume.mountPath }}"
         subPath: "{{ .Values.persistentVolume.subPath }}"
+      {{- if .Values.webConfiguration }}
+      - name: web-config
+        mountPath: "/etc/config"
+      {{- end }}
       {{- with .Values.extraVolumeMounts }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
@@ -223,10 +268,21 @@ volumes:
   {{- else }}
     emptyDir: {}
   {{- end }}
+  {{- if .Values.webConfiguration }}
+  - name: web-config
+    secret:
+      secretName: {{ include "prometheus-pushgateway.fullname" . }}
+  {{- end }}
   {{- end }}
   {{- if .Values.extraVolumes }}
   {{- toYaml .Values.extraVolumes  | nindent 2 }}
   {{- else if $storageVolumeAsPVCTemplate }}
+  {{- if .Values.webConfiguration }}
+  - name: web-config
+    secret:
+      secretName: {{ include "prometheus-pushgateway.fullname" . }}
+  {{- else }}
   []
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/prometheus-pushgateway/templates/_helpers.tpl
+++ b/charts/prometheus-pushgateway/templates/_helpers.tpl
@@ -177,30 +177,44 @@ containers:
         containerPort: 9091
         protocol: TCP
     {{- if .Values.liveness.enabled }}
+    {{- $livenessCommon := omit .Values.liveness.probe "httpGet" }}
     livenessProbe:
+    {{- with .Values.liveness.probe }}
       httpGet:
-        path: {{ .Values.liveness.probe.httpGet.path }}
-        port: {{ .Values.liveness.probe.httpGet.port }}
+        path: {{ .httpGet.path }}
+        port: {{ .httpGet.port }}
+        {{- if or .httpGet.httpHeaders $.Values.webConfiguration.basicAuthUsers }}
         httpHeaders:
-        {{- if .Values.webConfiguration.basicAuthUsers }}
+        {{- if $.Values.webConfiguration.basicAuthUsers }}
           - name: Authorization
-            value: Basic {{ include "prometheus-pushgateway.Authorization" . | b64enc }}
+            value: Basic {{ include "prometheus-pushgateway.Authorization" $ | b64enc }}
         {{- end }}
-      initialDelaySeconds: {{ .Values.liveness.probe.initialDelaySeconds }}
-      timeoutSeconds: {{ .Values.liveness.probe.timeoutSeconds }}
+        {{- with .httpGet.httpHeaders }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- end }}
+        {{- toYaml $livenessCommon | nindent 6 }}
+      {{- end }}
     {{- end }}
     {{- if .Values.readiness.enabled }}
+    {{- $readinessCommon := omit .Values.readiness.probe "httpGet" }}
     readinessProbe:
+    {{- with .Values.readiness.probe }}
       httpGet:
-        path: {{ .Values.readiness.probe.httpGet.path }}
-        port: {{ .Values.readiness.probe.httpGet.port }}
+        path: {{ .httpGet.path }}
+        port: {{ .httpGet.port }}
+        {{- if or .httpGet.httpHeaders $.Values.webConfiguration.basicAuthUsers }}
         httpHeaders:
-        {{- if .Values.webConfiguration.basicAuthUsers }}
+        {{- if $.Values.webConfiguration.basicAuthUsers }}
           - name: Authorization
-            value: Basic {{ include "prometheus-pushgateway.Authorization" . | b64enc }}
+            value: Basic {{ include "prometheus-pushgateway.Authorization" $ | b64enc }}
         {{- end }}
-      initialDelaySeconds: {{ .Values.readiness.probe.initialDelaySeconds }}
-      timeoutSeconds: {{ .Values.readiness.probe.timeoutSeconds }}
+        {{- with .httpGet.httpHeaders }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- end }}
+        {{- toYaml $readinessCommon | nindent 6 }}
+      {{- end }}
     {{- end }}
     {{- with .Values.resources }}
     resources:

--- a/charts/prometheus-pushgateway/templates/secret.yaml
+++ b/charts/prometheus-pushgateway/templates/secret.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "prometheus-pushgateway.fullname" . }}
+  labels:
+    {{- include "prometheus-pushgateway.defaultLabels" . | nindent 4 }}
 data:
   web-config.yaml: {{ include "prometheus-pushgateway.webConfiguration" . | b64enc}}
 {{- end }}

--- a/charts/prometheus-pushgateway/templates/secret.yaml
+++ b/charts/prometheus-pushgateway/templates/secret.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.webConfiguration }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "prometheus-pushgateway.fullname" . }}
+data:
+  web-config.yaml: {{ include "prometheus-pushgateway.webConfiguration" . | b64enc}}
+{{- end }}

--- a/charts/prometheus-pushgateway/values.yaml
+++ b/charts/prometheus-pushgateway/values.yaml
@@ -107,6 +107,12 @@ resources: {}
   #   cpu: 100m
   #   memory: 30Mi
 
+# -- Sets web configuration
+# To enable basic authentication, provide basicAuthUsers as a map
+webConfiguration: {}
+  # basicAuthUsers:
+  #   username: password
+
 liveness:
   enabled: true
   probe:


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Since [pushgateway supports basic authentication](https://github.com/prometheus/pushgateway/tree/master?tab=readme-ov-file#tls-and-basic-authentication), this PR enables this functionality by introducing the `webConfiguration.basicAuthUsers` value. 

It also makes sure that credentials for basic authentication have to be specified only once in Values and can be utilised in the `httpHeaders` for the liveness and readiness probes as well as in the `web.config.file` provided from the mounted Secret. I think it is a neat feature, that you don't have to specify the same credentials twice in different forms. 

Maintainer's EDIT: The description of the breaking change removed as none has been introduced.

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
