### PR TITLE
[kube-prometheus-stack]: Add probes for prometheus-operator

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 61.7.1
+version: 61.7.2
 appVersion: v0.75.2
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -167,26 +167,30 @@ spec:
           {{- with .Values.prometheusOperator.extraVolumeMounts }}
           {{- toYaml . | nindent 12 }}
           {{- end }}
-          livenessProbe:
-            httpGet:
-              path: /healthz
-            {{- if .Values.prometheusOperator.tls.enabled }}
-              port: https
-              scheme: HTTPS
-            {{- else }}
-              port: http
-              scheme: HTTP
-            {{- end }}
+          {{- if .Values.prometheusOperator.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /healthz
-            {{- if .Values.prometheusOperator.tls.enabled }}
-              port: https
-              scheme: HTTPS
-            {{- else }}
-              port: http
-              scheme: HTTP
-            {{- end }}
+              port: {{ .Values.prometheusOperator.tls.enabled | ternary "https" "http" }}
+              scheme: {{ .Values.prometheusOperator.tls.enabled | ternary "HTTPS" "HTTP" }}
+            initialDelaySeconds: {{ .Values.prometheusOperator.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.prometheusOperator.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.prometheusOperator.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.prometheusOperator.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.prometheusOperator.readinessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.prometheusOperator.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.prometheusOperator.tls.enabled | ternary "https" "http" }}
+              scheme: {{ .Values.prometheusOperator.tls.enabled | ternary "HTTPS" "HTTP" }}
+            initialDelaySeconds: {{ .Values.prometheusOperator.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.prometheusOperator.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.prometheusOperator.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.prometheusOperator.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.prometheusOperator.livenessProbe.failureThreshold }}
+          {{- end }}
       volumes:
         {{- if .Values.prometheusOperator.tls.enabled }}
         - name: tls-secret

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -167,6 +167,26 @@ spec:
           {{- with .Values.prometheusOperator.extraVolumeMounts }}
           {{- toYaml . | nindent 12 }}
           {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+            {{- if .Values.prometheusOperator.tls.enabled }}
+              port: https
+              scheme: HTTPS
+            {{- else }}
+              port: http
+              scheme: HTTP
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+            {{- if .Values.prometheusOperator.tls.enabled }}
+              port: https
+              scheme: HTTPS
+            {{- else }}
+              port: http
+              scheme: HTTP
+            {{- end }}
       volumes:
         {{- if .Values.prometheusOperator.tls.enabled }}
         - name: tls-secret

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -2220,6 +2220,25 @@ prometheusOperator:
     # The default webhook port is 10250 in order to work out-of-the-box in GKE private clusters and avoid adding firewall rules.
     internalPort: 10250
 
+  ## Liveness probe for the prometheusOperator deployment
+  ##
+  livenessProbe:
+    enabled: true
+    failureThreshold: 3
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 1
+  ## Readiness probe for the prometheusOperator deployment
+  ##
+  readinessProbe:
+    enabled: true
+    failureThreshold: 3
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 1
+
   ## Admission webhook support for PrometheusRules resources added in Prometheus Operator 0.30 can be enabled to prevent incorrectly formatted
   ## rules from making their way into prometheus and potentially preventing the container from starting
   admissionWebhooks:


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Add readiness and liveness probe for the prometheus-operator deployment for the kube-prometheus-stack helm chart.
#### Special notes for your reviewer

#### Checklist

- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
