### PR TITLE
[prometheus-json-exporter]: scrape timeout must be lower than interval

### DIFF
--- a/charts/prometheus-json-exporter/Chart.yaml
+++ b/charts/prometheus-json-exporter/Chart.yaml
@@ -10,7 +10,7 @@ type: application
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-version: 0.16.0
+version: 0.16.1
 appVersion: "v0.7.0"
 home: https://github.com/prometheus-community/json_exporter
 maintainers:

--- a/charts/prometheus-json-exporter/values.yaml
+++ b/charts/prometheus-json-exporter/values.yaml
@@ -74,7 +74,7 @@ serviceMonitor:
     additionalRelabels: []
     interval: 10s
     labels: {}
-    scrapeTimeout: 30s
+    scrapeTimeout: 8s
 
   targets:
 #    - name: example                    # Human readable URL that will appear in Prometheus / AlertManager


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Fixes the default scrapeTimeout to be a valid value

#### Which issue this PR fixes

Commit [c50b12e526e5fd2769b52cc6d7438163e8d5da10](https://github.com/prometheus-community/helm-charts/commit/c50b12e526e5fd2769b52cc6d7438163e8d5da10) changed the behavior so that the scrapeTimeout is always set. However, [the current defaults](https://github.com/prometheus-community/helm-charts/blob/3171fe0905a4e3125fd33cc1b12a572834cb7c06/charts/prometheus-json-exporter/values.yaml#L72-L77) are invalid, since the timeout is larger than the interval.

Due to that, at least alloy rejects to scrape the ServiceMonitor with the error

> scrape timeout greater than scrape interval for scrape config with job name \"serviceMonitor/namespace/service-monitor-name/0\"

#### Special notes for your reviewer

This is a breaking change for any users that have set an interval higher than 30s and rely on the scrapeTimeout to be higher than 8s. Since the prometheus default is 1m, this might occur in some cases.

However, I still decided to lower the default scrapeTimeout since this is where the issue was introduced.

If we touch the default interval, it is a breaking change for all users that don't configure their interval. By changing the default scrapeTimeout, it is a breaking change only for users that have the interval higher than 30s and rely on the scrapeTimeout to be higher than 8s.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
