### PR TITLE
[prometheus-snmp-exporter] Extend metric relabels

### DIFF
--- a/charts/prometheus-snmp-exporter/Chart.yaml
+++ b/charts/prometheus-snmp-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus SNMP Exporter
 name: prometheus-snmp-exporter
-version: 5.2.0
+version: 5.3.0
 appVersion: v0.25.0
 home: https://github.com/prometheus/snmp_exporter
 sources:

--- a/charts/prometheus-snmp-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-snmp-exporter/templates/servicemonitor.yaml
@@ -39,6 +39,9 @@ spec:
         replacement: {{ $replacement }}
         action: replace
         {{- end }}
+      {{- if (or .additionalMetricsRelabelConfigs $.Values.serviceMonitor.additionalMetricsRelabelConfigs) }}
+      {{- toYaml (default $.Values.serviceMonitor.additionalMetricsRelabelConfigs .additionalMetricsRelabelConfigs) | nindent 6 }}
+      {{- end }}
     {{- if (or .relabelings $.Values.serviceMonitor.relabelings) }}
     relabelings:
       {{- toYaml (default $.Values.serviceMonitor.relabelings .relabelings) | nindent 6 }}

--- a/charts/prometheus-snmp-exporter/values.yaml
+++ b/charts/prometheus-snmp-exporter/values.yaml
@@ -226,6 +226,7 @@ serviceMonitor:
     # Relabelings. Overrides value set in serviceMonitor.relabelings
     #   relabelings: []
     # Map of metric labels and values to add. Overrides value set in serviceMonitor.additionalMetricsRelabels
+    # This sets fixed relabel configs with action 'replace'.
     #   additionalMetricsRelabels: {}
     # Metrics relabelings. Overrides value set in serviceMonitor.additionalMetricsRelabelConfigs
     #   additionalMetricsRelabelConfigs: []

--- a/charts/prometheus-snmp-exporter/values.yaml
+++ b/charts/prometheus-snmp-exporter/values.yaml
@@ -187,6 +187,8 @@ serviceMonitor:
   # Set if defined unless overriden by params.additionalMetricsRelabels.
   # This sets fixed relabel configs with action 'replace'.
   additionalMetricsRelabels: {}
+    # targetLabel1: replacementValue1
+    # targetLabel2: replacementValue2
 
   # Metric relabeling is applied to samples as the last step before ingestion.
   # Set if defined unless overridden by params.additionalMetricsRelabelConfigs.

--- a/charts/prometheus-snmp-exporter/values.yaml
+++ b/charts/prometheus-snmp-exporter/values.yaml
@@ -185,7 +185,19 @@ serviceMonitor:
 
   # Metric relabeling is applied to samples as the last step before ingestion.
   # Set if defined unless overriden by params.additionalMetricsRelabels.
+  # This sets fixed relabel configs with action 'replace'.
   additionalMetricsRelabels: {}
+
+  # Metric relabeling is applied to samples as the last step before ingestion.
+  # Set if defined unless overridden by params.additionalMetricsRelabelConfigs.
+  # This allows setting arbitrary relabel configs.
+  # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.RelabelConfig
+  additionalMetricsRelabelConfigs: []
+    # - sourceLabels: [__name__]
+    #   targetLabel: __name__
+    #   action: replace
+    #   regex: (.*)
+    #   replacement: prefix_$1
 
   # Label for selecting service monitors as set in Prometheus CRD.
   # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.PrometheusSpec
@@ -215,6 +227,8 @@ serviceMonitor:
     #   relabelings: []
     # Map of metric labels and values to add. Overrides value set in serviceMonitor.additionalMetricsRelabels
     #   additionalMetricsRelabels: {}
+    # Metrics relabelings. Overrides value set in serviceMonitor.additionalMetricsRelabelConfigs
+    #   additionalMetricsRelabelConfigs: []
 
 # Extra manifests to deploy as an array
 extraManifests: []


### PR DESCRIPTION
- In addition to fixed '$key: $value' metric relabelings, allow arbitrary relabel configs in order to support e.g. common label prefixes

@walker-tom @xiu @Miouge1 

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Metric relabeling is currently limited to fixed label replacements .

In order to support arbitrary [relabel configs](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.RelabelConfig), a new value `serviceMonitor.additionalMetricsRelabelConfigs` resp. `serviceMonitor.params.additionalMetricsRelabelConfigs` has been introduced.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
