### PR TITLE
[prometheus-postgres-exporter] support custom TLS config

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v0.15.0"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 6.3.1
+version: 6.4.0
 home: https://github.com/prometheus-community/postgres_exporter
 sources:
 - https://github.com/prometheus-community/postgres_exporter

--- a/charts/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/charts/prometheus-postgres-exporter/templates/deployment.yaml
@@ -144,18 +144,14 @@ spec:
             - name: http
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
+          {{- with .Values.livenessProbe }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
-            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-            httpGet:
-              path: /
-              port: http
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
           readinessProbe:
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-            httpGet:
-              path: /
-              port: http
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           {{- with .Values.securityContext }}

--- a/charts/prometheus-postgres-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-postgres-exporter/templates/servicemonitor.yaml
@@ -20,6 +20,9 @@ spec:
 {{- if .Values.serviceMonitor.telemetryPath }}
     path: {{ .Values.serviceMonitor.telemetryPath }}
 {{- end }}
+{{- if .Values.serviceMonitor.scheme }}
+    scheme: {{ .Values.serviceMonitor.scheme }}
+{{- end }}
 {{- if .Values.serviceMonitor.timeout }}
     scrapeTimeout: {{ .Values.serviceMonitor.timeout }}
 {{- end }}
@@ -30,6 +33,10 @@ spec:
 {{- if .Values.serviceMonitor.relabelings }}
     relabelings:
 {{ toYaml .Values.serviceMonitor.relabelings | nindent 4 }}
+{{- end }}
+{{- with .Values.serviceMonitor.tlsConfig }}
+    tlsConfig:
+{{- toYaml . | nindent 6 }}
 {{- end }}
   jobLabel: {{ template "prometheus-postgres-exporter.fullname" . }}
   namespaceSelector:

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -45,6 +45,10 @@ serviceMonitor:
   # metricRelabelings: []
   # Set relabel_configs as per https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
   # relabelings: []
+  # HTTP scheme to use for scraping. For example `http` or `https`. Default is `http`.
+  # scheme: http
+  # TLS configuration to use when scraping the metric endpoint by Prometheus.
+  # tlsConfig: {}
 
 prometheusRule:
   enabled: false
@@ -195,13 +199,25 @@ annotations: {}
 
 podLabels: {}
 
-# Configurable health checks
+# Configurable probes. If TLS client authentication is enabled at the exporter, TCP probe must be used.
 livenessProbe:
   initialDelaySeconds: 0
+  httpGet:
+    path: /
+    port: http
+    scheme: HTTP
+  # tcpSocket:
+  #   port: http
   timeoutSeconds: 3
 
 readinessProbe:
   initialDelaySeconds: 0
+  httpGet:
+    path: /
+    port: http
+    scheme: HTTP
+  # tcpSocket:
+  #   port: http
   timeoutSeconds: 1
 
 # Labels and annotations to attach to the deployment resource


### PR DESCRIPTION
The following patch extends the serviceMonitor resource to allow users to apply a custom TLS configuration for TLS authentication and encryption between prometheus and the postgres-exporter. Furthermore, the protocol scheme can now be customized. The default is `http` but needs to be changed to `https`, when TLS authentication/encryption should be applied.

A user-specific TLS configuration can be applied as follows.

```yaml
serviceMonitor:
  enabled: true
  scheme: https
  tlsConfig:
    caFile: /etc/prometheus/tls/ca/ca.crt
    certFile: /etc/prometheus/tls/app2app/tls.crt
    keyFile: /etc/prometheus/tls/app2app/tls.key
    insecureSkipVerify: false
    serverName: prometheus-postgres-exporter
```

Important Note: The `serverName` attribute must correspond to the CommonName or a Subject Alternative Name (SAN) of the TLS certificate. If this is not the case, prometheus will reject the connection trying to match the IP address of the pod with the CommonName / SAN.

The client certificate and private key as well as the certificate of the certificate authorithy must be mounted additionally via the `extraVolumes` and `extraVolumeMounts` option. This configuration is not standard and must also be implemented by the user if TLS client authentication is required.

#### Which issue this PR fixes

- fixes #4940

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)