### PR TITLE
[prometheus-windows-exporter] Set the correct path for readiness and liveness probes

### DIFF
--- a/charts/prometheus-windows-exporter/Chart.yaml
+++ b/charts/prometheus-windows-exporter/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - exporter
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: 0.26.1
 home: https://github.com/prometheus-community/windows_exporter/
 sources:

--- a/charts/prometheus-windows-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-windows-exporter/templates/daemonset.yaml
@@ -75,7 +75,7 @@ spec:
               - name: {{ $header.name }}
                 value: {{ $header.value }}
               {{- end }}
-              path: /
+              path: {{ .Values.livenessProbe.httpGet.path }}
               port: {{ .Values.service.port }}
               scheme: {{ upper .Values.livenessProbe.httpGet.scheme }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
@@ -90,7 +90,7 @@ spec:
               - name: {{ $header.name }}
                 value: {{ $header.value }}
               {{- end }}
-              path: /
+              path: {{ .Values.readinessProbe.httpGet.path }}
               port: {{ .Values.service.port }}
               scheme: {{ upper .Values.readinessProbe.httpGet.scheme }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}

--- a/charts/prometheus-windows-exporter/values.yaml
+++ b/charts/prometheus-windows-exporter/values.yaml
@@ -350,6 +350,7 @@ livenessProbe:
   failureThreshold: 3
   httpGet:
     httpHeaders: []
+    path: /health
     scheme: http
   initialDelaySeconds: 0
   periodSeconds: 10
@@ -362,6 +363,7 @@ readinessProbe:
   failureThreshold: 3
   httpGet:
     httpHeaders: []
+    path: /health
     scheme: http
   initialDelaySeconds: 0
   periodSeconds: 10


### PR DESCRIPTION
#### What this PR does / why we need it
This PR sets the HTTP path for the readiness and liveness probes for the Windows Exporter daemonset to `/health` and makes it configurable. It is currently set to `/` which returns 404 for many of my windows nodes on both AKS and EKS clusters. Likely because that path [was removed recently](https://github.com/prometheus-community/windows_exporter/commit/b977c8484b6341f706943cc1fc03247e5e836e99). When I manually edit the path to choose `/health` the probes start working again.


#### Which issue this PR fixes

- fixes #4790 

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
