### PR TITLE
[prometheus-ipmi-exporter] Optionally pull config from a Secret

### DIFF
--- a/charts/prometheus-ipmi-exporter/Chart.yaml
+++ b/charts/prometheus-ipmi-exporter/Chart.yaml
@@ -4,7 +4,7 @@ description: This is an IPMI exporter for Prometheus.
 
 type: application
 
-version: 0.3.0
+version: 0.4.0
 
 appVersion: "v1.8.0"
 

--- a/charts/prometheus-ipmi-exporter/templates/configmap.yaml
+++ b/charts/prometheus-ipmi-exporter/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.configMapFile -}}
+{{- if not .Values.configSecret.enabled -}}
 {{- $fullName := include "prometheus-ipmi-exporter.fullname" . -}}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/prometheus-ipmi-exporter/templates/deployment.yaml
+++ b/charts/prometheus-ipmi-exporter/templates/deployment.yaml
@@ -56,8 +56,16 @@ spec:
               memory: {{ .Values.resources.requests.memory }}
       volumes:
         - name: config-volume
+        {{- if .Values.configSecret.enabled }}
+          secret:
+            secretName: {{ .Values.configSecret.name }}
+            items:
+            - key: {{ .Values.configSecret.key }}
+              path: config.yml
+        {{- else }}
           configMap:
             name: {{ template "prometheus-ipmi-exporter.fullname" . }}
+        {{- end }}
         {{- with .Values.extraVolumes }}
             {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/prometheus-ipmi-exporter/values.yaml
+++ b/charts/prometheus-ipmi-exporter/values.yaml
@@ -63,6 +63,11 @@ serviceMonitor:
 
   # Configuration file for ipmi_exporter
 
+configSecret:
+  enabled: false
+  name: ipmi-secret
+  key: config.yml
+
 # This is an example config for scraping remote hosts via IPMI.
 # Information required to access remote IPMI interfaces can be supplied in the
 # 'modules' section. A scrape can request the usage of a given config by


### PR DESCRIPTION
#### What this PR does / why we need it

The way this currently works is that it builds a config file from values inlined via Helm, and this may need to include some sensitive information such as usernames and passwords that should be otherwise kept out of a repo in the cases where you're managing all of your cluster configuration via git.

This PR update the Chart to add an option to be able to reference a Secret instead.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
