### PR TITLE
[kube-prometheus-stack] Add NetworkPolicy support for Alertmanager

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -31,7 +31,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 69.3.1
+version: 69.3.2
 appVersion: v0.80.0
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/alertmanager/networkpolicy.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/networkpolicy.yaml
@@ -12,22 +12,22 @@ spec:
     matchLabels:
       app.kubernetes.io/name: alertmanager
   policyTypes:
-    - Ingress
-    - Egress
+    {{- toYaml .Values.alertmanager.networkPolicy.policyTypes | nindent 4 }}
   ingress:
-    # Allow ingress from the ingress controller
+    # Allow ingress from gateway
     - from:
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: {{ .Values.alertmanager.networkPolicy.ingressNS }}
+              kubernetes.io/metadata.name: {{ .Values.alertmanager.networkPolicy.gateway.namespace }}
           podSelector:
             matchLabels:
-              {{- toYaml .Values.alertmanager.networkPolicy.ingressPodLabels | nindent 14 }}
+              {{- toYaml .Values.alertmanager.networkPolicy.gateway.podLabels | nindent 14 }}
       ports:
         - port: {{ .Values.alertmanager.service.port }}
           protocol: TCP
         - port: {{ .Values.alertmanager.service.clusterPort }}
           protocol: TCP
+    {{- if .Values.alertmanager.networkPolicy.monitoringRules.prometheus }}
     # Allow ingress from Prometheus
     - from:
         - podSelector:
@@ -36,44 +36,45 @@ spec:
       ports:
         - port: {{ .Values.alertmanager.service.port }}
           protocol: TCP
-  egress:
-    # Allow DNS resolution
-    - to:
-        - namespaceSelector: {}
-          podSelector:
+    {{- end }}
+    {{- if .Values.alertmanager.networkPolicy.monitoringRules.loki }}
+    # Allow ingress from Loki
+    - from:
+        - podSelector:
             matchLabels:
-              k8s-app: kube-dns
+              app.kubernetes.io/name: loki
       ports:
-        - port: 53
-          protocol: UDP
-        - port: 53
+        - port: {{ .Values.alertmanager.service.port }}
           protocol: TCP
-    # Allow outbound SMTP for email notifications
-    - to:
-        - ipBlock:
-            cidr: 0.0.0.0/0
-            except:
-              - 10.0.0.0/8
-              - 172.16.0.0/12
-              - 192.168.0.0/16
+    {{- end }}
+    {{- if .Values.alertmanager.networkPolicy.enableClusterRules }}
+    # Allow ingress from other Alertmanager pods (for clustering)
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: alertmanager
       ports:
-        - port: 25
+        - port: {{ .Values.alertmanager.service.clusterPort }}
           protocol: TCP
-        - port: 587
-          protocol: TCP
-        - port: 465
-          protocol: TCP
-    # Allow webhook notifications
-    - to:
-        - ipBlock:
-            cidr: 0.0.0.0/0
-            except:
-              - 10.0.0.0/8
-              - 172.16.0.0/12
-              - 192.168.0.0/16
+    {{- end }}
+    {{- if .Values.alertmanager.networkPolicy.monitoringRules.configReloader }}
+    # Allow ingress for config reloader metrics
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: alertmanager
+              component: config-reloader
       ports:
-        - port: 443
+        - port: 8080
           protocol: TCP
-        - port: 80
-          protocol: TCP
+    {{- end }}
+    {{- with .Values.alertmanager.networkPolicy.additionalIngress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if .Values.alertmanager.networkPolicy.egress.enabled }}
+  egress:
+    {{- with .Values.alertmanager.networkPolicy.egress.rules }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/alertmanager/networkpolicy.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/networkpolicy.yaml
@@ -1,0 +1,79 @@
+{{- if and .Values.alertmanager.enabled .Values.alertmanager.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "kube-prometheus-stack.fullname" . }}-alertmanager
+  namespace: {{ template "kube-prometheus-stack.namespace" . }}
+  labels:
+    app: {{ template "kube-prometheus-stack.name" . }}-alertmanager
+    {{- include "kube-prometheus-stack.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow ingress from the ingress controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.alertmanager.networkPolicy.ingressNS }}
+          podSelector:
+            matchLabels:
+              {{- toYaml .Values.alertmanager.networkPolicy.ingressPodLabels | nindent 14 }}
+      ports:
+        - port: {{ .Values.alertmanager.service.port }}
+          protocol: TCP
+        - port: {{ .Values.alertmanager.service.clusterPort }}
+          protocol: TCP
+    # Allow ingress from Prometheus
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - port: {{ .Values.alertmanager.service.port }}
+          protocol: TCP
+  egress:
+    # Allow DNS resolution
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Allow outbound SMTP for email notifications
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - port: 25
+          protocol: TCP
+        - port: 587
+          protocol: TCP
+        - port: 465
+          protocol: TCP
+    # Allow webhook notifications
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - port: 443
+          protocol: TCP
+        - port: 80
+          protocol: TCP
+{{- end }}

--- a/charts/kube-prometheus-stack/templates/alertmanager/networkpolicy.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/networkpolicy.yaml
@@ -19,9 +19,11 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: {{ .Values.alertmanager.networkPolicy.gateway.namespace }}
+          {{- if and .Values.alertmanager.networkPolicy.gateway.podLabels (not (empty .Values.alertmanager.networkPolicy.gateway.podLabels)) }}
           podSelector:
             matchLabels:
               {{- toYaml .Values.alertmanager.networkPolicy.gateway.podLabels | nindent 14 }}
+          {{- end }}
       ports:
         - port: {{ .Values.alertmanager.service.port }}
           protocol: TCP

--- a/charts/kube-prometheus-stack/unittests/alertmanager/networkpolicy_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/alertmanager/networkpolicy_test.yaml
@@ -1,0 +1,65 @@
+suite: test networkpolicy
+templates:
+  - alertmanager/networkpolicy.yaml
+tests:
+  - it: should be empty if alertmanager is not enabled
+    set:
+      alertmanager.enabled: false
+      alertmanager.networkPolicy.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should be empty if networkpolicy is not enabled
+    set:
+      alertmanager.enabled: true
+      alertmanager.networkPolicy.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should have apiVersion networking.k8s.io/v1
+    set:
+      alertmanager.enabled: true
+      alertmanager.networkPolicy.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: NetworkPolicy
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+
+  - it: should configure default ingress namespace correctly
+    set:
+      alertmanager.enabled: true
+      alertmanager.networkPolicy.enabled: true
+      alertmanager.networkPolicy.ingressNS: ingress-nginx
+    asserts:
+      - equal:
+          path: spec.ingress[0].from[0].namespaceSelector.matchLabels
+          value:
+            kubernetes.io/metadata.name: ingress-nginx
+
+  - it: should configure custom ingress namespace correctly
+    set:
+      alertmanager.enabled: true
+      alertmanager.networkPolicy.enabled: true
+      alertmanager.networkPolicy.ingressNS: custom-ingress
+    asserts:
+      - equal:
+          path: spec.ingress[0].from[0].namespaceSelector.matchLabels
+          value:
+            kubernetes.io/metadata.name: custom-ingress
+
+  - it: should have correct pod selector labels
+    set:
+      alertmanager.enabled: true
+      alertmanager.networkPolicy.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.podSelector.matchLabels
+          value:
+            app.kubernetes.io/name: alertmanager

--- a/charts/kube-prometheus-stack/unittests/alertmanager/networkpolicy_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/alertmanager/networkpolicy_test.yaml
@@ -18,7 +18,7 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: should have apiVersion networking.k8s.io/v1
+  - it: should have correct API version and kind
     set:
       alertmanager.enabled: true
       alertmanager.networkPolicy.enabled: true
@@ -30,36 +30,101 @@ tests:
       - isAPIVersion:
           of: networking.k8s.io/v1
 
-  - it: should configure default ingress namespace correctly
+  - it: should configure gateway namespace correctly
     set:
       alertmanager.enabled: true
       alertmanager.networkPolicy.enabled: true
-      alertmanager.networkPolicy.ingressNS: ingress-nginx
+      alertmanager.networkPolicy.gateway.namespace: custom-gateway
     asserts:
       - equal:
-          path: spec.ingress[0].from[0].namespaceSelector.matchLabels
-          value:
-            kubernetes.io/metadata.name: ingress-nginx
+          path: spec.ingress[0].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: custom-gateway
 
-  - it: should configure custom ingress namespace correctly
+  - it: should configure gateway pod labels correctly
     set:
       alertmanager.enabled: true
       alertmanager.networkPolicy.enabled: true
-      alertmanager.networkPolicy.ingressNS: custom-ingress
+      alertmanager.networkPolicy.gateway.podLabels:
+        app.kubernetes.io/name: custom-gateway
     asserts:
       - equal:
-          path: spec.ingress[0].from[0].namespaceSelector.matchLabels
+          path: spec.ingress[0].from[0].podSelector.matchLabels
           value:
-            kubernetes.io/metadata.name: custom-ingress
+            app.kubernetes.io/name: custom-gateway
 
-  - it: should have correct pod selector labels
+  - it: should include Prometheus rules when enabled
     set:
       alertmanager.enabled: true
       alertmanager.networkPolicy.enabled: true
+      alertmanager.networkPolicy.monitoringRules.prometheus: true
+      alertmanager.service.port: 9093
     asserts:
-      - hasDocuments:
-          count: 1
+      - matchRegex:
+          path: spec.ingress[1].from[0].podSelector.matchLabels["app.kubernetes.io/name"]
+          pattern: prometheus
+
+  - it: should include Loki rules when enabled
+    set:
+      alertmanager.enabled: true
+      alertmanager.networkPolicy.enabled: true
+      alertmanager.networkPolicy.monitoringRules.loki: true
+      alertmanager.service.port: 9093
+    asserts:
+      - matchRegex:
+          path: spec.ingress[2].from[0].podSelector.matchLabels["app.kubernetes.io/name"]
+          pattern: loki
+
+  - it: should include cluster rules when enabled
+    set:
+      alertmanager.enabled: true
+      alertmanager.networkPolicy.enabled: true
+      alertmanager.networkPolicy.enableClusterRules: true
+      alertmanager.service.clusterPort: 9094
+    asserts:
+      - matchRegex:
+          path: spec.ingress[3].from[0].podSelector.matchLabels["app.kubernetes.io/name"]
+          pattern: alertmanager
+
+  - it: should add additional ingress rules when specified
+    set:
+      alertmanager.enabled: true
+      alertmanager.networkPolicy.enabled: true
+      alertmanager.networkPolicy.additionalIngress:
+        - from:
+            - namespaceSelector:
+                matchLabels:
+                  name: custom-namespace
+    asserts:
       - equal:
-          path: spec.podSelector.matchLabels
+          path: spec.ingress[-1].from[0].namespaceSelector.matchLabels.name
+          value: custom-namespace
+
+  - it: should include egress rules when enabled
+    set:
+      alertmanager.enabled: true
+      alertmanager.networkPolicy.enabled: true
+      alertmanager.networkPolicy.egress:
+        enabled: true
+        rules:
+          - to:
+              - podSelector:
+                  matchLabels:
+                    name: smtp-relay
+    asserts:
+      - equal:
+          path: spec.egress[0].to[0].podSelector.matchLabels.name
+          value: smtp-relay
+
+  - it: should use specified policy types
+    set:
+      alertmanager.enabled: true
+      alertmanager.networkPolicy.enabled: true
+      alertmanager.networkPolicy.policyTypes:
+        - Ingress
+        - Egress
+    asserts:
+      - equal:
+          path: spec.policyTypes
           value:
-            app.kubernetes.io/name: alertmanager
+            - Ingress
+            - Egress

--- a/charts/kube-prometheus-stack/unittests/alertmanager/networkpolicy_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/alertmanager/networkpolicy_test.yaml
@@ -128,3 +128,23 @@ tests:
           value:
             - Ingress
             - Egress
+
+  - it: should handle empty gateway pod labels
+    set:
+      alertmanager.enabled: true
+      alertmanager.networkPolicy.enabled: true
+      alertmanager.networkPolicy.gateway.namespace: custom-gateway
+      alertmanager.networkPolicy.gateway.podLabels: null
+      alertmanager.networkPolicy.policyTypes[0]: Ingress
+      alertmanager.service.port: 9093
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: spec.ingress[0].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: custom-gateway
+      - equal:
+          path: spec.ingress[0].ports[0].port
+          value: 9093

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -417,7 +417,7 @@ alertmanager:
     # -- Define policy types. If egress is enabled, both Ingress and Egress will be used
     # Valid values are ["Ingress"] or ["Ingress", "Egress"]
     ##
-    policyTypes: 
+    policyTypes:
       - Ingress
 
     # -- Gateway (formerly ingress controller) configuration

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -412,24 +412,70 @@ alertmanager:
   ##
   networkPolicy:
     # -- Enable network policy for Alertmanager
-    ## Allows ingress from:
-    ## - Specified ingress controller
-    ## - Prometheus pods
-    ## - Other Alertmanager pods (for clustering)
-    ## Allows egress for:
-    ## - DNS resolution (port 53)
-    ## - SMTP notifications (ports 25, 587, 465)
-    ## - Webhook notifications (ports 80, 443)
     enabled: false
-    # -- Ingress controller namespace
-    ## Namespace of the ingress controller
+
+    # -- Define policy types. If egress is enabled, both Ingress and Egress will be used
+    # Valid values are ["Ingress"] or ["Ingress", "Egress"]
     ##
-    ingressNS: "ingress-nginx"
-    # -- Ingress controller pod labels
-    ## Pod labels of the ingress controller
+    policyTypes: 
+      - Ingress
+
+    # -- Gateway (formerly ingress controller) configuration
     ##
-    ingressPodLabels:
-      app.kubernetes.io/name: ingress-nginx
+    gateway:
+      # -- Gateway namespace
+      ##
+      namespace: "ingress-nginx"
+      # -- Gateway pod labels
+      ##
+      podLabels:
+        app.kubernetes.io/name: ingress-nginx
+
+    # -- Additional custom ingress rules
+    ##
+    additionalIngress: []
+    # - from:
+    #   - namespaceSelector:
+    #       matchLabels:
+    #         name: another-namespace
+    #     podSelector:
+    #       matchLabels:
+    #         app: another-app
+
+    # -- Configure egress rules
+    ##
+    egress:
+      # -- Enable egress rules. When enabled, policyTypes will include Egress
+      ##
+      enabled: false
+      # -- Custom egress rules
+      ##
+      rules: []
+      # - to:
+      #   - namespaceSelector: {}
+      #     podSelector:
+      #       matchLabels:
+      #         name: smtp-relay
+      #   ports:
+      #   - port: 25
+      #     protocol: TCP
+
+    # -- Enable rules for alertmanager cluster traffic
+    ##
+    enableClusterRules: true
+
+    # -- Configure monitoring component rules
+    ##
+    monitoringRules:
+      # -- Enable ingress from Prometheus
+      ##
+      prometheus: true
+      # -- Enable ingress from Loki
+      ##
+      loki: true
+      # -- Enable ingress for config reloader metrics
+      ##
+      configReloader: true
 
   ## Service account for Alertmanager to use.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -408,6 +408,29 @@ alertmanager:
   ##
   forceDeployDashboards: false
 
+  ## Network Policy configuration
+  ##
+  networkPolicy:
+    # -- Enable network policy for Alertmanager
+    ## Allows ingress from:
+    ## - Specified ingress controller
+    ## - Prometheus pods
+    ## - Other Alertmanager pods (for clustering)
+    ## Allows egress for:
+    ## - DNS resolution (port 53)
+    ## - SMTP notifications (ports 25, 587, 465)
+    ## - Webhook notifications (ports 80, 443)
+    enabled: false
+    # -- Ingress controller namespace
+    ## Namespace of the ingress controller
+    ##
+    ingressNS: "ingress-nginx"
+    # -- Ingress controller pod labels
+    ## Pod labels of the ingress controller
+    ##
+    ingressPodLabels:
+      app.kubernetes.io/name: ingress-nginx
+
   ## Service account for Alertmanager to use.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
   ##


### PR DESCRIPTION
#### This PR adds NetworkPolicy support for Alertmanager to address issue #5247.

#### Changes
- Added NetworkPolicy template for Alertmanager
- Added NetworkPolicy configuration options in values.yaml
- Added comprehensive unit tests
- Updated documentation

The NetworkPolicy configuration allows:

- Ingress from configured ingress controller
- Ingress from Prometheus pods
- Inter-pod communication for clustering
- Egress for DNS resolution
- Egress for SMTP notifications (ports 25, 587, 465)
- Egress for webhook notifications (ports 80, 443)

#### Testing
- Added unit tests for NetworkPolicy configuration
- Verified template rendering
- Tested with both default and custom configurations

#### Checklist
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name 
- [x] DCO signed

Fixes #5247 
