### PR TITLE
[prometheus-snmp-exporter] Extend workload config

### DIFF
--- a/charts/prometheus-snmp-exporter/Chart.yaml
+++ b/charts/prometheus-snmp-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus SNMP Exporter
 name: prometheus-snmp-exporter
-version: 5.1.2
+version: 5.2.0
 appVersion: v0.25.0
 home: https://github.com/prometheus/snmp_exporter
 sources:

--- a/charts/prometheus-snmp-exporter/Chart.yaml
+++ b/charts/prometheus-snmp-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus SNMP Exporter
 name: prometheus-snmp-exporter
-version: 5.1.1
+version: 5.1.2
 appVersion: v0.25.0
 home: https://github.com/prometheus/snmp_exporter
 sources:

--- a/charts/prometheus-snmp-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-snmp-exporter/templates/daemonset.yaml
@@ -122,4 +122,7 @@ spec:
       {{- with .Values.extraVolumes }}
       {{ toYaml . | nindent 8 }}
       {{- end }}
+  {{- with .Values.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/prometheus-snmp-exporter/templates/deployment.yaml
+++ b/charts/prometheus-snmp-exporter/templates/deployment.yaml
@@ -129,4 +129,7 @@ spec:
       {{- with .Values.extraVolumes }}
       {{ toYaml . | nindent 8 }}
       {{- end }}
+  {{- with .Values.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
 {{- end }}

--- a/charts/prometheus-snmp-exporter/values.yaml
+++ b/charts/prometheus-snmp-exporter/values.yaml
@@ -132,6 +132,10 @@ envFrom: []
 #      name: name-of-secret
 
 replicas: 1
+
+# Uncomment to set a specific revisionHistoryLimit. Defaults to 10 as per Kubernetes API if not set.
+# revisionHistoryLimit: 3
+
 ## Monitors ConfigMap changes and POSTs to a URL
 ## Ref: https://github.com/jimmidyson/configmap-reload
 ##


### PR DESCRIPTION
- Introduce optional revisionHistoryLimit for Deployment / DaemonSet

@Miouge1 @xiu @walker-tom 

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Make the Deployment / DaemonSet `revisionHistoryLimit` configurable by introducing an optional Parameter to `values.yaml`.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
