### PR TITLE
[kube-prometheus-stack]: bump to 0.79.2

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,8 +23,8 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 67.3.0
-appVersion: v0.79.1
+version: 67.3.1
+appVersion: v0.79.2
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus
 keywords:

--- a/charts/kube-prometheus-stack/charts/crds/crds/crd-alertmanagerconfigs.yaml
+++ b/charts/kube-prometheus-stack/charts/crds/crds/crd-alertmanagerconfigs.yaml
@@ -1,11 +1,11 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.1/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.2/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.79.1
+    operator.prometheus.io/version: 0.79.2
   name: alertmanagerconfigs.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/charts/kube-prometheus-stack/charts/crds/crds/crd-alertmanagers.yaml
+++ b/charts/kube-prometheus-stack/charts/crds/crds/crd-alertmanagers.yaml
@@ -1,11 +1,11 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.1/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.2/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.79.1
+    operator.prometheus.io/version: 0.79.2
   name: alertmanagers.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/charts/kube-prometheus-stack/charts/crds/crds/crd-podmonitors.yaml
+++ b/charts/kube-prometheus-stack/charts/crds/crds/crd-podmonitors.yaml
@@ -1,11 +1,11 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.1/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.2/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.79.1
+    operator.prometheus.io/version: 0.79.2
   name: podmonitors.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/charts/kube-prometheus-stack/charts/crds/crds/crd-probes.yaml
+++ b/charts/kube-prometheus-stack/charts/crds/crds/crd-probes.yaml
@@ -1,11 +1,11 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.1/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.2/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.79.1
+    operator.prometheus.io/version: 0.79.2
   name: probes.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/charts/kube-prometheus-stack/charts/crds/crds/crd-prometheusagents.yaml
+++ b/charts/kube-prometheus-stack/charts/crds/crds/crd-prometheusagents.yaml
@@ -1,11 +1,11 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.2/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.79.1
+    operator.prometheus.io/version: 0.79.2
   name: prometheusagents.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/charts/kube-prometheus-stack/charts/crds/crds/crd-prometheuses.yaml
+++ b/charts/kube-prometheus-stack/charts/crds/crds/crd-prometheuses.yaml
@@ -1,11 +1,11 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.2/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.79.1
+    operator.prometheus.io/version: 0.79.2
   name: prometheuses.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/charts/kube-prometheus-stack/charts/crds/crds/crd-prometheusrules.yaml
+++ b/charts/kube-prometheus-stack/charts/crds/crds/crd-prometheusrules.yaml
@@ -1,11 +1,11 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.2/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.79.1
+    operator.prometheus.io/version: 0.79.2
   name: prometheusrules.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/charts/kube-prometheus-stack/charts/crds/crds/crd-scrapeconfigs.yaml
+++ b/charts/kube-prometheus-stack/charts/crds/crds/crd-scrapeconfigs.yaml
@@ -1,11 +1,11 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.1/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.2/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.79.1
+    operator.prometheus.io/version: 0.79.2
   name: scrapeconfigs.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/charts/kube-prometheus-stack/charts/crds/crds/crd-servicemonitors.yaml
+++ b/charts/kube-prometheus-stack/charts/crds/crds/crd-servicemonitors.yaml
@@ -1,11 +1,11 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.1/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.2/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.79.1
+    operator.prometheus.io/version: 0.79.2
   name: servicemonitors.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/charts/kube-prometheus-stack/charts/crds/crds/crd-thanosrulers.yaml
+++ b/charts/kube-prometheus-stack/charts/crds/crds/crd-thanosrulers.yaml
@@ -1,11 +1,11 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.1/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.2/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.79.1
+    operator.prometheus.io/version: 0.79.2
   name: thanosrulers.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com


### PR DESCRIPTION
#### What this PR does / why we need it

Updates to the latest prometheus operator (0.79.2) for kube-prometheus-stack.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer

None.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)