### PR TITLE
[prometheus-yet-another-cloudwatch-exporter] consistent naming of chart (make it match directory)

### DIFF
--- a/charts/prometheus-yet-another-cloudwatch-exporter/Chart.yaml
+++ b/charts/prometheus-yet-another-cloudwatch-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-name: yet-another-cloudwatch-exporter
+name: prometheus-yet-another-cloudwatch-exporter
 description: Yace - Yet Another CloudWatch Exporter
 type: application
-version: 0.39.1
+version: 0.39.2
 appVersion: "v0.62.1"
 home: https://github.com/prometheus-community/helm-charts
 sources:

--- a/charts/prometheus-yet-another-cloudwatch-exporter/README.md
+++ b/charts/prometheus-yet-another-cloudwatch-exporter/README.md
@@ -16,7 +16,7 @@ _See [`helm repo`](https://helm.sh/docs/helm/helm_repo/) for command documentati
 ## Install Chart
 
 ```console
-helm install [RELEASE_NAME] prometheus-community/yet-another-cloudwatch-exporter
+helm install [RELEASE_NAME] prometheus-community/prometheus-yet-another-cloudwatch-exporter
 ```
 
 _See [configuration](#configuration) below._
@@ -40,5 +40,5 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
 
 ```console
-helm show values prometheus-community/yet-another-cloudwatch-exporter
+helm show values prometheus-community/prometheus-yet-another-cloudwatch-exporter
 ```


### PR DESCRIPTION
see: https://github.com/prometheus-community/helm-charts/pull/5165#issuecomment-2590325789

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
