### PR TITLE
[kube-prometheus-stack] Fix exemplar indentation for consistency

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 58.4.1
+version: 58.4.2
 appVersion: v0.73.2
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -103,7 +103,7 @@ spec:
 {{- end }}
 {{- if and (not .Values.prometheus.agentMode) .Values.prometheus.prometheusSpec.exemplars }}
   exemplars:
-  {{ toYaml .Values.prometheus.prometheusSpec.exemplars | indent 4 }}
+    {{- toYaml .Values.prometheus.prometheusSpec.exemplars | nindent 4 }}
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.enableFeatures }}
   enableFeatures:


### PR DESCRIPTION
This matches the indentation of everything else in the file. Existing template indents the final yaml by 2 spaces too many

Before:
```yaml
  exemplars:
      maxSize: 100000
```

After:
```yaml
  exemplars:
    maxSize: 100000
```