### PR TITLE
[prometheus-postgres-exporter] Use non default database in multi-targets

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v0.16.0"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 6.7.1
+version: 6.8.0
 home: https://github.com/prometheus-community/postgres_exporter
 sources:
 - https://github.com/prometheus-community/postgres_exporter

--- a/charts/prometheus-postgres-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-postgres-exporter/templates/servicemonitor.yaml
@@ -47,7 +47,11 @@ spec:
   {{- end }}
       params:
         target:
+        {{- if .databaseName }}
+          - {{ .endpoint }}:{{ .port | default 5432 }}/{{ .databaseName | default "" }}
+        {{- else }}
           - {{ .endpoint }}:{{ .port | default 5432 }}
+        {{- end }}
         {{- if $.Values.serviceMonitor.multipleTarget.sharedAuthModule.enabled }}
         auth_module:
           - {{ $.Values.serviceMonitor.multipleTarget.sharedAuthModule.name }}

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -65,6 +65,7 @@ serviceMonitor:
       # - endpoint: pg01.local
       #   name: pg01 (there needs to exist an authModule with key "client.pg01" if not using sharedAuthModule)
       #   port: default 5432
+      #   databaseName: default '' (Set the database name to connect to)
 
 prometheusRule:
   enabled: false


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR introduces the ability to **select the database to connect to in a multi-target configuration** and have the servicemonitor correctly scrape databases that do not match username.

The multi-target configuration section is completed with the new optional parameter `databaseName` as follows:

```yaml
serviceMonitor:
  enabled: true
   # Use multipleTarget mode
  multipleTarget:
    enabled: true
    targets:
      - endpoint: pg01.local
        name: pg01
      - endpoint: pg02.local
        name: pg02
        databaseName: mydb     # <== New optional parameter for selecting database
```

This configuration produces the following servicemonitor resource:

```yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
# ... [redacted]
spec:
  endpoints:
  - metricRelabelings:
    # ... [redacted]
    params:
      auth_module:
      - client.pg01
      target:
      - pg01.local:5432
    path: /probe
    port: http
  - metricRelabelings:
    # ... [redacted]
    params:
      auth_module:
      - client.pg02
      target:
      - pg02.local:5432/mydb     # <== Target references the database in its path
    path: /probe
    port: http
  # ... [redacted]
```

#### Special notes for your reviewer

The multi-target feature is currently in beta, but such configuration would be needed for any users relying on a Postgres user dedicated to monitoring purposes, without a database matching its name.

Currently, a workaround is to keep the servicemonitor of this chart disabled and define a custom servicemonitor.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
