### PR TITLE
[kube-state-metrics] Allow configuration of startupProbe

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - kubernetes
 type: application
-version: 5.22.0
+version: 5.23.0
 appVersion: 2.13.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/kube-state-metrics/templates/deployment.yaml
@@ -147,6 +147,26 @@ spec:
           name: "metrics"
         {{- end }}
         {{- end }}
+        {{- if .Values.startupProbe.enabled }}
+        startupProbe:
+          failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          httpGet:
+            {{- if .Values.hostNetwork }}
+            host: 127.0.0.1
+            {{- end }}
+            httpHeaders:
+            {{- range $_, $header := .Values.startupProbe.httpGet.httpHeaders }}
+            - name: {{ $header.name }}
+              value: {{ $header.value }}
+            {{- end }}
+            path: /livez
+            port: {{ $servicePort }}
+            scheme: {{ upper .Values.startupProbe.httpGet.scheme }}
+          initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+          successThreshold: {{ .Values.startupProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+        {{- end }}
         livenessProbe:
           failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           httpGet:

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -497,6 +497,23 @@ initContainers: []
   # - name: crd-sidecar
   #   image: kiwigrid/k8s-sidecar:latest
 
+## Settings for startup, liveness and readiness probes
+## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+##
+
+## Startup probe can optionally be enabled.
+##
+startupProbe:
+  enabled: false
+  failureThreshold: 3
+  httpGet:
+    httpHeaders: []
+    scheme: http
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 5
+
 ## Liveness probe
 ##
 livenessProbe:


### PR DESCRIPTION
#### What this PR does / why we need it

As in previous PRs, e.g. #3811 or #4696, I would like to enable users of the `kube-state-metrics` chart to optionally configure a `startupProbe` in the `Deployment`, if external circumstances require it.

#### Special notes for your reviewer

As requested in the PR template, CC'ing @tariq1890 @mrueg @dotdc

The PRs I looked at as inspiration for this change had different approaches for making the `startupProbe` configurable, e.g. just passing on the entire value block, or configuring defaults for most fields vs a simple `startupProbe: {}`. I opted to keep it similar to the `readinessProbe` and `livenessProbe` already available in this chart, for consistency.

First PR here, happy about any feedback regarding the change itself or the PR process in general.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
