### PR TITLE
[kube-prometheus-stack] Allow to configure kube-api-server service monitor path

### DIFF
--- a/charts/kube-prometheus-stack/templates/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-api-server/servicemonitor.yaml
@@ -24,6 +24,9 @@ spec:
     {{- if .Values.kubeApiServer.serviceMonitor.proxyUrl }}
     proxyUrl: {{ .Values.kubeApiServer.serviceMonitor.proxyUrl }}
     {{- end }}
+    {{- if .Values.kubeApiServer.serviceMonitor.path }}
+    path: {{ .Values.kubeApiServer.serviceMonitor.path }}
+    {{- end }}
     port: https
     scheme: https
 {{- if .Values.kubeApiServer.serviceMonitor.metricRelabelings }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1392,6 +1392,10 @@ kubeApiServer:
     ##
     proxyUrl: ""
 
+    ## path: path that should be used for scraping. Example /metrics for EKS cluster
+    ##
+    path: ""
+
     jobLabel: component
     selector:
       matchLabels:


### PR DESCRIPTION
For EKS cluster, it's necessary to update path of serviceMonitor to scrape metrics (need to add /metrics).

I add this optional configuration on this serviceMonitor.