### PR TITLE
[kube-prometheus-stack] add aws-node exporter

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 58.2.1
+version: 58.3.0
 appVersion: v0.73.2
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/ci/01-provision-crds-values.yaml
+++ b/charts/kube-prometheus-stack/ci/01-provision-crds-values.yaml
@@ -1,5 +1,7 @@
 alertmanager:
   enabled: false
+awsNode:
+  enabled: false
 coreDns:
   enabled: false
 kubeApiServer:

--- a/charts/kube-prometheus-stack/ci/03-non-defaults-values.yaml
+++ b/charts/kube-prometheus-stack/ci/03-non-defaults-values.yaml
@@ -49,6 +49,7 @@ kubeControllerManager:
       matchLabels:
         component: kube-controller-manager
 awsNode:
+  enabled: true
   service:
     enabled: false
   serviceMonitor:

--- a/charts/kube-prometheus-stack/ci/03-non-defaults-values.yaml
+++ b/charts/kube-prometheus-stack/ci/03-non-defaults-values.yaml
@@ -48,6 +48,13 @@ kubeControllerManager:
     selector:
       matchLabels:
         component: kube-controller-manager
+awsNode:
+  service:
+    enabled: false
+  serviceMonitor:
+    selector:
+      matchLabels:
+        k8s-app: aws-node
 coreDns:
   service:
     enabled: false

--- a/charts/kube-prometheus-stack/templates/exporters/aws-node/service.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/aws-node/service.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.awsNode.enabled .Values.awsNode.service.enabled .Values.kubernetesServiceMonitors.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "kube-prometheus-stack.fullname" . }}-aws-node
+  labels:
+    app: {{ template "kube-prometheus-stack.name" . }}-aws-node
+    jobLabel: aws-node
+{{- include "kube-prometheus-stack.labels" . | indent 4 }}
+  namespace: kube-system
+spec:
+  clusterIP: None
+  ports:
+    - name: {{ .Values.awsNode.serviceMonitor.port }}
+      port: {{ .Values.awsNode.service.port }}
+      protocol: TCP
+      targetPort: {{ .Values.awsNode.service.targetPort }}
+  selector:
+    {{- if .Values.awsNode.service.selector }}
+{{ toYaml .Values.awsNode.service.selector | indent 4 }}
+    {{- else }}
+    k8s-app: aws-node
+    {{- end }}
+{{- end }}

--- a/charts/kube-prometheus-stack/templates/exporters/aws-node/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/aws-node/servicemonitor.yaml
@@ -1,0 +1,47 @@
+{{- if and .Values.awsNode.enabled .Values.awsNode.serviceMonitor.enabled .Values.kubernetesServiceMonitors.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "kube-prometheus-stack.fullname" . }}-aws-node
+  {{- if .Values.prometheus.prometheusSpec.ignoreNamespaceSelectors }}
+  namespace: kube-system
+  {{- else }}
+  namespace: {{ template "kube-prometheus-stack.namespace" . }}
+  {{- end }}
+  labels:
+    app: {{ template "kube-prometheus-stack.name" . }}-aws-node
+  {{- with .Values.awsNode.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- include "kube-prometheus-stack.labels" . | indent 4 }}
+spec:
+  jobLabel: {{ .Values.awsNode.serviceMonitor.jobLabel }}
+  {{- include "servicemonitor.scrapeLimits" .Values.awsNode.serviceMonitor | nindent 2 -}}
+  selector:
+    {{- if .Values.awsNode.serviceMonitor.selector }}
+    {{ tpl (toYaml .Values.awsNode.serviceMonitor.selector | nindent 4) . }}
+    {{- else }}
+    matchLabels:
+      app: {{ template "kube-prometheus-stack.name" . }}-aws-node
+      release: {{ $.Release.Name | quote }}
+    {{- end }}
+  namespaceSelector:
+    matchNames:
+      - "kube-system"
+  endpoints:
+    - port: {{ .Values.awsNode.serviceMonitor.port }}
+    {{- if .Values.awsNode.serviceMonitor.interval}}
+      interval: {{ .Values.awsNode.serviceMonitor.interval }}
+    {{- end }}
+    {{- if .Values.awsNode.serviceMonitor.proxyUrl }}
+      proxyUrl: {{ .Values.awsNode.serviceMonitor.proxyUrl}}
+    {{- end }}
+{{- if .Values.awsNode.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+{{ tpl (toYaml .Values.awsNode.serviceMonitor.metricRelabelings | indent 4) . }}
+{{- end }}
+{{- if .Values.awsNode.serviceMonitor.relabelings }}
+      relabelings:
+{{ tpl (toYaml .Values.awsNode.serviceMonitor.relabelings | indent 4) . }}
+{{- end }}
+{{- end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1540,6 +1540,78 @@ kubeControllerManager:
     additionalLabels: {}
     #  foo: bar
 
+## Component scraping aws node (cni-metrics)
+awsNode:
+  enabled: true
+  service:
+    enabled: true
+    port: 61678
+    targetPort: 61678
+    # selector:
+    #   k8s-app: aws-node
+  serviceMonitor:
+    enabled: true
+    ## Scrape interval. If not set, the Prometheus default scrape interval is used.
+    ##
+    interval: ""
+
+    ## SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.
+    ##
+    sampleLimit: 0
+
+    ## TargetLimit defines a limit on the number of scraped targets that will be accepted.
+    ##
+    targetLimit: 0
+
+    ## Per-scrape limit on number of labels that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+    ##
+    labelLimit: 0
+
+    ## Per-scrape limit on length of labels name that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+    ##
+    labelNameLengthLimit: 0
+
+    ## Per-scrape limit on length of labels value that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+    ##
+    labelValueLengthLimit: 0
+
+    ## proxyUrl: URL of a proxy that should be used for scraping.
+    ##
+    proxyUrl: ""
+
+    ## port: Name of the port the metrics will be scraped from
+    ##
+    port: http-metrics
+
+    jobLabel: jobLabel
+    selector: {}
+    #  matchLabels:
+    #    k8s-app: aws-node
+
+    ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ##
+    metricRelabelings: []
+    # - action: keep
+    #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
+    #   sourceLabels: [__name__]
+
+    ## RelabelConfigs to apply to samples before scraping
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ##
+    relabelings: []
+    # - sourceLabels: [__meta_kubernetes_pod_node_name]
+    #   separator: ;
+    #   regex: ^(.*)$
+    #   targetLabel: nodename
+    #   replacement: $1
+    #   action: replace
+
+    ## Additional labels
+    ##
+    additionalLabels: {}
+    #  foo: bar
+
 ## Component scraping coreDns. Use either this or kubeDns
 ##
 coreDns:


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Hello, as part of our project to migrate from old prometheus stack deployed independently, we moved to prometheus operator.
Previously we had a job in our config to get metrics from pod aws-node deployed on our EKS cluster.
Instead of declare an additionalScrape config I would like to continue on the new logic (serviceMonitor) to get metrics

- create a dedicated service for aws-node
- create a dedicated serviceMonitor to scrape aws-node metrics using the service 
 
#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

As part of our project to migrate from old prometheus stack deployed independently, we moved to prometheus operator.
Previously we had a job in our config to get metrics from pod aws-node deployed on our EKS cluster.
Instead of declaring an additionalScrape config I would like to continue on the new logic (serviceMonitor) to get metrics from pods.

#### Special notes for your reviewer
I've generated manifest and deployed them on my cluster
```shell
❯ k get servicemonitor
NAME                                           AGE
prometheus-operator-kube-p-alertmanager        96d
prometheus-operator-kube-p-coredns             96d
prometheus-operator-kube-p-kubelet             96d
prometheus-operator-kube-p-operator            96d
prometheus-operator-kube-p-prometheus          96d
prometheus-operator-kube-promethe-aws-node     16m
prometheus-operator-kube-state-metrics         96d
prometheus-operator-prometheus-node-exporter   96d
❯ k get service -n kube-system
NAME                                         TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                        AGE
kube-dns                                     ClusterIP   172.20.0.10     <none>        53/UDP,53/TCP                  165d
metrics-server                               ClusterIP   172.20.102.30   <none>        443/TCP                        491d
node-local-dns                               ClusterIP   None            <none>        9253/TCP                       324d
node-local-dns-upstream                      ClusterIP   172.20.24.237   <none>        53/UDP,53/TCP                  395d
prometheus-operator-kube-p-coredns           ClusterIP   None            <none>        9153/TCP                       96d
prometheus-operator-kube-p-kubelet           ClusterIP   None            <none>        10250/TCP,10255/TCP,4194/TCP   107d
prometheus-operator-kube-promethe-aws-node   ClusterIP   None            <none>        61678/TCP                      6h15m
```
![image](https://github.com/prometheus-community/helm-charts/assets/3457770/f6a60a89-f9e1-421e-b981-e0c095ef7b16)

![image](https://github.com/prometheus-community/helm-charts/assets/3457770/d0360a8c-605a-4862-9943-c299228264a3)

Then I'm able to query all metrics

![image](https://github.com/prometheus-community/helm-charts/assets/3457770/27169129-57cf-483b-94d0-e29c142c76c8)
 

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
