### PR TITLE
[kube-prometheus-stack] Fix mixins generation and fix update on mac

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 61.3.2
+version: 61.3.3
 appVersion: v0.75.1
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/hack/sync_grafana_dashboards.py
+++ b/charts/kube-prometheus-stack/hack/sync_grafana_dashboards.py
@@ -29,11 +29,11 @@ def change_style(style, representer):
 
 refs = {
     # https://github.com/prometheus-operator/kube-prometheus
-    'ref.kube-prometheus': 'b5b59bc0b45508b85647eb7a84b96dc167be15f1',
+    'ref.kube-prometheus': 'defa2bd1e242519c62a5c2b3b786b1caa6d906d4',
     # https://github.com/kubernetes-monitoring/kubernetes-mixin
-    'ref.kubernetes-mixin': 'de834e9a291b49396125768f041e2078763f48b5',
+    'ref.kubernetes-mixin': 'dd5c59ab4491159593ed370a344a553b57146a7d',
     # https://github.com/etcd-io/etcd
-    'ref.etcd': '1c22e7b36bc5d8543f1646212f2960f9fe503b8c',
+    'ref.etcd': '9f59ef8ead097f836271f125d0e3774ddae4e71d',
 }
 
 # Source files list

--- a/charts/kube-prometheus-stack/hack/sync_prometheus_rules.py
+++ b/charts/kube-prometheus-stack/hack/sync_prometheus_rules.py
@@ -29,11 +29,11 @@ def change_style(style, representer):
 
 refs = {
     # https://github.com/prometheus-operator/kube-prometheus
-    'ref.kube-prometheus': 'b5b59bc0b45508b85647eb7a84b96dc167be15f1',
+    'ref.kube-prometheus': 'defa2bd1e242519c62a5c2b3b786b1caa6d906d4',
     # https://github.com/kubernetes-monitoring/kubernetes-mixin
-    'ref.kubernetes-mixin': 'de834e9a291b49396125768f041e2078763f48b5',
+    'ref.kubernetes-mixin': 'dd5c59ab4491159593ed370a344a553b57146a7d',
     # https://github.com/etcd-io/etcd
-    'ref.etcd': '1c22e7b36bc5d8543f1646212f2960f9fe503b8c',
+    'ref.etcd': '9f59ef8ead097f836271f125d0e3774ddae4e71d',
 }
 
 # Source files list
@@ -42,12 +42,12 @@ charts = [
         'git': 'https://github.com/prometheus-operator/kube-prometheus.git',
         'branch': refs['ref.kube-prometheus'],
         'source': 'main.libsonnet',
-        'cwd': 'jsonnet/kube-prometheus',
+        'cwd': '',
         'destination': '../templates/prometheus/rules-1.14',
         'min_kubernetes': '1.14.0-0',
         'mixin': """
         local kp =
-          (import 'main.libsonnet') + {
+          (import 'jsonnet/kube-prometheus/main.libsonnet') + {
             values+:: {
               common+: {
                 namespace: 'monitoring',
@@ -343,7 +343,7 @@ def add_custom_labels(rules_str, group, indent=4, label_indent=2):
     # should only be added if there are .Values defaultRules.additionalRuleLabels defined
     rule_seperator = "\n" + " " * indent + "-.*"
     label_seperator = "\n" + " " * indent + "  labels:"
-    section_seperator = "\n" + " " * indent + "  \S"
+    section_seperator = "\n" + " " * indent + "  \\S"
     section_seperator_len = len(section_seperator)-1
     rules_positions = re.finditer(rule_seperator,rules_str)
 

--- a/charts/kube-prometheus-stack/hack/update_mixins.sh
+++ b/charts/kube-prometheus-stack/hack/update_mixins.sh
@@ -2,6 +2,14 @@
 
 set -euo pipefail
 
+sedi () {
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' "$@"
+  else
+    sed -i "$@"
+  fi
+}
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 trap 'rm -rf "${SCRIPT_DIR}/tmp"' EXIT
@@ -17,8 +25,8 @@ for REPO_PATH in "${SCRIPT_DIR}/tmp/"*; do
   SHA=$(git -C "$REPO_PATH" log -1 --pretty=format:"%H")
   REPO_NAME=$(basename "$REPO_PATH")
   echo "Updating $REPO_NAME to $SHA"
-  sed -i -e "s/'ref.$REPO_NAME'.*:.*'.*'/'ref.$REPO_NAME': '$SHA'/" "${SCRIPT_DIR}/sync_grafana_dashboards.py"
-  sed -i -e "s/'ref.$REPO_NAME'.*:.*'.*'/'ref.$REPO_NAME': '$SHA'/" "${SCRIPT_DIR}/sync_prometheus_rules.py"
+  sedi -e "s/'ref.$REPO_NAME'.*:.*'.*'/'ref.$REPO_NAME': '$SHA'/" "${SCRIPT_DIR}/sync_grafana_dashboards.py"
+  sedi -e "s/'ref.$REPO_NAME'.*:.*'.*'/'ref.$REPO_NAME': '$SHA'/" "${SCRIPT_DIR}/sync_prometheus_rules.py"
 done
 
 export PIP_DISABLE_PIP_VERSION_CHECK=1

--- a/charts/kube-prometheus-stack/hack/update_mixins.sh
+++ b/charts/kube-prometheus-stack/hack/update_mixins.sh
@@ -2,13 +2,10 @@
 
 set -euo pipefail
 
-sedi () {
-  if [[ "$OSTYPE" == "darwin"* ]]; then
-    sed -i '' "$@"
-  else
-    sed -i "$@"
-  fi
-}
+case $(sed --help 2>&1) in
+*BusyBox* | *GNU*) _sed_i() { sed -i "$@"; } ;;
+*) _sed_i() { sed -i '' "$@"; } ;;
+esac
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
@@ -25,8 +22,8 @@ for REPO_PATH in "${SCRIPT_DIR}/tmp/"*; do
   SHA=$(git -C "$REPO_PATH" log -1 --pretty=format:"%H")
   REPO_NAME=$(basename "$REPO_PATH")
   echo "Updating $REPO_NAME to $SHA"
-  sedi -e "s/'ref.$REPO_NAME'.*:.*'.*'/'ref.$REPO_NAME': '$SHA'/" "${SCRIPT_DIR}/sync_grafana_dashboards.py"
-  sedi -e "s/'ref.$REPO_NAME'.*:.*'.*'/'ref.$REPO_NAME': '$SHA'/" "${SCRIPT_DIR}/sync_prometheus_rules.py"
+  _sed_i -e "s/'ref.$REPO_NAME'.*:.*'.*'/'ref.$REPO_NAME': '$SHA'/" "${SCRIPT_DIR}/sync_grafana_dashboards.py"
+  _sed_i -e "s/'ref.$REPO_NAME'.*:.*'.*'/'ref.$REPO_NAME': '$SHA'/" "${SCRIPT_DIR}/sync_prometheus_rules.py"
 done
 
 export PIP_DISABLE_PIP_VERSION_CHECK=1

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/alertmanager-overview.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/alertmanager-overview.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'alertmanager-overview' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/b5b59bc0b45508b85647eb7a84b96dc167be15f1/manifests/grafana-dashboardDefinitions.yaml
+Generated from 'alertmanager-overview' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/defa2bd1e242519c62a5c2b3b786b1caa6d906d4/manifests/grafana-dashboardDefinitions.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/apiserver.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/apiserver.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'apiserver' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/b5b59bc0b45508b85647eb7a84b96dc167be15f1/manifests/grafana-dashboardDefinitions.yaml
+Generated from 'apiserver' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/defa2bd1e242519c62a5c2b3b786b1caa6d906d4/manifests/grafana-dashboardDefinitions.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/cluster-total.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/cluster-total.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'cluster-total' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/b5b59bc0b45508b85647eb7a84b96dc167be15f1/manifests/grafana-dashboardDefinitions.yaml
+Generated from 'cluster-total' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/defa2bd1e242519c62a5c2b3b786b1caa6d906d4/manifests/grafana-dashboardDefinitions.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/controller-manager.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/controller-manager.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'controller-manager' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/b5b59bc0b45508b85647eb7a84b96dc167be15f1/manifests/grafana-dashboardDefinitions.yaml
+Generated from 'controller-manager' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/defa2bd1e242519c62a5c2b3b786b1caa6d906d4/manifests/grafana-dashboardDefinitions.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/grafana-overview.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/grafana-overview.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'grafana-overview' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/b5b59bc0b45508b85647eb7a84b96dc167be15f1/manifests/grafana-dashboardDefinitions.yaml
+Generated from 'grafana-overview' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/defa2bd1e242519c62a5c2b3b786b1caa6d906d4/manifests/grafana-dashboardDefinitions.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-cluster.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-cluster.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'k8s-resources-cluster' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/b5b59bc0b45508b85647eb7a84b96dc167be15f1/manifests/grafana-dashboardDefinitions.yaml
+Generated from 'k8s-resources-cluster' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/defa2bd1e242519c62a5c2b3b786b1caa6d906d4/manifests/grafana-dashboardDefinitions.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-multicluster.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-multicluster.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'k8s-resources-multicluster' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/b5b59bc0b45508b85647eb7a84b96dc167be15f1/manifests/grafana-dashboardDefinitions.yaml
+Generated from 'k8s-resources-multicluster' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/defa2bd1e242519c62a5c2b3b786b1caa6d906d4/manifests/grafana-dashboardDefinitions.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-namespace.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-namespace.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'k8s-resources-namespace' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/b5b59bc0b45508b85647eb7a84b96dc167be15f1/manifests/grafana-dashboardDefinitions.yaml
+Generated from 'k8s-resources-namespace' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/defa2bd1e242519c62a5c2b3b786b1caa6d906d4/manifests/grafana-dashboardDefinitions.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-node.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-node.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'k8s-resources-node' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/b5b59bc0b45508b85647eb7a84b96dc167be15f1/manifests/grafana-dashboardDefinitions.yaml
+Generated from 'k8s-resources-node' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/defa2bd1e242519c62a5c2b3b786b1caa6d906d4/manifests/grafana-dashboardDefinitions.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-pod.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-pod.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'k8s-resources-pod' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/b5b59bc0b45508b85647eb7a84b96dc167be15f1/manifests/grafana-dashboardDefinitions.yaml
+Generated from 'k8s-resources-pod' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/defa2bd1e242519c62a5c2b3b786b1caa6d906d4/manifests/grafana-dashboardDefinitions.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-workload.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-workload.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'k8s-resources-workload' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/b5b59bc0b45508b85647eb7a84b96dc167be15f1/manifests/grafana-dashboardDefinitions.yaml
+Generated from 'k8s-resources-workload' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/defa2bd1e242519c62a5c2b3b786b1caa6d906d4/manifests/grafana-dashboardDefinitions.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-workloads-namespace.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/k8s-resources-workloads-namespace.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'k8s-resources-workloads-namespace' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/b5b59bc0b45508b85647eb7a84b96dc167be15f1/manifests/grafana-dashboardDefinitions.yaml
+Generated from 'k8s-resources-workloads-namespace' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/defa2bd1e242519c62a5c2b3b786b1caa6d906d4/manifests/grafana-dashboardDefinitions.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/kubelet.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/kubelet.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'kubelet' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/b5b59bc0b45508b85647eb7a84b96dc167be15f1/manifests/grafana-dashboardDefinitions.yaml
+Generated from 'kubelet' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/defa2bd1e242519c62a5c2b3b786b1caa6d906d4/manifests/grafana-dashboardDefinitions.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/namespace-by-pod.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/namespace-by-pod.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'namespace-by-pod' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/b5b59bc0b45508b85647eb7a84b96dc167be15f1/manifests/grafana-dashboardDefinitions.yaml
+Generated from 'namespace-by-pod' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/defa2bd1e242519c62a5c2b3b786b1caa6d906d4/manifests/grafana-dashboardDefinitions.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/namespace-by-workload.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/namespace-by-workload.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'namespace-by-workload' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/b5b59bc0b45508b85647eb7a84b96dc167be15f1/manifests/grafana-dashboardDefinitions.yaml
+Generated from 'namespace-by-workload' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/defa2bd1e242519c62a5c2b3b786b1caa6d906d4/manifests/grafana-dashboardDefinitions.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/node-cluster-rsrc-use.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/node-cluster-rsrc-use.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'node-cluster-rsrc-use' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/b5b59bc0b45508b85647eb7a84b96dc167be15f1/manifests/grafana-dashboardDefinitions.yaml
+Generated from 'node-cluster-rsrc-use' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/defa2bd1e242519c62a5c2b3b786b1caa6d906d4/manifests/grafana-dashboardDefinitions.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/node-rsrc-use.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/node-rsrc-use.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'node-rsrc-use' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/b5b59bc0b45508b85647eb7a84b96dc167be15f1/manifests/grafana-dashboardDefinitions.yaml
+Generated from 'node-rsrc-use' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/defa2bd1e242519c62a5c2b3b786b1caa6d906d4/manifests/grafana-dashboardDefinitions.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/nodes-darwin.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/nodes-darwin.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'nodes-darwin' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/b5b59bc0b45508b85647eb7a84b96dc167be15f1/manifests/grafana-dashboardDefinitions.yaml
+Generated from 'nodes-darwin' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/defa2bd1e242519c62a5c2b3b786b1caa6d906d4/manifests/grafana-dashboardDefinitions.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/nodes.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/nodes.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'nodes' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/b5b59bc0b45508b85647eb7a84b96dc167be15f1/manifests/grafana-dashboardDefinitions.yaml
+Generated from 'nodes' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/defa2bd1e242519c62a5c2b3b786b1caa6d906d4/manifests/grafana-dashboardDefinitions.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/persistentvolumesusage.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/persistentvolumesusage.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'persistentvolumesusage' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/b5b59bc0b45508b85647eb7a84b96dc167be15f1/manifests/grafana-dashboardDefinitions.yaml
+Generated from 'persistentvolumesusage' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/defa2bd1e242519c62a5c2b3b786b1caa6d906d4/manifests/grafana-dashboardDefinitions.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/pod-total.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/pod-total.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'pod-total' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/b5b59bc0b45508b85647eb7a84b96dc167be15f1/manifests/grafana-dashboardDefinitions.yaml
+Generated from 'pod-total' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/defa2bd1e242519c62a5c2b3b786b1caa6d906d4/manifests/grafana-dashboardDefinitions.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/prometheus-remote-write.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/prometheus-remote-write.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'prometheus-remote-write' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/b5b59bc0b45508b85647eb7a84b96dc167be15f1/manifests/grafana-dashboardDefinitions.yaml
+Generated from 'prometheus-remote-write' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/defa2bd1e242519c62a5c2b3b786b1caa6d906d4/manifests/grafana-dashboardDefinitions.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/prometheus.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'prometheus' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/b5b59bc0b45508b85647eb7a84b96dc167be15f1/manifests/grafana-dashboardDefinitions.yaml
+Generated from 'prometheus' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/defa2bd1e242519c62a5c2b3b786b1caa6d906d4/manifests/grafana-dashboardDefinitions.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/proxy.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/proxy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'proxy' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/b5b59bc0b45508b85647eb7a84b96dc167be15f1/manifests/grafana-dashboardDefinitions.yaml
+Generated from 'proxy' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/defa2bd1e242519c62a5c2b3b786b1caa6d906d4/manifests/grafana-dashboardDefinitions.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/scheduler.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/scheduler.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'scheduler' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/b5b59bc0b45508b85647eb7a84b96dc167be15f1/manifests/grafana-dashboardDefinitions.yaml
+Generated from 'scheduler' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/defa2bd1e242519c62a5c2b3b786b1caa6d906d4/manifests/grafana-dashboardDefinitions.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}

--- a/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/workload-total.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14/workload-total.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Generated from 'workload-total' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/b5b59bc0b45508b85647eb7a84b96dc167be15f1/manifests/grafana-dashboardDefinitions.yaml
+Generated from 'workload-total' from https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/defa2bd1e242519c62a5c2b3b786b1caa6d906d4/manifests/grafana-dashboardDefinitions.yaml
 Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

https://github.com/kubernetes/kube-state-metrics/pull/2388 introduced a syntax error. The syntax error has an effect to our pipeline.

I take a look closer into this, since we are using fixed shasums for dependencies but somewhere else, floating version are used.

It turns out that the lockfile for Jsonnet dependencies in [kube-prometheus](https://github.com/prometheus-operator/kube-prometheus/blob/main/jsonnetfile.lock.json) is located in the repository root. To respect the lockfile, I had to change the update mixin configuration to run the generation from the repository root.

I also fixed the update script for macOS.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
