### PR TITLE
[kube-prometheus-stack] add tpl to some templates 

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 65.2.0
+version: 65.2.1
 appVersion: v0.77.1
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -217,7 +217,7 @@ spec:
 {{- end }}
     {{- with .Values.prometheusOperator.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
+{{ tpl (toYaml .) $ | indent 8 }}
     {{- end }}
     {{- with .Values.prometheusOperator.affinity }}
       affinity:
@@ -225,6 +225,6 @@ spec:
     {{- end }}
     {{- with .Values.prometheusOperator.tolerations }}
       tolerations:
-{{ toYaml . | indent 8 }}
+{{ tpl (toYaml .) $ | indent 8 }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**

We're moving our infra charts from Terraform to ArgoCD/ApplicationSets and we need the ability to template nodeSelector and tolerations

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)