### PR TITLE
[prometheus-mysql-exporter] fix incorrect indentation in env variables

### DIFF
--- a/charts/prometheus-mysql-exporter/Chart.yaml
+++ b/charts/prometheus-mysql-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for prometheus mysql exporter with cloudsqlproxy
 name: prometheus-mysql-exporter
-version: 2.6.0
+version: 2.6.1
 home: https://github.com/prometheus/mysqld_exporter
 appVersion: v0.15.1
 sources:

--- a/charts/prometheus-mysql-exporter/templates/deployment.yaml
+++ b/charts/prometheus-mysql-exporter/templates/deployment.yaml
@@ -68,16 +68,16 @@ spec:
           {{- end }}
           env:
           {{- if (.Values.resources.limits).cpu }}
-          - name: GOMAXPROCS
-            valueFrom:
-              resourceFieldRef:
-                resource: limits.cpu
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
           {{- end }}
           {{- if (.Values.resources.limits).memory }}
-          - name: GOMEMLIMIT
-            valueFrom:
-              resourceFieldRef:
-                resource: limits.memory
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
           {{- end }}
           {{- if and (not .Values.mysql.existingConfigSecret.name) (.Values.mysql.existingPasswordSecret.name) }}
             - name: MYSQLD_EXPORTER_PASSWORD


### PR DESCRIPTION
- fixes #4724

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
