### PR TITLE
[prometheus-kube-stack] Fix relabeling and metricRelabeling for additional serviceMonitor

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 67.9.0
+version: 67.10.0
 appVersion: v0.79.2
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/prometheus/servicemonitors.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/servicemonitors.yaml
@@ -23,11 +23,11 @@ items:
     {{- end }}
     {{- if .metricRelabelings }}
           metricRelabelings:
-            {{ toYaml .metricRelabelings | nindent 12 }}
+            {{- toYaml .metricRelabelings | nindent 12 }}
     {{- end }}
     {{- if .relabelings }}
           relabelings:
-            {{ toYaml .relabelings | nindent 12 }}
+            {{- toYaml .relabelings | nindent 12 }}
     {{- end }}
 
     {{- if .namespaceSelector }}

--- a/charts/kube-prometheus-stack/templates/prometheus/servicemonitors.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/servicemonitors.yaml
@@ -21,7 +21,6 @@ items:
     {{- if .jobLabel }}
       jobLabel: {{ .jobLabel }}
     {{- end }}
-
     {{- if .namespaceSelector }}
       namespaceSelector:
 {{ toYaml .namespaceSelector | indent 8 }}

--- a/charts/kube-prometheus-stack/templates/prometheus/servicemonitors.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/servicemonitors.yaml
@@ -21,6 +21,15 @@ items:
     {{- if .jobLabel }}
       jobLabel: {{ .jobLabel }}
     {{- end }}
+    {{- if .metricRelabelings }}
+          metricRelabelings:
+            {{ toYaml .metricRelabelings | nindent 12 }}
+    {{- end }}
+    {{- if .relabelings }}
+          relabelings:
+            {{ toYaml .relabelings | nindent 12 }}
+    {{- end }}
+
     {{- if .namespaceSelector }}
       namespaceSelector:
 {{ toYaml .namespaceSelector | indent 8 }}
@@ -34,14 +43,6 @@ items:
     {{- if .podTargetLabels }}
       podTargetLabels:
 {{ toYaml .podTargetLabels | indent 8 }}
-    {{- end }}
-    {{- if .metricRelabelings }}
-      metricRelabelings:
-{{ toYaml .metricRelabelings | indent 8 }}
-    {{- end }}
-    {{- if .relabelings }}
-      relabelings:
-{{ toYaml .relabelings | indent 8 }}
     {{- end }}
     {{- if .fallbackScrapeProtocol }}
       fallbackScrapeProtocol: {{ .fallbackScrapeProtocol }}

--- a/charts/kube-prometheus-stack/templates/prometheus/servicemonitors.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/servicemonitors.yaml
@@ -21,14 +21,6 @@ items:
     {{- if .jobLabel }}
       jobLabel: {{ .jobLabel }}
     {{- end }}
-    {{- if .metricRelabelings }}
-          metricRelabelings:
-            {{- toYaml .metricRelabelings | nindent 12 }}
-    {{- end }}
-    {{- if .relabelings }}
-          relabelings:
-            {{- toYaml .relabelings | nindent 12 }}
-    {{- end }}
 
     {{- if .namespaceSelector }}
       namespaceSelector:

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -4409,24 +4409,24 @@ prometheus:
           ##
           # serverName: ""
 
-    ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
-    ##
-    # metricRelabelings: []
-    # - action: keep
-    #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
-    #   sourceLabels: [__name__]
+      ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
+      ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+      ##
+      # metricRelabelings: []
+      # - action: keep
+      #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
+      #   sourceLabels: [__name__]
 
-    ## RelabelConfigs to apply to samples before scraping
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
-    ##
-    # relabelings: []
-    # - sourceLabels: [__meta_kubernetes_pod_node_name]
-    #   separator: ;
-    #   regex: ^(.*)$
-    #   targetLabel: nodename
-    #   replacement: $1
-    #   action: replace
+      ## RelabelConfigs to apply to samples before scraping
+      ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+      ##
+      # relabelings: []
+      # - sourceLabels: [__meta_kubernetes_pod_node_name]
+      #   separator: ;
+      #   regex: ^(.*)$
+      #   targetLabel: nodename
+      #   replacement: $1
+      #   action: replace
 
     ## Fallback scrape protocol used by Prometheus for scraping metrics
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.ScrapeProtocol


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

The current kube-prometheus-stack does not allow relabeling and metricRelabeling for additional service monitors. The issue is that, these values are not placed under endpoint and we get the following error.
```bash
Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(ServiceMonitor.spec): unknown field "relabelings" in com.coreos.monitoring.v1.ServiceMonitor.spec
```
The MR moves metricRelabeling and relabeling under endpoint. To test the helm chart one can use the following values.

```yaml
prometheus:
  additionalServiceMonitors:
    - name: test                          
      selector:
        matchLabels:
          app.kubernetes.io/name: test 
      namespaceSelector:
        matchNames:
          - test
      endpoints:
        - path: /metrics
          port: http
      relabelings:
      - sourceLabels: [__meta_kubernetes_pod_node_name]
        separator: ;
        regex: ^(.*)$
        targetLabel: nodename
        replacement: $1
        action: replace
```

#### Which issue this PR fixes



- fixes #
https://github.com/prometheus-community/helm-charts/issues/5120
https://github.com/prometheus-community/helm-charts/pull/5125

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
