### PR TITLE
[prometheus-json-exporter] make liveness and readiness probes fully configurable

### DIFF
--- a/charts/prometheus-json-exporter/Chart.yaml
+++ b/charts/prometheus-json-exporter/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.0
+version: 0.14.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/prometheus-json-exporter/ci/default-values.yaml
+++ b/charts/prometheus-json-exporter/ci/default-values.yaml
@@ -1,2 +1,5 @@
 deploymentAnnotations:
   test-annotation: "true"
+
+livenessProbe:
+  timeoutSeconds: 5

--- a/charts/prometheus-json-exporter/templates/deployment.yaml
+++ b/charts/prometheus-json-exporter/templates/deployment.yaml
@@ -59,14 +59,12 @@ spec:
             - name: http
               containerPort: 7979
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /metrics
-              port: http
-          readinessProbe:
-            httpGet:
-              path: /metrics
-              port: http
+          {{- with .Values.livenessProbe }}
+          livenessProbe: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe: {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/prometheus-json-exporter/values.yaml
+++ b/charts/prometheus-json-exporter/values.yaml
@@ -42,6 +42,15 @@ securityContext: {}
 # runAsNonRoot: true
 # runAsUser: 1000
 
+livenessProbe:
+  httpGet:
+    path: /metrics
+    port: http
+readinessProbe:
+  httpGet:
+    path: /metrics
+    port: http
+
 service:
   type: ClusterIP
   port: 7979


### PR DESCRIPTION
#### What this PR does / why we need it

json-exporter, make liveness and readiness probes fully configurable

This changes makes both probes fully configurable, e.g. you are now able to override timeoutSeconds and other settings.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
