### PR TITLE
[alertmanager] add baseURL value

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 1.10.0
+version: 1.11.0
 appVersion: v0.27.0
 kubeVersion: ">=1.19.0-0"
 keywords:

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -171,6 +171,9 @@ spec:
             {{- range $key, $value := .Values.extraArgs }}
             - --{{ $key }}={{ $value }}
             {{- end }}
+            {{- if .Values.baseURL }}
+            - --web.external-url={{ .Values.baseURL }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 9093

--- a/charts/alertmanager/values.schema.json
+++ b/charts/alertmanager/values.schema.json
@@ -237,6 +237,14 @@
             "description": "Container image parameters.",
             "$ref": "#/definitions/image"
         },
+        "baseURL": {
+            "description": "External URL where alertmanager is reachable.",
+            "type": "string",
+            "default": "",
+            "examples": [
+                "https://alertmanager.example.com"
+            ]
+        },
         "extraArgs": {
             "description": "Additional alertmanager container arguments. Use args without '--', only 'key: value' syntax.",
             "type": "object",

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -15,6 +15,9 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+# Full external URL where alertmanager is reachable, used for backlinks.
+baseURL: ""
+
 extraArgs: {}
 
 ## Additional Alertmanager Secret mounts


### PR DESCRIPTION
#### What this PR does / why we need it
While using `extraArgs` is possible, `baseURL` is consistent with the
Prometheus chart and is more discoverable.
The template modification is taken from the prometheus chart.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
