### PR TITLE
[kube-prometheus-stack] update chart information about how to use newly installed chart

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -31,7 +31,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 68.4.4
+version: 68.4.5
 appVersion: v0.79.2
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/NOTES.txt
+++ b/charts/kube-prometheus-stack/templates/NOTES.txt
@@ -1,4 +1,13 @@
 {{ $.Chart.Name }} has been installed. Check its status by running:
   kubectl --namespace {{ template "kube-prometheus-stack.namespace" . }} get pods -l "release={{ $.Release.Name }}"
 
+Get Grafana '{{ .Values.grafana.adminUser }}' user password by running:
+
+  kubectl --namespace {{ template "kube-prometheus-stack.namespace" . }} get secrets prom-grafana -ojsonpath="{.data.admin-password}" | base64 -d ; echo
+
+Access Grafana local instance:
+
+  export POD_NAME=$(kubectl --namespace {{ template "kube-prometheus-stack.namespace" . }} get pod -l "app.kubernetes.io/name={{ default "grafana" .Values.grafana.name }},app.kubernetes.io/instance={{ $.Release.Name }}" -oname)
+  kubectl --namespace {{ template "kube-prometheus-stack.namespace" . }} port-forward $POD_NAME 3000
+  
 Visit https://github.com/prometheus-operator/kube-prometheus for instructions on how to create & configure Alertmanager and Prometheus instances using the Operator.

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1150,6 +1150,7 @@ grafana:
   ##
   defaultDashboardsEditable: true
 
+  adminUser: admin
   adminPassword: prom-operator
 
   rbac:


### PR DESCRIPTION
#### Which issue this PR fixes 

- fixes #5267 

- Enhances the chart with additional Grafana connection details

![Screenshot 2025-02-04 at 01 13 19](https://github.com/user-attachments/assets/8b6a76cc-62d4-409f-923b-bcfb790dd28a)


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[kube-prometheus-stack]`)