### PR TITLE
[prometheus-yet-another-cloudwatch-exporter] remove capabilities checks

### DIFF
--- a/charts/prometheus-yet-another-cloudwatch-exporter/Chart.yaml
+++ b/charts/prometheus-yet-another-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-yet-another-cloudwatch-exporter
 description: Yace - Yet Another CloudWatch Exporter
 type: application
-version: 0.39.3
+version: 0.39.4
 appVersion: "v0.62.1"
 home: https://github.com/prometheus-community/helm-charts
 sources:

--- a/charts/prometheus-yet-another-cloudwatch-exporter/templates/prometheusrule.yaml
+++ b/charts/prometheus-yet-another-cloudwatch-exporter/templates/prometheusrule.yaml
@@ -1,4 +1,4 @@
-{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.prometheusRule.enabled ) }}
+{{- if .Values.prometheusRule.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/charts/prometheus-yet-another-cloudwatch-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-yet-another-cloudwatch-exporter/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.serviceMonitor.enabled ) }}
+{{- if .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
#### What this PR does / why we need it

These capabilities come from CRDs which makes impossible to get `ServiceMonitor`definition  with `helm template` command without `--validate` flag.

```
$ helm template . --kube-version 1.31.0 | grep ServiceMonitor
# no result

$ helm template . --validate | grep ServiceMonitor
kind: ServiceMonitor
```

As in the `values.yaml`, there's already the possibility to enable/disable `serviceMonitor` and `prometheusRule`, I think we can simply remove these checks.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
