### PR TITLE
[alertmanager-snmp-notifier] bump to 1.6.0

### DIFF
--- a/charts/alertmanager-snmp-notifier/Chart.yaml
+++ b/charts/alertmanager-snmp-notifier/Chart.yaml
@@ -5,8 +5,8 @@ home: https://github.com/maxwo/snmp_notifier
 sources:
   - https://github.com/maxwo/snmp_notifier
 type: application
-version: 0.3.0
-appVersion: v1.5.0
+version: 0.4.0
+appVersion: v1.6.0
 keywords:
   - monitoring
 maintainers:

--- a/charts/alertmanager-snmp-notifier/README.md
+++ b/charts/alertmanager-snmp-notifier/README.md
@@ -20,7 +20,7 @@ _See [helm repository](https://helm.sh/docs/helm/helm_repo/) for command documen
 ## Install Chart
 
 ```console
-helm install [RELEASE_NAME] prometheus-community/snmp-notifier
+helm install [RELEASE_NAME] prometheus-community/alertmanager-snmp-notifier
 ```
 
 _See [configuration](#configuration) below._


### PR DESCRIPTION
#### What this PR does / why we need it

It keeps the helm charts up to date with latest version of SNMP-notifier. It includes new options as well as security fixes.

#### Which issue this PR fixes

No fix, just a version update.

#### Special notes for your reviewer

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
