### PR TITLE
[kube-state-metrics] Align probing endpoints with recommendations

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - kubernetes
 type: application
-version: 5.23.0
+version: 5.24.0
 appVersion: 2.13.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/kube-state-metrics/templates/deployment.yaml
@@ -159,7 +159,7 @@ spec:
             - name: {{ $header.name }}
               value: {{ $header.value }}
             {{- end }}
-            path: /livez
+            path: /healthz
             port: {{ $servicePort }}
             scheme: {{ upper .Values.startupProbe.httpGet.scheme }}
           initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Just after #4740 got merged, I realized a small mistake I made. `kube-state-metrics` actually recommends to use the `/healthz` endpoint for the `startupProbe`, not the `/livez` one (see [kube-state-metrics healthcheck endpoints docs](https://github.com/kubernetes/kube-state-metrics/?tab=readme-ov-file#healthcheck-endpoints)).

#### Which issue this PR fixes

Me not reading the documentation properly.

#### Special notes for your reviewer

Sorry for the extra work!

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
