### PR TITLE
[kube-state-metrics] add Controller Selection

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - kubernetes
 type: application
-version: 5.28.0
+version: 5.28.1
 appVersion: 2.14.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - kubernetes
 type: application
-version: 5.28.1
+version: 5.29.0
 appVersion: 2.14.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/daemonset.yaml
+++ b/charts/kube-state-metrics/templates/daemonset.yaml
@@ -1,10 +1,6 @@
-{{- if eq (.Values.controller | default "deployment") "deployment" }}
+{{- if eq (.Values.controller | default "deployment") "daemonset" }}
 apiVersion: apps/v1
-{{- if .Values.autosharding.enabled }}
-kind: StatefulSet
-{{- else }}
-kind: Deployment
-{{- end }}
+kind: DaemonSet
 metadata:
   name: {{ template "kube-state-metrics.fullname" . }}
   namespace: {{ template "kube-state-metrics.namespace" . }}
@@ -19,15 +15,8 @@ spec:
     matchLabels:
       {{- include "kube-state-metrics.selectorLabels" . | indent 6 }}
   replicas: {{ .Values.replicas }}
-  {{- if not .Values.autosharding.enabled }}
-  strategy:
+  updateStrategy:
     type: {{ .Values.updateStrategy | default "RollingUpdate" }}
-  {{- end }}
-  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  {{- if .Values.autosharding.enabled }}
-  serviceName: {{ template "kube-state-metrics.fullname" . }}
-  volumeClaimTemplates: []
-  {{- end }}
   template:
     metadata:
       labels:
@@ -57,26 +46,15 @@ spec:
       {{- $servicePort := ternary 9090 (.Values.service.port | default 8080) .Values.kubeRBACProxy.enabled}}
       {{- $telemetryPort := ternary 9091 (.Values.selfMonitor.telemetryPort | default 8081) .Values.kubeRBACProxy.enabled}}
       - name: {{ template "kube-state-metrics.name" . }}
-        {{- if  .Values.autosharding.enabled }}
         env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        {{- if .Values.env }}
-        {{- toYaml .Values.env | nindent 8 }}
-        {{- end }}
-        {{ else }}
-        {{- if .Values.env }}
-        env:
-        {{- toYaml .Values.env | nindent 8 }}
-        {{- end }}
-        {{- end }}
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: spec.nodeName
         args:
+        - --resources=pods
+        - --node=$(NODE_NAME)
         {{-  if .Values.extraArgs  }}
         {{- .Values.extraArgs | toYaml | nindent 8 }}
         {{-  end  }}
@@ -110,10 +88,6 @@ spec:
         {{- end }}
         {{- if .Values.namespacesDenylist }}
         - --namespaces-denylist={{ tpl (.Values.namespacesDenylist | join ",") $ }}
-        {{- end }}
-        {{- if .Values.autosharding.enabled }}
-        - --pod=$(POD_NAME)
-        - --pod-namespace=$(POD_NAMESPACE)
         {{- end }}
         {{- if .Values.kubeconfig.enabled }}
         - --kubeconfig=/opt/k8s/.kube/config
@@ -310,13 +284,13 @@ spec:
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- if .Values.nodeSelector }}
       nodeSelector:
-{{ tpl (toYaml .) $ | indent 8 }}
+{{ toYaml .Values.nodeSelector | indent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- if .Values.tolerations }}
       tolerations:
-{{ tpl (toYaml .) $ | indent 8 }}
+{{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/kube-state-metrics/templates/stsdiscovery-role.yaml
+++ b/charts/kube-state-metrics/templates/stsdiscovery-role.yaml
@@ -1,3 +1,4 @@
+{{- if eq (.Values.controller | default "deployment") "deployment" }}
 {{- if and .Values.autosharding.enabled .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -23,4 +24,5 @@ rules:
   - get
   - list
   - watch
+{{- end }}
 {{- end }}

--- a/charts/kube-state-metrics/templates/stsdiscovery-rolebinding.yaml
+++ b/charts/kube-state-metrics/templates/stsdiscovery-rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if eq (.Values.controller | default "deployment") "deployment" }}
 {{- if and .Values.autosharding.enabled .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -14,4 +15,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "kube-state-metrics.serviceAccountName" . }}
     namespace: {{ template "kube-state-metrics.namespace" . }}
+{{- end }}
 {{- end }}

--- a/charts/kube-state-metrics/templates/verticalpodautoscaler.yaml
+++ b/charts/kube-state-metrics/templates/verticalpodautoscaler.yaml
@@ -31,8 +31,10 @@ spec:
       {{- end }}
   targetRef:
     apiVersion: apps/v1
-    {{- if .Values.autosharding.enabled }}
+    {{- if and .Values.autosharding.enabled (eq (.Values.controller | default "deployment") "deployment") }}
     kind: StatefulSet
+    {{- else if eq (.Values.controller | default "deployment") "daemonset" }}
+    kind: DaemonSet
     {{- else }}
     kind: Deployment
     {{- end }}

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -28,6 +28,11 @@ global:
   # Allow parent charts to override registry hostname
   imageRegistry: ""
 
+# Specifies the type of controller that is created to host the application.
+# Possible values: deployment, daemonset
+# If autosharding.enabled: true, Deployment will be rolled out as StatefulSet
+controller: deployment
+
 # If set to true, this will deploy kube-state-metrics as a StatefulSet and the data
 # will be automatically sharded across <.Values.replicas> pods using the built-in
 # autodiscovery feature: https://github.com/kubernetes/kube-state-metrics#automated-sharding


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR aims to implement the possibility of deploying the image as a `DaemonSet`. Currently only `Deployment` and `StatefulSet` are supported. 
When scraping metrics exported by `kube-state-metrics`, they will be labeled to originate from the node the pod is running on. In our case some `grafana-agent` collects metrics exposed by pods and adds an `x_host` label according to the node this pod is running on. By adding the possibility of running `kube-state-metrics` as a `DaemonSet`, metrics are correctly labeled with their node-origin.

#### Which issue this PR fixes

Implements #4770

#### Special notes for your reviewer

 - I tried to stay backward compatible by adding `{{- if eq (.Values.controller | default "deployment") "deployment" }}` in a few places.
 - `daemonset.yaml` is a copy of `deployment.yaml` with removal of `.Values.autosharding.enabled` and additional setting of the node name env variable according to [this](https://github.com/kubernetes/kube-state-metrics?tab=readme-ov-file#daemonset-sharding-for-pod-metrics).

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
