### PR TITLE
[prometheus-blackbox-exporter] Add missing port names to ServiceMonitor endpoints

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 9.2.0
+version: 9.2.1
 appVersion: v0.25.0
 kubeVersion: ">=1.21.0-0"
 home: https://github.com/prometheus/blackbox_exporter

--- a/charts/prometheus-blackbox-exporter/ci/servicemonitor-values.yaml
+++ b/charts/prometheus-blackbox-exporter/ci/servicemonitor-values.yaml
@@ -1,0 +1,4 @@
+serviceMonitor:
+  selfMonitor:
+    enabled: true
+  enabled: true

--- a/charts/prometheus-blackbox-exporter/templates/selfservicemonitor.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/selfservicemonitor.yaml
@@ -16,9 +16,7 @@ spec:
     interval: {{ .Values.serviceMonitor.selfMonitor.interval }}
     scrapeTimeout: {{ .Values.serviceMonitor.selfMonitor.scrapeTimeout }}
     scheme: {{ .Values.serviceMonitor.selfMonitor.scheme }}
-    {{- with .Values.serviceMonitor.selfMonitor.port }}
-    port: {{ . }}
-    {{- end }}
+    port: http
     {{- if .Values.serviceMonitor.selfMonitor.additionalMetricsRelabels }}
     metricRelabelings:
       {{- toYaml .Values.serviceMonitor.selfMonitor.additionalMetricsRelabels | nindent 6 }}
@@ -36,6 +34,7 @@ spec:
     interval: {{ .Values.configReloader.serviceMonitor.selfMonitor.interval }}
     scrapeTimeout: {{ .Values.configReloader.serviceMonitor.selfMonitor.scrapeTimeout }}
     scheme: {{ .Values.configReloader.serviceMonitor.selfMonitor.scheme }}
+    port: reloader-web
     {{- if .Values.configReloader.serviceMonitor.selfMonitor.tlsConfig }}
     tlsConfig:
       {{- toYaml .Values.configReloader.serviceMonitor.selfMonitor.tlsConfig | nindent 6 }}

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -287,8 +287,6 @@ serviceMonitor:
     tlsConfig: {}
     interval: 30s
     scrapeTimeout: 30s
-    ## Port can be defined by assigning a value for the port key below
-    ## port:
 
   ## If true, a ServiceMonitor CRD is created for a prometheus operator
   ## https://github.com/coreos/prometheus-operator for each target


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This correctly sets the port name in the generated ServiceMonitor for both the blackbox-exporter itself as well as the config-reloader. The templating for the port name of the blackbox-exporter was removed since the associated Service hardcodes the port name to `http` and does not allow to change it.

#### Which issue this PR fixes

- fixes #5321 

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)

pinging @desaintmartin @gianrubio @rsotnychenko @monotek since you guys are listed as maintainers in the Chart.yaml file.