### PR TITLE
[kube-state-metrics] Adding Path to servicemonitor

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - kubernetes
 type: application
-version: 5.25.2
+version: 5.25.1
 appVersion: 2.13.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - kubernetes
 type: application
-version: 5.25.1
+version: 5.25.2
 appVersion: 2.13.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/servicemonitor.yaml
+++ b/charts/kube-state-metrics/templates/servicemonitor.yaml
@@ -40,6 +40,8 @@ spec:
     {{- end }}
   endpoints:
     - port: http
+    {{- if or .Values.prometheus.monitor.http.path .Values.prometheus.monitor.path }}
+      path: {{ .Values.prometheus.monitor.http.path | default .Values.prometheus.monitor.path }}
     {{- if or .Values.prometheus.monitor.http.interval .Values.prometheus.monitor.interval }}
       interval: {{ .Values.prometheus.monitor.http.interval | default .Values.prometheus.monitor.interval }}
     {{- end }}

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -193,6 +193,7 @@ prometheus:
 
     ## kube-state-metrics endpoint
     http:
+      path: "/metrics"
       interval: ""
       scrapeTimeout: ""
       proxyUrl: ""


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
In various scraping tools the path to the metrics endpoint is needed, therefore added the path to the service-monitor. 

#### Which issue this PR fixes

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
