### PR TITLE
[prometheus-pushgateway] allow overriding service port name

### DIFF
--- a/charts/prometheus-pushgateway/Chart.yaml
+++ b/charts/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v1.8.0"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 2.12.1
+version: 2.13.0
 home: https://github.com/prometheus/pushgateway
 sources:
   - https://github.com/prometheus/pushgateway

--- a/charts/prometheus-pushgateway/Chart.yaml
+++ b/charts/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v1.8.0"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 2.12.0
+version: 2.12.1
 home: https://github.com/prometheus/pushgateway
 sources:
   - https://github.com/prometheus/pushgateway

--- a/charts/prometheus-pushgateway/templates/service.yaml
+++ b/charts/prometheus-pushgateway/templates/service.yaml
@@ -40,6 +40,6 @@ spec:
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}
       protocol: TCP
-      name: http
+      name: {{ .Values.service.portName }}
   selector:
     {{- include "prometheus-pushgateway.selectorLabels" . | nindent 4 }}

--- a/charts/prometheus-pushgateway/templates/servicemonitor.yaml
+++ b/charts/prometheus-pushgateway/templates/servicemonitor.yaml
@@ -15,7 +15,7 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-  - port: http
+  - port: {{ .Values.service.portName }}
     {{- with .Values.serviceMonitor.interval }}
     interval: {{ . }}
     {{- end }}

--- a/charts/prometheus-pushgateway/values.yaml
+++ b/charts/prometheus-pushgateway/values.yaml
@@ -25,6 +25,7 @@ service:
   port: 9091
   targetPort: 9091
   # nodePort: 32100
+  portName: http
 
   # Optional - Can be used for headless if value is "None"
   clusterIP: ""


### PR DESCRIPTION
#### What this PR does / why we need it

This PR introduces the ability to customize the hard-coded port name `http` for the pushgateway service. This enhancement is necessary for environments where a Prometheus ServiceMonitor already exists on Kubernetes to scrape metrics from the services, using port name different than `http` (e.g. `metrics`).

#### Which issue this PR fixes

None

#### Special notes for your reviewer

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
