### PR TITLE
[kube-prometheus-stack] Fix: Add default values to subchart to allow rendering

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -31,7 +31,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 69.2.4
+version: 69.2.5
 appVersion: v0.80.0
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/charts/crds/unittests/rendering_test.yaml
+++ b/charts/kube-prometheus-stack/charts/crds/unittests/rendering_test.yaml
@@ -1,0 +1,6 @@
+suite: test rendering
+tests:
+  # 5307
+  - it: should render when no values are set
+    asserts:
+      - notFailedTemplate: {}

--- a/charts/kube-prometheus-stack/charts/crds/values.yaml
+++ b/charts/kube-prometheus-stack/charts/crds/values.yaml
@@ -1,0 +1,4 @@
+## Check out kube-prometheus-stack/values.yaml for more information
+## on this parameter
+upgradeJob:
+  enabled: false


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

The kube-prometheus-stack CRD subchart fails to render on the current version with

```
Error: template: crds/templates/upgrade/serviceaccount.yaml:1:18: executing "crds/templates/upgrade/serviceaccount.yaml" at <.Values.upgradeJob.enabled>: nil pointer evaluating interface {}.enabled
```

This is because of the preview upgradejob feature that was added:

> This feature is in preview, off by default and may change in the future.

The CRD subchart has no default `values.yaml` and sets no defaults itself for statements like

```
{{- if .Values.upgradeJob.enabled }}
```

Which produces the error above.

This PR adds a default values.yaml ensuring rendering and a unittest to prevent regression.

#### Note

I understand the intent might not be for people to install this CRD chart directly, but instead render it through the main `kube-prometheus-stack` chart, but people have taken to using it considering the linked issue. It's easier to point tools like Argo at this subchart to render the CRDs before installing the main chart.

When the feature leaves preview, it will be a moot point, but until then it would be nice if the chart maintained its original behavior and rendered without issues.

I bumped the main `kube-prometheus-stack` version since this chart's seems to be locked to `0.0.0`.

#### Which issue this PR fixes

- fixes #5307

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
