### PR TITLE
kube-prometheus-stack - targetLabels support for kubelet and node-exporter

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 65.6.0
+version: 65.7.0
 appVersion: v0.77.2
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus
@@ -49,7 +49,7 @@ dependencies:
     repository: https://prometheus-community.github.io/helm-charts
     condition: kubeStateMetrics.enabled
   - name: prometheus-node-exporter
-    version: "4.40.*"
+    version: "4.42.*"
     repository: https://prometheus-community.github.io/helm-charts
     condition: nodeExporter.enabled
   - name: grafana

--- a/charts/kube-prometheus-stack/templates/exporters/kubelet/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kubelet/servicemonitor.yaml
@@ -223,6 +223,10 @@ spec:
 {{- end }}
   {{- end }}
   jobLabel: k8s-app
+  {{- with .Values.kubelet.serviceMonitor.targetLabels }}
+  targetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   namespaceSelector:
     matchNames:
     - {{ .Values.kubelet.namespace }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -65,6 +65,9 @@ spec:
             {{- end }}
             - --kubelet-endpoints={{ .Values.prometheusOperator.kubeletEndpointsEnabled }}
             - --kubelet-endpointslice={{ .Values.prometheusOperator.kubeletEndpointSliceEnabled }}
+            {{- if .Values.prometheusOperator.kubeletService.labels }}
+            - --labels={{ .Values.prometheusOperator.kubeletService.labels }}
+            {{- end }}
             {{- if .Values.prometheusOperator.logFormat }}
             - --log-format={{ .Values.prometheusOperator.logFormat }}
             {{- end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1464,6 +1464,11 @@ kubelet:
     additionalLabels: {}
     #  foo: bar
 
+    ## serviceMonitor targetLabels
+    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+    targetLabels: []
+    # - cluster
+
 ## Component scraping the kube controller manager
 ##
 kubeControllerManager:
@@ -2700,6 +2705,8 @@ prometheusOperator:
     selector: ""
     ## Use '{{ template "kube-prometheus-stack.fullname" . }}-kubelet' by default
     name: ""
+    ### Pass additional labels for kubelet resources to convert to targetLabels using servicemonitor with format as key=val
+    labels: ""
 
   ## Create Endpoints objects for kubelet targets.
   kubeletEndpointsEnabled: true

--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - prometheus
   - exporter
 type: application
-version: 4.41.0
+version: 4.42.0
 appVersion: 1.8.2
 home: https://github.com/prometheus/node_exporter/
 sources:

--- a/charts/prometheus-node-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-node-exporter/templates/servicemonitor.yaml
@@ -16,6 +16,10 @@ spec:
   podTargetLabels:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.prometheus.monitor.targetLabels }}
+  targetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
     {{- with .Values.prometheus.monitor.selectorOverride }}

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -182,6 +182,10 @@ prometheus:
     # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
     podTargetLabels: []
 
+    # List of pod labels to add to node exporter metrics
+    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+    targetLabels: []
+
     scheme: http
     basicAuth: {}
     bearerTokenFile:


### PR DESCRIPTION
#### What this PR does / why we need it
These changes will add support to pass the targetLabels to both kubelet and node-exporter.

#### Which issue this PR fixes

- fixes # 4966