### PR TITLE
[kube-prometheus-stack] Remove Plus Character From Upgrade Job for Custom Distros

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -31,7 +31,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 69.2.0
+version: 69.1.1
 appVersion: v0.80.0
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -31,7 +31,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 69.1.0
+version: 69.2.0
 appVersion: v0.80.0
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/charts/crds/templates/upgrade/job.yaml
+++ b/charts/kube-prometheus-stack/charts/crds/templates/upgrade/job.yaml
@@ -75,10 +75,11 @@ spec:
       containers:
         - name: kubectl
           {{- $kubectlRegistry := .Values.global.imageRegistry | default .Values.upgradeJob.image.kubectl.registry -}}
+          {{- $defaultKubernetesVersion := regexReplaceAll "\\+.*" .Capabilities.KubeVersion.Version "" }}
           {{- if .Values.upgradeJob.image.kubectl.sha }}
-          image: "{{ $kubectlRegistry }}/{{ .Values.upgradeJob.image.kubectl.repository }}:{{ .Values.upgradeJob.image.kubectl.tag | default .Capabilities.KubeVersion.Version }}@sha256:{{ .Values.upgradeJob.image.kubectl.sha }}"
+          image: "{{ $kubectlRegistry }}/{{ .Values.upgradeJob.image.kubectl.repository }}:{{ .Values.upgradeJob.image.kubectl.tag | default $defaultKubernetesVersion }}@sha256:{{ .Values.upgradeJob.image.kubectl.sha }}"
           {{- else }}
-          image: "{{ $kubectlRegistry }}/{{ .Values.upgradeJob.image.kubectl.repository }}:{{ .Values.upgradeJob.image.kubectl.tag | default .Capabilities.KubeVersion.Version }}"
+          image: "{{ $kubectlRegistry }}/{{ .Values.upgradeJob.image.kubectl.repository }}:{{ .Values.upgradeJob.image.kubectl.tag | default $defaultKubernetesVersion }}"
           {{- end }}
           imagePullPolicy: "{{ .Values.upgradeJob.image.kubectl.pullPolicy }}"
           command:


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Many custom Kubernetes distros add +<custom-distro-name> to the end of the Kubernetes version. This removes the + so we get the correct version of the kubectl container.
#### Which issue this PR fixes

- fixes #5291 



