### PR TITLE
[kube-prometheus-stack] Fix README.md

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 66.2.0
+version: 66.2.1
 appVersion: v0.78.1
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/README.md
+++ b/charts/kube-prometheus-stack/README.md
@@ -84,7 +84,7 @@ A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an 
 
 ### From 65.x to 66.x
 
-This version upgrades Prometheus-Operator to v0.77.1
+This version upgrades Prometheus-Operator to v0.78.1
 
 Run these commands to update the CRDs before applying the upgrade.
 


### PR DESCRIPTION
#### What this PR does / why we need it
Fix operator version in "From 65.x to 66.x"

Version was bumped in #4979, but wrong version was written in Readme.

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
