### PR TITLE
[prometheus-sql-exporter] Fix labels/matchLabels by using include instead of duplicating declaration in each file

### DIFF
--- a/charts/prometheus-sql-exporter/Chart.yaml
+++ b/charts/prometheus-sql-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus SQL Exporter
 name: prometheus-sql-exporter
-version: 0.1.3
+version: 0.2.0
 appVersion: v0.5.8
 home: https://github.com/justwatchcom/sql_exporter
 sources:

--- a/charts/prometheus-sql-exporter/Chart.yaml
+++ b/charts/prometheus-sql-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus SQL Exporter
 name: prometheus-sql-exporter
-version: 0.1.2
+version: 0.1.3
 appVersion: v0.5.8
 home: https://github.com/justwatchcom/sql_exporter
 sources:

--- a/charts/prometheus-sql-exporter/templates/NOTES.txt
+++ b/charts/prometheus-sql-exporter/templates/NOTES.txt
@@ -9,7 +9,7 @@
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "prometheus-sql-exporter.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "prometheus-sql-exporter.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "prometheus-sql-exporter.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl port-forward $POD_NAME 8080:9187
 {{- end }}

--- a/charts/prometheus-sql-exporter/templates/deployment.yaml
+++ b/charts/prometheus-sql-exporter/templates/deployment.yaml
@@ -3,24 +3,19 @@ kind: Deployment
 metadata:
   name: {{ template "prometheus-sql-exporter.fullname" . }}
   labels:
-    app: {{ template "prometheus-sql-exporter.name" . }}
-    chart: {{ template "prometheus-sql-exporter.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "prometheus-sql-exporter.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "prometheus-sql-exporter.name" . }}
-      release: {{ .Release.Name }}
+      {{- include "prometheus-sql-exporter.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app: {{ template "prometheus-sql-exporter.name" . }}
-        release: {{ .Release.Name }}
-{{- if .Values.podLabels }}
+        {{- include "prometheus-sql-exporter.selectorLabels" . | nindent 8 }}
+      {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | trim | indent 8 }}
-{{- end }}
+      {{- end }}
       annotations:
         kubectl.kubernetes.io/default-container: {{ .Chart.Name }}
 {{- if .Values.annotations }}

--- a/charts/prometheus-sql-exporter/templates/networkpolicy.yaml
+++ b/charts/prometheus-sql-exporter/templates/networkpolicy.yaml
@@ -10,8 +10,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: {{ template "prometheus-sql-exporter.name" . }}
-      release: {{ .Release.Name }}
+      {{- include "prometheus-sql-exporter.selectorLabels" . | nindent 8 }}
   policyTypes:
     - Ingress
   ingress:

--- a/charts/prometheus-sql-exporter/templates/pdb.yaml
+++ b/charts/prometheus-sql-exporter/templates/pdb.yaml
@@ -4,14 +4,10 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ template "prometheus-sql-exporter.fullname" . }}
   labels:
-    app: {{ template "prometheus-sql-exporter.name" . }}
-    chart: {{ template "prometheus-sql-exporter.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "prometheus-sql-exporter.selectorLabels" . | nindent 8 }}
 spec:
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
   selector:
     matchLabels:
-      app: {{ template "prometheus-sql-exporter.name" . }}
-      release: {{ .Release.Name }}
+      {{- include "prometheus-sql-exporter.selectorLabels" . | nindent 8 }}
 {{- end }}

--- a/charts/prometheus-sql-exporter/templates/prometheusrule.yaml
+++ b/charts/prometheus-sql-exporter/templates/prometheusrule.yaml
@@ -7,10 +7,7 @@ metadata:
   namespace: {{ . }}
 {{- end }}
   labels:
-    app: {{ template "prometheus-sql-exporter.name" . }}
-    chart: {{ template "prometheus-sql-exporter.chart" . }}
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+    {{- include "prometheus-sql-exporter.labels" . | nindent 4 }}
 {{- with .Values.prometheusRule.additionalLabels }}
 {{ toYaml . | indent 4 }}
 {{- end }}

--- a/charts/prometheus-sql-exporter/templates/role.yaml
+++ b/charts/prometheus-sql-exporter/templates/role.yaml
@@ -4,10 +4,7 @@ kind: Role
 metadata:
   name: {{ template "prometheus-sql-exporter.fullname" . }}
   labels:
-    app: {{ template "prometheus-sql-exporter.name" . }}
-    chart: {{ template "prometheus-sql-exporter.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus-sql-exporter.labels" . | nindent 4 }}
 {{- if .Values.rbac.pspEnabled }}
 rules:
 - apiGroups:      ['extensions']

--- a/charts/prometheus-sql-exporter/templates/rolebinding.yaml
+++ b/charts/prometheus-sql-exporter/templates/rolebinding.yaml
@@ -4,10 +4,7 @@ kind: RoleBinding
 metadata:
   name: {{ template "prometheus-sql-exporter.fullname" . }}
   labels:
-    app: {{ template "prometheus-sql-exporter.name" . }}
-    chart: {{ template "prometheus-sql-exporter.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus-sql-exporter.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/prometheus-sql-exporter/templates/service.yaml
+++ b/charts/prometheus-sql-exporter/templates/service.yaml
@@ -7,10 +7,7 @@ metadata:
 {{ toYaml .Values.service.annotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ template "prometheus-sql-exporter.name" . }}
-    chart: {{ template "prometheus-sql-exporter.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "prometheus-sql-exporter.labels" . | nindent 4 }}
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | trim | indent 4 }}
 {{- end }}
@@ -22,5 +19,4 @@ spec:
       protocol: TCP
       name: {{ .Values.service.name }}
   selector:
-    app: {{ template "prometheus-sql-exporter.name" . }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus-sql-exporter.selectorLabels" . | nindent 8 }}

--- a/charts/prometheus-sql-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-sql-exporter/templates/serviceaccount.yaml
@@ -4,10 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ template "prometheus-sql-exporter.serviceAccountName" . }}
   labels:
-    app: {{ template "prometheus-sql-exporter.name" . }}
-    chart: {{ template "prometheus-sql-exporter.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "prometheus-sql-exporter.labels" . | nindent 4 }}
   {{- if .Values.serviceAccount.annotations }}
   annotations:
     {{ toYaml .Values.serviceAccount.annotations }}

--- a/charts/prometheus-sql-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-sql-exporter/templates/servicemonitor.yaml
@@ -36,8 +36,7 @@ spec:
     - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      app: {{ template "prometheus-sql-exporter.name" . }}
-      release: {{ .Release.Name }}
+      {{- include "prometheus-sql-exporter.selectorLabels" . | nindent 8 }}
 {{- if .Values.serviceMonitor.targetLabels }}
   targetLabels:
 {{- range .Values.serviceMonitor.targetLabels }}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Instead of duplicating the labels & matchLabels in each file we are not relying on include.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer

None

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
