### PR TITLE
kube-prometheus-stack bugfix wrong line break and add https redirect route

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -31,7 +31,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 69.2.4
+version: 69.3.0
 appVersion: v0.80.0
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/alertmanager/route.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/route.yaml
@@ -2,7 +2,7 @@
   {{- $serviceName := printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "alertmanager" }}
   {{- $servicePort := .Values.alertmanager.ingress.servicePort | default .Values.alertmanager.service.port -}}
   {{- range $name, $route := .Values.alertmanager.route }}
-    {{- if $route.enabled -}}
+  {{- if $route.enabled }}
 ---
 apiVersion: {{ $route.apiVersion | default "gateway.networking.k8s.io/v1" }}
 kind: {{ $route.kind | default "HTTPRoute" }}
@@ -32,6 +32,13 @@ spec:
     {{- if $route.additionalRules }}
     {{- tpl (toYaml $route.additionalRules) $ | nindent 4 }}
     {{- end }}
+    {{- if $route.httpsRedirect }}
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+    {{- else }}
     - backendRefs:
         - name: {{ $serviceName }}
           port: {{ $servicePort }}
@@ -44,5 +51,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     {{- end }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/route.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/route.yaml
@@ -2,7 +2,7 @@
   {{- $serviceName := printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "prometheus" -}}
   {{- $servicePort := .Values.prometheus.ingress.servicePort | default .Values.prometheus.service.port -}}
   {{- range $name, $route := .Values.prometheus.route }}
-    {{- if $route.enabled -}}
+    {{- if $route.enabled }}
 ---
 apiVersion: {{ $route.apiVersion | default "gateway.networking.k8s.io/v1" }}
 kind: {{ $route.kind | default "HTTPRoute" }}
@@ -32,6 +32,13 @@ spec:
     {{- if $route.additionalRules }}
     {{- tpl (toYaml $route.additionalRules) $ | nindent 4 }}
     {{- end }}
+    {{- if $route.httpsRedirect }}
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+    {{- else }}
     - backendRefs:
         - name: {{ $serviceName }}
           port: {{ $servicePort }}
@@ -44,5 +51,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     {{- end }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/route.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/route.yaml
@@ -2,7 +2,7 @@
   {{- $serviceName := printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "prometheus" -}}
   {{- $servicePort := .Values.prometheus.ingress.servicePort | default .Values.prometheus.service.port -}}
   {{- range $name, $route := .Values.prometheus.route }}
-    {{- if $route.enabled }}
+  {{- if $route.enabled }}
 ---
 apiVersion: {{ $route.apiVersion | default "gateway.networking.k8s.io/v1" }}
 kind: {{ $route.kind | default "HTTPRoute" }}

--- a/charts/kube-prometheus-stack/templates/thanos-ruler/route.yaml
+++ b/charts/kube-prometheus-stack/templates/thanos-ruler/route.yaml
@@ -2,7 +2,7 @@
   {{- $serviceName := include "kube-prometheus-stack.thanosRuler.name" . }}
   {{- $servicePort := .Values.thanosRuler.service.port -}}
   {{- range $name, $route := .Values.thanosRuler.route }}
-    {{- if $route.enabled }}
+  {{- if $route.enabled }}
 ---
 apiVersion: {{ $route.apiVersion | default "gateway.networking.k8s.io/v1" }}
 kind: {{ $route.kind | default "HTTPRoute" }}

--- a/charts/kube-prometheus-stack/templates/thanos-ruler/route.yaml
+++ b/charts/kube-prometheus-stack/templates/thanos-ruler/route.yaml
@@ -2,7 +2,7 @@
   {{- $serviceName := include "kube-prometheus-stack.thanosRuler.name" . }}
   {{- $servicePort := .Values.thanosRuler.service.port -}}
   {{- range $name, $route := .Values.thanosRuler.route }}
-    {{- if $route.enabled -}}
+    {{- if $route.enabled }}
 ---
 apiVersion: {{ $route.apiVersion | default "gateway.networking.k8s.io/v1" }}
 kind: {{ $route.kind | default "HTTPRoute" }}
@@ -32,6 +32,13 @@ spec:
     {{- if $route.additionalRules }}
     {{- tpl (toYaml $route.additionalRules) $ | nindent 4 }}
     {{- end }}
+    {{- if $route.httpsRedirect }}
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+    {{- else }}
     - backendRefs:
         - name: {{ $serviceName }}
           port: {{ $servicePort }}
@@ -44,5 +51,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     {{- end }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -4748,7 +4748,8 @@ thanosRuler:
       parentRefs: []
       # - name: acme-gw
 
-      # -- create http route for redirect (https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/#http-to-https-redirects)
+      ## create http route for https redirect (https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/#http-to-https-redirects).
+      ## matches, filters and additionalRules will be ignored if this is set to true
       httpsRedirect: false
 
       matches:

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -580,6 +580,8 @@ alertmanager:
       # - name: acme-gw
 
       # -- create http route for redirect (https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/#http-to-https-redirects)
+      ## Take care that you only enable this on the http listener of the gateway to avoid an infinite redirect.
+      ## matches, filters and additionalRules will be ignored if this is set to true. Be are
       httpsRedirect: false
 
       matches:
@@ -3591,12 +3593,14 @@ prometheus:
       # - name: acme-gw
 
       # -- create http route for redirect (https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/#http-to-https-redirects)
+      ## Take care that you only enable this on the http listener of the gateway to avoid an infinite redirect.
+      ## matches, filters and additionalRules will be ignored if this is set to true. Be are
       httpsRedirect: false
 
       matches:
-      - path:
-          type: PathPrefix
-          value: /
+        - path:
+            type: PathPrefix
+            value: /
 
       ## Filters define the filters that are applied to requests that match this rule.
       filters: []
@@ -4748,8 +4752,9 @@ thanosRuler:
       parentRefs: []
       # - name: acme-gw
 
-      ## create http route for https redirect (https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/#http-to-https-redirects).
-      ## matches, filters and additionalRules will be ignored if this is set to true
+      # -- create http route for redirect (https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/#http-to-https-redirects)
+      ## Take care that you only enable this on the http listener of the gateway to avoid an infinite redirect.
+      ## matches, filters and additionalRules will be ignored if this is set to true. Be are
       httpsRedirect: false
 
       matches:

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -579,6 +579,9 @@ alertmanager:
       parentRefs: []
       # - name: acme-gw
 
+      # -- create http route for redirect (https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/#http-to-https-redirects)
+      httpsRedirect: false
+
       matches:
         - path:
             type: PathPrefix
@@ -3587,6 +3590,9 @@ prometheus:
       parentRefs: []
       # - name: acme-gw
 
+      # -- create http route for redirect (https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/#http-to-https-redirects)
+      httpsRedirect: false
+
       matches:
       - path:
           type: PathPrefix
@@ -4741,6 +4747,9 @@ thanosRuler:
       # - my-filter.example.com
       parentRefs: []
       # - name: acme-gw
+
+      # -- create http route for redirect (https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/#http-to-https-redirects)
+      httpsRedirect: false
 
       matches:
         - path:


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Bugfixing an issue by creating multiple routes for alertmanager, prometheus and thanosruler. In this case the linebreak does not work and the outcome is not a valid resource.

Adding new feature to create a route for https redirect see also https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/#http-to-https-redirects

#### Which issue this PR fixes

No open issue found that points to this bug and feature

#### Special notes for your reviewer

@andrewgkew  @gianrubio @gkarthiks @GMartinez-Sisti @jkroepke @scottrigby @Xtigyro @QuentinBisson

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
