### PR TITLE
[prometheus-mysql-exporter] remove base `metrics` endpoint from serviceMonitor when Multitarget is enabled

### DIFF
--- a/charts/prometheus-mysql-exporter/Chart.yaml
+++ b/charts/prometheus-mysql-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for prometheus mysql exporter with cloudsqlproxy
 name: prometheus-mysql-exporter
-version: 2.5.2
+version: 2.5.3
 home: https://github.com/prometheus/mysqld_exporter
 appVersion: v0.15.1
 sources:

--- a/charts/prometheus-mysql-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-mysql-exporter/templates/servicemonitor.yaml
@@ -73,6 +73,7 @@ spec:
         {{- end }}
   {{- end }}
   {{- end }}
+  {{- if not .Values.serviceMonitor.multipleTarget.enabled }}
     - path: /metrics
       port: {{ .Values.service.name }}
   {{- if .Values.serviceMonitor.interval }}
@@ -86,5 +87,6 @@ spec:
   {{- end }}
   {{- if .Values.serviceMonitor.relabelings }}
       relabelings: {{ toYaml .Values.serviceMonitor.relabelings | nindent 8 }}
+  {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
This PR modifies the serviceMonitor template in the Prometheus MySQL Exporter Helm chart to prevent the default endpoint with the '/metrics' path from being scraped by Prometheus when the multi-target feature is enabled.

The need for this modification arises from the desire to have more control over which endpoints are scraped by Prometheus when using the multi-target feature. Before this, when the multi-target feature was enabled, all endpoints within the MySQL Exporter pod were be scraped, including the '/metrics' endpoint, which may not be desired in certain scenarios.

With this change, users can ensure that only the specific endpoints they want to scrape are included, providing greater flexibility and control over monitoring configurations. This can help optimize resource usage and reduce potential noise in monitoring systems by excluding unnecessary endpoints from scraping.

#### Which issue this PR fixes


#### Special notes for your reviewer
None other than requesting to approve initial checks and linting.
@Juanchimienti @monotek 

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
