### PR TITLE
[prometheus-snmp-exporter] add selfMonitor

### DIFF
--- a/charts/prometheus-snmp-exporter/Chart.yaml
+++ b/charts/prometheus-snmp-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus SNMP Exporter
 name: prometheus-snmp-exporter
-version: 5.5.1
+version: 5.6.0
 appVersion: v0.26.0
 home: https://github.com/prometheus/snmp_exporter
 sources:

--- a/charts/prometheus-snmp-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-snmp-exporter/templates/_helpers.tpl
@@ -73,6 +73,6 @@ Namespace override
   {{- if .Values.namespaceOverride -}}
     {{- .Values.namespaceOverride -}}
   {{- else -}}
-    {{- .Release.namespace -}}
+    {{- .Release.Namespace -}}
   {{- end -}}
 {{- end -}}

--- a/charts/prometheus-snmp-exporter/templates/selfservicemonitor.yaml
+++ b/charts/prometheus-snmp-exporter/templates/selfservicemonitor.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.serviceMonitor.selfMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "prometheus-snmp-exporter.fullname" $ }}
+  namespace: {{ template "prometheus-snmp-exporter.namespace" $ }}
+  labels:
+    {{- include "prometheus-snmp-exporter.labels" $ | nindent 4 }}
+    {{- if .Values.serviceMonitor.selfMonitor.labels  }}
+    {{- toYaml (.Values.serviceMonitor.selfMonitor.labels) | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+  - path: {{ .Values.serviceMonitor.selfMonitor.path }}
+    interval: {{ .Values.serviceMonitor.selfMonitor.interval }}
+    scrapeTimeout: {{ .Values.serviceMonitor.selfMonitor.scrapeTimeout }}
+    scheme: {{ .Values.serviceMonitor.selfMonitor.scheme }}
+    {{- with .Values.serviceMonitor.selfMonitor.port }}
+    port: {{ . }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.selfMonitor.additionalMetricsRelabels }}
+    metricRelabelings:
+      {{- toYaml .Values.serviceMonitor.selfMonitor.additionalMetricsRelabels | nindent 6 }}
+    {{- end }}  
+    {{- if .Values.serviceMonitor.selfMonitor.tlsConfig }}
+    tlsConfig:
+      {{- toYaml .Values.serviceMonitor.selfMonitor.tlsConfig | nindent 6 }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.selfMonitor.additionalRelabeling }}
+    relabelings:
+      {{- toYaml .Values.serviceMonitor.selfMonitor.additionalRelabeling | nindent 6 }}
+    {{- end }}
+  jobLabel: "{{ .Release.Name }}"
+  selector:
+    matchLabels:
+      {{- include "prometheus-snmp-exporter.selectorLabels" $ | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ template "prometheus-snmp-exporter.namespace" $ }}
+
+{{- end }}

--- a/charts/prometheus-snmp-exporter/values.yaml
+++ b/charts/prometheus-snmp-exporter/values.yaml
@@ -237,6 +237,19 @@ serviceMonitor:
     # Metrics relabelings. Overrides value set in serviceMonitor.additionalMetricsRelabelConfigs
     #   additionalMetricsRelabelConfigs: []
 
+  ## If true, a ServiceMonitor CRD is created for snmp-exporter itself
+  ##
+  selfMonitor:
+    enabled: false
+    additionalMetricsRelabels: {}
+    additionalRelabeling: []
+    labels: {}
+    path: /metrics
+    scheme: http
+    tlsConfig: {}
+    interval: 30s
+    scrapeTimeout: 30s
+
 # Extra manifests to deploy as an array
 extraManifests: []
   # - |


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Added a `selfMonitor` configuration to allow the prometheus-operator to monitor the SNMP Exporter itself. This is inspired by the implementation of `prometheus-blackbox-exporter` and is largely similar in content.

https://github.com/prometheus-community/helm-charts/blob/0529c1011be5ffd26419ef941920368ebdc2ee6f/charts/prometheus-blackbox-exporter/values.yaml#L273-L285
https://github.com/prometheus-community/helm-charts/blob/0529c1011be5ffd26419ef941920368ebdc2ee6f/charts/prometheus-blackbox-exporter/templates/selfservicemonitor.yaml

<img width="1393" alt="prometheus-targets" src="https://github.com/user-attachments/assets/edd98d81-08c2-4658-b6e7-1900c3447e40">


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
