### PR TITLE
[kube-prometheus-stack] Chore: Improve kubelet ServiceMonitor

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 66.7.0
+version: 66.7.1
 appVersion: v0.79.0
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/_helpers.tpl
+++ b/charts/kube-prometheus-stack/templates/_helpers.tpl
@@ -318,3 +318,16 @@ global:
 {{ $fullname }}-webhook.{{ $namespace }}.svc
 {{- end }}
 {{- end }}
+
+{{/* To help configure the kubelet servicemonitor for http or https. */}}
+{{- define "kube-prometheus-stack.kubelet.scheme" }}
+{{- if .Values.kubelet.serviceMonitor.https }}https{{ else }}http{{ end }}
+{{- end }}
+{{- define "kube-prometheus-stack.kubelet.authConfig" }}
+{{- if .Values.kubelet.serviceMonitor.https }}
+tlsConfig:
+  caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  insecureSkipVerify: {{ .Values.kubelet.serviceMonitor.insecureSkipVerify }}
+bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+{{- end }}
+{{- end }}

--- a/charts/kube-prometheus-stack/templates/exporters/kubelet/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kubelet/servicemonitor.yaml
@@ -20,213 +20,6 @@ spec:
   attachMetadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  endpoints:
-  {{- if .Values.kubelet.serviceMonitor.https }}
-  - port: https-metrics
-    scheme: https
-    {{- if .Values.kubelet.serviceMonitor.interval }}
-    interval: {{ .Values.kubelet.serviceMonitor.interval }}
-    {{- end }}
-    {{- if .Values.kubelet.serviceMonitor.proxyUrl }}
-    proxyUrl: {{ .Values.kubelet.serviceMonitor.proxyUrl }}
-    {{- end }}
-    {{- if .Values.kubelet.serviceMonitor.scrapeTimeout }}
-    scrapeTimeout: {{ .Values.kubelet.serviceMonitor.scrapeTimeout }}
-    {{- end }}
-    tlsConfig:
-      caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-      insecureSkipVerify: {{ .Values.kubelet.serviceMonitor.insecureSkipVerify }}
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    honorLabels: {{ .Values.kubelet.serviceMonitor.honorLabels }}
-    honorTimestamps: {{ .Values.kubelet.serviceMonitor.honorTimestamps }}
-{{- if .Values.kubelet.serviceMonitor.metricRelabelings }}
-    metricRelabelings:
-{{ tpl (toYaml .Values.kubelet.serviceMonitor.metricRelabelings | indent 4) . }}
-{{- end }}
-{{- if .Values.kubelet.serviceMonitor.relabelings }}
-    relabelings:
-{{ tpl (toYaml .Values.kubelet.serviceMonitor.relabelings | indent 4) . }}
-{{- end }}
-{{- if .Values.kubelet.serviceMonitor.cAdvisor }}
-  - port: https-metrics
-    scheme: https
-    path: /metrics/cadvisor
-    {{- if .Values.kubelet.serviceMonitor.interval }}
-    interval: {{ .Values.kubelet.serviceMonitor.interval }}
-    {{- end }}
-    {{- if .Values.kubelet.serviceMonitor.proxyUrl }}
-    proxyUrl: {{ .Values.kubelet.serviceMonitor.proxyUrl }}
-    {{- end }}
-    {{- if .Values.kubelet.serviceMonitor.scrapeTimeout }}
-    scrapeTimeout: {{ .Values.kubelet.serviceMonitor.scrapeTimeout }}
-    {{- end }}
-    honorLabels: {{ .Values.kubelet.serviceMonitor.honorLabels }}
-    honorTimestamps: {{ .Values.kubelet.serviceMonitor.honorTimestamps }}
-    trackTimestampsStaleness: {{ .Values.kubelet.serviceMonitor.trackTimestampsStaleness }}
-    tlsConfig:
-      caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-      insecureSkipVerify: true
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-{{- if .Values.kubelet.serviceMonitor.cAdvisorMetricRelabelings }}
-    metricRelabelings:
-{{ tpl (toYaml .Values.kubelet.serviceMonitor.cAdvisorMetricRelabelings | indent 4) . }}
-{{- end }}
-{{- if .Values.kubelet.serviceMonitor.cAdvisorRelabelings }}
-    relabelings:
-{{ tpl (toYaml .Values.kubelet.serviceMonitor.cAdvisorRelabelings | indent 4) . }}
-{{- end }}
-{{- end }}
-{{- if .Values.kubelet.serviceMonitor.probes }}
-  - port: https-metrics
-    scheme: https
-    path: /metrics/probes
-    {{- if .Values.kubelet.serviceMonitor.interval }}
-    interval: {{ .Values.kubelet.serviceMonitor.interval }}
-    {{- end }}
-    {{- if .Values.kubelet.serviceMonitor.proxyUrl }}
-    proxyUrl: {{ .Values.kubelet.serviceMonitor.proxyUrl }}
-    {{- end }}
-    {{- if .Values.kubelet.serviceMonitor.scrapeTimeout }}
-    scrapeTimeout: {{ .Values.kubelet.serviceMonitor.scrapeTimeout }}
-    {{- end }}
-    honorLabels: {{ .Values.kubelet.serviceMonitor.honorLabels }}
-    honorTimestamps: {{ .Values.kubelet.serviceMonitor.honorTimestamps }}
-    tlsConfig:
-      caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-      insecureSkipVerify: true
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-{{- if .Values.kubelet.serviceMonitor.probesMetricRelabelings }}
-    metricRelabelings:
-{{ tpl (toYaml .Values.kubelet.serviceMonitor.probesMetricRelabelings | indent 4) . }}
-{{- end }}
-{{- if .Values.kubelet.serviceMonitor.probesRelabelings }}
-    relabelings:
-{{ tpl (toYaml .Values.kubelet.serviceMonitor.probesRelabelings | indent 4) . }}
-{{- end }}
-{{- end }}
-{{- if .Values.kubelet.serviceMonitor.resource }}
-  - port: https-metrics
-    scheme: https
-    path: {{ .Values.kubelet.serviceMonitor.resourcePath }}
-    {{- if .Values.kubelet.serviceMonitor.interval }}
-    interval: {{ .Values.kubelet.serviceMonitor.interval }}
-    {{- end }}
-    {{- if .Values.kubelet.serviceMonitor.proxyUrl }}
-    proxyUrl: {{ .Values.kubelet.serviceMonitor.proxyUrl }}
-    {{- end }}
-    {{- if .Values.kubelet.serviceMonitor.scrapeTimeout }}
-    scrapeTimeout: {{ .Values.kubelet.serviceMonitor.scrapeTimeout }}
-    {{- end }}
-    honorLabels: {{ .Values.kubelet.serviceMonitor.honorLabels }}
-    honorTimestamps: {{ .Values.kubelet.serviceMonitor.honorTimestamps }}
-    trackTimestampsStaleness: {{ .Values.kubelet.serviceMonitor.trackTimestampsStaleness }}
-    tlsConfig:
-      caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-      insecureSkipVerify: true
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-{{- if .Values.kubelet.serviceMonitor.resourceMetricRelabelings }}
-    metricRelabelings:
-{{ tpl (toYaml .Values.kubelet.serviceMonitor.resourceMetricRelabelings | indent 4) . }}
-{{- end }}
-{{- if .Values.kubelet.serviceMonitor.resourceRelabelings }}
-    relabelings:
-{{ tpl (toYaml .Values.kubelet.serviceMonitor.resourceRelabelings | indent 4) . }}
-{{- end }}
-{{- end }}
-  {{- else }}
-  - port: http-metrics
-    {{- if .Values.kubelet.serviceMonitor.interval }}
-    interval: {{ .Values.kubelet.serviceMonitor.interval }}
-    {{- end }}
-    {{- if .Values.kubelet.serviceMonitor.proxyUrl }}
-    proxyUrl: {{ .Values.kubelet.serviceMonitor.proxyUrl }}
-    {{- end }}
-    {{- if .Values.kubelet.serviceMonitor.scrapeTimeout }}
-    scrapeTimeout: {{ .Values.kubelet.serviceMonitor.scrapeTimeout }}
-    {{- end }}
-    honorLabels: {{ .Values.kubelet.serviceMonitor.honorLabels }}
-    honorTimestamps: {{ .Values.kubelet.serviceMonitor.honorTimestamps }}
-    trackTimestampsStaleness: {{ .Values.kubelet.serviceMonitor.trackTimestampsStaleness }}
-{{- if .Values.kubelet.serviceMonitor.metricRelabelings }}
-    metricRelabelings:
-{{ tpl (toYaml .Values.kubelet.serviceMonitor.metricRelabelings | indent 4) . }}
-{{- end }}
-{{- if .Values.kubelet.serviceMonitor.relabelings }}
-    relabelings:
-{{ tpl (toYaml .Values.kubelet.serviceMonitor.relabelings | indent 4) . }}
-{{- end }}
-{{- if .Values.kubelet.serviceMonitor.cAdvisor }}
-  - port: http-metrics
-    path: /metrics/cadvisor
-    {{- if .Values.kubelet.serviceMonitor.interval }}
-    interval: {{ .Values.kubelet.serviceMonitor.interval }}
-    {{- end }}
-    {{- if .Values.kubelet.serviceMonitor.proxyUrl }}
-    proxyUrl: {{ .Values.kubelet.serviceMonitor.proxyUrl }}
-    {{- end }}
-    {{- if .Values.kubelet.serviceMonitor.scrapeTimeout }}
-    scrapeTimeout: {{ .Values.kubelet.serviceMonitor.scrapeTimeout }}
-    {{- end }}
-    honorLabels: {{ .Values.kubelet.serviceMonitor.honorLabels }}
-    honorTimestamps: {{ .Values.kubelet.serviceMonitor.honorTimestamps }}
-    trackTimestampsStaleness: {{ .Values.kubelet.serviceMonitor.trackTimestampsStaleness }}
-{{- if .Values.kubelet.serviceMonitor.cAdvisorMetricRelabelings }}
-    metricRelabelings:
-{{ tpl (toYaml .Values.kubelet.serviceMonitor.cAdvisorMetricRelabelings | indent 4) . }}
-{{- end }}
-{{- if .Values.kubelet.serviceMonitor.cAdvisorRelabelings }}
-    relabelings:
-{{ tpl (toYaml .Values.kubelet.serviceMonitor.cAdvisorRelabelings | indent 4) . }}
-{{- end }}
-{{- if .Values.kubelet.serviceMonitor.probes }}
-  - port: http-metrics
-    path: /metrics/probes
-    {{- if .Values.kubelet.serviceMonitor.interval }}
-    interval: {{ .Values.kubelet.serviceMonitor.interval }}
-    {{- end }}
-    {{- if .Values.kubelet.serviceMonitor.proxyUrl }}
-    proxyUrl: {{ .Values.kubelet.serviceMonitor.proxyUrl }}
-    {{- end }}
-    {{- if .Values.kubelet.serviceMonitor.scrapeTimeout }}
-    scrapeTimeout: {{ .Values.kubelet.serviceMonitor.scrapeTimeout }}
-    {{- end }}
-    honorLabels: {{ .Values.kubelet.serviceMonitor.honorLabels }}
-    honorTimestamps: {{ .Values.kubelet.serviceMonitor.honorTimestamps }}
-{{- if .Values.kubelet.serviceMonitor.probesMetricRelabelings }}
-    metricRelabelings:
-{{ tpl (toYaml .Values.kubelet.serviceMonitor.probesMetricRelabelings | indent 4) . }}
-{{- end }}
-{{- if .Values.kubelet.serviceMonitor.probesRelabelings }}
-    relabelings:
-{{ tpl (toYaml .Values.kubelet.serviceMonitor.probesRelabelings | indent 4) . }}
-{{- end }}
-{{- end }}
-{{- if .Values.kubelet.serviceMonitor.resource }}
-  - port: http-metrics
-    path: {{ .Values.kubelet.serviceMonitor.resourcePath }}
-    {{- if .Values.kubelet.serviceMonitor.interval }}
-    interval: {{ .Values.kubelet.serviceMonitor.interval }}
-    {{- end }}
-    {{- if .Values.kubelet.serviceMonitor.proxyUrl }}
-    proxyUrl: {{ .Values.kubelet.serviceMonitor.proxyUrl }}
-    {{- end }}
-    {{- if .Values.kubelet.serviceMonitor.scrapeTimeout }}
-    scrapeTimeout: {{ .Values.kubelet.serviceMonitor.scrapeTimeout }}
-    {{- end }}
-    honorLabels: {{ .Values.kubelet.serviceMonitor.honorLabels }}
-    honorTimestamps: {{ .Values.kubelet.serviceMonitor.honorTimestamps }}
-    trackTimestampsStaleness: {{ .Values.kubelet.serviceMonitor.trackTimestampsStaleness }}
-{{- if .Values.kubelet.serviceMonitor.resourceMetricRelabelings }}
-    metricRelabelings:
-{{ tpl (toYaml .Values.kubelet.serviceMonitor.resourceMetricRelabelings | indent 4) . }}
-{{- end }}
-{{- if .Values.kubelet.serviceMonitor.resourceRelabelings }}
-    relabelings:
-{{ tpl (toYaml .Values.kubelet.serviceMonitor.resourceRelabelings | indent 4) . }}
-{{- end }}
-{{- end }}
-{{- end }}
-  {{- end }}
   jobLabel: k8s-app
   {{- with .Values.kubelet.serviceMonitor.targetLabels }}
   targetLabels:
@@ -239,4 +32,104 @@ spec:
     matchLabels:
       app.kubernetes.io/name: kubelet
       k8s-app: kubelet
-{{- end}}
+  endpoints:
+  - port: {{ template "kube-prometheus-stack.kubelet.scheme" . }}-metrics
+    scheme: {{ template "kube-prometheus-stack.kubelet.scheme" . }}
+    {{- if .Values.kubelet.serviceMonitor.interval }}
+    interval: {{ .Values.kubelet.serviceMonitor.interval }}
+    {{- end }}
+    {{- if .Values.kubelet.serviceMonitor.proxyUrl }}
+    proxyUrl: {{ .Values.kubelet.serviceMonitor.proxyUrl }}
+    {{- end }}
+    {{- if .Values.kubelet.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.kubelet.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+    {{- include "kube-prometheus-stack.kubelet.authConfig" . | indent 4 }}
+    honorLabels: {{ .Values.kubelet.serviceMonitor.honorLabels }}
+    honorTimestamps: {{ .Values.kubelet.serviceMonitor.honorTimestamps }}
+{{- if .Values.kubelet.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ tpl (toYaml .Values.kubelet.serviceMonitor.metricRelabelings | indent 4) . }}
+{{- end }}
+{{- if .Values.kubelet.serviceMonitor.relabelings }}
+    relabelings:
+{{ tpl (toYaml .Values.kubelet.serviceMonitor.relabelings | indent 4) . }}
+{{- end }}
+{{- if .Values.kubelet.serviceMonitor.cAdvisor }}
+  - port: {{ template "kube-prometheus-stack.kubelet.scheme" . }}-metrics
+    scheme: {{ template "kube-prometheus-stack.kubelet.scheme" . }}
+    path: /metrics/cadvisor
+    {{- if .Values.kubelet.serviceMonitor.interval }}
+    interval: {{ .Values.kubelet.serviceMonitor.interval }}
+    {{- end }}
+    {{- if .Values.kubelet.serviceMonitor.proxyUrl }}
+    proxyUrl: {{ .Values.kubelet.serviceMonitor.proxyUrl }}
+    {{- end }}
+    {{- if .Values.kubelet.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.kubelet.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+    honorLabels: {{ .Values.kubelet.serviceMonitor.honorLabels }}
+    honorTimestamps: {{ .Values.kubelet.serviceMonitor.honorTimestamps }}
+    trackTimestampsStaleness: {{ .Values.kubelet.serviceMonitor.trackTimestampsStaleness }}
+    {{- include "kube-prometheus-stack.kubelet.authConfig" . | indent 4 }}
+{{- if .Values.kubelet.serviceMonitor.cAdvisorMetricRelabelings }}
+    metricRelabelings:
+{{ tpl (toYaml .Values.kubelet.serviceMonitor.cAdvisorMetricRelabelings | indent 4) . }}
+{{- end }}
+{{- if .Values.kubelet.serviceMonitor.cAdvisorRelabelings }}
+    relabelings:
+{{ tpl (toYaml .Values.kubelet.serviceMonitor.cAdvisorRelabelings | indent 4) . }}
+{{- end }}
+{{- end }}
+{{- if .Values.kubelet.serviceMonitor.probes }}
+  - port: {{ template "kube-prometheus-stack.kubelet.scheme" . }}-metrics
+    scheme: {{ template "kube-prometheus-stack.kubelet.scheme" . }}
+    path: /metrics/probes
+    {{- if .Values.kubelet.serviceMonitor.interval }}
+    interval: {{ .Values.kubelet.serviceMonitor.interval }}
+    {{- end }}
+    {{- if .Values.kubelet.serviceMonitor.proxyUrl }}
+    proxyUrl: {{ .Values.kubelet.serviceMonitor.proxyUrl }}
+    {{- end }}
+    {{- if .Values.kubelet.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.kubelet.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+    honorLabels: {{ .Values.kubelet.serviceMonitor.honorLabels }}
+    honorTimestamps: {{ .Values.kubelet.serviceMonitor.honorTimestamps }}
+    {{- include "kube-prometheus-stack.kubelet.authConfig" . | indent 4 }}
+{{- if .Values.kubelet.serviceMonitor.probesMetricRelabelings }}
+    metricRelabelings:
+{{ tpl (toYaml .Values.kubelet.serviceMonitor.probesMetricRelabelings | indent 4) . }}
+{{- end }}
+{{- if .Values.kubelet.serviceMonitor.probesRelabelings }}
+    relabelings:
+{{ tpl (toYaml .Values.kubelet.serviceMonitor.probesRelabelings | indent 4) . }}
+{{- end }}
+{{- end }}
+{{- if .Values.kubelet.serviceMonitor.resource }}
+  - port: {{ template "kube-prometheus-stack.kubelet.scheme" . }}-metrics
+    scheme: {{ template "kube-prometheus-stack.kubelet.scheme" . }}
+    path: {{ .Values.kubelet.serviceMonitor.resourcePath }}
+    {{- if .Values.kubelet.serviceMonitor.interval }}
+    interval: {{ .Values.kubelet.serviceMonitor.interval }}
+    {{- end }}
+    {{- if .Values.kubelet.serviceMonitor.proxyUrl }}
+    proxyUrl: {{ .Values.kubelet.serviceMonitor.proxyUrl }}
+    {{- end }}
+    {{- if .Values.kubelet.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.kubelet.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+    honorLabels: {{ .Values.kubelet.serviceMonitor.honorLabels }}
+    honorTimestamps: {{ .Values.kubelet.serviceMonitor.honorTimestamps }}
+    trackTimestampsStaleness: {{ .Values.kubelet.serviceMonitor.trackTimestampsStaleness }}
+    {{- include "kube-prometheus-stack.kubelet.authConfig" .  | indent 4 }}
+{{- if .Values.kubelet.serviceMonitor.resourceMetricRelabelings }}
+    metricRelabelings:
+{{ tpl (toYaml .Values.kubelet.serviceMonitor.resourceMetricRelabelings | indent 4) . }}
+{{- end }}
+{{- if .Values.kubelet.serviceMonitor.resourceRelabelings }}
+    relabelings:
+{{ tpl (toYaml .Values.kubelet.serviceMonitor.resourceRelabelings | indent 4) . }}
+{{- end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it
Refactor the Kubelet ServiceMonitor with a helper template for handling http/https schema. This will reduce the chance of copy-pasta mistakes when updating the different kubelet monitoring endpoints.
* Define `kube-prometheus-stack.kubelet.scheme` for the port/schema.
* Define `kube-prometheus-stack.kubelet.authConfig` for TLS access controls.

#### Which issue this PR fixes

- none

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
