### PR TITLE
Add revision history limit value to all deployments

### DIFF
--- a/charts/prometheus-blackbox-exporter/templates/deployment.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/deployment.yaml
@@ -12,6 +12,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicas }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "prometheus-blackbox-exporter.selectorLabels" . | nindent 6 }}

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -6,7 +6,6 @@ global:
 restartPolicy: Always
 
 kind: Deployment
-revisionHistoryLimit: 10
 
 ## Override the namespace
 ##

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -6,7 +6,6 @@ global:
 restartPolicy: Always
 
 kind: Deployment
-revisionHistoryLimit: 10
 
 ## Override the namespace
 ##
@@ -194,6 +193,8 @@ resources: {}
   #   memory: 300Mi
   # requests:
   #   memory: 50Mi
+
+revisionHistoryLimit: 10
 
 priorityClassName: ""
 

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -194,6 +194,8 @@ resources: {}
   # requests:
   #   memory: 50Mi
 
+## Number of replicasets to retain ##
+## default value is 10, 0 will not retain any replicasets and make rollbacks impossible ##
 revisionHistoryLimit: 10
 
 priorityClassName: ""

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -6,6 +6,7 @@ global:
 restartPolicy: Always
 
 kind: Deployment
+revisionHistoryLimit: 10
 
 ## Override the namespace
 ##

--- a/charts/prometheus-cloudwatch-exporter/templates/deployment.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/deployment.yaml
@@ -17,6 +17,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       app: {{ template "prometheus-cloudwatch-exporter.name" . }}

--- a/charts/prometheus-cloudwatch-exporter/values.yaml
+++ b/charts/prometheus-cloudwatch-exporter/values.yaml
@@ -61,6 +61,8 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+revisionHistoryLimit: 10
+
 aws:
   role:
   # Enables usage of regional STS endpoints rather than global which is default

--- a/charts/prometheus-cloudwatch-exporter/values.yaml
+++ b/charts/prometheus-cloudwatch-exporter/values.yaml
@@ -61,6 +61,8 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+## Number of replicasets to retain ##
+## default value is 10, 0 will not retain any replicasets and make rollbacks impossible ##
 revisionHistoryLimit: 10
 
 aws:

--- a/charts/prometheus-consul-exporter/templates/deployment.yaml
+++ b/charts/prometheus-consul-exporter/templates/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       app: {{ template "prometheus-consul-exporter.name" . }}

--- a/charts/prometheus-consul-exporter/values.yaml
+++ b/charts/prometheus-consul-exporter/values.yaml
@@ -62,6 +62,8 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 
+revisionHistoryLimit: 10
+
 serviceMonitor:
   # When set true then use a ServiceMonitor to configure scraping
   enabled: false

--- a/charts/prometheus-couchdb-exporter/templates/deployment.yaml
+++ b/charts/prometheus-couchdb-exporter/templates/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       app: {{ template "prometheus-couchdb-exporter.name" . }}

--- a/charts/prometheus-couchdb-exporter/values.yaml
+++ b/charts/prometheus-couchdb-exporter/values.yaml
@@ -50,6 +50,10 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 
+## Number of replicasets to retain ##
+## default value is 10, 0 will not retain any replicasets and make rollbacks impossible ##
+revisionHistoryLimit: 10
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/prometheus-druid-exporter/templates/deployment.yaml
+++ b/charts/prometheus-druid-exporter/templates/deployment.yaml
@@ -13,6 +13,7 @@ metadata:
   annotations:
     {{- toYaml .Values.annotations | nindent 4 }}
 spec:
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "prometheus-druid-exporter.fullname" . }}

--- a/charts/prometheus-druid-exporter/values.yaml
+++ b/charts/prometheus-druid-exporter/values.yaml
@@ -18,6 +18,10 @@ logFormat: json
 
 exporterPort: 8080
 
+## Number of replicasets to retain ##
+## default value is 10, 0 will not retain any replicasets and make rollbacks impossible ##
+revisionHistoryLimit: 10
+
 serviceAccount:
   create: true
 

--- a/charts/prometheus-fastly-exporter/templates/deployment.yaml
+++ b/charts/prometheus-fastly-exporter/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "prometheus-fastly-exporter.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "prometheus-fastly-exporter.selectorLabels" . | nindent 6 }}

--- a/charts/prometheus-fastly-exporter/values.yaml
+++ b/charts/prometheus-fastly-exporter/values.yaml
@@ -73,6 +73,10 @@ resources:
   #  cpu: 100m
   #  memory: 128Mi
 
+## Number of replicasets to retain ##
+## default value is 10, 0 will not retain any replicasets and make rollbacks impossible ##
+revisionHistoryLimit: 10
+
 serviceMonitor:
   # When set true then use a ServiceMonitor to configure scraping
   enabled: false

--- a/charts/prometheus-ipmi-exporter/templates/deployment.yaml
+++ b/charts/prometheus-ipmi-exporter/templates/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- include "prometheus-ipmi-exporter.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "prometheus-ipmi-exporter.selectorLabels" . | nindent 6 }}

--- a/charts/prometheus-ipmi-exporter/values.yaml
+++ b/charts/prometheus-ipmi-exporter/values.yaml
@@ -33,6 +33,10 @@ resources:
     cpu: 100m
     memory: 128Mi
 
+## Number of replicasets to retain ##
+## default value is 10, 0 will not retain any replicasets and make rollbacks impossible ##
+revisionHistoryLimit: 10
+
 additionalAnnotations: {}
 
 # container-level security context

--- a/charts/prometheus-json-exporter/templates/deployment.yaml
+++ b/charts/prometheus-json-exporter/templates/deployment.yaml
@@ -13,6 +13,7 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "prometheus-json-exporter.selectorLabels" . | nindent 6 }}

--- a/charts/prometheus-json-exporter/values.yaml
+++ b/charts/prometheus-json-exporter/values.yaml
@@ -115,6 +115,10 @@ resources: {}
 #   cpu: 100m
 #   memory: 128Mi
 
+## Number of replicasets to retain ##
+## default value is 10, 0 will not retain any replicasets and make rollbacks impossible ##
+revisionHistoryLimit: 10
+
 environmentVariables: []
   # - name: some-secret-variable
   #   valueFrom:

--- a/charts/prometheus-kafka-exporter/templates/deployment.yaml
+++ b/charts/prometheus-kafka-exporter/templates/deployment.yaml
@@ -12,6 +12,7 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       app: {{ template "prometheus-kafka-exporter.name" . }}

--- a/charts/prometheus-kafka-exporter/values.yaml
+++ b/charts/prometheus-kafka-exporter/values.yaml
@@ -145,6 +145,10 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 
+## Number of replicasets to retain ##
+## default value is 10, 0 will not retain any replicasets and make rollbacks impossible ##
+revisionHistoryLimit: 10
+
 nodeSelector: {}
 
 # Annotations to attach to pod

--- a/charts/prometheus-memcached-exporter/templates/deployment.yaml
+++ b/charts/prometheus-memcached-exporter/templates/deployment.yaml
@@ -8,6 +8,7 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "prometheus-memcached-exporter.selectorLabels" . | nindent 6 }}

--- a/charts/prometheus-memcached-exporter/values.yaml
+++ b/charts/prometheus-memcached-exporter/values.yaml
@@ -56,6 +56,10 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+## Number of replicasets to retain ##
+## default value is 10, 0 will not retain any replicasets and make rollbacks impossible ##
+revisionHistoryLimit: 10
+
 autoscaling:
   enabled: false
   minReplicas: 1

--- a/charts/prometheus-modbus-exporter/templates/deployment.yaml
+++ b/charts/prometheus-modbus-exporter/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "prometheus-modbus-exporter.labels" . | nindent 4 }}
 spec:
   replicas: 1
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "prometheus-modbus-exporter.selectorLabels" . | nindent 6 }}

--- a/charts/prometheus-modbus-exporter/values.yaml
+++ b/charts/prometheus-modbus-exporter/values.yaml
@@ -158,6 +158,10 @@ resources: {}
 #   cpu: 100m
 #   memory: 128Mi
 
+## Number of replicasets to retain ##
+## default value is 10, 0 will not retain any replicasets and make rollbacks impossible ##
+revisionHistoryLimit: 10
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/prometheus-mongodb-exporter/templates/deployment.yaml
+++ b/charts/prometheus-mongodb-exporter/templates/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- toYaml .Values.annotations | nindent 4 }}
 spec:
   replicas: {{ .Values.replicas }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "prometheus-mongodb-exporter.selectorLabels" . | nindent 6 }}

--- a/charts/prometheus-mongodb-exporter/values.yaml
+++ b/charts/prometheus-mongodb-exporter/values.yaml
@@ -71,6 +71,10 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+## Number of replicasets to retain ##
+## default value is 10, 0 will not retain any replicasets and make rollbacks impossible ##
+revisionHistoryLimit: 10
+
 # Customize securityContext of the pod.
 # See https://kubernetes.io/docs/concepts/policy/security-context/ for more.
 podSecurityContext: {}

--- a/charts/prometheus-mysql-exporter/templates/deployment.yaml
+++ b/charts/prometheus-mysql-exporter/templates/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- include "prometheus-mysql-exporter.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "prometheus-mysql-exporter.selectorLabels" . | nindent 6 }}

--- a/charts/prometheus-mysql-exporter/values.yaml
+++ b/charts/prometheus-mysql-exporter/values.yaml
@@ -85,6 +85,10 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 
+## Number of replicasets to retain ##
+## default value is 10, 0 will not retain any replicasets and make rollbacks impossible ##
+revisionHistoryLimit: 10
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/prometheus-nats-exporter/templates/deployment.yaml
+++ b/charts/prometheus-nats-exporter/templates/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     helm.sh/chart: {{ include "prometheus-nats-exporter.chart" . }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "prometheus-nats-exporter.name" . }}

--- a/charts/prometheus-nats-exporter/values.yaml
+++ b/charts/prometheus-nats-exporter/values.yaml
@@ -36,6 +36,10 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 
+## Number of replicasets to retain ##
+## default value is 10, 0 will not retain any replicasets and make rollbacks impossible ##
+revisionHistoryLimit: 10
+
 config:
   nats:
     # See https://github.com/helm/charts/blob/master/stable/nats/templates/monitoring-svc.yaml

--- a/charts/prometheus-nginx-exporter/templates/deployment.yaml
+++ b/charts/prometheus-nginx-exporter/templates/deployment.yaml
@@ -11,6 +11,7 @@ metadata:
     {{- include "prometheus-nginx-exporter.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "prometheus-nginx-exporter.selectorLabels" . | indent 6 }}

--- a/charts/prometheus-nginx-exporter/values.yaml
+++ b/charts/prometheus-nginx-exporter/values.yaml
@@ -72,6 +72,10 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+## Number of replicasets to retain ##
+## default value is 10, 0 will not retain any replicasets and make rollbacks impossible ##
+revisionHistoryLimit: 10
+
 serviceMonitor:
   # When set true then use a ServiceMonitor to configure scraping
   enabled: false

--- a/charts/prometheus-opencost-exporter/templates/deployment.yaml
+++ b/charts/prometheus-opencost-exporter/templates/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.opencost.exporter.replicas }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels: {{- include "prometheus-opencost-exporter.selectorLabels" . | nindent 6 }}
   strategy:

--- a/charts/prometheus-opencost-exporter/values.yaml
+++ b/charts/prometheus-opencost-exporter/values.yaml
@@ -32,6 +32,10 @@ priorityClassName: ~
 podSecurityContext: {}
   # fsGroup: 2000
 
+## Number of replicasets to retain ##
+## default value is 10, 0 will not retain any replicasets and make rollbacks impossible ##
+revisionHistoryLimit: 10
+
 service:
   enabled: true
   # --  Annotations to add to the service

--- a/charts/prometheus-pgbouncer-exporter/templates/deployment.yaml
+++ b/charts/prometheus-pgbouncer-exporter/templates/deployment.yaml
@@ -12,6 +12,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       app: {{ template "prometheus-pgbouncer-exporter.name" . }}

--- a/charts/prometheus-pgbouncer-exporter/values.yaml
+++ b/charts/prometheus-pgbouncer-exporter/values.yaml
@@ -71,6 +71,10 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+## Number of replicasets to retain ##
+## default value is 10, 0 will not retain any replicasets and make rollbacks impossible ##
+revisionHistoryLimit: 10
+
 rbac:
   # Specifies whether RBAC resources should be created
   create: true

--- a/charts/prometheus-pingdom-exporter/templates/deployment.yaml
+++ b/charts/prometheus-pingdom-exporter/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "prometheus-pingdom-exporter.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "prometheus-pingdom-exporter.selectorLabels" . | nindent 6 }}

--- a/charts/prometheus-pingdom-exporter/values.yaml
+++ b/charts/prometheus-pingdom-exporter/values.yaml
@@ -32,6 +32,10 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 
+## Number of replicasets to retain ##
+## default value is 10, 0 will not retain any replicasets and make rollbacks impossible ##
+revisionHistoryLimit: 10
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/prometheus-pingmesh-exporter/templates/deployment.yaml
+++ b/charts/prometheus-pingmesh-exporter/templates/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- include "prometheus-pingmesh-exporter.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicas }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "prometheus-pingmesh-exporter.selectorLabels" . | nindent 6 }}

--- a/charts/prometheus-pingmesh-exporter/values.yaml
+++ b/charts/prometheus-pingmesh-exporter/values.yaml
@@ -252,6 +252,10 @@ resources: {}
   #  cpu: 200m
   #  memory: 256Mi
 
+## Number of replicasets to retain ##
+## default value is 10, 0 will not retain any replicasets and make rollbacks impossible ##
+revisionHistoryLimit: 10
+
 priorityClassName: ""
 
 service:

--- a/charts/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/charts/prometheus-postgres-exporter/templates/deployment.yaml
@@ -16,6 +16,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "prometheus-postgres-exporter.selectorLabels" . | nindent 6 }}

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -97,6 +97,10 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+## Number of replicasets to retain ##
+## default value is 10, 0 will not retain any replicasets and make rollbacks impossible ##
+revisionHistoryLimit: 10
+
 rbac:
   # Specifies whether RBAC resources should be created
   create: true

--- a/charts/prometheus-pushgateway/templates/deployment.yaml
+++ b/charts/prometheus-pushgateway/templates/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   namespace: {{ template "prometheus-pushgateway.namespace" . }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   {{- with .Values.strategy }}
   strategy:
     {{- toYaml . | nindent 4 }}

--- a/charts/prometheus-pushgateway/values.yaml
+++ b/charts/prometheus-pushgateway/values.yaml
@@ -108,6 +108,10 @@ resources: {}
   #   cpu: 100m
   #   memory: 30Mi
 
+## Number of replicasets to retain ##
+## default value is 10, 0 will not retain any replicasets and make rollbacks impossible ##
+revisionHistoryLimit: 10
+
 # -- Sets web configuration
 # To enable basic authentication, provide basicAuthUsers as a map
 webConfiguration: {}

--- a/charts/prometheus-rabbitmq-exporter/templates/deployment.yaml
+++ b/charts/prometheus-rabbitmq-exporter/templates/deployment.yaml
@@ -12,6 +12,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       app: {{ template "prometheus-rabbitmq-exporter.name" . }}

--- a/charts/prometheus-rabbitmq-exporter/values.yaml
+++ b/charts/prometheus-rabbitmq-exporter/values.yaml
@@ -26,6 +26,10 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 
+## Number of replicasets to retain ##
+## default value is 10, 0 will not retain any replicasets and make rollbacks impossible ##
+revisionHistoryLimit: 10
+
 priorityClassName: ""
 
 nodeSelector: {}

--- a/charts/prometheus-redis-exporter/templates/deployment.yaml
+++ b/charts/prometheus-redis-exporter/templates/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
 {{ toYaml .Values.annotations | indent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "prometheus-redis-exporter.selectorLabels" . | nindent 6 }}

--- a/charts/prometheus-redis-exporter/values.yaml
+++ b/charts/prometheus-redis-exporter/values.yaml
@@ -44,6 +44,10 @@ service:
     # prometheus.io/scrape: "true"
 resources: {}
 
+## Number of replicasets to retain ##
+## default value is 10, 0 will not retain any replicasets and make rollbacks impossible ##
+revisionHistoryLimit: 10
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/prometheus-snmp-exporter/templates/deployment.yaml
+++ b/charts/prometheus-snmp-exporter/templates/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- include "prometheus-snmp-exporter.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.replicas }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "prometheus-snmp-exporter.selectorLabels" . | indent 6 }}

--- a/charts/prometheus-snmp-exporter/values.yaml
+++ b/charts/prometheus-snmp-exporter/values.yaml
@@ -87,6 +87,10 @@ resources: {}
   # requests:
   #   memory: 50Mi
 
+## Number of replicasets to retain ##
+## default value is 10, 0 will not retain any replicasets and make rollbacks impossible ##
+revisionHistoryLimit: 10
+
 livenessProbe:
   httpGet:
     path: /

--- a/charts/prometheus-sql-exporter/templates/deployment.yaml
+++ b/charts/prometheus-sql-exporter/templates/deployment.yaml
@@ -13,6 +13,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "prometheus-sql-exporter.selectorLabels" . | nindent 6 }}

--- a/charts/prometheus-sql-exporter/values.yaml
+++ b/charts/prometheus-sql-exporter/values.yaml
@@ -61,6 +61,10 @@ resources:
   #   cpu: 100m
   #   memory: 128Mi
 
+## Number of replicasets to retain ##
+## default value is 10, 0 will not retain any replicasets and make rollbacks impossible ##
+revisionHistoryLimit: 10
+
 rbac:
   # Specifies whether RBAC resources should be created
   create: true

--- a/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
@@ -10,6 +10,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "stackdriver-exporter.selectorLabels" . | indent 6 }}

--- a/charts/prometheus-stackdriver-exporter/values.yaml
+++ b/charts/prometheus-stackdriver-exporter/values.yaml
@@ -31,6 +31,10 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+## Number of replicasets to retain ##
+## default value is 10, 0 will not retain any replicasets and make rollbacks impossible ##
+revisionHistoryLimit: 10
+
 securityContext: {}
 
 containerSecurityContext: {}

--- a/charts/prometheus-yet-another-cloudwatch-exporter/templates/deployment.yaml
+++ b/charts/prometheus-yet-another-cloudwatch-exporter/templates/deployment.yaml
@@ -11,6 +11,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "yet-another-cloudwatch-exporter.selectorLabels" . | nindent 6 }}

--- a/charts/prometheus-yet-another-cloudwatch-exporter/values.yaml
+++ b/charts/prometheus-yet-another-cloudwatch-exporter/values.yaml
@@ -85,6 +85,10 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+## Number of replicasets to retain ##
+## default value is 10, 0 will not retain any replicasets and make rollbacks impossible ##
+revisionHistoryLimit: 10
+
 nodeSelector: {}
 
 priorityClassName:


### PR DESCRIPTION
#### What this PR does / why we need it
This PR adds a configurable value of revisionHistoryLimit to all deployments across all prometheus helm charts and initializes them at the default value of 10.

This will enable users of this helm chart to easily decrease the number of retained replicaSets per deployment to fit into smaller clusters or environments or just to get a better overview. 

#### Which issue this PR fixes

- fixes #5227

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
