### PR TITLE
[kube-prometheus-stack] Fix Kubectl Version #2

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -31,7 +31,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 69.2.0
+version: 69.2.1
 appVersion: v0.80.0
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/charts/crds/templates/upgrade/job.yaml
+++ b/charts/kube-prometheus-stack/charts/crds/templates/upgrade/job.yaml
@@ -75,7 +75,7 @@ spec:
       containers:
         - name: kubectl
           {{- $kubectlRegistry := .Values.global.imageRegistry | default .Values.upgradeJob.image.kubectl.registry -}}
-          {{- $defaultKubernetesVersion := regexFind "v\\d+\\.\\d+\\.\\d+" .Capabilities.KubeVersion.Version -}}
+          {{- $defaultKubernetesVersion := regexFind "v\\d+\\.\\d+\\.\\d+" .Capabilities.KubeVersion.Version }}
           {{- if .Values.upgradeJob.image.kubectl.sha }}
           image: "{{ $kubectlRegistry }}/{{ .Values.upgradeJob.image.kubectl.repository }}:{{ .Values.upgradeJob.image.kubectl.tag | default $defaultKubernetesVersion }}@sha256:{{ .Values.upgradeJob.image.kubectl.sha }}"
           {{- else }}

--- a/charts/kube-prometheus-stack/charts/crds/templates/upgrade/job.yaml
+++ b/charts/kube-prometheus-stack/charts/crds/templates/upgrade/job.yaml
@@ -75,7 +75,7 @@ spec:
       containers:
         - name: kubectl
           {{- $kubectlRegistry := .Values.global.imageRegistry | default .Values.upgradeJob.image.kubectl.registry -}}
-          {{- $defaultKubernetesVersion := regexReplaceAll "\\+.*" .Capabilities.KubeVersion.Version "" }}
+          {{- $defaultKubernetesVersion := regexFind "v\\d+\\.\\d+\\.\\d+" .Capabilities.KubeVersion.Version -}}
           {{- if .Values.upgradeJob.image.kubectl.sha }}
           image: "{{ $kubectlRegistry }}/{{ .Values.upgradeJob.image.kubectl.repository }}:{{ .Values.upgradeJob.image.kubectl.tag | default $defaultKubernetesVersion }}@sha256:{{ .Values.upgradeJob.image.kubectl.sha }}"
           {{- else }}


### PR DESCRIPTION

#### What this PR does / why we need it
Fixes issue where custom Kubernetes distros append special versions to the upgrade job. Distros are not consistent with their naming conventions. Some add a +<distro-name> while others add a -<distro-name>. This PR extracts the Kubernetes version from the custom distro name using a Regex expression. According to Kubernetes versioning docs, released versions are always x.y.z. See
https://kubernetes.io/releases/version-skew-policy/
#### Which issue this PR fixes

- fixes #5291 

#### Special notes for your reviewer

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
