### PR TITLE
[prometheus-operator-crds] bump to 0.79.2

### DIFF
--- a/charts/prometheus-operator-crds/Chart.yaml
+++ b/charts/prometheus-operator-crds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 type: application
-version: 17.0.1
+version: 17.0.2
 name: prometheus-operator-crds
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
 description: |
@@ -9,7 +9,7 @@ description: |
 keywords:
   - prometheus
   - crds
-appVersion: v0.79.1
+appVersion: v0.79.2
 kubeVersion: ">=1.16.0-0"
 sources:
   - https://github.com/prometheus-community/helm-charts

--- a/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
+++ b/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.1/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.2/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -8,7 +8,7 @@ metadata:
 {{- toYaml . | nindent 4 }}
 {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.79.1
+    operator.prometheus.io/version: 0.79.2
   name: alertmanagerconfigs.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagers.yaml
+++ b/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagers.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.1/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.2/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -8,7 +8,7 @@ metadata:
 {{- toYaml . | nindent 4 }}
 {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.79.1
+    operator.prometheus.io/version: 0.79.2
   name: alertmanagers.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/charts/prometheus-operator-crds/charts/crds/templates/crd-podmonitors.yaml
+++ b/charts/prometheus-operator-crds/charts/crds/templates/crd-podmonitors.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.1/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.2/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -8,7 +8,7 @@ metadata:
 {{- toYaml . | nindent 4 }}
 {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.79.1
+    operator.prometheus.io/version: 0.79.2
   name: podmonitors.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/charts/prometheus-operator-crds/charts/crds/templates/crd-probes.yaml
+++ b/charts/prometheus-operator-crds/charts/crds/templates/crd-probes.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.1/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.2/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -8,7 +8,7 @@ metadata:
 {{- toYaml . | nindent 4 }}
 {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.79.1
+    operator.prometheus.io/version: 0.79.2
   name: probes.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/charts/prometheus-operator-crds/charts/crds/templates/crd-prometheusagents.yaml
+++ b/charts/prometheus-operator-crds/charts/crds/templates/crd-prometheusagents.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.2/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -8,7 +8,7 @@ metadata:
 {{- toYaml . | nindent 4 }}
 {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.79.1
+    operator.prometheus.io/version: 0.79.2
   name: prometheusagents.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/charts/prometheus-operator-crds/charts/crds/templates/crd-prometheuses.yaml
+++ b/charts/prometheus-operator-crds/charts/crds/templates/crd-prometheuses.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.2/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -8,7 +8,7 @@ metadata:
 {{- toYaml . | nindent 4 }}
 {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.79.1
+    operator.prometheus.io/version: 0.79.2
   name: prometheuses.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/charts/prometheus-operator-crds/charts/crds/templates/crd-prometheusrules.yaml
+++ b/charts/prometheus-operator-crds/charts/crds/templates/crd-prometheusrules.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.2/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -8,7 +8,7 @@ metadata:
 {{- toYaml . | nindent 4 }}
 {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.79.1
+    operator.prometheus.io/version: 0.79.2
   name: prometheusrules.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/charts/prometheus-operator-crds/charts/crds/templates/crd-scrapeconfigs.yaml
+++ b/charts/prometheus-operator-crds/charts/crds/templates/crd-scrapeconfigs.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.1/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.2/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -8,7 +8,7 @@ metadata:
 {{- toYaml . | nindent 4 }}
 {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.79.1
+    operator.prometheus.io/version: 0.79.2
   name: scrapeconfigs.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/charts/prometheus-operator-crds/charts/crds/templates/crd-servicemonitors.yaml
+++ b/charts/prometheus-operator-crds/charts/crds/templates/crd-servicemonitors.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.1/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.2/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -8,7 +8,7 @@ metadata:
 {{- toYaml . | nindent 4 }}
 {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.79.1
+    operator.prometheus.io/version: 0.79.2
   name: servicemonitors.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/charts/prometheus-operator-crds/charts/crds/templates/crd-thanosrulers.yaml
+++ b/charts/prometheus-operator-crds/charts/crds/templates/crd-thanosrulers.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.1/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.79.2/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -8,7 +8,7 @@ metadata:
 {{- toYaml . | nindent 4 }}
 {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.79.1
+    operator.prometheus.io/version: 0.79.2
   name: thanosrulers.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com


### PR DESCRIPTION
#### What this PR does / why we need it

Updates to the latest prometheus operator (0.79.2).

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer

None

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
