### PR TITLE
[kube-prometheus-stack] fix the retentionSize value

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 58.5.0
+version: 58.5.1
 appVersion: v0.73.2
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -125,7 +125,9 @@ spec:
 {{ toYaml .Values.prometheus.prometheusSpec.resources | indent 4 }}
 {{- end }}
 {{- if not .Values.prometheus.agentMode }}
+{{- if not .Values.prometheus.prometheusSpec.retentionSize }}
   retention: {{ .Values.prometheus.prometheusSpec.retention | quote  }}
+{{- end }}
 {{- if .Values.prometheus.prometheusSpec.retentionSize }}
   retentionSize: {{ .Values.prometheus.prometheusSpec.retentionSize | quote }}
 {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

There is a bug in the chart related to the `prometheus.prometheusSpec.retentionSize` value.

In the default values currently there is specified value for `prometheus.prometheusSpec.retention: 10d`.
When you try to add the value `prometheus.prometheusSpec.retentionSize` it will also generate the `prometheus.prometheusSpec.retention: 10d` from those default values.

This is a problem because according to the [docs](https://prometheus.io/docs/prometheus/latest/storage/#operational-aspects) only one of those values can be configured. 

```
If both time and size retention policies are specified, whichever triggers first will be used.
```

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x ] Chart Version bumped
- [ x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
