### PR TITLE
[prometheus-blackbox-exporter] Adjust configPath handling

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 9.2.0
+version: 10.0.0
 appVersion: v0.25.0
 kubeVersion: ">=1.21.0-0"
 home: https://github.com/prometheus/blackbox_exporter

--- a/charts/prometheus-blackbox-exporter/README.md
+++ b/charts/prometheus-blackbox-exporter/README.md
@@ -48,6 +48,12 @@ helm upgrade [RELEASE_NAME] [CHART] --install
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
+### To 10.0.0
+
+This version changed the config path handing.
+- The `configPath` value overwrites the default config path.
+- The default value, if no `config` is defined, got removed. You can set the removed default `/etc/blackbox_exporter/config.yml` via the `configPath` value.
+
 ### To 9.0.0
 
 This version remove pod security policy as it is deprecated.

--- a/charts/prometheus-blackbox-exporter/README.md
+++ b/charts/prometheus-blackbox-exporter/README.md
@@ -50,9 +50,9 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 
 ### To 10.0.0
 
-This version changed the config path handing.
-- The `configPath` value overwrites the default config path.
-- The default value, if no `config` is defined, got removed. You can set the removed default `/etc/blackbox_exporter/config.yml` via the `configPath` value.
+This version renamed the `configPath` value to `configFile` and changed the config handing.
+- The `configFile` value overwrites the default config file path.
+- The default value, if no `config` is defined, got removed. You can set the removed default `/etc/blackbox_exporter/config.yml` via the `configFile` value.
 
 ### To 9.0.0
 

--- a/charts/prometheus-blackbox-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-blackbox-exporter/templates/_helpers.tpl
@@ -228,7 +228,7 @@ containers:
   {{- end }}
   {{- end }}
   args:
-  - --config-file={{ .Values.configPath | default "/config/blackbox.yaml" }}
+  - --config.file={{ .Values.configPath | default "/config/blackbox.yaml" }}
   {{- with .Values.extraArgs }}
 {{ tpl (toYaml .) $ | indent 2 }}
   {{- end }}

--- a/charts/prometheus-blackbox-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-blackbox-exporter/templates/_helpers.tpl
@@ -228,15 +228,7 @@ containers:
   {{- end }}
   {{- end }}
   args:
-  {{- if .Values.config }}
-  {{- if .Values.configPath }}
-  - "--config.file={{ .Values.configPath }}"
-  {{- else }}
-  - "--config.file=/config/blackbox.yaml"
-  {{- end }}
-  {{- else }}
-  - "--config.file=/etc/blackbox_exporter/config.yml"
-  {{- end }}
+  - --config-file={{ .Values.configPath | default "/config/blackbox.yaml" }}
   {{- with .Values.extraArgs }}
 {{ tpl (toYaml .) $ | indent 2 }}
   {{- end }}

--- a/charts/prometheus-blackbox-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-blackbox-exporter/templates/_helpers.tpl
@@ -180,7 +180,7 @@ containers:
   image: {{ include "prometheus-blackbox-exporter.config-reloader.image" . }}
   imagePullPolicy: {{ .Values.configReloader.image.pullPolicy }}
   args:
-    - --config-file={{ .Values.configPath | default "/config/blackbox.yaml" }}
+    - --config-file={{ .Values.configFile | default "/config/blackbox.yaml" }}
     - --watch-interval={{ .Values.configReloader.config.watchInterval }}
     - --reload-url=http://127.0.0.1:{{ .Values.containerPort }}/-/reload
     - --listen-address=:{{ .Values.configReloader.containerPort }}

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -172,8 +172,8 @@ config:
         follow_redirects: true
         preferred_ip_protocol: "ip4"
 
-# Set custom config path, other than default /config/blackbox.yaml. If let empty, path will be "/config/blackbox.yaml"
-# configPath: "/foo/bar"
+# Set custom config file, other than default /config/blackbox.yaml. If let empty, path will be "/config/blackbox.yaml"
+# configFile: "/foo/blackbox.yaml"
 
 extraConfigmapMounts: []
   # - name: certs-configmap


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
**Issue**
I want to deploy the config map for the Blackbox config on my own, as I want to write some logic that adjust the ConfigMap more dynamically. Therefore I need to `null` the `config` value as otherwise the ConfigMap is created with the default chart values. When setting `config` to `null` the config path is set to `/etc/blackbox_exporter/config.yml` which does not exist.

**Changes**
I changed the config path logic to match the one of the config reloader. If no `configPath` is set, we use the default of `/config/blackbox.yaml` otherwise we use the `configPath` value. The default value of `/etc/blackbox_exporter/config.yml` gets removed as I don´t see the point in keeping it. If needed it can be set via `configPath`.

As it its a breaking change, I also bumped the version.

#### Which issue this PR fixes
 None

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
