### PR TITLE
[prometheus-operator-crds] bump to 0.79.1

### DIFF
--- a/charts/prometheus-operator-crds/Chart.yaml
+++ b/charts/prometheus-operator-crds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 type: application
-version: 17.0.0
+version: 17.0.1
 name: prometheus-operator-crds
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
 description: |
@@ -9,7 +9,7 @@ description: |
 keywords:
   - prometheus
   - crds
-appVersion: v0.79.0
+appVersion: v0.79.1
 kubeVersion: ">=1.16.0-0"
 sources:
   - https://github.com/prometheus-community/helm-charts

--- a/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
+++ b/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.1/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -8,7 +8,7 @@ metadata:
 {{- toYaml . | nindent 4 }}
 {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.79.0
+    operator.prometheus.io/version: 0.79.1
   name: alertmanagerconfigs.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagers.yaml
+++ b/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagers.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.1/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -8,7 +8,7 @@ metadata:
 {{- toYaml . | nindent 4 }}
 {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.79.0
+    operator.prometheus.io/version: 0.79.1
   name: alertmanagers.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/charts/prometheus-operator-crds/charts/crds/templates/crd-podmonitors.yaml
+++ b/charts/prometheus-operator-crds/charts/crds/templates/crd-podmonitors.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.0/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.1/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -8,7 +8,7 @@ metadata:
 {{- toYaml . | nindent 4 }}
 {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.79.0
+    operator.prometheus.io/version: 0.79.1
   name: podmonitors.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -80,6 +80,18 @@ spec:
 
                   It requires Prometheus >= v2.28.0.
                 pattern: (^0|([0-9]*[.])?[0-9]+((K|M|G|T|E|P)i?)?B)$
+                type: string
+              fallbackScrapeProtocol:
+                description: |-
+                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
+
+                  It requires Prometheus >= v3.0.0.
+                enum:
+                - PrometheusProto
+                - OpenMetricsText0.0.1
+                - OpenMetricsText1.0.0
+                - PrometheusText0.0.4
+                - PrometheusText1.0.0
                 type: string
               jobLabel:
                 description: |-
@@ -1097,18 +1109,6 @@ spec:
                   Whether to scrape a classic histogram that is also exposed as a native histogram.
                   It requires Prometheus >= v2.45.0.
                 type: boolean
-              scrapeFallbackProtocol:
-                description: |-
-                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
-
-                  It requires Prometheus >= v3.0.0.
-                enum:
-                - PrometheusProto
-                - OpenMetricsText0.0.1
-                - OpenMetricsText1.0.0
-                - PrometheusText0.0.4
-                - PrometheusText1.0.0
-                type: string
               scrapeProtocols:
                 description: |-
                   `scrapeProtocols` defines the protocols to negotiate during a scrape. It tells clients the

--- a/charts/prometheus-operator-crds/charts/crds/templates/crd-probes.yaml
+++ b/charts/prometheus-operator-crds/charts/crds/templates/crd-probes.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.0/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.1/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -8,7 +8,7 @@ metadata:
 {{- toYaml . | nindent 4 }}
 {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.79.0
+    operator.prometheus.io/version: 0.79.1
   name: probes.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -177,6 +177,18 @@ spec:
                 - key
                 type: object
                 x-kubernetes-map-type: atomic
+              fallbackScrapeProtocol:
+                description: |-
+                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
+
+                  It requires Prometheus >= v3.0.0.
+                enum:
+                - PrometheusProto
+                - OpenMetricsText0.0.1
+                - OpenMetricsText1.0.0
+                - PrometheusText0.0.4
+                - PrometheusText1.0.0
+                type: string
               interval:
                 description: |-
                   Interval at which targets are probed using the configured prober.
@@ -686,18 +698,6 @@ spec:
                   Whether to scrape a classic histogram that is also exposed as a native histogram.
                   It requires Prometheus >= v2.45.0.
                 type: boolean
-              scrapeFallbackProtocol:
-                description: |-
-                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
-
-                  It requires Prometheus >= v3.0.0.
-                enum:
-                - PrometheusProto
-                - OpenMetricsText0.0.1
-                - OpenMetricsText1.0.0
-                - PrometheusText0.0.4
-                - PrometheusText1.0.0
-                type: string
               scrapeProtocols:
                 description: |-
                   `scrapeProtocols` defines the protocols to negotiate during a scrape. It tells clients the

--- a/charts/prometheus-operator-crds/charts/crds/templates/crd-prometheusagents.yaml
+++ b/charts/prometheus-operator-crds/charts/crds/templates/crd-prometheusagents.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -8,7 +8,7 @@ metadata:
 {{- toYaml . | nindent 4 }}
 {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.79.0
+    operator.prometheus.io/version: 0.79.1
   name: prometheusagents.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -6859,18 +6859,6 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
-              scrapeFallbackProtocol:
-                description: |-
-                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
-
-                  It requires Prometheus >= v3.0.0.
-                enum:
-                - PrometheusProto
-                - OpenMetricsText0.0.1
-                - OpenMetricsText1.0.0
-                - PrometheusText0.0.4
-                - PrometheusText1.0.0
-                type: string
               scrapeInterval:
                 default: 30s
                 description: |-

--- a/charts/prometheus-operator-crds/charts/crds/templates/crd-prometheuses.yaml
+++ b/charts/prometheus-operator-crds/charts/crds/templates/crd-prometheuses.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -8,7 +8,7 @@ metadata:
 {{- toYaml . | nindent 4 }}
 {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.79.0
+    operator.prometheus.io/version: 0.79.1
   name: prometheuses.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -8567,18 +8567,6 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
-              scrapeFallbackProtocol:
-                description: |-
-                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
-
-                  It requires Prometheus >= v3.0.0.
-                enum:
-                - PrometheusProto
-                - OpenMetricsText0.0.1
-                - OpenMetricsText1.0.0
-                - PrometheusText0.0.4
-                - PrometheusText1.0.0
-                type: string
               scrapeInterval:
                 default: 30s
                 description: |-

--- a/charts/prometheus-operator-crds/charts/crds/templates/crd-prometheusrules.yaml
+++ b/charts/prometheus-operator-crds/charts/crds/templates/crd-prometheusrules.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -8,7 +8,7 @@ metadata:
 {{- toYaml . | nindent 4 }}
 {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.79.0
+    operator.prometheus.io/version: 0.79.1
   name: prometheusrules.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/charts/prometheus-operator-crds/charts/crds/templates/crd-scrapeconfigs.yaml
+++ b/charts/prometheus-operator-crds/charts/crds/templates/crd-scrapeconfigs.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.0/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.1/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -8,7 +8,7 @@ metadata:
 {{- toYaml . | nindent 4 }}
 {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.79.0
+    operator.prometheus.io/version: 0.79.1
   name: scrapeconfigs.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -4078,6 +4078,18 @@ spec:
                   - server
                   type: object
                 type: array
+              fallbackScrapeProtocol:
+                description: |-
+                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
+
+                  It requires Prometheus >= v3.0.0.
+                enum:
+                - PrometheusProto
+                - OpenMetricsText0.0.1
+                - OpenMetricsText1.0.0
+                - PrometheusText0.0.4
+                - PrometheusText1.0.0
+                type: string
               fileSDConfigs:
                 description: FileSDConfigs defines a list of file service discovery
                   configurations.
@@ -11262,18 +11274,6 @@ spec:
                   Whether to scrape a classic histogram that is also exposed as a native histogram.
                   It requires Prometheus >= v2.45.0.
                 type: boolean
-              scrapeFallbackProtocol:
-                description: |-
-                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
-
-                  It requires Prometheus >= v3.0.0.
-                enum:
-                - PrometheusProto
-                - OpenMetricsText0.0.1
-                - OpenMetricsText1.0.0
-                - PrometheusText0.0.4
-                - PrometheusText1.0.0
-                type: string
               scrapeInterval:
                 description: ScrapeInterval is the interval between consecutive scrapes.
                 pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$

--- a/charts/prometheus-operator-crds/charts/crds/templates/crd-servicemonitors.yaml
+++ b/charts/prometheus-operator-crds/charts/crds/templates/crd-servicemonitors.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.0/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.1/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -8,7 +8,7 @@ metadata:
 {{- toYaml . | nindent 4 }}
 {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.79.0
+    operator.prometheus.io/version: 0.79.1
   name: servicemonitors.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -1014,6 +1014,18 @@ spec:
                       type: boolean
                   type: object
                 type: array
+              fallbackScrapeProtocol:
+                description: |-
+                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
+
+                  It requires Prometheus >= v3.0.0.
+                enum:
+                - PrometheusProto
+                - OpenMetricsText0.0.1
+                - OpenMetricsText1.0.0
+                - PrometheusText0.0.4
+                - PrometheusText1.0.0
+                type: string
               jobLabel:
                 description: |-
                   `jobLabel` selects the label from the associated Kubernetes `Service`
@@ -1111,18 +1123,6 @@ spec:
                   Whether to scrape a classic histogram that is also exposed as a native histogram.
                   It requires Prometheus >= v2.45.0.
                 type: boolean
-              scrapeFallbackProtocol:
-                description: |-
-                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
-
-                  It requires Prometheus >= v3.0.0.
-                enum:
-                - PrometheusProto
-                - OpenMetricsText0.0.1
-                - OpenMetricsText1.0.0
-                - PrometheusText0.0.4
-                - PrometheusText1.0.0
-                type: string
               scrapeProtocols:
                 description: |-
                   `scrapeProtocols` defines the protocols to negotiate during a scrape. It tells clients the

--- a/charts/prometheus-operator-crds/charts/crds/templates/crd-thanosrulers.yaml
+++ b/charts/prometheus-operator-crds/charts/crds/templates/crd-thanosrulers.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.0/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.1/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -8,7 +8,7 @@ metadata:
 {{- toYaml . | nindent 4 }}
 {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.79.0
+    operator.prometheus.io/version: 0.79.1
   name: thanosrulers.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com


### PR DESCRIPTION
#### What this PR does / why we need it

Updates to the latest prometheus operator CRDs (0.79.1).

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer

CRDs copied in from prometheus-operator, straightforward changes.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
