### PR TITLE
[prometheus-mongodb-exporter] Allow to configure pod security context

### DIFF
--- a/charts/prometheus-mongodb-exporter/Chart.yaml
+++ b/charts/prometheus-mongodb-exporter/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: prometheus-mongodb-exporter
 sources:
   - https://github.com/percona/mongodb_exporter
-version: 3.10.0
+version: 3.11.0

--- a/charts/prometheus-mongodb-exporter/ci/podsecuritycontext-values.yaml
+++ b/charts/prometheus-mongodb-exporter/ci/podsecuritycontext-values.yaml
@@ -1,0 +1,9 @@
+---
+# Test customize podSecurityContext
+
+mongodb:
+  uri: mongodb://localhost:9216
+
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault

--- a/charts/prometheus-mongodb-exporter/templates/deployment.yaml
+++ b/charts/prometheus-mongodb-exporter/templates/deployment.yaml
@@ -82,6 +82,10 @@ spec:
       {{- end }}
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- tpl (toYaml .) $ | nindent 8 }}

--- a/charts/prometheus-mongodb-exporter/values.yaml
+++ b/charts/prometheus-mongodb-exporter/values.yaml
@@ -71,10 +71,17 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+# Customize securityContext of the pod.
+# See https://kubernetes.io/docs/concepts/policy/security-context/ for more.
+podSecurityContext: {}
+  # seccompProfile:
+  #  type: RuntimeDefault
+
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:
-    drop: ["all"]
+    drop:
+      - ALL
   readOnlyRootFilesystem: true
   runAsGroup: 10000
   runAsNonRoot: true


### PR DESCRIPTION
## What this PR does / why we need it

Allow to configure pod security context

Add value _**podSecurityContext**_ as it's present on most of other chart as _prometheus-postgres-exporter_ and _prometheus-elasticsearch-exporter_

Don't set default value to avoid breaking change.

@steven-sheehy
@zeritti


