### PR TITLE
[prometheus-postgres-exporter] Don't set initialDelaySeconds to the default values

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v0.15.0"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 6.4.0
+version: 6.4.1
 home: https://github.com/prometheus-community/postgres_exporter
 sources:
 - https://github.com/prometheus-community/postgres_exporter

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -201,7 +201,6 @@ podLabels: {}
 
 # Configurable probes. If TLS client authentication is enabled at the exporter, TCP probe must be used.
 livenessProbe:
-  initialDelaySeconds: 0
   httpGet:
     path: /
     port: http
@@ -211,7 +210,6 @@ livenessProbe:
   timeoutSeconds: 3
 
 readinessProbe:
-  initialDelaySeconds: 0
   httpGet:
     path: /
     port: http


### PR DESCRIPTION
#### What this PR does / why we need it

Stop setting `livenessProbe.initialDelaySeconds` and `readinessProbe.initialDelaySeconds` to the Kubernetes defaults of `0` in `values.yaml`

#### Which issue this PR fixes

Setting these values to the Kubernetes defaults causes permanent diffs in GitOps tooling, e.g. ArgoCD (see https://github.com/argoproj/argo-cd/issues/8833 for an example) as defaults are pruned when reading back the resource from the API.

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
