### PR TITLE
[prometheus-node-exporter] prevent node exporter from being scheduled on fargate or virtual nodes

### DIFF
--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - prometheus
   - exporter
 type: application
-version: 4.42.1
+version: 4.43.0
 appVersion: 1.8.2
 home: https://github.com/prometheus/node_exporter/
 sources:

--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - prometheus
   - exporter
 type: application
-version: 4.42.0
+version: 4.42.1
 appVersion: 1.8.2
 home: https://github.com/prometheus/node_exporter/
 sources:

--- a/charts/prometheus-node-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-node-exporter/templates/_helpers.tpl
@@ -200,3 +200,38 @@ labelValueLengthLimit: {{ . }}
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+The default node affinity to exclude 
+- AWS Fargate 
+- Azure virtual nodes
+*/}}
+{{- define "prometheus-node-exporter.defaultAffinity" -}}
+nodeAffinity:
+  requiredDuringSchedulingIgnoredDuringExecution:
+    nodeSelectorTerms:
+    - matchExpressions:
+      - key: eks.amazonaws.com/compute-type
+        operator: NotIn
+        values:
+        - fargate
+      - key: type
+        operator: NotIn
+        values:
+        - virtual-kubelet
+{{- end -}}
+{{- define "prometheus-node-exporter.mergedAffinities" -}}
+{{- $defaultAffinity := include "prometheus-node-exporter.defaultAffinity" . | fromYaml -}}
+{{- with .Values.affinity -}}
+  {{- if .nodeAffinity -}}
+    {{- $_ := set $defaultAffinity "nodeAffinity" (mergeOverwrite $defaultAffinity.nodeAffinity .nodeAffinity) -}}
+  {{- end -}}
+  {{- if .podAffinity -}}
+    {{- $_ := set $defaultAffinity "podAffinity" .podAffinity -}}
+  {{- end -}}
+  {{- if .podAntiAffinity -}}
+    {{- $_ := set $defaultAffinity "podAntiAffinity" .podAntiAffinity -}}
+  {{- end -}}
+{{- end -}}
+{{- toYaml $defaultAffinity -}}
+{{- end -}}

--- a/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -267,10 +267,8 @@ spec:
       hostNetwork: {{ .Values.hostNetwork }}
       hostPID: {{ .Values.hostPID }}
       hostIPC: {{ .Values.hostIPC }}
-      {{- with .Values.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- include "prometheus-node-exporter.mergedAffinities" . | nindent 8 }}
       {{- with .Values.dnsConfig }}
       dnsConfig:
         {{- toYaml . | nindent 8 }}

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -408,7 +408,8 @@ hostSysFsMount:
   mountPropagation: ""
 
 ## Assign a group of affinity scheduling rules
-##
+## The default nodeAffinity excludes Fargate nodes and virtual kubelets from scheduling 
+## unless overriden by hard node affinity set in the field.
 affinity: {}
 #   nodeAffinity:
 #     requiredDuringSchedulingIgnoredDuringExecution:

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -408,7 +408,7 @@ hostSysFsMount:
   mountPropagation: ""
 
 ## Assign a group of affinity scheduling rules
-## The default nodeAffinity excludes Fargate nodes and virtual kubelets from scheduling 
+## The default nodeAffinity excludes Fargate nodes and virtual kubelets from scheduling
 ## unless overriden by hard node affinity set in the field.
 affinity: {}
 #   nodeAffinity:


### PR DESCRIPTION
#### What this PR does / why we need it

This PR prevents node-exporter from being scheduled on fargate

#### Which issue this PR fixes

- fixes #4735

#### Special notes for your reviewer

If my understanding is correct, then for people that have already added this nodeAffinity this would not be a breaking change, it would simply be redundant - but this I am not completely sure about.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
