### PR TITLE
Docs: prometheus-operator documentation references

### DIFF
--- a/charts/kube-prometheus-stack/README.md
+++ b/charts/kube-prometheus-stack/README.md
@@ -644,7 +644,7 @@ kubectl delete daemonset -l app=prometheus-node-exporter
 helm upgrade -i kube-prometheus-stack prometheus-community/kube-prometheus-stack
 ```
 
-If you use your own custom [ServiceMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor) or [PodMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#podmonitor), please ensure to upgrade their `selector` fields accordingly to the new labels.
+If you use your own custom [ServiceMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#servicemonitor) or [PodMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#podmonitor), please ensure to upgrade their `selector` fields accordingly to the new labels.
 
 ### From 38.x to 39.x
 
@@ -1052,8 +1052,8 @@ For more in-depth documentation of configuration options meanings, please see
 The prometheus operator does not support annotation-based discovery of services, using the `PodMonitor` or `ServiceMonitor` CRD in its place as they provide far more configuration options.
 For information on how to use PodMonitors/ServiceMonitors, please see the documentation on the `prometheus-operator/prometheus-operator` documentation here:
 
-- [ServiceMonitors](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md#include-servicemonitors)
-- [PodMonitors](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md#include-podmonitors)
+- [ServiceMonitors](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/developer/getting-started.md#include-servicemonitors)
+- [PodMonitors](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/developer/getting-started.md#include-podmonitors)
 - [Running Exporters](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/running-exporters.md)
 
 By default, Prometheus discovers PodMonitors and ServiceMonitors within its namespace, that are labeled with the same release tag as the prometheus-operator release.

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -650,7 +650,7 @@ alertmanager:
     scheme: ""
 
     ## enableHttp2: Whether to enable HTTP2.
-    ## See https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint
+    ## See https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#endpoint
     enableHttp2: true
 
     ## tlsConfig: TLS configuration to use when scraping the endpoint. For example if using istio mTLS.
@@ -660,7 +660,7 @@ alertmanager:
     bearerTokenFile:
 
     ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
     ##
     metricRelabelings: []
     # - action: keep
@@ -668,7 +668,7 @@ alertmanager:
     #   sourceLabels: [__name__]
 
     ## RelabelConfigs to apply to samples before scraping
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
     ##
     relabelings: []
     # - sourceLabels: [__meta_kubernetes_pod_node_name]
@@ -685,7 +685,7 @@ alertmanager:
     #   path: /metrics
 
   ## Settings affecting alertmanagerSpec
-  ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#alertmanagerspec
+  ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#alertmanagerspec
   ##
   alertmanagerSpec:
     ## Statefulset's persistent volume claim retention policy
@@ -736,7 +736,7 @@ alertmanager:
     # configSecret:
 
     ## WebTLSConfig defines the TLS parameters for HTTPS
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#alertmanagerwebspec
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#alertmanagerwebspec
     web: {}
 
     ## AlertmanagerConfigs to be selected to merge and configure Alertmanager with.
@@ -1219,7 +1219,7 @@ grafana:
     scrapeTimeout: 30s
 
     ## RelabelConfigs to apply to samples before scraping
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
     ##
     relabelings: []
     # - sourceLabels: [__meta_kubernetes_pod_node_name]
@@ -1277,7 +1277,7 @@ kubeApiServer:
         provider: kubernetes
 
     ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
     ##
     metricRelabelings:
       # Drop excessively noisy apiserver buckets.
@@ -1291,7 +1291,7 @@ kubeApiServer:
     #   sourceLabels: [__name__]
 
     ## RelabelConfigs to apply to samples before scraping
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
     ##
     relabelings: []
     # - sourceLabels:
@@ -1309,7 +1309,7 @@ kubeApiServer:
     #  foo: bar
 
     ## defines the labels which are transferred from the associated Kubernetes Service object onto the ingested metrics.
-    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#servicemonitor
     targetLabels: []
 
 ## Component scraping the kubelet and kubelet-hosted cAdvisor
@@ -1402,7 +1402,7 @@ kubelet:
     ## if kubelet.serviceMonitor.interval is not empty.
     cAdvisorInterval: 10s
     ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
     ##
     cAdvisorMetricRelabelings:
       # Drop less useful container CPU metrics.
@@ -1452,7 +1452,7 @@ kubelet:
     #   action: drop
 
     ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
     ##
     probesMetricRelabelings: []
     # - sourceLabels: [__name__, image]
@@ -1467,7 +1467,7 @@ kubelet:
     #   action: drop
 
     ## RelabelConfigs to apply to samples before scraping
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
     ##
     ## metrics_path is required to match upstream rules and charts
     cAdvisorRelabelings:
@@ -1482,7 +1482,7 @@ kubelet:
     #   action: replace
 
     ## RelabelConfigs to apply to samples before scraping
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
     ##
     probesRelabelings:
       - action: replace
@@ -1496,7 +1496,7 @@ kubelet:
     #   action: replace
 
     ## RelabelConfigs to apply to samples before scraping
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
     ##
     resourceRelabelings:
       - action: replace
@@ -1510,7 +1510,7 @@ kubelet:
     #   action: replace
 
     ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
     ##
     metricRelabelings:
       # Reduce bucket cardinality of kubelet storage operations.
@@ -1529,7 +1529,7 @@ kubelet:
     #   action: drop
 
     ## RelabelConfigs to apply to samples before scraping
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
     ##
     ## metrics_path is required to match upstream rules and charts
     relabelings:
@@ -1549,7 +1549,7 @@ kubelet:
     #  foo: bar
 
     ## defines the labels which are transferred from the associated Kubernetes Service object onto the ingested metrics.
-    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#servicemonitor
     targetLabels: []
 
 ## Component scraping the kube controller manager
@@ -1632,7 +1632,7 @@ kubeControllerManager:
     serverName: null
 
     ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
     ##
     metricRelabelings: []
     # - action: keep
@@ -1640,7 +1640,7 @@ kubeControllerManager:
     #   sourceLabels: [__name__]
 
     ## RelabelConfigs to apply to samples before scraping
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
     ##
     relabelings: []
     # - sourceLabels: [__meta_kubernetes_pod_node_name]
@@ -1656,7 +1656,7 @@ kubeControllerManager:
     #  foo: bar
 
     ## defines the labels which are transferred from the associated Kubernetes Service object onto the ingested metrics.
-    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#servicemonitor
     targetLabels: []
 
 ## Component scraping coreDns. Use either this or kubeDns
@@ -1714,7 +1714,7 @@ coreDns:
     #    k8s-app: kube-dns
 
     ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
     ##
     metricRelabelings: []
     # - action: keep
@@ -1722,7 +1722,7 @@ coreDns:
     #   sourceLabels: [__name__]
 
     ## RelabelConfigs to apply to samples before scraping
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
     ##
     relabelings: []
     # - sourceLabels: [__meta_kubernetes_pod_node_name]
@@ -1738,7 +1738,7 @@ coreDns:
     #  foo: bar
 
     ## defines the labels which are transferred from the associated Kubernetes Service object onto the ingested metrics.
-    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#servicemonitor
     targetLabels: []
 
 ## Component scraping kubeDns. Use either this or coreDns
@@ -1793,7 +1793,7 @@ kubeDns:
     #    k8s-app: kube-dns
 
     ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
     ##
     metricRelabelings: []
     # - action: keep
@@ -1801,7 +1801,7 @@ kubeDns:
     #   sourceLabels: [__name__]
 
     ## RelabelConfigs to apply to samples before scraping
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
     ##
     relabelings: []
     # - sourceLabels: [__meta_kubernetes_pod_node_name]
@@ -1812,7 +1812,7 @@ kubeDns:
     #   action: replace
 
     ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
     ##
     dnsmasqMetricRelabelings: []
     # - action: keep
@@ -1820,7 +1820,7 @@ kubeDns:
     #   sourceLabels: [__name__]
 
     ## RelabelConfigs to apply to samples before scraping
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
     ##
     dnsmasqRelabelings: []
     # - sourceLabels: [__meta_kubernetes_pod_node_name]
@@ -1836,7 +1836,7 @@ kubeDns:
     #  foo: bar
 
     ## defines the labels which are transferred from the associated Kubernetes Service object onto the ingested metrics.
-    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#servicemonitor
     targetLabels: []
 
 ## Component scraping etcd
@@ -1921,7 +1921,7 @@ kubeEtcd:
     #    component: etcd
 
     ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
     ##
     metricRelabelings: []
     # - action: keep
@@ -1929,7 +1929,7 @@ kubeEtcd:
     #   sourceLabels: [__name__]
 
     ## RelabelConfigs to apply to samples before scraping
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
     ##
     relabelings: []
     # - sourceLabels: [__meta_kubernetes_pod_node_name]
@@ -1945,7 +1945,7 @@ kubeEtcd:
     #  foo: bar
 
     ## defines the labels which are transferred from the associated Kubernetes Service object onto the ingested metrics.
-    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#servicemonitor
     targetLabels: []
 
 ## Component scraping kube scheduler
@@ -2027,7 +2027,7 @@ kubeScheduler:
     serverName: null
 
     ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
     ##
     metricRelabelings: []
     # - action: keep
@@ -2035,7 +2035,7 @@ kubeScheduler:
     #   sourceLabels: [__name__]
 
     ## RelabelConfigs to apply to samples before scraping
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
     ##
     relabelings: []
     # - sourceLabels: [__meta_kubernetes_pod_node_name]
@@ -2051,7 +2051,7 @@ kubeScheduler:
     #  foo: bar
 
     ## defines the labels which are transferred from the associated Kubernetes Service object onto the ingested metrics.
-    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#servicemonitor
     targetLabels: []
 
 ## Component scraping kube proxy
@@ -2122,7 +2122,7 @@ kubeProxy:
     https: false
 
     ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
     ##
     metricRelabelings: []
     # - action: keep
@@ -2130,7 +2130,7 @@ kubeProxy:
     #   sourceLabels: [__name__]
 
     ## RelabelConfigs to apply to samples before scraping
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
     ##
     relabelings: []
     # - action: keep
@@ -2143,7 +2143,7 @@ kubeProxy:
     #  foo: bar
 
     ## defines the labels which are transferred from the associated Kubernetes Service object onto the ingested metrics.
-    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#servicemonitor
     targetLabels: []
 
 ## Component scraping kube state metrics
@@ -2199,7 +2199,7 @@ kube-state-metrics:
       honorLabels: true
 
       ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
-      ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+      ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
       ##
       metricRelabelings: []
       # - action: keep
@@ -2207,7 +2207,7 @@ kube-state-metrics:
       #   sourceLabels: [__name__]
 
       ## RelabelConfigs to apply to samples before scraping
-      ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+      ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
       ##
       relabelings: []
       # - sourceLabels: [__meta_kubernetes_pod_node_name]
@@ -2296,7 +2296,7 @@ prometheus-node-exporter:
       proxyUrl: ""
 
       ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
-      ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+      ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
       ##
       metricRelabelings: []
       # - sourceLabels: [__name__]
@@ -2306,7 +2306,7 @@ prometheus-node-exporter:
       #   action: drop
 
       ## RelabelConfigs to apply to samples before scraping
-      ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+      ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
       ##
       relabelings: []
       # - sourceLabels: [__meta_kubernetes_pod_node_name]
@@ -3554,7 +3554,7 @@ prometheus:
     scheme: ""
 
     ## tlsConfig: TLS configuration to use when scraping the endpoint. For example if using istio mTLS.
-    ## Of type: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#tlsconfig
+    ## Of type: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#tlsconfig
     tlsConfig: {}
 
     bearerTokenFile:
@@ -3583,7 +3583,7 @@ prometheus:
     #   path: /metrics
 
   ## Settings affecting prometheusSpec
-  ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#prometheusspec
+  ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#prometheusspec
   ##
   prometheusSpec:
     ## Statefulset's persistent volume claim retention policy
@@ -3606,12 +3606,12 @@ prometheus:
 
     disableCompaction: false
     ## APIServerConfig
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#apiserverconfig
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#apiserverconfig
     ##
     apiserverConfig: {}
 
     ## Allows setting additional arguments for the Prometheus container
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.Prometheus
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#monitoring.coreos.com/v1.Prometheus
     additionalArgs: []
 
     ## Interval between consecutive scrapes.
@@ -3653,7 +3653,7 @@ prometheus:
     version: ""
 
     ## WebTLSConfig defines the TLS parameters for HTTPS
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#webtlsconfig
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#webtlsconfig
     web: {}
 
     ## Exemplars related settings that are runtime reloadable.
@@ -3698,7 +3698,7 @@ prometheus:
     #       app: prometheus
 
     ## Alertmanagers to which alerts will be sent
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#alertmanagerendpoints
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#alertmanagerendpoints
     ##
     ## Default configuration will connect to the alertmanager deployed as part of this release
     ##
@@ -3758,7 +3758,7 @@ prometheus:
     configMaps: []
 
     ## QuerySpec defines the query command line flags when starting Prometheus.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#queryspec
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#queryspec
     ##
     query: {}
 
@@ -3969,14 +3969,14 @@ prometheus:
     #         - e2e-az2
 
     ## The remote_read spec configuration for Prometheus.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#remotereadspec
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#remotereadspec
     remoteRead: []
     # - url: http://remote1/read
     ## additionalRemoteRead is appended to remoteRead
     additionalRemoteRead: []
 
     ## The remote_write spec configuration for Prometheus.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#remotewritespec
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#remotewritespec
     remoteWrite: []
     # - url: http://remote1/push
     ## additionalRemoteWrite is appended to remoteWrite
@@ -4132,7 +4132,7 @@ prometheus:
 
     ## SecurityContext holds pod-level security attributes and common container settings.
     ## This defaults to non root user with uid 1000 and gid 2000.
-    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md
+    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md
     ##
     securityContext:
       runAsGroup: 2000
@@ -4149,7 +4149,7 @@ prometheus:
     ## Thanos configuration allows configuring various aspects of a Prometheus server in a Thanos environment.
     ## This section is experimental, it may change significantly without deprecation notice in any release.
     ## This is experimental and may change significantly without backward compatibility in any release.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#thanosspec
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#thanosspec
     ##
     thanos: {}
       # secretProviderClass:
@@ -4234,7 +4234,7 @@ prometheus:
     ## ExcludedFromEnforcement - list of object references to PodMonitor, ServiceMonitor, Probe and PrometheusRule objects
     ## to be excluded from enforcing a namespace label of origin.
     ## Works only if enforcedNamespaceLabel set to true.
-    ## See https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#objectreference
+    ## See https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#objectreference
     excludedFromEnforcement: []
 
     ## QueryLogFile specifies the file to which PromQL queries are logged. Note that this location must be writable,
@@ -4302,7 +4302,7 @@ prometheus:
     #      - b1.app.local
 
     ## TracingConfig configures tracing in Prometheus.
-    ## See https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#prometheustracingconfig
+    ## See https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#prometheustracingconfig
     tracingConfig: {}
 
     ## Defines the service discovery role used to discover targets from ServiceMonitor objects and Alertmanager endpoints.
@@ -4432,7 +4432,7 @@ prometheus:
           # serverName: ""
 
       ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
-      ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+      ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
       ##
       # metricRelabelings: []
       # - action: keep
@@ -4440,7 +4440,7 @@ prometheus:
       #   sourceLabels: [__name__]
 
       ## RelabelConfigs to apply to samples before scraping
-      ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+      ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
       ##
       # relabelings: []
       # - sourceLabels: [__meta_kubernetes_pod_node_name]
@@ -4451,7 +4451,7 @@ prometheus:
       #   action: replace
 
     ## Fallback scrape protocol used by Prometheus for scraping metrics
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.ScrapeProtocol
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#monitoring.coreos.com/v1.ScrapeProtocol
     ##
     # fallbackScrapeProtocol: ""
 
@@ -4506,12 +4506,12 @@ prometheus:
       # matchNames: []
 
     ## Endpoints of the selected pods to be monitored
-    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#podmetricsendpoint
+    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#podmetricsendpoint
     ##
     # podMetricsEndpoints: []
 
     ## Fallback scrape protocol used by Prometheus for scraping metrics
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.ScrapeProtocol
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#monitoring.coreos.com/v1.ScrapeProtocol
     ##
     # fallbackScrapeProtocol: ""
 
@@ -4702,7 +4702,7 @@ thanosRuler:
     bearerTokenFile:
 
     ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
     ##
     metricRelabelings: []
     # - action: keep
@@ -4710,7 +4710,7 @@ thanosRuler:
     #   sourceLabels: [__name__]
 
     ## RelabelConfigs to apply to samples before scraping
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
     ##
     relabelings: []
     # - sourceLabels: [__meta_kubernetes_pod_node_name]
@@ -4727,7 +4727,7 @@ thanosRuler:
     #   path: /metrics
 
   ## Settings affecting thanosRulerpec
-  ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#thanosrulerspec
+  ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#thanosrulerspec
   ##
   thanosRulerSpec:
     ## Standard object's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -4745,7 +4745,7 @@ thanosRuler:
 
     ## Namespaces to be selected for PrometheusRules discovery.
     ## If nil, select own namespace. Namespaces to be selected for ServiceMonitor discovery.
-    ## See https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#namespaceselector for usage
+    ## See https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#namespaceselector for usage
     ##
     ruleNamespaceSelector: {}
 
@@ -4900,7 +4900,7 @@ thanosRuler:
     paused: false
 
     ## Allows setting additional arguments for the ThanosRuler container
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#thanosruler
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#thanosruler
     ##
     additionalArgs: []
       # - name: remote-write.config
@@ -5008,7 +5008,7 @@ thanosRuler:
     portName: "web"
 
     ## WebTLSConfig defines the TLS parameters for HTTPS
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#thanosrulerwebspec
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#thanosrulerwebspec
     web: {}
 
     ## Additional configuration which is not covered by the properties above. (passed through tpl)

--- a/charts/prom-label-proxy/values.yaml
+++ b/charts/prom-label-proxy/values.yaml
@@ -189,11 +189,11 @@ metrics:
     scrapeTimeout: ""
 
     # RelabelConfigs to apply to samples before scraping
-    # ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    # ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
     relabelings: []
 
     # MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
-    # ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    # ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#relabelconfig
     metricRelabelings: []
 
     # Additional settings for Endpoint.

--- a/charts/prometheus-kafka-exporter/values.yaml
+++ b/charts/prometheus-kafka-exporter/values.yaml
@@ -112,7 +112,7 @@ prometheus:
     additionalLabels: {}
     targetLabels: []
     # Relabel configs to apply to target's labelset before the target gets scraped.
-    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.RelabelConfig
+    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#monitoring.coreos.com/v1.RelabelConfig
     relabelings: null
     # - sourceLabels: [__meta_kubernetes_pod_node_name]
     #   separator: ;
@@ -121,7 +121,7 @@ prometheus:
     #   replacement: $1
     #   action: replace
     # Metric relabeling is applied to samples as the last step before ingestion
-    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.RelabelConfig
+    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#monitoring.coreos.com/v1.RelabelConfig
     metricRelabelings: null
     # - sourceLabels: [__meta_kubernetes_pod_node_name]
     #   separator: ;

--- a/charts/prometheus-modbus-exporter/values.yaml
+++ b/charts/prometheus-modbus-exporter/values.yaml
@@ -69,7 +69,7 @@ serviceMonitor:
       - "1"
   ## configurations common for all above endpoints:
   endpointsCommonConfig:
-    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.Endpoint
+    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#monitoring.coreos.com/v1.Endpoint
     scheme: http
     interval: 10s
     scrapeTimeout: 1s

--- a/charts/prometheus-node-exporter/README.md
+++ b/charts/prometheus-node-exporter/README.md
@@ -50,7 +50,7 @@ kubectl delete daemonset -l app=prometheus-node-exporter
 helm upgrade -i prometheus-node-exporter prometheus-community/prometheus-node-exporter
 ```
 
-If you use your own custom [ServiceMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor) or [PodMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#podmonitor), please ensure to upgrade their `selector` fields accordingly to the new labels.
+If you use your own custom [ServiceMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#servicemonitor) or [PodMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#podmonitor), please ensure to upgrade their `selector` fields accordingly to the new labels.
 
 ### From 2.x to 3.x
 

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -179,11 +179,11 @@ prometheus:
     jobLabel: ""
 
     # List of pod labels to add to node exporter metrics
-    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#servicemonitor
     podTargetLabels: []
 
     # List of target labels to add to node exporter metrics
-    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#servicemonitor
     targetLabels: []
 
     scheme: http
@@ -232,7 +232,7 @@ prometheus:
     labelValueLengthLimit: 0
 
   # PodMonitor defines monitoring for a set of pods.
-  # ref. https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.PodMonitor
+  # ref. https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#monitoring.coreos.com/v1.PodMonitor
   # Using a PodMonitor may be preferred in some environments where there is very large number
   # of Node Exporter endpoints (1000+) behind a single service.
   # The PodMonitor is disabled by default. When switching from ServiceMonitor to PodMonitor,
@@ -273,10 +273,10 @@ prometheus:
     # TLS configuration to use when scraping the endpoint.
     tlsConfig: {}
     # Authorization section for this endpoint.
-    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.SafeAuthorization
+    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#monitoring.coreos.com/v1.SafeAuthorization
     authorization: {}
     # OAuth2 for the URL. Only valid in Prometheus versions 2.27.0 and newer.
-    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.OAuth2
+    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#monitoring.coreos.com/v1.OAuth2
     oauth2: {}
 
     # ProxyURL eg http://proxyserver:2195. Directs scrapes through proxy to this endpoint.

--- a/charts/prometheus-operator-admission-webhook/values.yaml
+++ b/charts/prometheus-operator-admission-webhook/values.yaml
@@ -285,7 +285,7 @@ service:
 tolerations: []
 
 ## prometheusRule for creating prometheus rules
-## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.PrometheusRule
+## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#monitoring.coreos.com/v1.PrometheusRule
 prometheusRule:
   enabled: false
   ## Override namespace where the rules get deployed
@@ -307,7 +307,7 @@ prometheusRule:
 
 ## serviceMonitor allows creating a service monitor for Prometheus operator to assemble corresponding
 ## configuration for Prometheus
-## Ref. https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.ServiceMonitor
+## Ref. https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#monitoring.coreos.com/v1.ServiceMonitor
 serviceMonitor:
   ## Enable service monitor
   enabled: false

--- a/charts/prometheus-snmp-exporter/values.yaml
+++ b/charts/prometheus-snmp-exporter/values.yaml
@@ -180,7 +180,7 @@ serviceMonitor:
 
   # Relabelings dynamically rewrite the label set of a target before it gets scraped.
   # Set if defined unless overriden by params.relabelings.
-  # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.RelabelConfig
+  # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#monitoring.coreos.com/v1.RelabelConfig
   relabelings: []
     # - sourceLabels: [__address__]
     #   targetLabel: __param_target
@@ -197,7 +197,7 @@ serviceMonitor:
   # Metric relabeling is applied to samples as the last step before ingestion.
   # Set if defined unless overridden by params.additionalMetricsRelabelConfigs.
   # This allows setting arbitrary relabel configs.
-  # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.RelabelConfig
+  # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#monitoring.coreos.com/v1.RelabelConfig
   additionalMetricsRelabelConfigs: []
     # - sourceLabels: [__name__]
     #   targetLabel: __name__
@@ -206,12 +206,12 @@ serviceMonitor:
     #   replacement: prefix_$1
 
   # Label for selecting service monitors as set in Prometheus CRD.
-  # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.PrometheusSpec
+  # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#monitoring.coreos.com/v1.PrometheusSpec
   selector:
     prometheus: kube-prometheus
 
   # Retain the job and instance labels of the metrics retrieved by the snmp-exporter
-  # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.Endpoint
+  # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#monitoring.coreos.com/v1.Endpoint
   honorLabels: true
 
   params: []

--- a/charts/prometheus-stackdriver-exporter/README.md
+++ b/charts/prometheus-stackdriver-exporter/README.md
@@ -120,7 +120,7 @@ spec:
 ...
 ```
 
-If you use your own custom [ServiceMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor) or [PodMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#podmonitor), please ensure to upgrade their `selector` fields accordingly to the new labels.
+If you use your own custom [ServiceMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#servicemonitor) or [PodMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#podmonitor), please ensure to upgrade their `selector` fields accordingly to the new labels.
 
 #### 1.x to 2.x
 

--- a/charts/prometheus-windows-exporter/values.yaml
+++ b/charts/prometheus-windows-exporter/values.yaml
@@ -63,7 +63,7 @@ prometheus:
     jobLabel: ""
 
     # List of pod labels to add to windows exporter metrics
-    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#servicemonitor
     podTargetLabels: []
 
     scheme: http
@@ -112,7 +112,7 @@ prometheus:
     labelValueLengthLimit: 0
 
   # PodMonitor defines monitoring for a set of pods.
-  # ref. https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.PodMonitor
+  # ref. https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#monitoring.coreos.com/v1.PodMonitor
   # Using a PodMonitor may be preferred in some environments where there is very large number
   # of Windows Exporter endpoints (1000+) behind a single service.
   # The PodMonitor is disabled by default. When switching from ServiceMonitor to PodMonitor,
@@ -153,10 +153,10 @@ prometheus:
     # TLS configuration to use when scraping the endpoint.
     tlsConfig: {}
     # Authorization section for this endpoint.
-    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.SafeAuthorization
+    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#monitoring.coreos.com/v1.SafeAuthorization
     authorization: {}
     # OAuth2 for the URL. Only valid in Prometheus versions 2.27.0 and newer.
-    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.OAuth2
+    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api-reference/api.md#monitoring.coreos.com/v1.OAuth2
     oauth2: {}
 
     # ProxyURL eg http://proxyserver:2195. Directs scrapes through proxy to this endpoint.


### PR DESCRIPTION
After the[ refactor of the documentation in the prometheus-operator repository](https://github.com/prometheus-operator/prometheus-operator/pull/7229).

This PR fixed the documentation references