### PR TITLE
[prometheus-mysql-exporter] Set GOMAXPROCS and GOMEMLIMIT environment variables based on container resources

### DIFF
--- a/charts/prometheus-mysql-exporter/Chart.yaml
+++ b/charts/prometheus-mysql-exporter/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart for prometheus mysql exporter with cloudsqlproxy
 name: prometheus-mysql-exporter
 version: 2.5.3
 home: https://github.com/prometheus/mysqld_exporter
-appVersion: v0.15.1
+appVersion: v0.16.0
 sources:
   - https://github.com/prometheus/mysqld_exporter
 maintainers:

--- a/charts/prometheus-mysql-exporter/templates/deployment.yaml
+++ b/charts/prometheus-mysql-exporter/templates/deployment.yaml
@@ -66,8 +66,20 @@ spec:
           {{- end }}
           {{- end }}
           {{- end }}
-          {{- if and (not .Values.mysql.existingConfigSecret.name) (.Values.mysql.existingPasswordSecret.name) }}
           env:
+          {{- if (.Values.resources.limits).cpu }}
+          - name: GOMAXPROCS
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.cpu
+          {{- end }}
+          {{- if (.Values.resources.limits).memory }}
+          - name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.memory
+          {{- end }}
+          {{- if and (not .Values.mysql.existingConfigSecret.name) (.Values.mysql.existingPasswordSecret.name) }}
             - name: MYSQLD_EXPORTER_PASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Set `GOMAXPROCS` and `GOMEMLIMIT` environment variables based on container resources. This should reduce potential CPU throttling and OOMKills on containers.

The [`resourceFieldRef`](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/#downwardapi-resourceFieldRef) is a very specific Kubernetes directive that is created specifically for passing resource-related values, which rounds up the CPU value to the nearest whole number (e.g. 250m to 1) and passes the memory as a numeric value; so `64Mi` would result in the environment variable being set to `67108864`. This by design makes it completely compatible with Go's API.

An example is documented within Kubernetes documentation itself: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/#use-container-fields-as-values-for-environment-variables.

Inspired by https://github.com/traefik/traefik-helm-chart/pull/1029.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer

This creates an empty `env` key for those not setting resource values (and not using existing config secret). This is only a little ugly, but should not be harmful. Alternatively, the could be some combined conditional wrapper around the whole `env` block to only make it appear if a value is set, but that will look quite complicated and quite prone to (future) errors.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
