### PR TITLE
[prometheus-elasticsearch-exporter] Allow to override imageRegistry globally

### DIFF
--- a/charts/prometheus-elasticsearch-exporter/Chart.yaml
+++ b/charts/prometheus-elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: prometheus-elasticsearch-exporter
-version: 5.7.1
+version: 5.8.0
 kubeVersion: ">=1.10.0-0"
 appVersion: "v1.7.0"
 home: https://github.com/prometheus-community/elasticsearch_exporter

--- a/charts/prometheus-elasticsearch-exporter/Chart.yaml
+++ b/charts/prometheus-elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: prometheus-elasticsearch-exporter
-version: 5.7.0
+version: 5.7.1
 kubeVersion: ">=1.10.0-0"
 appVersion: "v1.7.0"
 home: https://github.com/prometheus-community/elasticsearch_exporter

--- a/charts/prometheus-elasticsearch-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-elasticsearch-exporter/templates/_helpers.tpl
@@ -83,3 +83,18 @@ imagePullSecrets:
     {{- end }}
   {{- end }}
 {{- end -}}
+
+{{/*
+Return the correct (overridden global) image registry.
+*/}}
+{{- define "elasticsearch-exporter.image.repository" -}}
+  {{- $registry := .Values.image.registry -}}
+  {{- if .Values.global.imageRegistry }}
+    {{- $registry = .Values.global.imageRegistry -}}
+  {{- end }}
+  {{- if $registry -}}
+    {{- printf "%s/%s" $registry .Values.image.repository -}}
+  {{- else -}}
+    {{- printf "%s" .Values.image.repository -}}
+  {{- end }}
+{{- end -}}

--- a/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
+++ b/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
@@ -75,7 +75,7 @@ spec:
           - secretRef:
               name: {{ .Values.envFromSecret }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{- include "elasticsearch-exporter.image.repository" .}}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["elasticsearch_exporter",
                     {{- with .Values.log.format }}

--- a/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
+++ b/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
@@ -75,7 +75,7 @@ spec:
           - secretRef:
               name: {{ .Values.envFromSecret }}
           {{- end }}
-          image: "{{- include "elasticsearch-exporter.image.repository" .}}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{- include "elasticsearch-exporter.image.repository" . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["elasticsearch_exporter",
                     {{- with .Values.log.format }}

--- a/charts/prometheus-elasticsearch-exporter/values.yaml
+++ b/charts/prometheus-elasticsearch-exporter/values.yaml
@@ -3,6 +3,7 @@
 ## to set the same values for each chart (and image) separately
 global:
   imagePullSecrets: []
+  imageRegistry: ""
 
 ## number of exporter instances
 ##
@@ -13,6 +14,7 @@ replicaCount: 1
 restartPolicy: Always
 
 image:
+  registry: ""
   repository: quay.io/prometheuscommunity/elasticsearch-exporter
   # if not set appVersion field from Chart.yaml is used
   tag: ""


### PR DESCRIPTION
…lobally

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR allows to override the image registry for the `prometheus-elasticsearch-exporter` using a `global.imageRegistry` flag, which is a common way to override the registry when this chart is bundled as a sub-chart.

The PR is made such that it is backwards compatible with the current version of the chart so that only a patch increment is needed according to semver. 

#### Which issue this PR fixes


#### Special notes for your reviewer

@svenmueller @desaintmartin @zeritti 

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
