### PR TITLE
[prometheus-node-exporter] Allow for custom ingress NetworkPolicy

### DIFF
--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - prometheus
   - exporter
 type: application
-version: 4.39.0
+version: 4.40.0
 appVersion: 1.8.2
 home: https://github.com/prometheus/node_exporter/
 sources:

--- a/charts/prometheus-node-exporter/ci/networkpolicy-values.yaml
+++ b/charts/prometheus-node-exporter/ci/networkpolicy-values.yaml
@@ -1,0 +1,5 @@
+networkPolicy:
+  enabled: true
+  ingress:
+  - ports:
+    - port: 9100

--- a/charts/prometheus-node-exporter/templates/networkpolicy.yaml
+++ b/charts/prometheus-node-exporter/templates/networkpolicy.yaml
@@ -12,8 +12,12 @@ metadata:
   {{- end }}
 spec:
   ingress:
+    {{- if .Values.networkPolicy.ingress }}
+      {{- toYaml .Values.networkPolicy.ingress | nindent 4 }}
+    {{- else }}
     - ports:
       - port: {{ .Values.service.port }}
+    {{- end }}
   policyTypes:
     - Egress
     - Ingress

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -126,10 +126,13 @@ service:
   externalTrafficPolicy: ""
 
 # Set a NetworkPolicy with:
-# ingress only on service.port
+# ingress only on service.port or custom policy
 # no egress permitted
 networkPolicy:
   enabled: false
+  
+  # ingress:
+  # - {}
 
 # Additional environment variables that will be passed to the daemonset
 env: {}

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -130,7 +130,7 @@ service:
 # no egress permitted
 networkPolicy:
   enabled: false
-  
+
   # ingress:
   # - {}
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
When enabled, the current NetworkPolicy blocks all egress traffic, and allows all ingress traffic destined for `.Values.service.port`. 
This PR allows for specifying a custom ingress NetworkPolicy for the prometheus-node-exporter. For example, we may want to restrict ingress traffic to only pods with a particular label.
```
networkPolicy:
  enabled: true
  ingress:
  - from:
    - podSelector:
        matchLabels:
          app.kubernetes.io/instance: foo
```

@gianrubio 
@zanhsieh
@zeritti

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
