### PR TITLE
[prometheus-node-exporter] targetLabels support for node-exporter

### DIFF
--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - prometheus
   - exporter
 type: application
-version: 4.41.0
+version: 4.42.0
 appVersion: 1.8.2
 home: https://github.com/prometheus/node_exporter/
 sources:

--- a/charts/prometheus-node-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-node-exporter/templates/servicemonitor.yaml
@@ -16,6 +16,10 @@ spec:
   podTargetLabels:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.prometheus.monitor.targetLabels }}
+  targetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
     {{- with .Values.prometheus.monitor.selectorOverride }}

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -182,6 +182,10 @@ prometheus:
     # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
     podTargetLabels: []
 
+    # List of target labels to add to node exporter metrics
+    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+    targetLabels: []
+
     scheme: http
     basicAuth: {}
     bearerTokenFile:


### PR DESCRIPTION
#### What this PR does / why we need it
This PR will add support of targetLabels in serviceMonitor to node-exporter.

#### Which issue this PR fixes
- fixes #4966 for node-exporter