### PR TITLE
[kube-prometheus-stack] ThanosRuler limit resource names up to 63 characters

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 58.4.0
+version: 58.4.1
 appVersion: v0.73.2
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/_helpers.tpl
+++ b/charts/kube-prometheus-stack/templates/_helpers.tpl
@@ -58,11 +58,12 @@ The longest name that gets created adds and extra 37 characters, so truncation s
 {{- end }}
 
 {{/* ThanosRuler custom resource instance name */}}
+{{/* Subtracting 1 from 26 truncation of kube-prometheus-stack.fullname */}}
 {{- define "kube-prometheus-stack.thanosRuler.crname" -}}
 {{- if .Values.cleanPrometheusOperatorObjectNames }}
 {{- include "kube-prometheus-stack.fullname" . }}
 {{- else }}
-{{- print (include "kube-prometheus-stack.fullname" .) "-thanos-ruler" -}}
+{{- print (include "kube-prometheus-stack.fullname" . | trunc 25 | trimSuffix "-") "-thanos-ruler" -}}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Prometheus operator creates a configMap for thanos-ruler rulerfiles using the following pattern:
`thanos-ruler-{.Values.kube-prometheus-stack.thanosRuler.crname}-thanos-ruler-rulefiles-0`

This can lead to a configMap name with more than the allowed 63 characters, if `cleanPrometheusOperatorObjectNames == false`.

When `cleanPrometheusOperatorObjectNames == true`, the limit is respected already, because `kube-prometheus-stack.thanosRuler.crname == kube-prometheus-stack.fullname` and `kube-prometheus-stack.fullname` is already truncated to 26 characters.

This PR is subtracting 1 from 26 truncation of `kube-prometheus-stack.fullname` for `kube-prometheus-stack.thanosRuler.crname` evaluation. This will ensure that the thanos-ruler created resources will have names compliant with the 63 char limit.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes https://github.com/prometheus-community/helm-charts/issues/4511

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
