### PR TITLE
[kube-prometheus-stack] Improve various metric relabelings

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 67.11.0
+version: 68.0.0
 appVersion: v0.79.2
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/README.md
+++ b/charts/kube-prometheus-stack/README.md
@@ -82,6 +82,28 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 
 A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an incompatible breaking change needing manual actions.
 
+### From 67.x to 68.x
+
+This version drops several metrics by default in order to reduce unnecessary cardinality.
+
+This version also fixes histogram bucket matching for Prometheus 3.x.
+
+From `{job="apiserver"}` drop excessive histogram buckets for the following metrics:
+
+- `apiserver_request_sli_duration_seconds_bucket`
+- `apiserver_request_slo_duration_seconds_bucket`
+- `etcd_request_duration_seconds_bucket`
+
+From `{job="kubelet",metrics_path="/metrics"}` reduce bucket cardinality of kubelet storage operations:
+
+- `csi_operations_seconds_bucket`
+- `storage_operation_duration_seconds_bucket`
+
+From `{job="kubelet",metrics_path="/metrics/cadvisor"}`:
+
+- Drop `container_memory_failures_total{scope="hierarchy"}` metrics, we only need the container scope here.
+- Drop `container_network_...` metrics that match various interfaces correspond to CNI and similar interfaces.
+
 ### From 66.x to 67.x
 
 This version upgrades Prometheus Image to v3.0.1 as it is the default version starting with operator version v0.79.0

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1417,6 +1417,17 @@ kubelet:
       - sourceLabels: [__name__]
         action: drop
         regex: 'container_(file_descriptors|tasks_state|threads_max)'
+      # Drop container_memory_failures_total{scope="hierarchy"} metrics,
+      # we only need the container scope.
+      - sourceLabels: [__name__, scope]
+        action: drop
+        regex: 'container_memory_failures_total;hierarchy'
+      # Drop container_network_... metrics that match various interfaces that
+      # correspond to CNI and similar interfaces. This avoids capturing network
+      # metrics for host network containers.
+      - sourceLabels: [__name__, interface]
+        action: drop
+        regex: 'container_network_.*;(cali|cilium|cni|lxc|nodelocaldns|tunl).*'
       # Drop container spec metrics that overlap with kube-state-metrics.
       - sourceLabels: [__name__]
         action: drop

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1278,7 +1278,7 @@ kubeApiServer:
     metricRelabelings:
       # Drop excessively noisy apiserver buckets.
       - action: drop
-        regex: apiserver_request_duration_seconds_bucket;(0.15|0.2|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2|3|3.5|4|4.5|6|7|8|9|15|25|40|50)
+        regex: (etcd_request|apiserver_request_slo|apiserver_request_sli|apiserver_request)_duration_seconds_bucket;(0\.15|0\.2|0\.3|0\.35|0\.4|0\.45|0\.6|0\.7|0\.8|0\.9|1\.25|1\.5|1\.75|2|3|3\.5|4|4\.5|6|7|8|9|15|20|30|40|45|50)(\.0)?
         sourceLabels:
           - __name__
           - le

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1508,7 +1508,11 @@ kubelet:
     ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
     ##
-    metricRelabelings: []
+    metricRelabelings:
+      # Reduce bucket cardinality of kubelet storage operations.
+      - action: drop
+        sourceLabels: [__name__, le]
+        regex: (csi_operations|storage_operation_duration)_seconds_bucket;(0.25|2.5|15|25|120|600)(\.0)?
     # - sourceLabels: [__name__, image]
     #   separator: ;
     #   regex: container_([a-z_]+);


### PR DESCRIPTION
#### What this PR does / why we need it

Update API metric relablings for Prometheus 3.0
    
Prometheus 3.0 normalizes bucket float values to include `.0` for
integers. Update the
* Add additional noisy apiserver metrics to the bucket filter.
  * `apiserver_request_sli_duration_seconds_bucket`
  * `apiserver_request_slo_duration_seconds_bucket`
  * `etcd_request_duration_seconds_bucket`
* Improve regex match to explicitly match `.`.

Improve cAdvisor metric filtering

Add new metricRelablings to the cAdvisor filter to reduce
default cardinality by eliminating noisy metrics.
* Drop container_memory_failures_total{scope="hierarchy"} metrics, we only need the container scope.
* Drop container_network_... metrics that match various interfaces that correspond to CNI and similar interfaces.

Add kubelet default metricRelabings

Reduce bucket cardinality of kubelet storage operations.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
