### PR TITLE
[prometheus-rabbitmq-exporter] Create secret to store credentials when provided

### DIFF
--- a/charts/prometheus-rabbitmq-exporter/Chart.yaml
+++ b/charts/prometheus-rabbitmq-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Rabbitmq metrics exporter for prometheus
 name: prometheus-rabbitmq-exporter
-version: 1.12.1
+version: 1.13.0
 appVersion: v0.29.0
 home: https://github.com/kbudde/rabbitmq_exporter
 sources:

--- a/charts/prometheus-rabbitmq-exporter/templates/deployment.yaml
+++ b/charts/prometheus-rabbitmq-exporter/templates/deployment.yaml
@@ -57,7 +57,10 @@ spec:
                   key: "{{ .Values.rabbitmq.existingPasswordSecretKey }}"
             {{- else if .Values.rabbitmq.password  }}
             - name: RABBIT_PASSWORD
-              value: {{ .Values.rabbitmq.password }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "prometheus-rabbitmq-exporter.fullname" . }}
+                  key: RABBIT_PASSWORD
             {{- end }}
             {{- if .Values.rabbitmq.existingUserSecret }}
             - name: RABBIT_USER
@@ -67,7 +70,10 @@ spec:
                   key: "{{ .Values.rabbitmq.existingUserSecretKey }}"
             {{- else if .Values.rabbitmq.user }}
             - name: RABBIT_USER
-              value: {{ .Values.rabbitmq.user }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "prometheus-rabbitmq-exporter.fullname" . }}
+                  key: RABBIT_USER
             {{- end }}
             {{- if .Values.rabbitmq.url }}
             - name: RABBIT_URL

--- a/charts/prometheus-rabbitmq-exporter/templates/secret.yaml
+++ b/charts/prometheus-rabbitmq-exporter/templates/secret.yaml
@@ -1,0 +1,22 @@
+{{- if or (and (.Values.rabbitmq.password) (not .Values.rabbitmq.existingPasswordSecret)) (and (.Values.rabbitmq.user) (not .Values.rabbitmq.existingUserSecret)) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "prometheus-rabbitmq-exporter.fullname" . }}
+  labels:
+    app: {{ template "prometheus-rabbitmq-exporter.name" . }}
+    chart: {{ template "prometheus-rabbitmq-exporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- if .Values.additionalLabels }}
+{{ toYaml .Values.additionalLabels | indent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  {{- if and (.Values.rabbitmq.password) (not .Values.rabbitmq.existingPasswordSecret)  }}
+  RABBIT_PASSWORD: {{ .Values.rabbitmq.password | b64enc }}
+  {{- end }}
+  {{- if and (.Values.rabbitmq.user) (not .Values.rabbitmq.existingUserSecret)  }}
+  RABBIT_USER: {{ .Values.rabbitmq.user | b64enc }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Connection credentials should be stored securely using secrets. Right now, the chart allows to provide your own secret, but if the credentials are given as values to the chart, they are exposed in the deployment env variables.

This PR adds a new secret, that will be created only if the user or password is provided and if the existing user/password secret is not given.

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
