### PR TITLE
[prometheus] pdb template values

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus
 appVersion: v2.55.1
-version: 25.30.1
+version: 25.30.2
 kubeVersion: ">=1.19.0-0"
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/templates/pdb.yaml
+++ b/charts/prometheus/templates/pdb.yaml
@@ -11,5 +11,10 @@ spec:
   selector:
     matchLabels:
       {{- include "prometheus.server.matchLabels" . | nindent 6 }}
-  {{- toYaml $pdbSpec | nindent 2 }}
+  {{- if $pdbSpec.minAvailable }}
+  minAvailable: {{ $pdbSpec.minAvailable }}
+  {{- end }}
+  {{- if $pdbSpec.maxUnavailable }}
+  maxUnavailable: {{ $pdbSpec.maxUnavailable }}
+  {{- end }}
 {{- end }}

--- a/charts/prometheus/templates/pdb.yaml
+++ b/charts/prometheus/templates/pdb.yaml
@@ -22,5 +22,5 @@ spec:
   {{- end }}
   {{- if hasKey $pdbSpec "unhealthyPodEvictionPolicy" }}
   unhealthyPodEvictionPolicy: {{ $pdbSpec.unhealthyPodEvictionPolicy }}
-  {{- end }}}}
+  {{- end }}
 {{- end }}

--- a/charts/prometheus/templates/pdb.yaml
+++ b/charts/prometheus/templates/pdb.yaml
@@ -11,10 +11,16 @@ spec:
   selector:
     matchLabels:
       {{- include "prometheus.server.matchLabels" . | nindent 6 }}
-  {{- if $pdbSpec.minAvailable }}
+  {{- if not (or (hasKey $pdbSpec "minAvailable") (hasKey $pdbSpec "maxUnavailable")) }}
+  maxUnavailable: 1
+  {{- end }}
+  {{- if hasKey $pdbSpec "minAvailable" }}
   minAvailable: {{ $pdbSpec.minAvailable }}
   {{- end }}
-  {{- if $pdbSpec.maxUnavailable }}
+  {{- if hasKey $pdbSpec "maxUnavailable" }}
   maxUnavailable: {{ $pdbSpec.maxUnavailable }}
   {{- end }}
+  {{- if hasKey $pdbSpec "unhealthyPodEvictionPolicy" }}
+  unhealthyPodEvictionPolicy: {{ $pdbSpec.unhealthyPodEvictionPolicy }}
+  {{- end }}}}
 {{- end }}

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -453,7 +453,7 @@ server:
   ##
   podDisruptionBudget:
     enabled: false
-    maxUnavailable: 1
+    # maxUnavailable: 1
     # minAvailable: 1
     ## unhealthyPodEvictionPolicy is available since 1.27.0 (beta)
     ## https://kubernetes.io/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes:
- FIX to PDB template. Here we are seeing maxUnavailable defaulting to 1. If we try to only spec minAvailable, maxUnavailable is templating due to default value. K8s does not allow both of these specs. 
- This PR sees a change to allow specific values without issue. 

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
