### PR TITLE
[prometheus-blackbox-exporter] feat: add revisionHistoryLimit as a value to blackbox-exporter helmchart

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 9.1.0
+version: 9.2.0
 appVersion: v0.25.0
 kubeVersion: ">=1.21.0-0"
 home: https://github.com/prometheus/blackbox_exporter

--- a/charts/prometheus-blackbox-exporter/templates/deployment.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/deployment.yaml
@@ -12,6 +12,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicas }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "prometheus-blackbox-exporter.selectorLabels" . | nindent 6 }}

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -79,6 +79,8 @@ extraContainers: []
   #     - mountPath: /etc/prometheus/secrets/blackbox-tls
   #       name: secret-blackbox-tls
 
+revisionHistoryLimit: 10
+
 # String mode
 # extraContainers: |-
 #   - name: oAuth2-proxy

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -79,6 +79,8 @@ extraContainers: []
   #     - mountPath: /etc/prometheus/secrets/blackbox-tls
   #       name: secret-blackbox-tls
 
+## Number of replicasets to retain ##
+## default value is 10, 0 will not retain any replicasets and make rollbacks impossible ##
 revisionHistoryLimit: 10
 
 # String mode


### PR DESCRIPTION
#### What this PR does / why we need it
This PR adds a configurable value of revisionHistoryLimit to the blackbox-exporter and initializes it at the default value of 10.

This will enable users of this helm chart to easily decrease the number of retained replicaSets to fit into smaller clusters or environments or just to get a better overview. 

#### Which issue this PR fixes

- fixes #5227

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)