### PR TITLE
[kube-prometheus-stack] feat: configure datasource auto-deletion

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 61.7.0
+version: 61.7.1
 appVersion: v0.75.2
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/grafana/configmaps-datasources.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/configmaps-datasources.yaml
@@ -19,6 +19,9 @@ data:
     deleteDatasources:
 {{ tpl (toYaml .Values.grafana.deleteDatasources | indent 6) . }}
 {{- end }}
+{{- if .Values.grafana.prune }}
+    prune: {{ .Values.grafana.prune }}
+{{- end }}
     datasources:
 {{- $scrapeInterval := .Values.grafana.sidecar.datasources.defaultDatasourceScrapeInterval | default .Values.prometheus.prometheusSpec.scrapeInterval | default "30s" }}
 {{- if .Values.grafana.sidecar.datasources.defaultDatasourceEnabled }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1126,6 +1126,11 @@ grafana:
   #   url: https://{{ printf "%s-prometheus.svc" .Release.Name }}:9090
   #   version: 1
 
+  # Flag to mark provisioned data sources for deletion if they are no longer configured.
+  # It takes no effect if data sources are already listed in the deleteDatasources section.
+  # ref: https://grafana.com/docs/grafana/latest/administration/provisioning/#example-data-source-config-file
+  prune: false
+  
   ## Passed to grafana subchart and used by servicemonitor below
   ##
   service:

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1130,7 +1130,7 @@ grafana:
   # It takes no effect if data sources are already listed in the deleteDatasources section.
   # ref: https://grafana.com/docs/grafana/latest/administration/provisioning/#example-data-source-config-file
   prune: false
-  
+
   ## Passed to grafana subchart and used by servicemonitor below
   ##
   service:


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This parameter enables configuration of datasource pruning / auto deletion for Grafana through the Helm chart, functionality introduced in Grafana v11.1 (https://github.com/grafana/grafana/pull/83034)

#### Which issue this PR fixes

- fixes #

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
