### PR TITLE
[prometheus-operator-admission-webhook] issuerRef needs to be an object

### DIFF
--- a/charts/prometheus-operator-admission-webhook/Chart.yaml
+++ b/charts/prometheus-operator-admission-webhook/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: Prometheus Operator Admission Webhook
 name: prometheus-operator-admission-webhook
-version: 0.18.1
+version: 0.18.2
 appVersion: 0.79.2
 home: https://github.com/prometheus-operator/prometheus-operator
 icon: https://github.com/prometheus-operator/prometheus-operator/raw/main/Documentation/logos/prometheus-operator-logo.png

--- a/charts/prometheus-operator-admission-webhook/values.schema.json
+++ b/charts/prometheus-operator-admission-webhook/values.schema.json
@@ -18,7 +18,7 @@
                     "type": "boolean"
                 },
                 "issuerRef": {
-                    "type": "string"
+                    "type": "object"
                 },
                 "rootCert": {
                     "type": "object"

--- a/charts/prometheus-operator-admission-webhook/values.yaml
+++ b/charts/prometheus-operator-admission-webhook/values.yaml
@@ -104,7 +104,8 @@ certManager:
   issuerRef: {}
     # name: ""
     # kind: ""
-    ## group is optional since cert-manager will default to this value however
+    ## group is optional since cert-manager will default to this value anyway
+    ## if you are using an external issuer, change this to that issuer group.
     # group: "cert-manager.io"
   ## rootCert allows setting certificate's lifetime when creating an issuer, defaults to 5y
   rootCert: {}

--- a/charts/prometheus-operator-admission-webhook/values.yaml
+++ b/charts/prometheus-operator-admission-webhook/values.yaml
@@ -101,7 +101,11 @@ certManager:
   ## An issuer represents a certificate issuing authority.
   ## If not set, new issuers will be created.
   ## ref. https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.Issuer
-  issuerRef: ""
+  issuerRef: {}
+    # name: ""
+    # kind: ""
+    ## group is optional since cert-manager will default to this value however
+    # group: "cert-manager.io"
   ## rootCert allows setting certificate's lifetime when creating an issuer, defaults to 5y
   rootCert: {}
     # duration: "43800h0m0s"


### PR DESCRIPTION
## Problem
issuerRef was failing schema validation . It was expecting a string instead of an object

## scope of the PR
changes the type from string to object in the values.schema.json

## Problem origin

### trying this 
```yaml
certManager:
  enabled: true
  ## issuerRef references an existing issuer for the webhook certificate.
  ## An issuer represents a certificate issuing authority.
  ## If not set, new issuers will be created.
  ## ref. https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.Issuer
  issuerRef:
    name: rootca-for-sandbox-issuer
    kind: ClusterIssuer
  ## rootCert allows setting certificate's lifetime when creating an issuer, defaults to 5y
  rootCert: {}
    # duration: "43800h0m0s"
  ## webhookCert allows setting webhook certificate's lifetime, defaults to 1y
  webhookCert: {}
    # duration: "8760h0m0s"
```

### Result on applying
```bash
shivansh.singla@NRHN958E MSYS ~/Desktop/terraform-req/prometheus (main)
$ helm upgrade --install prometheus-operator-admission-webhook prometheus-community/prometheus-operator-admission-webhook --values webhook-values.yaml
coalesce.go:289: warning: destination for prometheus-operator-admission-webhook.certManager.issuerRef is a table. Ignoring non-table value ()
Error: UPGRADE FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
prometheus-operator-admission-webhook:
- certManager.issuerRef: Invalid type. Expected: string, given: object
```

### so tried giving just a string with cluster-issuer name

```yaml
certManager:
  enabled: true
  ## issuerRef references an existing issuer for the webhook certificate.
  ## An issuer represents a certificate issuing authority.
  ## If not set, new issuers will be created.
  ## ref. https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.Issuer
  issuerRef: "root-ca-for-sandbox-issuer"
```
I didn't receive a schema validation error
but It generated the wrong template
```yaml
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: prometheus-operator-admission-webhook-cert
  namespace: monitoring
spec:
  secretName: prometheus-operator-admission-webhook-cert
  duration: "8760h0m0s"
  issuerRef:
    root-ca-for-sandbox-issuer
  dnsNames:
  - prometheus-operator-admission-webhook
  - prometheus-operator-admission-webhook.monitoring
  - prometheus-operator-admission-webhook.monitoring.svc
  ```
I also get an error from webhook of cert-manager
```bash
shivansh.singla@NRHN958E MSYS ~/Desktop/terraform-req/prometheus (main)
$ helm upgrade --install prometheus-operator-admission-webhook prometheus-community/prometheus-operator-admission-webhook --values webhook-values.yaml
Error: UPGRADE FAILED: failed to create resource: Certificate.cert-manager.io "prometheus-operator-admission-webhook-cert" is invalid: spec.issuerRef: Invalid value: "string": spec.issuerRef in body must be of type object: "string"
```

## Temporary Solution
### values.yaml
```yaml
certManager:
  enabled: true
  ## issuerRef references an existing issuer for the webhook certificate.
  ## An issuer represents a certificate issuing authority.
  ## If not set, new issuers will be created.
  ## ref. https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.Issuer
  issuerRef:
    name: rootca-for-sandbox-issuer
    kind: ClusterIssuer
  ## rootCert allows setting certificate's lifetime when creating an issuer, defaults to 5y
  rootCert: {}
    # duration: "43800h0m0s"
  ## webhookCert allows setting webhook certificate's lifetime, defaults to 1y
  webhookCert: {}
    # duration: "8760h0m0s"
```
### Template generated with skip-schema-validation flag
```yaml
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: prometheus-operator-admission-webhook-cert
  namespace: monitoring
spec:
  secretName: prometheus-operator-admission-webhook-cert
  duration: "8760h0m0s"
  issuerRef:
    kind: ClusterIssuer
    name: rootca-for-sandbox-issuer
  dnsNames:
  - prometheus-operator-admission-webhook
  - prometheus-operator-admission-webhook.monitoring
  - prometheus-operator-admission-webhook.monitoring.svc
  ```
### apply with skip-schema-validation
```bash
shivansh.singla@NRHN958E MSYS ~/Desktop/terraform-req/prometheus (main)
$ helm upgrade --install prometheus-operator-admission-webhook prometheus-community/prometheus-operator-admission-webhook --values webhook-values.yaml --skip-schema-validation
coalesce.go:289: warning: destination for prometheus-operator-admission-webhook.certManager.issuerRef is a table. Ignoring non-table value ()
Release "prometheus-operator-admission-webhook" has been upgraded. Happy Helming!
NAME: prometheus-operator-admission-webhook
LAST DEPLOYED: Thu Feb  6 16:48:00 2025
NAMESPACE: default
STATUS: deployed
REVISION: 11
TEST SUITE: None
NOTES:
See https://prometheus-operator.dev/docs/user-guides/webhook/ for more information on the admission webhook.

1. Get the webhook's URL by running these commands:

  export POD_NAME="$(kubectl get pods --namespace monitoring -l "app.kubernetes.io/name=prometheus-operator-admission-webhook,app.kubernetes.io/instance=prometheus-operator-admission-webhook" -o jsonpath="{.items[0].metadata.name}")"



  export POD_NAME="$(kubectl get pods --namespace monitoring -l "app.kubernetes.io/name=prometheus-operator-admission-webhook,app.kubernetes.io/instance=prometheus-operator-admission-webhook" -o jsonpath="{.items[0].metadata.name}")"
  export CONTAINER_PORT="$(kubectl get pod --namespace monitoring $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")"

2. Set port forwarding:

   kubectl --namespace monitoring port-forward $POD_NAME 8080:$CONTAINER_PORT

3. Verify the admission-webhook's deployment by checking its health endpoint by command

   curl -k https://127.0.0.1:8080/healthz

   JSON-formatted "status: up" is expected at that point.
```

## permanent solution
Permanent solution is to change the type from string to object for issuerRef in values.schema.json which is also the scope of the PR



