### PR TITLE
[kube-prometheus-stack] - targetLabels for all exporters

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 65.7.0
+version: 65.8.0
 appVersion: v0.77.2
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/ci/03-non-defaults-values.yaml
+++ b/charts/kube-prometheus-stack/ci/03-non-defaults-values.yaml
@@ -19,6 +19,8 @@ prometheusOperator:
         operator: NotIn
         values:
         - "true"
+  extraArgs:
+    - --labels="cluster=talos-cluster"
 
 alertmanager:
   alertmanagerSpec:

--- a/charts/kube-prometheus-stack/templates/exporters/core-dns/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/core-dns/servicemonitor.yaml
@@ -16,6 +16,10 @@ metadata:
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
   jobLabel: {{ .Values.coreDns.serviceMonitor.jobLabel }}
+  {{- with .Values.coreDns.serviceMonitor.targetLabels }}
+  targetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- include "servicemonitor.scrapeLimits" .Values.coreDns.serviceMonitor | nindent 2 }}
   selector:
     {{- if .Values.coreDns.serviceMonitor.selector }}

--- a/charts/kube-prometheus-stack/templates/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-api-server/servicemonitor.yaml
@@ -39,6 +39,10 @@ spec:
       serverName: {{ .Values.kubeApiServer.tlsConfig.serverName }}
       insecureSkipVerify: {{ .Values.kubeApiServer.tlsConfig.insecureSkipVerify }}
   jobLabel: {{ .Values.kubeApiServer.serviceMonitor.jobLabel }}
+  {{- with .Values.kubeApiServer.serviceMonitor.targetLabels }}
+  targetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   namespaceSelector:
     matchNames:
     - default

--- a/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/servicemonitor.yaml
@@ -16,6 +16,10 @@ metadata:
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
   jobLabel: {{ .Values.kubeControllerManager.serviceMonitor.jobLabel }}
+  {{- with .Values.kubeControllerManager.serviceMonitor.targetLabels }}
+  targetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- include "servicemonitor.scrapeLimits" .Values.kubeControllerManager.serviceMonitor | nindent 2 }}
   selector:
     {{- if .Values.kubeControllerManager.serviceMonitor.selector }}

--- a/charts/kube-prometheus-stack/templates/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-dns/servicemonitor.yaml
@@ -16,6 +16,10 @@ metadata:
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
   jobLabel: {{ .Values.kubeDns.serviceMonitor.jobLabel }}
+  {{- with .Values.kubeDns.serviceMonitor.targetLabels }}
+  targetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- include "servicemonitor.scrapeLimits" .Values.kubeDns.serviceMonitor | nindent 2 }}
   selector:
     {{- if .Values.kubeDns.serviceMonitor.selector }}

--- a/charts/kube-prometheus-stack/templates/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-etcd/servicemonitor.yaml
@@ -16,6 +16,10 @@ metadata:
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
   jobLabel: {{ .Values.kubeEtcd.serviceMonitor.jobLabel }}
+  {{- with .Values.kubeEtcd.serviceMonitor.targetLabels }}
+  targetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- include "servicemonitor.scrapeLimits" .Values.kubeEtcd.serviceMonitor | nindent 4 }}
   selector:
     {{- if .Values.kubeEtcd.serviceMonitor.selector }}

--- a/charts/kube-prometheus-stack/templates/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-proxy/servicemonitor.yaml
@@ -16,6 +16,10 @@ metadata:
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
   jobLabel: {{ .Values.kubeProxy.serviceMonitor.jobLabel }}
+  {{- with .Values.kubeProxy.serviceMonitor.targetLabels }}
+  targetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- include "servicemonitor.scrapeLimits" .Values.kubeProxy.serviceMonitor | nindent 2 }}
   selector:
     {{- if .Values.kubeProxy.serviceMonitor.selector }}

--- a/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -16,6 +16,10 @@ metadata:
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
   jobLabel: {{ .Values.kubeScheduler.serviceMonitor.jobLabel }}
+  {{- with .Values.kubeScheduler.serviceMonitor.targetLabels }}
+  targetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- include "servicemonitor.scrapeLimits" .Values.kubeScheduler.serviceMonitor | nindent 2 }}
   selector:
     {{- if .Values.kubeScheduler.serviceMonitor.selector }}

--- a/charts/kube-prometheus-stack/templates/exporters/kubelet/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kubelet/servicemonitor.yaml
@@ -223,6 +223,10 @@ spec:
 {{- end }}
   {{- end }}
   jobLabel: k8s-app
+  {{- with .Values.kubelet.serviceMonitor.targetLabels }}
+  targetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   namespaceSelector:
     matchNames:
     - {{ .Values.kubelet.namespace }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -143,10 +143,8 @@ spec:
             - --web.key-file=/cert/{{ if .Values.prometheusOperator.admissionWebhooks.certManager.enabled }}tls.key{{ else }}key{{ end }}
             - --web.listen-address=:{{ .Values.prometheusOperator.tls.internalPort }}
             - --web.tls-min-version={{ .Values.prometheusOperator.tls.tlsMinVersion }}
-            {{- if .Values.prometheusOperator.extraArgs }}
-            {{- range .Values.prometheusOperator.extraArgs }}
-            - {{ . }}
-            {{- end }}
+            {{- with.Values.prometheusOperator.extraArgs }}
+            {{- tpl (toYaml .) $ | nindent 12 }}
             {{- end }}
           ports:
             - containerPort: {{ .Values.prometheusOperator.tls.internalPort }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -143,6 +143,11 @@ spec:
             - --web.key-file=/cert/{{ if .Values.prometheusOperator.admissionWebhooks.certManager.enabled }}tls.key{{ else }}key{{ end }}
             - --web.listen-address=:{{ .Values.prometheusOperator.tls.internalPort }}
             - --web.tls-min-version={{ .Values.prometheusOperator.tls.tlsMinVersion }}
+            {{- if .Values.prometheusOperator.extraArgs }}
+            {{- range .Values.prometheusOperator.extraArgs }}
+            - {{ . }}
+            {{- end }}
+            {{- end }}
           ports:
             - containerPort: {{ .Values.prometheusOperator.tls.internalPort }}
               name: https

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -65,9 +65,6 @@ spec:
             {{- end }}
             - --kubelet-endpoints={{ .Values.prometheusOperator.kubeletEndpointsEnabled }}
             - --kubelet-endpointslice={{ .Values.prometheusOperator.kubeletEndpointSliceEnabled }}
-            {{- if .Values.prometheusOperator.kubeletService.labels }}
-            - --labels={{ .Values.prometheusOperator.kubeletService.labels }}
-            {{- end }}
             {{- if .Values.prometheusOperator.logFormat }}
             - --log-format={{ .Values.prometheusOperator.logFormat }}
             {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -65,6 +65,9 @@ spec:
             {{- end }}
             - --kubelet-endpoints={{ .Values.prometheusOperator.kubeletEndpointsEnabled }}
             - --kubelet-endpointslice={{ .Values.prometheusOperator.kubeletEndpointSliceEnabled }}
+            {{- if .Values.prometheusOperator.kubeletService.labels }}
+            - --labels={{ .Values.prometheusOperator.kubeletService.labels }}
+            {{- end }}
             {{- if .Values.prometheusOperator.logFormat }}
             - --log-format={{ .Values.prometheusOperator.logFormat }}
             {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -143,7 +143,7 @@ spec:
             - --web.key-file=/cert/{{ if .Values.prometheusOperator.admissionWebhooks.certManager.enabled }}tls.key{{ else }}key{{ end }}
             - --web.listen-address=:{{ .Values.prometheusOperator.tls.internalPort }}
             - --web.tls-min-version={{ .Values.prometheusOperator.tls.tlsMinVersion }}
-            {{- with.Values.prometheusOperator.extraArgs }}
+            {{- with .Values.prometheusOperator.extraArgs }}
             {{- tpl (toYaml .) $ | nindent 12 }}
             {{- end }}
           ports:

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -2773,7 +2773,7 @@ prometheusOperator:
   kubeletEndpointsEnabled: true
   ## Create EndpointSlice objects for kubelet targets.
   kubeletEndpointSliceEnabled: false
-  
+
   ## Extra arguments to pass to prometheusOperator
   # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/operator.md
   extraArgs: []

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -2768,8 +2768,6 @@ prometheusOperator:
     selector: ""
     ## Use '{{ template "kube-prometheus-stack.fullname" . }}-kubelet' by default
     name: ""
-    ## defines the labels which are transferred from the associated Kubernetes Pod object onto the ingested metrics.
-    labels: ""
 
   ## Create Endpoints objects for kubelet targets.
   kubeletEndpointsEnabled: true

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1294,6 +1294,10 @@ kubeApiServer:
     additionalLabels: {}
     #  foo: bar
 
+    ## defines the labels which are transferred from the associated Kubernetes Service object onto the ingested metrics.
+    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+    targetLabels: []
+
 ## Component scraping the kubelet and kubelet-hosted cAdvisor
 ##
 kubelet:
@@ -1500,6 +1504,10 @@ kubelet:
     additionalLabels: {}
     #  foo: bar
 
+    ## defines the labels which are transferred from the associated Kubernetes Service object onto the ingested metrics.
+    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+    targetLabels: []
+
 ## Component scraping the kube controller manager
 ##
 kubeControllerManager:
@@ -1603,6 +1611,10 @@ kubeControllerManager:
     additionalLabels: {}
     #  foo: bar
 
+    ## defines the labels which are transferred from the associated Kubernetes Service object onto the ingested metrics.
+    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+    targetLabels: []
+
 ## Component scraping coreDns. Use either this or kubeDns
 ##
 coreDns:
@@ -1680,6 +1692,10 @@ coreDns:
     ##
     additionalLabels: {}
     #  foo: bar
+
+    ## defines the labels which are transferred from the associated Kubernetes Service object onto the ingested metrics.
+    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+    targetLabels: []
 
 ## Component scraping kubeDns. Use either this or coreDns
 ##
@@ -1774,6 +1790,10 @@ kubeDns:
     ##
     additionalLabels: {}
     #  foo: bar
+
+    ## defines the labels which are transferred from the associated Kubernetes Service object onto the ingested metrics.
+    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+    targetLabels: []
 
 ## Component scraping etcd
 ##
@@ -1880,6 +1900,10 @@ kubeEtcd:
     additionalLabels: {}
     #  foo: bar
 
+    ## defines the labels which are transferred from the associated Kubernetes Service object onto the ingested metrics.
+    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+    targetLabels: []
+
 ## Component scraping kube scheduler
 ##
 kubeScheduler:
@@ -1982,6 +2006,10 @@ kubeScheduler:
     additionalLabels: {}
     #  foo: bar
 
+    ## defines the labels which are transferred from the associated Kubernetes Service object onto the ingested metrics.
+    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+    targetLabels: []
+
 ## Component scraping kube proxy
 ##
 kubeProxy:
@@ -2069,6 +2097,10 @@ kubeProxy:
     ##
     additionalLabels: {}
     #  foo: bar
+
+    ## defines the labels which are transferred from the associated Kubernetes Service object onto the ingested metrics.
+    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+    targetLabels: []
 
 ## Component scraping kube state metrics
 ##
@@ -2736,6 +2768,8 @@ prometheusOperator:
     selector: ""
     ## Use '{{ template "kube-prometheus-stack.fullname" . }}-kubelet' by default
     name: ""
+    ## defines the labels which are transferred from the associated Kubernetes Pod object onto the ingested metrics.
+    labels: ""
 
   ## Create Endpoints objects for kubelet targets.
   kubeletEndpointsEnabled: true

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -2773,6 +2773,11 @@ prometheusOperator:
   kubeletEndpointsEnabled: true
   ## Create EndpointSlice objects for kubelet targets.
   kubeletEndpointSliceEnabled: false
+  
+  ## Extra arguments to pass to prometheusOperator
+  # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/operator.md
+  extraArgs: []
+  #  - --labels="cluster=talos-cluster"
 
   ## Create a servicemonitor for the operator
   ##


### PR DESCRIPTION
#### What this PR does / why we need it

This PR will add the support for targetLabels for all exporters in kube-prometheus-stack

#### Which issue this PR fixes

- fixes #4966 kube-prometheus-stack exporters part
