### PR TITLE
[kube-prometheus-stack] add the possibility to specify objectSelector for admissionWebhooks objects

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 58.5.2
+version: 58.5.3
 appVersion: v0.73.2
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/mutatingWebhookConfiguration.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/mutatingWebhookConfiguration.yaml
@@ -74,10 +74,8 @@ webhooks:
         {{- end }}
       {{- end }}
     {{- end }}
-    {{- if .Values.prometheusOperator.admissionWebhooks.objectSelector }}
+    {{- with .Values.prometheusOperator.admissionWebhooks.objectSelector }}
     objectSelector:
-      {{- with .Values.prometheusOperator.admissionWebhooks.objectSelector }}
-      {{- toYaml . | nindent 6}}
-      {{- end }}
+      {{- toYaml . | nindent 6 }}
     {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/mutatingWebhookConfiguration.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/mutatingWebhookConfiguration.yaml
@@ -74,4 +74,10 @@ webhooks:
         {{- end }}
       {{- end }}
     {{- end }}
+    {{- if .Values.prometheusOperator.admissionWebhooks.objectSelector }}
+    objectSelector:
+      {{- with .Values.prometheusOperator.admissionWebhooks.objectSelector }}
+      {{- toYaml . | nindent 6}}
+      {{- end }}
+    {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/validatingWebhookConfiguration.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/validatingWebhookConfiguration.yaml
@@ -74,10 +74,8 @@ webhooks:
         {{- end }}
       {{- end }}
     {{- end }}
-    {{- if .Values.prometheusOperator.admissionWebhooks.objectSelector }}
+    {{- with .Values.prometheusOperator.admissionWebhooks.objectSelector }}
     objectSelector:
-      {{- with .Values.prometheusOperator.admissionWebhooks.objectSelector }}
-      {{- toYaml . | nindent 6}}
-      {{- end }}
+      {{- toYaml . | nindent 6 }}
     {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/validatingWebhookConfiguration.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/validatingWebhookConfiguration.yaml
@@ -74,4 +74,10 @@ webhooks:
         {{- end }}
       {{- end }}
     {{- end }}
+    {{- if .Values.prometheusOperator.admissionWebhooks.objectSelector }}
+    objectSelector:
+      {{- with .Values.prometheusOperator.admissionWebhooks.objectSelector }}
+      {{- toYaml . | nindent 6}}
+      {{- end }}
+    {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -2228,6 +2228,8 @@ prometheusOperator:
     #   argocd.argoproj.io/hook-delete-policy: HookSucceeded
 
     namespaceSelector: {}
+    objectSelector: {}
+
 
     deployment:
       enabled: false


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### Add the possibility to specify objectSelector for admissionWebhooks objects

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
