### PR TITLE
[kube-prometheus-stack] add tpl to prometheus service account

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 65.0.0
+version: 65.1.0
 appVersion: v0.77.1
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/serviceaccount.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/serviceaccount.yaml
@@ -9,9 +9,9 @@ metadata:
     app.kubernetes.io/name: {{ template "kube-prometheus-stack.name" . }}-prometheus
     app.kubernetes.io/component: prometheus
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
-{{- if .Values.prometheus.serviceAccount.annotations }}
+{{- with .Values.prometheus.serviceAccount.annotations }}
   annotations:
-{{ toYaml .Values.prometheus.serviceAccount.annotations | indent 4 }}
+{{ tpl (toYaml .) $ | indent 4 }}
 {{- end }}
 automountServiceAccountToken: {{ .Values.prometheus.serviceAccount.automountServiceAccountToken }}
 {{- if .Values.global.imagePullSecrets }}


### PR DESCRIPTION
**What this PR does / why we need it**

We're moving our infra charts from Terraform to ArgoCD/ApplicationSets and we need the ability to template
some values with an environment name, accountID and etc ... 

In this case, we need the ability to template the service account and inject account id and environment name to the IAM role ARN 

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)