### PR TITLE
[prometheus-redis-exporter] Update Redis Exporter to 1.61.0

### DIFF
--- a/charts/prometheus-redis-exporter/Chart.yaml
+++ b/charts/prometheus-redis-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v1.58.0
+appVersion: v1.61.0
 description: Prometheus exporter for Redis metrics
 name: prometheus-redis-exporter
-version: 6.2.0
+version: 6.3.0
 home: https://github.com/oliver006/redis_exporter
 sources:
   - https://github.com/oliver006/redis_exporter

--- a/charts/prometheus-redis-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-redis-exporter/templates/_helpers.tpl
@@ -60,7 +60,7 @@ Common labels
 helm.sh/chart: {{ include "prometheus-redis-exporter.chart" . }}
 {{ include "prometheus-redis-exporter.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.customLabels}}

--- a/charts/prometheus-redis-exporter/templates/deployment.yaml
+++ b/charts/prometheus-redis-exporter/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
 {{ include "prometheus-redis-exporter.labels" . | indent 4 }}
   annotations:
-{{ toYaml .Values.annotations | indent 8 }}
+{{ toYaml .Values.annotations | indent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:


### PR DESCRIPTION
#### What this PR does / why we need it

#### Which issue this PR fixes

- updates app version from v1.58.0 to v1.61.0
- fixes version label when image tag override is set
- fixes deployment annotation indentation

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
