### PR TITLE
[ci] add github workflow to the bump version of an Chart version

### DIFF
--- a/.github/workflows/renovate-bump-chart-version.yaml
+++ b/.github/workflows/renovate-bump-chart-version.yaml
@@ -1,0 +1,92 @@
+name: Renovate Bump Chart Version
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'charts/**/*'
+
+jobs:
+  renovate-bump-chart-version:
+    name: Renovate Bump Chart Version
+    runs-on: ubuntu-latest
+    if: github.actor == 'renovate[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.6.1
+
+      - name: Detect changed charts
+        id: list-changed
+        run: |
+          changed="$(ct list-changed --config .github/linters/ct.yaml)"
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "changed_list=\"${changed//$'\n'/ }\"" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump chart version
+        if: steps.list-changed.outputs.changed == 'true'
+        env:
+          CHART: ${{ steps.list-changed.outputs.changed_list }}
+        run: |
+          if [[ $CHANGED_LIST == *" "* ]]; then
+            echo "Multiple charts changed, skipping bumping chart version"
+            exit 0
+          fi
+
+          CHART_VERSION=$(grep -e "^version:" "$CHART/Chart.yaml" | cut -d ":" -f 2 | tr -d '[:space:]' | tr -d '"')
+          CHART_MAJOR_VERSION=$(printf '%s' "$CHART_VERSION" | cut -d "." -f 1)
+          CHART_MINOR_VERSION=$(printf '%s' "$CHART_VERSION" | cut -d "." -f 2)
+          CHART_MINOR_VERSION=$((CHART_MINOR_VERSION+1))
+          CHART_NEW_VERSION="${CHART_MAJOR_VERSION}.${CHART_MINOR_VERSION}.0"
+          sed -i "s/^version:.*/version: \"${CHART_NEW_VERSION}\"/" "$CHART/Chart.yaml"
+
+      - name: Commit changes
+        if: steps.list-changed.outputs.changed == 'true'
+        env:
+          CHART: ${{ steps.list-changed.outputs.changed_list }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl https://api.github.com/graphql -f \
+               -sSf -H "Authorization: Bearer $GITHUB_TOKEN" \
+               --data @- <<GRAPHQL | jq
+          {
+            "query": "mutation (\$input: CreateCommitOnBranchInput!) {
+              createCommitOnBranch(input: \$input) { 
+                commit { 
+                  url 
+                } 
+              } 
+            }",
+            "variables": {
+              "input": {
+                "branch": {
+                  "repositoryNameWithOwner": "${{ github.repository }}",
+                  "branchName": "${{ github.ref_name }}"
+                },
+                "message": { "headline": "Update Chart.yaml" },
+                "fileChanges": {
+                  "additions": [
+                    {
+                      "path": "$CHART/Chart.yaml",
+                      "contents": "$(base64 -w 0 <"$CHART/Chart.yaml")"
+                    }
+                  ]
+                },
+                "expectedHeadOid": "${{ github.sha }}"
+              }
+            }
+          }
+          GRAPHQL

--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,54 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
   "dependencyDashboardApproval": true,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "(^|/).+\\.(py|yaml)$"
+      ],
+      "matchStrings": [
+        "\\s*#\\s?renovate: (?<datasource>.*?)=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s+[\\w+\\.\\-]+(?:[:=]|\\s+\\S+)\\s*[\\\"']?(?<currentValue>[\\w+\\.\\-]*)(?:@(?<currentDigest>sha256:[a-f0-9]+))?[\\\"']?"
+      ],
+      "datasourceTemplate": "{{#if (equals datasource 'github')}}github-tags{{else}}{{{datasource}}}{{/if}}",
+      "versioningTemplate": "{{#if (equals datasource 'docker')}}docker{{else if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "(^|/).+\\.yaml$"
+      ],
+      "matchStrings": [
+        "\\s*image:\\s+registry:\\s*[\\\"']?(?<registry>.*?)[\\\"']?\\s+name:\\s*[\\\"']?(?<repository>.*?)[\\\"']?\\s+tag:\\s*[\\\"']?(?<currentValue>[\\w+\\.\\-]*)(?:@(?<currentDigest>sha256:[a-f0-9]+))?[\\\"']?"
+      ],
+      "depNameTemplate": "{{{ registry }}}/{{{ repository }}}",
+      "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "(^|/).+\\.yaml$"
+      ],
+      "matchStrings": [
+        "\\s*image:\\s+[\\\"']?(?<registry>.+\\..+?)\\/(?<repository>.*?):(?<currentValue>[\\w+\\.\\-]*)(?:@(?<currentDigest>sha256:[a-f0-9]+))?[\\\"']?"
+      ],
+      "depNameTemplate": "{{{ registry }}}/{{{ repository }}}",
+      "datasourceTemplate": "docker"
+    }
+  ],
   "packageRules": [
     {
+      "enabled": false,
+      "matchPackageNames": [
+        "*"
+      ]
+    },
+    {
+      "enabled": true,
       "matchPackagePatterns": [
         "*"
       ],
@@ -16,34 +59,20 @@
       "groupName": "github-workflow dependency updates"
     },
     {
+      "enabled": true,
       "matchPackagePatterns": [
         "*"
       ],
       "matchPaths": [
         "charts/kube-prometheus-stack/**"
       ],
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "commitMessagePrefix": "[kube-prometheus-stack] ",
-      "groupName": "kube-prometheus-stack dependency major updates"
-    },
-    {
-      "matchPackagePatterns": [
-        "*"
-      ],
-      "matchPaths": [
-        "charts/kube-prometheus-stack/**"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch",
-        "digest",
-        "pin",
-        "pinDigest"
-      ],
-      "commitMessagePrefix": "[kube-prometheus-stack] ",
-      "groupName": "kube-prometheus-stack dependency non-major updates"
+      "commitMessagePrefix": "[{{ lookup (split packageFileDir '/') 1 }}] ",
+      "groupName": "{{ lookup (split packageFileDir '/') 1 }} dependency non-major updates",
+      "separateMajorMinor": true,
+      "postUpdateOptions": "helmUpdateSubChartArchives",
+      "major": {
+        "groupName": "{{ lookup (split packageFileDir '/') 1 }} dependency major updates"
+      }
     }
   ]
 }


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

xref: #4292 

This PR continues the integration of Renovate into this repository. Unfortunately, Renovate cannot automatically bump the Helm chart version for changes made in the values files.

To address this, a support workflow has been added, which uses GitHub Actions to bump the version.

Additionally, the renovate.json file is configured to group version bumps by chart directory. Custom managers have been added from our internal company repository. These custom managers allow developers to enable automated dependency updates by adding Renovate annotations, using code comments. The regex patterns include common use cases, such as the following example:
https://github.com/prometheus-community/helm-charts/blob/7c7bc2e63639ff9cfb8ebae1903efeb4037b3923/charts/kube-prometheus-stack/values.yaml#L708-L711

Once worked, the next iteration is extend the renovate-bump-chart-version workflow to run the hack/update*sh scripts.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
