### PR TITLE
[kube-prometheus-stack] add k merge key and merge strategy to groups and rules in promethues rule crd

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -31,7 +31,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 68.4.0
+version: 68.5.0
 appVersion: v0.79.2
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/charts/crds/crds/crd-prometheusrules.yaml
+++ b/charts/kube-prometheus-stack/charts/crds/crds/crd-prometheusrules.yaml
@@ -145,6 +145,8 @@ spec:
                         - expr
                         type: object
                       type: array
+                      x-kubernetes-patch-merge-key: alert
+                      x-kubernetes-patch-strategy: merge
                   required:
                   - name
                   type: object
@@ -152,6 +154,8 @@ spec:
                 x-kubernetes-list-map-keys:
                 - name
                 x-kubernetes-list-type: map
+                x-kubernetes-patch-merge-key: name
+                x-kubernetes-patch-strategy: merge
             type: object
         required:
         - spec


### PR DESCRIPTION
Add k merge key and merge strategy to groups and rules in promethues rule crd  Signed-off-by: Hossein Mohammadi <hn.mohammadi7@gmail.com>

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
for strategic patching in kubernetes patch feature or using patch in kustomize when it comes to override the expr field or any other field, the whole patch is overwritten as a Rule/Group. This PR adds merge key and merge strategy, so **kubectl patch** or **kustomize patch** can recongnize PrometheusRule CRD properly and patch in a expected and desired way.

#### Which issue this PR fixes

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
