### PR TITLE
[alertmanager] Add apiVersion and kind to StatefulSet volumeClaimTemplates

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 1.12.0
+version: 1.12.1
 appVersion: v0.27.0
 kubeVersion: ">=1.19.0-0"
 keywords:

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -230,7 +230,9 @@ spec:
         {{- end }}
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: storage
       spec:
         accessModes:


### PR DESCRIPTION
#### Background
[ArgoCD](https://argo-cd.readthedocs.io/en/stable/user-guide/helm/#declarative) may take Helm charts as inputs, but does not install the Helm charts directly, instead it uses the `helm template` command that produces YAML file resources and then injects them directly. The result will look almost like a `helm install` command, but the deployment will not show up using `helm list`.

By using this mechanism ArgoCD can perform its own “diffing” and warn when the desired state does not match the cluster (for example if a person modified the resources after the deployment). It has the drawback that if some mechanism modifies the deployed resource(s) in an automatic way, ArgoCD will show the sync status as “OutOfSync” with a yellow arrow up icon.

#### What this PR does / why we need it
The Alertmanager StatefulSet has a `volumeClaimTemplates:`  with one volume claim template. This template is missing the fields `apiVersion` and `kind`. When installed by Helm, Kubernetes will automatically add these missing fields (by a mechanism I have not digged deeper into).

This pull request will make the StatefulSet look more similar when comparing `helm template` with how the resource looks like in the cluster. This will make ArgoCD happy (with a green checkmark icon).

This pull request is analogous to what #4610 fixed.

#### Which issue this PR fixes
- fixes #4848

#### Special notes for your reviewer

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
