### PR TITLE
[kube-prometheus-stack] Add downward compat for Prom CRD 

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 65.3.2
+version: 65.4.0
 appVersion: v0.77.1
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 65.2.0
+version: 65.3.0
 appVersion: v0.77.1
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -253,13 +253,13 @@ spec:
   scrapeConfigSelector:
     matchLabels:
       release: {{ $.Release.Name | quote }}
-{{ else }}
+{{ else if not (eq .Values.prometheus.prometheusSpec.scrapeConfigSelector nil) }}
   scrapeConfigSelector: {}
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.scrapeConfigNamespaceSelector }}
   scrapeConfigNamespaceSelector:
 {{ tpl (toYaml .Values.prometheus.prometheusSpec.scrapeConfigNamespaceSelector | indent 4) . }}
-{{ else }}
+{{ else if not (eq .Values.prometheus.prometheusSpec.scrapeConfigNamespaceSelector nil) }}
   scrapeConfigNamespaceSelector: {}
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.storageSpec }}

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -253,13 +253,13 @@ spec:
   scrapeConfigSelector:
     matchLabels:
       release: {{ $.Release.Name | quote }}
-{{ else if not (eq .Values.prometheus.prometheusSpec.scrapeConfigSelector nil) }}
+{{ else if ne .Values.prometheus.prometheusSpec.scrapeConfigSelector nil }}
   scrapeConfigSelector: {}
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.scrapeConfigNamespaceSelector }}
   scrapeConfigNamespaceSelector:
 {{ tpl (toYaml .Values.prometheus.prometheusSpec.scrapeConfigNamespaceSelector | indent 4) . }}
-{{ else if not (eq .Values.prometheus.prometheusSpec.scrapeConfigNamespaceSelector nil) }}
+{{ else if ne .Values.prometheus.prometheusSpec.scrapeConfigNamespaceSelector nil }}
   scrapeConfigNamespaceSelector: {}
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.storageSpec }}

--- a/charts/kube-prometheus-stack/unittests/prometheus/scrape_config_namespace_selector_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/prometheus/scrape_config_namespace_selector_test.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test scrapeConfigNamespaceSelector
+templates:
+  - prometheus/prometheus.yaml
+tests:
+  - it: should be empty by default
+    asserts:
+      - equal:
+          path: spec.scrapeConfigNamespaceSelector
+          value: {}
+  - it: should be set to a specific label
+    set:
+      prometheus:
+        prometheusSpec:
+          scrapeConfigNamespaceSelector:
+            matchLabels:
+              abc: def
+    asserts:
+      - equal:
+          path: spec.scrapeConfigNamespaceSelector.matchLabels.abc
+          value: def
+  - it: should be ignored, if set to null
+    set:
+      prometheus:
+        prometheusSpec:
+          scrapeConfigNamespaceSelector: null
+    asserts:
+      - notExists:
+          path: spec.scrapeConfigNamespaceSelector

--- a/charts/kube-prometheus-stack/unittests/prometheus/scrape_config_selector_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/prometheus/scrape_config_selector_test.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test scrapeConfigSelector
+templates:
+  - prometheus/prometheus.yaml
+tests:
+  - it: should match the release name by default 
+    asserts:
+      - equal:
+          path: spec.scrapeConfigSelector.matchLabels.release
+          value: RELEASE-NAME
+  - it: should be set to a specific label
+    set:
+      prometheus:
+        prometheusSpec:
+          scrapeConfigSelector:
+            abc: def
+    asserts:
+      - equal:
+          path: spec.scrapeConfigSelector
+          value:
+            abc: def
+  - it: should be set to a specific label
+    set:
+      prometheus:
+        prometheusSpec:
+          scrapeConfigSelector:
+            matchLabels:
+              abc: def
+    asserts:
+      - equal:
+          path: spec.scrapeConfigSelector.matchLabels.abc
+          value: def
+  - it: should be ignored, if set to null
+    set:
+      prometheus:
+        prometheusSpec:
+          scrapeConfigSelector: null
+          scrapeConfigSelectorNilUsesHelmValues: null
+    asserts:
+      - notExists:
+          path: spec.scrapeConfigSelector

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -3693,9 +3693,9 @@ prometheus:
     ## prometheus resource to be created with selectors based on values in the helm deployment,
     ## which will also match the scrapeConfigs created
     ##
-    ## If null and scrapeConfigSelector is also null, exclude field from the prometheusSpec  
-    ## (keeping downward compatibility with older versions of CRD)  
-    ##  
+    ## If null and scrapeConfigSelector is also null, exclude field from the prometheusSpec
+    ## (keeping downward compatibility with older versions of CRD)
+    ##
     scrapeConfigSelectorNilUsesHelmValues: true
 
     ## scrapeConfigs to be selected for target discovery.
@@ -3708,7 +3708,7 @@ prometheus:
     #     prometheus: somelabel
 
     ## If nil, select own namespace. Namespaces to be selected for scrapeConfig discovery.
-    ## If null, exclude the field from the prometheusSpec (keeping downward compatibility with older versions of CRD)  
+    ## If null, exclude the field from the prometheusSpec (keeping downward compatibility with older versions of CRD)
     scrapeConfigNamespaceSelector: {}
     ## Example which selects scrapeConfig in namespaces with label "prometheus" set to "somelabel"
     # scrapeConfigNamespaceSelector:

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -40,7 +40,7 @@ customRules: {}
   #   for: 3m
   # AlertmanagerMembersInconsistent:
   #   for: 5m
-  #   severity: "warning"
+#   severity: "warning"
 
 ## Create default rules for monitoring the cluster
 ##
@@ -220,7 +220,7 @@ global:
       ##
       # seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
       # seccomp.security.alpha.kubernetes.io/defaultProfileName: 'docker/default'
-      # apparmor.security.beta.kubernetes.io/defaultProfileName: 'runtime/default'
+    # apparmor.security.beta.kubernetes.io/defaultProfileName: 'runtime/default'
 
   ## Global image registry to use if it needs to be overriden for some specific use cases (e.g local registries, custom images, ...)
   ##
@@ -337,13 +337,13 @@ alertmanager:
       repeat_interval: 12h
       receiver: 'null'
       routes:
-      - receiver: 'null'
-        matchers:
-          - alertname = "Watchdog"
+        - receiver: 'null'
+          matchers:
+            - alertname = "Watchdog"
     receivers:
-    - name: 'null'
+      - name: 'null'
     templates:
-    - '/etc/alertmanager/config/*.tmpl'
+      - '/etc/alertmanager/config/*.tmpl'
 
   ## Alertmanager configuration directives (as string type, preferred over the config hash map)
   ## stringConfig will be used only, if tplConfig is true
@@ -410,7 +410,7 @@ alertmanager:
     ## Hosts must be provided if Ingress is enabled.
     ##
     hosts: []
-      # - alertmanager.domain.com
+    # - alertmanager.domain.com
 
     ## Paths to use for ingress rules - one path should match the alertmanagerSpec.routePrefix
     ##
@@ -1001,7 +1001,7 @@ grafana:
     ##
     annotations: {}
       # kubernetes.io/ingress.class: nginx
-      # kubernetes.io/tls-acme: "true"
+    # kubernetes.io/tls-acme: "true"
 
     ## Labels to be added to the Ingress
     ##
@@ -1099,7 +1099,7 @@ grafana:
       ## Can be provisioned via additionalDataSources
       exemplarTraceIdDestinations: {}
         # datasourceUid: Jaeger
-        # traceIdLabelName: trace_id
+      # traceIdLabelName: trace_id
       alertmanager:
         enabled: true
         name: Alertmanager
@@ -2294,7 +2294,7 @@ prometheusOperator:
       # Ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
       podDisruptionBudget: {}
         # maxUnavailable: 1
-        # minAvailable: 1
+      # minAvailable: 1
 
       ## Number of old replicasets to retain ##
       ## The default value is 10, 0 will garbage-collect old replicasets ##
@@ -2465,7 +2465,7 @@ prometheusOperator:
         #       - key: kubernetes.io/e2e-az-name
         #         operator: In
         #         values:
-        #         - e2e-az1
+      #         - e2e-az1
       #         - e2e-az2
       dnsConfig: {}
         # nameservers:
@@ -2476,7 +2476,7 @@ prometheusOperator:
         # options:
         #   - name: ndots
         #     value: "2"
-        #   - name: edns0
+      #   - name: edns0
       securityContext:
         fsGroup: 65534
         runAsGroup: 65534
@@ -2545,7 +2545,7 @@ prometheusOperator:
         readOnlyRootFilesystem: true
         capabilities:
           drop:
-          - ALL
+            - ALL
 
       # Security context for patch job container
     patchWebhookJob:
@@ -2554,7 +2554,7 @@ prometheusOperator:
         readOnlyRootFilesystem: true
         capabilities:
           drop:
-          - ALL
+            - ALL
 
     # Use certmanager to generate webhook certs
     certManager:
@@ -2574,7 +2574,7 @@ prometheusOperator:
   namespaces: {}
     # releaseNamespace: true
     # additional:
-    # - kube-system
+  # - kube-system
 
   ## Namespaces not to scope the interaction of the Prometheus Operator (deny list).
   ##
@@ -2629,32 +2629,32 @@ prometheusOperator:
       enabled: false
       ipFamilies: ["IPv6", "IPv4"]
       ipFamilyPolicy: "PreferDualStack"
-
-  ## Port to expose on each node
-  ## Only used if service.type is 'NodePort'
-  ##
+    
+    ## Port to expose on each node
+    ## Only used if service.type is 'NodePort'
+    ##
     nodePort: 30080
 
     nodePortTls: 30443
-
-  ## Additional ports to open for Prometheus operator service
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#multi-port-services
-  ##
+    
+    ## Additional ports to open for Prometheus operator service
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#multi-port-services
+    ##
     additionalPorts: []
-
-  ## Loadbalancer IP
-  ## Only use if service.type is "LoadBalancer"
-  ##
+    
+    ## Loadbalancer IP
+    ## Only use if service.type is "LoadBalancer"
+    ##
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
 
     ## Denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints
     ##
     externalTrafficPolicy: Cluster
-
-  ## Service type
-  ## NodePort, ClusterIP, LoadBalancer
-  ##
+    
+    ## Service type
+    ## NodePort, ClusterIP, LoadBalancer
+    ##
     type: ClusterIP
 
     ## List of IP addresses at which the Prometheus server service is available
@@ -2799,7 +2799,7 @@ prometheusOperator:
     #         operator: In
     #         values:
     #         - e2e-az1
-    #         - e2e-az2
+  #         - e2e-az2
   dnsConfig: {}
     # nameservers:
     #   - 1.2.3.4
@@ -2808,7 +2808,7 @@ prometheusOperator:
     #   - my.dns.search.suffix
     # options:
     #   - name: ndots
-    #     value: "2"
+  #     value: "2"
   #   - name: edns0
   securityContext:
     fsGroup: 65534
@@ -2826,7 +2826,7 @@ prometheusOperator:
     readOnlyRootFilesystem: true
     capabilities:
       drop:
-      - ALL
+        - ALL
 
   # Enable vertical pod autoscaler support for prometheus-operator
   verticalPodAutoscaler:
@@ -2905,7 +2905,7 @@ prometheusOperator:
       #   memory: 50Mi
       # limits:
       #   cpu: 200m
-      #   memory: 50Mi
+    #   memory: 50Mi
 
   ## Thanos side-car image when configured
   ##
@@ -3227,7 +3227,7 @@ prometheus:
     ## Hosts must be provided if Ingress is enabled.
     ##
     hosts: []
-      # - thanos-gateway.domain.com
+    # - thanos-gateway.domain.com
 
     ## Paths to use for ingress rules
     ##
@@ -3293,7 +3293,7 @@ prometheus:
     tls: []
       # - secretName: prometheus-general-tls
       #   hosts:
-      #     - prometheus.example.com
+    #     - prometheus.example.com
 
   ## Configuration for creating an Ingress that will map to each Prometheus replica service
   ## prometheus.servicePerReplica must be enabled
@@ -3490,7 +3490,7 @@ prometheus:
       ## Maximum number of exemplars stored in memory for all series.
       ## If not set, Prometheus uses its default value.
       ## A value of zero or less than zero disables the storage.
-      # maxSize: 100000
+    # maxSize: 100000
 
     # EnableFeatures API enables access to Prometheus disabled features.
     # ref: https://prometheus.io/docs/prometheus/latest/disabled_features/
@@ -3692,6 +3692,8 @@ prometheus:
     ## If true, a nil or {} value for prometheus.prometheusSpec.scrapeConfigSelector will cause the
     ## prometheus resource to be created with selectors based on values in the helm deployment,
     ## which will also match the scrapeConfigs created
+    ## If null and scrapeConfigSelector is also null, exclude field from the prometheusSpec
+    ## (keeping downward compatibility with older versions of CRD)
     ##
     scrapeConfigSelectorNilUsesHelmValues: true
 
@@ -3705,6 +3707,7 @@ prometheus:
     #     prometheus: somelabel
 
     ## If nil, select own namespace. Namespaces to be selected for scrapeConfig discovery.
+    ## If null, exclude the field from the prometheusSpec (keeping downward compatibility with older versions of CRD)
     scrapeConfigNamespaceSelector: {}
     ## Example which selects scrapeConfig in namespaces with label "prometheus" set to "somelabel"
     # scrapeConfigNamespaceSelector:
@@ -3902,7 +3905,7 @@ prometheus:
     additionalScrapeConfigsSecret: {}
       # enabled: false
       # name:
-      # key:
+    # key:
 
     ## additionalPrometheusSecretsAnnotations allows to add annotations to the kubernetes secret. This can be useful
     ## when deploying via spinnaker to disable versioning on the secret, strategy.spinnaker.io/versioned: 'false'
@@ -3931,7 +3934,7 @@ prometheus:
     additionalAlertManagerConfigsSecret: {}
       # name:
       # key:
-      # optional: false
+    # optional: false
 
     ## AdditionalAlertRelabelConfigs allows specifying Prometheus alert relabel configurations. Alert relabel configurations specified are appended
     ## to the configurations generated by the Prometheus Operator. Alert relabel configurations specified must have the form as specified in the
@@ -3952,7 +3955,7 @@ prometheus:
     ## Cannot be used with additionalAlertRelabelConfigs
     additionalAlertRelabelConfigsSecret: {}
       # name:
-      # key:
+    # key:
 
     ## SecurityContext holds pod-level security attributes and common container settings.
     ## This defaults to non root user with uid 1000 and gid 2000.
@@ -3998,7 +4001,7 @@ prometheus:
       #     #   endpoint: ""
       #     #   region: ""
       #     #   access_key: ""
-      #     #   secret_key: ""
+    #     #   secret_key: ""
 
     ## Containers allows injecting additional containers. This is meant to allow adding an authentication proxy to a Prometheus pod.
     ## if using proxy extraContainer update targetPort with proxy container port
@@ -4155,9 +4158,9 @@ prometheus:
   #    verbs: [ "get", "list", "watch" ]
 
   additionalServiceMonitors: []
-  ## Name of the ServiceMonitor to create
-  ##
-  # - name: ""
+    ## Name of the ServiceMonitor to create
+    ##
+    # - name: ""
 
     ## Additional labels to set used for the ServiceMonitorSelector. Together with standard labels from
     ## the chart
@@ -4184,64 +4187,64 @@ prometheus:
     ## Namespaces from which services are selected
     ##
     # namespaceSelector:
-      ## Match any namespace
-      ##
-      # any: false
-
-      ## Explicit list of namespace names to select
-      ##
-      # matchNames: []
+    ## Match any namespace
+    ##
+    # any: false
+    
+    ## Explicit list of namespace names to select
+    ##
+    # matchNames: []
 
     ## Endpoints of the selected service to be monitored
     ##
     # endpoints: []
-      ## Name of the endpoint's service port
-      ## Mutually exclusive with targetPort
-      # - port: ""
-
-      ## Name or number of the endpoint's target port
-      ## Mutually exclusive with port
-      # - targetPort: ""
-
-      ## File containing bearer token to be used when scraping targets
-      ##
-      #   bearerTokenFile: ""
-
-      ## Interval at which metrics should be scraped
-      ##
-      #   interval: 30s
-
-      ## HTTP path to scrape for metrics
-      ##
-      #   path: /metrics
-
-      ## HTTP scheme to use for scraping
-      ##
-      #   scheme: http
-
-      ## TLS configuration to use when scraping the endpoint
-      ##
-      #   tlsConfig:
-
-          ## Path to the CA file
-          ##
-          # caFile: ""
-
-          ## Path to client certificate file
-          ##
-          # certFile: ""
-
-          ## Skip certificate verification
-          ##
-          # insecureSkipVerify: false
-
-          ## Path to client key file
-          ##
-          # keyFile: ""
-
-          ## Server name used to verify host name
-          ##
-          # serverName: ""
+    ## Name of the endpoint's service port
+    ## Mutually exclusive with targetPort
+    # - port: ""
+    
+    ## Name or number of the endpoint's target port
+    ## Mutually exclusive with port
+    # - targetPort: ""
+    
+    ## File containing bearer token to be used when scraping targets
+    ##
+    #   bearerTokenFile: ""
+    
+    ## Interval at which metrics should be scraped
+    ##
+    #   interval: 30s
+    
+    ## HTTP path to scrape for metrics
+    ##
+    #   path: /metrics
+    
+    ## HTTP scheme to use for scraping
+    ##
+    #   scheme: http
+    
+    ## TLS configuration to use when scraping the endpoint
+    ##
+    #   tlsConfig:
+    
+    ## Path to the CA file
+    ##
+    # caFile: ""
+    
+    ## Path to client certificate file
+    ##
+    # certFile: ""
+    
+    ## Skip certificate verification
+    ##
+    # insecureSkipVerify: false
+    
+    ## Path to client key file
+    ##
+    # keyFile: ""
+    
+    ## Server name used to verify host name
+    ##
+    # serverName: ""
 
     ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
@@ -4260,12 +4263,12 @@ prometheus:
     #   regex: ^(.*)$
     #   targetLabel: nodename
     #   replacement: $1
-    #   action: replace
+  #   action: replace
 
   additionalPodMonitors: []
-  ## Name of the PodMonitor to create
-  ##
-  # - name: ""
+    ## Name of the PodMonitor to create
+    ##
+    # - name: ""
 
     ## Additional labels to set used for the PodMonitorSelector. Together with standard labels from
     ## the chart
@@ -4292,18 +4295,18 @@ prometheus:
     ## Namespaces from which pods are selected
     ##
     # namespaceSelector:
-      ## Match any namespace
-      ##
-      # any: false
-
-      ## Explicit list of namespace names to select
-      ##
-      # matchNames: []
+    ## Match any namespace
+    ##
+    # any: false
+    
+    ## Explicit list of namespace names to select
+    ##
+    # matchNames: []
 
     ## Endpoints of the selected pods to be monitored
     ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#podmetricsendpoint
     ##
-    # podMetricsEndpoints: []
+  # podMetricsEndpoints: []
 
 ## Configuration for thanosRuler
 ## ref: https://thanos.io/tip/components/rule.md/
@@ -4348,7 +4351,7 @@ thanosRuler:
     ## Hosts must be provided if Ingress is enabled.
     ##
     hosts: []
-      # - thanosruler.domain.com
+    # - thanosruler.domain.com
 
     ## Paths to use for ingress rules - one path should match the thanosruler.routePrefix
     ##
@@ -4568,7 +4571,7 @@ thanosRuler:
       # use existing secret, if configured, alertmanagersConfig.secret will not be used
       existingSecret: {}
         # name: ""
-        # key: ""
+      # key: ""
       # will render alertmanagersConfig secret data and configure it to be used by Thanos Ruler custom resource, ignored when alertmanagersConfig.existingSecret is set
       # https://thanos.io/tip/components/rule.md/#alertmanager
       secret: {}
@@ -4581,7 +4584,7 @@ thanosRuler:
         #   static_configs:
         #     - alertmanager.thanos.io
         #   scheme: http
-        #   timeout: 10s
+      #   timeout: 10s
 
     ## DEPRECATED. Define URLs to send alerts to Alertmanager. For Thanos v0.10.0 and higher, alertmanagersConfig should be used instead.
     ## Note: this field will be ignored if alertmanagersConfig is specified. Maps to the alertmanagers.url Thanos Ruler arg.
@@ -4605,7 +4608,7 @@ thanosRuler:
       # use existing secret, if configured, objectStorageConfig.secret will not be used
       existingSecret: {}
         # name: ""
-        # key: ""
+      # key: ""
       # will render objectStorageConfig secret data and configure it to be used by Thanos Ruler custom resource, ignored when objectStorageConfig.existingSecret is set
       # https://thanos.io/tip/thanos/storage.md/#s3
       secret: {}
@@ -4615,7 +4618,7 @@ thanosRuler:
         #   endpoint: ""
         #   region: ""
         #   access_key: ""
-        #   secret_key: ""
+      #   secret_key: ""
 
     ## Labels by name to drop before sending to alertmanager
     ## Maps to the --alert.label-drop flag of thanos ruler.
@@ -4631,7 +4634,7 @@ thanosRuler:
       # use existing secret, if configured, queryConfig.secret will not be used
       existingSecret: {}
         # name: ""
-        # key: ""
+      # key: ""
       # render queryConfig secret data and configure it to be used by Thanos Ruler custom resource, ignored when queryConfig.existingSecret is set
       # https://thanos.io/tip/components/rule.md/#query-api
       secret: {}
@@ -4642,7 +4645,7 @@ thanosRuler:
         #   static_configs:
         #     - URL
         #   scheme: http
-        #   timeout: 10s
+      #   timeout: 10s
 
     ## Labels configure the external label pairs to ThanosRuler. A default replica
     ## label `thanos_ruler_replica` will be always added as a label with the value
@@ -4662,7 +4665,7 @@ thanosRuler:
       #     "remote_write":
       #     - "name": "receiver-0"
       #       "remote_timeout": "30s"
-      #       "url": "http://thanos-receiver-0.thanos-receiver:8081/api/v1/receive"
+    #       "url": "http://thanos-receiver-0.thanos-receiver:8081/api/v1/receive"
 
     ## Define which Nodes the Pods are scheduled on.
     ## ref: https://kubernetes.io/docs/user-guide/node-selection/
@@ -4795,4 +4798,4 @@ extraManifests: []
   #   labels:
   #     name: prometheus-extra
   #   data:
-  #     extra-data: "value"
+#     extra-data: "value"

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -40,7 +40,7 @@ customRules: {}
   #   for: 3m
   # AlertmanagerMembersInconsistent:
   #   for: 5m
-#   severity: "warning"
+  #   severity: "warning"
 
 ## Create default rules for monitoring the cluster
 ##
@@ -220,7 +220,7 @@ global:
       ##
       # seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
       # seccomp.security.alpha.kubernetes.io/defaultProfileName: 'docker/default'
-    # apparmor.security.beta.kubernetes.io/defaultProfileName: 'runtime/default'
+      # apparmor.security.beta.kubernetes.io/defaultProfileName: 'runtime/default'
 
   ## Global image registry to use if it needs to be overriden for some specific use cases (e.g local registries, custom images, ...)
   ##
@@ -337,13 +337,13 @@ alertmanager:
       repeat_interval: 12h
       receiver: 'null'
       routes:
-        - receiver: 'null'
-          matchers:
-            - alertname = "Watchdog"
+      - receiver: 'null'
+        matchers:
+          - alertname = "Watchdog"
     receivers:
-      - name: 'null'
+    - name: 'null'
     templates:
-      - '/etc/alertmanager/config/*.tmpl'
+    - '/etc/alertmanager/config/*.tmpl'
 
   ## Alertmanager configuration directives (as string type, preferred over the config hash map)
   ## stringConfig will be used only, if tplConfig is true
@@ -410,7 +410,7 @@ alertmanager:
     ## Hosts must be provided if Ingress is enabled.
     ##
     hosts: []
-    # - alertmanager.domain.com
+      # - alertmanager.domain.com
 
     ## Paths to use for ingress rules - one path should match the alertmanagerSpec.routePrefix
     ##
@@ -1001,7 +1001,7 @@ grafana:
     ##
     annotations: {}
       # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+      # kubernetes.io/tls-acme: "true"
 
     ## Labels to be added to the Ingress
     ##
@@ -1099,7 +1099,7 @@ grafana:
       ## Can be provisioned via additionalDataSources
       exemplarTraceIdDestinations: {}
         # datasourceUid: Jaeger
-      # traceIdLabelName: trace_id
+        # traceIdLabelName: trace_id
       alertmanager:
         enabled: true
         name: Alertmanager
@@ -2294,7 +2294,7 @@ prometheusOperator:
       # Ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
       podDisruptionBudget: {}
         # maxUnavailable: 1
-      # minAvailable: 1
+        # minAvailable: 1
 
       ## Number of old replicasets to retain ##
       ## The default value is 10, 0 will garbage-collect old replicasets ##
@@ -2465,7 +2465,7 @@ prometheusOperator:
         #       - key: kubernetes.io/e2e-az-name
         #         operator: In
         #         values:
-      #         - e2e-az1
+        #         - e2e-az1
       #         - e2e-az2
       dnsConfig: {}
         # nameservers:
@@ -2476,7 +2476,7 @@ prometheusOperator:
         # options:
         #   - name: ndots
         #     value: "2"
-      #   - name: edns0
+        #   - name: edns0
       securityContext:
         fsGroup: 65534
         runAsGroup: 65534
@@ -2545,7 +2545,7 @@ prometheusOperator:
         readOnlyRootFilesystem: true
         capabilities:
           drop:
-            - ALL
+          - ALL
 
       # Security context for patch job container
     patchWebhookJob:
@@ -2554,7 +2554,7 @@ prometheusOperator:
         readOnlyRootFilesystem: true
         capabilities:
           drop:
-            - ALL
+          - ALL
 
     # Use certmanager to generate webhook certs
     certManager:
@@ -2574,7 +2574,7 @@ prometheusOperator:
   namespaces: {}
     # releaseNamespace: true
     # additional:
-  # - kube-system
+    # - kube-system
 
   ## Namespaces not to scope the interaction of the Prometheus Operator (deny list).
   ##
@@ -2629,32 +2629,32 @@ prometheusOperator:
       enabled: false
       ipFamilies: ["IPv6", "IPv4"]
       ipFamilyPolicy: "PreferDualStack"
-    
-    ## Port to expose on each node
-    ## Only used if service.type is 'NodePort'
-    ##
+
+  ## Port to expose on each node
+  ## Only used if service.type is 'NodePort'
+  ##
     nodePort: 30080
 
     nodePortTls: 30443
-    
-    ## Additional ports to open for Prometheus operator service
-    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#multi-port-services
-    ##
+
+  ## Additional ports to open for Prometheus operator service
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#multi-port-services
+  ##
     additionalPorts: []
-    
-    ## Loadbalancer IP
-    ## Only use if service.type is "LoadBalancer"
-    ##
+
+  ## Loadbalancer IP
+  ## Only use if service.type is "LoadBalancer"
+  ##
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
 
     ## Denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints
     ##
     externalTrafficPolicy: Cluster
-    
-    ## Service type
-    ## NodePort, ClusterIP, LoadBalancer
-    ##
+
+  ## Service type
+  ## NodePort, ClusterIP, LoadBalancer
+  ##
     type: ClusterIP
 
     ## List of IP addresses at which the Prometheus server service is available
@@ -2799,7 +2799,7 @@ prometheusOperator:
     #         operator: In
     #         values:
     #         - e2e-az1
-  #         - e2e-az2
+    #         - e2e-az2
   dnsConfig: {}
     # nameservers:
     #   - 1.2.3.4
@@ -2808,7 +2808,7 @@ prometheusOperator:
     #   - my.dns.search.suffix
     # options:
     #   - name: ndots
-  #     value: "2"
+    #     value: "2"
   #   - name: edns0
   securityContext:
     fsGroup: 65534
@@ -2826,7 +2826,7 @@ prometheusOperator:
     readOnlyRootFilesystem: true
     capabilities:
       drop:
-        - ALL
+      - ALL
 
   # Enable vertical pod autoscaler support for prometheus-operator
   verticalPodAutoscaler:
@@ -2905,7 +2905,7 @@ prometheusOperator:
       #   memory: 50Mi
       # limits:
       #   cpu: 200m
-    #   memory: 50Mi
+      #   memory: 50Mi
 
   ## Thanos side-car image when configured
   ##
@@ -3227,7 +3227,7 @@ prometheus:
     ## Hosts must be provided if Ingress is enabled.
     ##
     hosts: []
-    # - thanos-gateway.domain.com
+      # - thanos-gateway.domain.com
 
     ## Paths to use for ingress rules
     ##
@@ -3293,7 +3293,7 @@ prometheus:
     tls: []
       # - secretName: prometheus-general-tls
       #   hosts:
-    #     - prometheus.example.com
+      #     - prometheus.example.com
 
   ## Configuration for creating an Ingress that will map to each Prometheus replica service
   ## prometheus.servicePerReplica must be enabled
@@ -3490,7 +3490,7 @@ prometheus:
       ## Maximum number of exemplars stored in memory for all series.
       ## If not set, Prometheus uses its default value.
       ## A value of zero or less than zero disables the storage.
-    # maxSize: 100000
+      # maxSize: 100000
 
     # EnableFeatures API enables access to Prometheus disabled features.
     # ref: https://prometheus.io/docs/prometheus/latest/disabled_features/
@@ -3692,9 +3692,10 @@ prometheus:
     ## If true, a nil or {} value for prometheus.prometheusSpec.scrapeConfigSelector will cause the
     ## prometheus resource to be created with selectors based on values in the helm deployment,
     ## which will also match the scrapeConfigs created
-    ## If null and scrapeConfigSelector is also null, exclude field from the prometheusSpec
-    ## (keeping downward compatibility with older versions of CRD)
     ##
+    ## If null and scrapeConfigSelector is also null, exclude field from the prometheusSpec  
+    ## (keeping downward compatibility with older versions of CRD)  
+    ##  
     scrapeConfigSelectorNilUsesHelmValues: true
 
     ## scrapeConfigs to be selected for target discovery.
@@ -3707,7 +3708,7 @@ prometheus:
     #     prometheus: somelabel
 
     ## If nil, select own namespace. Namespaces to be selected for scrapeConfig discovery.
-    ## If null, exclude the field from the prometheusSpec (keeping downward compatibility with older versions of CRD)
+    ## If null, exclude the field from the prometheusSpec (keeping downward compatibility with older versions of CRD)  
     scrapeConfigNamespaceSelector: {}
     ## Example which selects scrapeConfig in namespaces with label "prometheus" set to "somelabel"
     # scrapeConfigNamespaceSelector:
@@ -3905,7 +3906,7 @@ prometheus:
     additionalScrapeConfigsSecret: {}
       # enabled: false
       # name:
-    # key:
+      # key:
 
     ## additionalPrometheusSecretsAnnotations allows to add annotations to the kubernetes secret. This can be useful
     ## when deploying via spinnaker to disable versioning on the secret, strategy.spinnaker.io/versioned: 'false'
@@ -3934,7 +3935,7 @@ prometheus:
     additionalAlertManagerConfigsSecret: {}
       # name:
       # key:
-    # optional: false
+      # optional: false
 
     ## AdditionalAlertRelabelConfigs allows specifying Prometheus alert relabel configurations. Alert relabel configurations specified are appended
     ## to the configurations generated by the Prometheus Operator. Alert relabel configurations specified must have the form as specified in the
@@ -3955,7 +3956,7 @@ prometheus:
     ## Cannot be used with additionalAlertRelabelConfigs
     additionalAlertRelabelConfigsSecret: {}
       # name:
-    # key:
+      # key:
 
     ## SecurityContext holds pod-level security attributes and common container settings.
     ## This defaults to non root user with uid 1000 and gid 2000.
@@ -4001,7 +4002,7 @@ prometheus:
       #     #   endpoint: ""
       #     #   region: ""
       #     #   access_key: ""
-    #     #   secret_key: ""
+      #     #   secret_key: ""
 
     ## Containers allows injecting additional containers. This is meant to allow adding an authentication proxy to a Prometheus pod.
     ## if using proxy extraContainer update targetPort with proxy container port
@@ -4158,9 +4159,9 @@ prometheus:
   #    verbs: [ "get", "list", "watch" ]
 
   additionalServiceMonitors: []
-    ## Name of the ServiceMonitor to create
-    ##
-    # - name: ""
+  ## Name of the ServiceMonitor to create
+  ##
+  # - name: ""
 
     ## Additional labels to set used for the ServiceMonitorSelector. Together with standard labels from
     ## the chart
@@ -4187,64 +4188,64 @@ prometheus:
     ## Namespaces from which services are selected
     ##
     # namespaceSelector:
-    ## Match any namespace
-    ##
-    # any: false
-    
-    ## Explicit list of namespace names to select
-    ##
-    # matchNames: []
+      ## Match any namespace
+      ##
+      # any: false
+
+      ## Explicit list of namespace names to select
+      ##
+      # matchNames: []
 
     ## Endpoints of the selected service to be monitored
     ##
     # endpoints: []
-    ## Name of the endpoint's service port
-    ## Mutually exclusive with targetPort
-    # - port: ""
-    
-    ## Name or number of the endpoint's target port
-    ## Mutually exclusive with port
-    # - targetPort: ""
-    
-    ## File containing bearer token to be used when scraping targets
-    ##
-    #   bearerTokenFile: ""
-    
-    ## Interval at which metrics should be scraped
-    ##
-    #   interval: 30s
-    
-    ## HTTP path to scrape for metrics
-    ##
-    #   path: /metrics
-    
-    ## HTTP scheme to use for scraping
-    ##
-    #   scheme: http
-    
-    ## TLS configuration to use when scraping the endpoint
-    ##
-    #   tlsConfig:
-    
-    ## Path to the CA file
-    ##
-    # caFile: ""
-    
-    ## Path to client certificate file
-    ##
-    # certFile: ""
-    
-    ## Skip certificate verification
-    ##
-    # insecureSkipVerify: false
-    
-    ## Path to client key file
-    ##
-    # keyFile: ""
-    
-    ## Server name used to verify host name
-    ##
-    # serverName: ""
+      ## Name of the endpoint's service port
+      ## Mutually exclusive with targetPort
+      # - port: ""
+
+      ## Name or number of the endpoint's target port
+      ## Mutually exclusive with port
+      # - targetPort: ""
+
+      ## File containing bearer token to be used when scraping targets
+      ##
+      #   bearerTokenFile: ""
+
+      ## Interval at which metrics should be scraped
+      ##
+      #   interval: 30s
+
+      ## HTTP path to scrape for metrics
+      ##
+      #   path: /metrics
+
+      ## HTTP scheme to use for scraping
+      ##
+      #   scheme: http
+
+      ## TLS configuration to use when scraping the endpoint
+      ##
+      #   tlsConfig:
+
+          ## Path to the CA file
+          ##
+          # caFile: ""
+
+          ## Path to client certificate file
+          ##
+          # certFile: ""
+
+          ## Skip certificate verification
+          ##
+          # insecureSkipVerify: false
+
+          ## Path to client key file
+          ##
+          # keyFile: ""
+
+          ## Server name used to verify host name
+          ##
+          # serverName: ""
 
     ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
@@ -4263,12 +4264,12 @@ prometheus:
     #   regex: ^(.*)$
     #   targetLabel: nodename
     #   replacement: $1
-  #   action: replace
+    #   action: replace
 
   additionalPodMonitors: []
-    ## Name of the PodMonitor to create
-    ##
-    # - name: ""
+  ## Name of the PodMonitor to create
+  ##
+  # - name: ""
 
     ## Additional labels to set used for the PodMonitorSelector. Together with standard labels from
     ## the chart
@@ -4295,18 +4296,18 @@ prometheus:
     ## Namespaces from which pods are selected
     ##
     # namespaceSelector:
-    ## Match any namespace
-    ##
-    # any: false
-    
-    ## Explicit list of namespace names to select
-    ##
-    # matchNames: []
+      ## Match any namespace
+      ##
+      # any: false
+
+      ## Explicit list of namespace names to select
+      ##
+      # matchNames: []
 
     ## Endpoints of the selected pods to be monitored
     ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#podmetricsendpoint
     ##
-  # podMetricsEndpoints: []
+    # podMetricsEndpoints: []
 
 ## Configuration for thanosRuler
 ## ref: https://thanos.io/tip/components/rule.md/
@@ -4351,7 +4352,7 @@ thanosRuler:
     ## Hosts must be provided if Ingress is enabled.
     ##
     hosts: []
-    # - thanosruler.domain.com
+      # - thanosruler.domain.com
 
     ## Paths to use for ingress rules - one path should match the thanosruler.routePrefix
     ##
@@ -4571,7 +4572,7 @@ thanosRuler:
       # use existing secret, if configured, alertmanagersConfig.secret will not be used
       existingSecret: {}
         # name: ""
-      # key: ""
+        # key: ""
       # will render alertmanagersConfig secret data and configure it to be used by Thanos Ruler custom resource, ignored when alertmanagersConfig.existingSecret is set
       # https://thanos.io/tip/components/rule.md/#alertmanager
       secret: {}
@@ -4584,7 +4585,7 @@ thanosRuler:
         #   static_configs:
         #     - alertmanager.thanos.io
         #   scheme: http
-      #   timeout: 10s
+        #   timeout: 10s
 
     ## DEPRECATED. Define URLs to send alerts to Alertmanager. For Thanos v0.10.0 and higher, alertmanagersConfig should be used instead.
     ## Note: this field will be ignored if alertmanagersConfig is specified. Maps to the alertmanagers.url Thanos Ruler arg.
@@ -4608,7 +4609,7 @@ thanosRuler:
       # use existing secret, if configured, objectStorageConfig.secret will not be used
       existingSecret: {}
         # name: ""
-      # key: ""
+        # key: ""
       # will render objectStorageConfig secret data and configure it to be used by Thanos Ruler custom resource, ignored when objectStorageConfig.existingSecret is set
       # https://thanos.io/tip/thanos/storage.md/#s3
       secret: {}
@@ -4618,7 +4619,7 @@ thanosRuler:
         #   endpoint: ""
         #   region: ""
         #   access_key: ""
-      #   secret_key: ""
+        #   secret_key: ""
 
     ## Labels by name to drop before sending to alertmanager
     ## Maps to the --alert.label-drop flag of thanos ruler.
@@ -4634,7 +4635,7 @@ thanosRuler:
       # use existing secret, if configured, queryConfig.secret will not be used
       existingSecret: {}
         # name: ""
-      # key: ""
+        # key: ""
       # render queryConfig secret data and configure it to be used by Thanos Ruler custom resource, ignored when queryConfig.existingSecret is set
       # https://thanos.io/tip/components/rule.md/#query-api
       secret: {}
@@ -4645,7 +4646,7 @@ thanosRuler:
         #   static_configs:
         #     - URL
         #   scheme: http
-      #   timeout: 10s
+        #   timeout: 10s
 
     ## Labels configure the external label pairs to ThanosRuler. A default replica
     ## label `thanos_ruler_replica` will be always added as a label with the value
@@ -4665,7 +4666,7 @@ thanosRuler:
       #     "remote_write":
       #     - "name": "receiver-0"
       #       "remote_timeout": "30s"
-    #       "url": "http://thanos-receiver-0.thanos-receiver:8081/api/v1/receive"
+      #       "url": "http://thanos-receiver-0.thanos-receiver:8081/api/v1/receive"
 
     ## Define which Nodes the Pods are scheduled on.
     ## ref: https://kubernetes.io/docs/user-guide/node-selection/
@@ -4798,4 +4799,4 @@ extraManifests: []
   #   labels:
   #     name: prometheus-extra
   #   data:
-#     extra-data: "value"
+  #     extra-data: "value"


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Running the latest prom-stack versions on legacy OpenShift clusters with no influence on the preinstalled CRDs results in errors such as this:

```
failed to create typed patch object (..): .spec.scrapeConfigNamespaceSelector: field not declared in schema
```

This PR provides a workaround using this values.yaml:

```
prometheus:
  prometheusSpec:
    scrapeConfigNamespaceSelector: null
    scrapeConfigSelectorNilUsesHelmValues: null
    scrapeConfigSelector: null
```

Yes, this is no ideal solution, but that seems to be what the enterprise-world  requires 😐️

At runtime, the operator yields some warnings about the missing fields, but apparently everything else works.

#### Special notes for your reviewer

As discussed with @jkroepke I'm launching another try to include this feature :slightly_smiling_face: 

This is the same functionality as in #4818, which unfortunately was reverted in #4883, because it hit a bug in helm helm/helm#12879.

If we go for my original minimally invasive approach, there is no breaking change we won't cause #4878 again.

It won't work for sub charts (because of aforementioned bug in helm) but at least for direct users of kps chart.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
