### PR TITLE
[prometheus-elasticsearch-exporter] Take into account image.pullSecret

### DIFF
--- a/charts/prometheus-elasticsearch-exporter/Chart.yaml
+++ b/charts/prometheus-elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Elasticsearch stats exporter for Prometheus
 name: prometheus-elasticsearch-exporter
-version: 6.3.0
+version: 6.3.1
 kubeVersion: ">=1.19.0-0"
 appVersion: "v1.7.0"
 home: https://github.com/prometheus-community/elasticsearch_exporter

--- a/charts/prometheus-elasticsearch-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-elasticsearch-exporter/templates/_helpers.tpl
@@ -79,6 +79,10 @@ global:
 - name: {{ tpl . $ }}
   {{- end }}
 {{- end }}
+{{/* Include local image pullSecret */}}
+{{- with .Values.image.pullSecret }}
+- name: {{ tpl . $ }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
+++ b/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
 {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
 {{- end }}
-      {{- if .Values.global.imagePullSecrets }}
+      {{- if or .Values.global.imagePullSecrets .Values.image.pullSecret }}
       imagePullSecrets:
       {{- include "elasticsearch-exporter.imagePullSecrets" . | indent 8 }}
       {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it

Include `image.pullSecret` to `elasticsearch-exporter.imagePullSecrets` template

#### Which issue this PR fixes

- fixes #4786 

#### Special notes for your reviewer

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
