### PR TITLE
[prom-label-proxy] add path templating

### DIFF
--- a/charts/prom-label-proxy/Chart.yaml
+++ b/charts/prom-label-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prom-label-proxy
 description: A proxy that enforces a given label in a given PromQL query.
 type: application
-version: 0.7.1
+version: 0.7.2
 appVersion: "v0.8.1"
 home: "https://github.com/prometheus-community/prom-label-proxy"
 keywords:

--- a/charts/prom-label-proxy/templates/ingress.yaml
+++ b/charts/prom-label-proxy/templates/ingress.yaml
@@ -46,7 +46,7 @@ spec:
       http:
         paths:
           {{- range .paths }}
-          - path: {{ .path }}
+          - path: {{ tpl .path $ | quote }}
             {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
             pathType: {{ .pathType }}
             {{- end }}

--- a/charts/prom-label-proxy/values.yaml
+++ b/charts/prom-label-proxy/values.yaml
@@ -93,7 +93,7 @@ nodeSelector: {}
 # -- Tolerations for pod assignment. Evaluated as a template.
 tolerations: []
 
-# -- Ingress hosts and annotations fields are passed through helm tpl function.
+# -- Ingress hosts, paths and annotations fields are passed through helm tpl function.
 ## ref: https://helm.sh/docs/developing_charts/#using-the-tpl-function
 ingress:
   enabled: false


### PR DESCRIPTION
#### What this PR does / why we need it

It is useful for the case when we use one domain name for a bunch of prom-label-proxy deployments. In this case, we have to use different paths to route requests, but we need templating for paths to implement it.

It doesn't break backward capabilities for existing value files.

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
