### PR TITLE
[prometheus-postgres-exporter] add namespace by default to the kubectl port-forward command 

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v0.16.0"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 6.8.0
+version: 6.8.1
 home: https://github.com/prometheus-community/postgres_exporter
 sources:
 - https://github.com/prometheus-community/postgres_exporter

--- a/charts/prometheus-postgres-exporter/templates/NOTES.txt
+++ b/charts/prometheus-postgres-exporter/templates/NOTES.txt
@@ -11,5 +11,5 @@
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "prometheus-postgres-exporter.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:9187
+  kubectl port-forward $POD_NAME 8080:9187 --namespace {{ .Release.Namespace }}
 {{- end }}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

By default, `kubectl port-forward` command in PostgreSQL exporter Helm chart doesn't include the namespace, which doesn't provide consistent experience for default and non-default namespaces installation

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
