### PR TITLE
[snmp-exporter] Adding ability to add custom volumeName to config-reloader

### DIFF
--- a/charts/prometheus-snmp-exporter/Chart.yaml
+++ b/charts/prometheus-snmp-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus SNMP Exporter
 name: prometheus-snmp-exporter
-version: 6.0.0
+version: 6.1.0
 appVersion: v0.27.0
 home: https://github.com/prometheus/snmp_exporter
 sources:

--- a/charts/prometheus-snmp-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-snmp-exporter/templates/daemonset.yaml
@@ -97,7 +97,7 @@ spec:
 {{ toYaml .Values.configmapReload.resources | indent 12 }}
           volumeMounts:
             - mountPath: /etc/config
-              name: config
+              name: "{{ .Values.configmapReload.volumeName }}"
               readOnly: true
       {{- end }}
       {{- if .Values.imagePullSecrets }}

--- a/charts/prometheus-snmp-exporter/templates/deployment.yaml
+++ b/charts/prometheus-snmp-exporter/templates/deployment.yaml
@@ -104,7 +104,7 @@ spec:
 {{ toYaml .Values.configmapReload.resources | indent 12 }}
           volumeMounts:
             - mountPath: /etc/config
-              name: config
+              name: "{{ .Values.configmapReload.volumeName }}"
               readOnly: true
       {{- end }}
       {{- if .Values.imagePullSecrets }}

--- a/charts/prometheus-snmp-exporter/values.yaml
+++ b/charts/prometheus-snmp-exporter/values.yaml
@@ -147,6 +147,10 @@ configmapReload:
   ## configmap-reload container name
   ##
   name: configmap-reload
+  ## volume name to mount to prometheus-config-reloader. Default "config"
+  ## Can use projected volume name in extraVolumes and mount multiple secrets, configmaps in single volume to watch for changes.
+  ##
+  volumeName: config
 
   ## configmap-reload container image
   ##


### PR DESCRIPTION
Adding ability to set custom volumeName for config-reloader. since now it is hardcoded to "config" and does not watch other volumeMounts
With this approach you can create extraVolumes for example projected volumes which contain secrets for auth or snmp mib data and mount those configs to config reloader to watch and reload snmp-exporter.

Commit tested on working k8s cluster.