### PR TITLE
[kube-prometheus-stack] Add the possibility to specify objectSelector for admissionWebhooks

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 58.4.0
+version: 58.4.1
 appVersion: v0.73.2
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/mutatingWebhookConfiguration.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/mutatingWebhookConfiguration.yaml
@@ -74,4 +74,10 @@ webhooks:
         {{- end }}
       {{- end }}
     {{- end }}
+    {{- if .Values.prometheusOperator.admissionWebhooks.objectSelector }}
+    objectSelector:
+      {{- with .Values.prometheusOperator.admissionWebhooks.objectSelector }}
+      {{- toYaml . | nindent 6}}
+      {{- end }}
+    {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/validatingWebhookConfiguration.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/validatingWebhookConfiguration.yaml
@@ -74,4 +74,10 @@ webhooks:
         {{- end }}
       {{- end }}
     {{- end }}
+    {{- if .Values.prometheusOperator.admissionWebhooks.objectSelector }}
+    objectSelector:
+      {{- with .Values.prometheusOperator.admissionWebhooks.objectSelector }}
+      {{- toYaml . | nindent 6}}
+      {{- end }}
+    {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -2222,6 +2222,7 @@ prometheusOperator:
     #   argocd.argoproj.io/hook-delete-policy: HookSucceeded
 
     namespaceSelector: {}
+    objectSelector: {}
 
     deployment:
       enabled: false


### PR DESCRIPTION

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Add the possibility to specify an objectSelector for admissionWebhooks (mutating and validating)

#### Which issue this PR fixes

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
