### PR TITLE
[kube-state-metrics] add additional environment variables support.

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - kubernetes
 type: application
-version: 5.27.1
+version: 5.28.0
 appVersion: 2.14.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/kube-state-metrics/templates/deployment.yaml
@@ -66,6 +66,14 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- if .Values.env }}
+        {{- toYaml .Values.env | nindent 8 }}
+        {{- end }}
+        {{ else }}
+        {{- if .Values.env }}
+        env:
+        {{- toYaml .Values.env | nindent 8 }}
+        {{- end }}
         {{- end }}
         args:
         {{-  if .Values.extraArgs  }}

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -160,6 +160,13 @@ serviceAccount:
   # If false then the user will opt out of automounting API credentials.
   automountServiceAccountToken: true
 
+# Additional Environment variables
+env: {}
+  # - name: GOMAXPROCS
+  #   valueFrom:
+  #     resourceFieldRef:
+  #       resource: limits.cpu
+
 prometheus:
   monitor:
     enabled: false


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

KSM support additional environment, in my case, i want to enable some client-go features with environment.


tested:

set env with normal
```
helm upgrade ksm .  --set "env[0].name=KUBE_FEATURE_ClientsAllowCBOR"  --set "env[1].name=KUBE_FEATURE_ClientsPreferCBOR" --set "env[0].value='true'" --set "env[1].value='true'" -i
```
and got the environment:
```yaml
    Environment:
      KUBE_FEATURE_ClientsAllowCBOR:   'true'
      KUBE_FEATURE_ClientsPreferCBOR:  'true'
```

set env with autosharding.
```
helm upgrade ksm . --set "autosharding.enabled='true'" --set "env[0].name=KUBE_FEATURE_ClientsAllowCBOR"  --set "env[1].name=KUBE_FEATURE_ClientsPreferCBOR" --set "env[0].value='true'" --set "env[1].value='true'" -i
```

and got the environment:
```yaml
    Environment:
      POD_NAME:                        ksm-kube-state-metrics-0 (v1:metadata.name)
      POD_NAMESPACE:                   default (v1:metadata.namespace)
      KUBE_FEATURE_ClientsAllowCBOR:   'true'
      KUBE_FEATURE_ClientsPreferCBOR:  'true'
```


#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
