### PR TITLE
[prometheus-windows-exporter] Extract the prometheus.io/scrape service annotation

### DIFF
--- a/charts/prometheus-windows-exporter/Chart.yaml
+++ b/charts/prometheus-windows-exporter/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - exporter
 type: application
-version: 0.7.2
+version: 0.8.0
 appVersion: 0.29.2
 home: https://github.com/prometheus-community/windows_exporter/
 sources:

--- a/charts/prometheus-windows-exporter/Chart.yaml
+++ b/charts/prometheus-windows-exporter/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - exporter
 type: application
-version: 0.7.1
+version: 0.7.2
 appVersion: 0.29.2
 home: https://github.com/prometheus-community/windows_exporter/
 sources:

--- a/charts/prometheus-windows-exporter/templates/service.yaml
+++ b/charts/prometheus-windows-exporter/templates/service.yaml
@@ -7,11 +7,7 @@ metadata:
     {{- include "prometheus-windows-exporter.labels" $ | nindent 4 }}
   {{- with .Values.service.annotations }}
   annotations:
-    {{- if or $.Values.prometheus.monitor.enabled $.Values.prometheus.podMonitor.enabled }}
-      {{- unset . "prometheus.io/scrape" | toYaml | nindent 4 }}
-    {{- else }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/charts/prometheus-windows-exporter/templates/service.yaml
+++ b/charts/prometheus-windows-exporter/templates/service.yaml
@@ -5,17 +5,13 @@ metadata:
   namespace: {{ include "prometheus-windows-exporter.namespace" . }}
   labels:
     {{- include "prometheus-windows-exporter.labels" $ | nindent 4 }}
-  {{- if or .Values.prometheus.monitor.enabled .Values.prometheus.podMonitor.enabled }}
   {{- with .Values.service.annotations }}
   annotations:
-    {{- unset . "prometheus.io/scrape" | toYaml | nindent 4 }}
-  {{- end }}
-  {{- else }}
-  annotations:
-    prometheus.io/scrape: "true"
-  {{- with .Values.service.annotations }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- if or $.Values.prometheus.monitor.enabled $.Values.prometheus.podMonitor.enabled }}
+      {{- unset . "prometheus.io/scrape" | toYaml | nindent 4 }}
+    {{- else }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/charts/prometheus-windows-exporter/values.yaml
+++ b/charts/prometheus-windows-exporter/values.yaml
@@ -49,8 +49,7 @@ service:
   ## Additional annotations and labels for the service.
   ## If prometheus.monitor.enabled or prometheus.podMonitor.enabled is true, the prometheus.io/scrape annotation will
   ## not be set.
-  annotations:
-    prometheus.io/scrape: "true"
+  annotations: {}
 
 # Additional environment variables that will be passed to the daemonset
 env: {}

--- a/charts/prometheus-windows-exporter/values.yaml
+++ b/charts/prometheus-windows-exporter/values.yaml
@@ -47,8 +47,6 @@ service:
   ## Name of the service port. Sets the port name of the main container (windows-exporter) as well.
   portName: metrics
   ## Additional annotations and labels for the service.
-  ## If prometheus.monitor.enabled or prometheus.podMonitor.enabled is true, the prometheus.io/scrape annotation will
-  ## not be set.
   annotations: {}
 
 # Additional environment variables that will be passed to the daemonset

--- a/charts/prometheus-windows-exporter/values.yaml
+++ b/charts/prometheus-windows-exporter/values.yaml
@@ -36,12 +36,21 @@ global:
   # Allow parent charts to override registry hostname
   imageRegistry: ""
 
+## Service configuration
 service:
+  ## Service type
   type: ClusterIP
+  ## Default service port. Sets the port of the exposed container as well (windows-exporter).
   port: 9182
+  ## Port number for service type NodePort
   nodePort:
+  ## Name of the service port. Sets the port name of the main container (windows-exporter) as well.
   portName: metrics
-  annotations: {}
+  ## Additional annotations and labels for the service.
+  ## If prometheus.monitor.enabled or prometheus.podMonitor.enabled is true, the prometheus.io/scrape annotation will
+  ## not be set.
+  annotations:
+    prometheus.io/scrape: "true"
 
 # Additional environment variables that will be passed to the daemonset
 env: {}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This change moves the `prometheus.io/scrape` service annotation into the values.yaml file where it can be disabled if not desired. 

Also add comments in the values.yaml file for the service section.

All of these changes make this match how things look and work in the Node Exporter helm chart.

#### Which issue this PR fixes

- fixes #5129 

#### Special notes for your reviewer

My testing to ensure that things behave correctly:
```bash
# Default
helm template test . | yq 'select(.kind == "Service") | .metadata.annotations'
# Result: prometheus.io/scrape: "true"

# Extra annotations
helm template test . --set 'service.annotations.extra=1234' | yq 'select(.kind == "Service") | .metadata.annotations'
# Result: prometheus.io/scrape: "true", extra: "1234"

# Disabling the prometheus.io/scrape annotation
helm template test . --set 'service.annotations.prometheus\.io/scrape=null' | yq 'select(.kind == "Service") | .metadata.annotations'
# Result: null

# ServiceMonitor still removes the prometheus.io/scrape annotation
helm template test . --set 'prometheus.monitor.enabled=true' | yq 'select(.kind == "Service") | .metadata.annotations'
# Result: {}

# PodMonitor still removes the prometheus.io/scrape annotation
helm template test . --set 'prometheus.podMonitor.enabled=true' | yq 'select(.kind == "Service") | .metadata.annotations'
# Result: {}

# PodMonitor with extra works
helm template test . --set 'prometheus.podMonitor.enabled=true' --set 'service.annotations.extra=1234' | yq 'select(.kind == "Service") | .metadata.annotations'
# Result: extra: 1234
```

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
