### PR TITLE
[kube-prometheus-stack] Add kubelet scrape flag

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -23,7 +23,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 67.10.0
+version: 67.11.0
 appVersion: v0.79.2
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/exporters/kubelet/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kubelet/servicemonitor.yaml
@@ -33,6 +33,7 @@ spec:
       app.kubernetes.io/name: kubelet
       k8s-app: kubelet
   endpoints:
+{{- if .Values.kubelet.serviceMonitor.kubelet }}
   - port: {{ template "kube-prometheus-stack.kubelet.scheme" . }}-metrics
     scheme: {{ template "kube-prometheus-stack.kubelet.scheme" . }}
     {{- if .Values.kubelet.serviceMonitor.interval }}
@@ -54,6 +55,7 @@ spec:
 {{- if .Values.kubelet.serviceMonitor.relabelings }}
     relabelings:
 {{ tpl (toYaml .Values.kubelet.serviceMonitor.relabelings | indent 4) . }}
+{{- end }}
 {{- end }}
 {{- if .Values.kubelet.serviceMonitor.cAdvisor }}
   - port: {{ template "kube-prometheus-stack.kubelet.scheme" . }}-metrics

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1315,6 +1315,9 @@ kubelet:
   namespace: kube-system
 
   serviceMonitor:
+    ## Enable scraping /metrics from kubelet's service
+    kubelet: true
+
     ## Attach metadata to discovered targets. Requires Prometheus v2.45 for endpoints created by the operator.
     ##
     attachMetadata:


### PR DESCRIPTION
#### What this PR does / why we need it

Add a boolean flag to control scrape of the Kubelet's `/metrics` endpoint. This is useful for K3s users. With K3s, the kubelet metrics duplicate the apiserver endpoint due to the shared metrics registry.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
