### PR TITLE
chore(ci): install prometheus operator CRDs in order to be able to test ServiceMonitors / PrometheusRules / etc validity in charts.

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -29,6 +29,7 @@ jobs:
           changed="$(ct list-changed --config .github/linters/ct.yaml)"
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "changed_list=\"${changed//$'\n'/ }\"" >> "$GITHUB_OUTPUT"
           fi
 
       # - name: install helm unittest plugin
@@ -46,6 +47,19 @@ jobs:
 
       - name: Apply Gateway API CRDs
         run: kubectl apply -k https://github.com/kubernetes-sigs/gateway-api/config/crd
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Apply Prometheus Operator CRDs (unless for charts already installing it)
+        env:
+          CHANGED_LIST: ${{ steps.list-changed.outputs.changed_list }}
+        run: |
+          # Always run unless only changed chart is one of impacted charts
+          echo "List is: $CHANGED_LIST"
+          if [ "$CHANGED_LIST" = '"charts/kube-prometheus-stack"' ] || [ "$CHANGED_LIST" = '"charts/prometheus-operator-crds"' ]; then
+            echo "Skipping install"
+          else
+            helm install prometheus-operator-crds oci://ghcr.io/prometheus-community/charts/prometheus-operator-crds
+          fi
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)


### PR DESCRIPTION
In the last years, I've come across a lot of wrongly defined ServiceMonitors, PrometheusRules, etc, either from myself or other people.

In other Charts repositories like Kubernetes Dashboard, I install Prometheus Operator CRDs in order to have related values correctly tested before merging (usually with an additional `ci/` file).

Here, we are in deeper trouble: we do _not_ want to install CRDs if we are installing charts with... CRDs (otherwise, we will no longer properly test those important charts).

Here is a proposal to conditionally install CRDs.

Pros: easily test Prometheus Operator related resources and improve quality of charts (and ease reviews)
Cons: hardcoded list of charts to avoid.

What do you think?

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

Here is TWO internal PRs to show wanted behaviors:
- https://github.com/desaintmartin/helm-charts-3/pull/2
- https://github.com/desaintmartin/helm-charts-3/pull/3

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
