### PR TITLE
[prometheus-rabbitmq-exporter] fix ConfigMap when additional labels are used

### DIFF
--- a/charts/prometheus-rabbitmq-exporter/Chart.yaml
+++ b/charts/prometheus-rabbitmq-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Rabbitmq metrics exporter for prometheus
 name: prometheus-rabbitmq-exporter
-version: 2.1.0
+version: 2.1.1
 appVersion: 1.0.0
 home: https://github.com/kbudde/rabbitmq_exporter
 sources:

--- a/charts/prometheus-rabbitmq-exporter/templates/configmap.yaml
+++ b/charts/prometheus-rabbitmq-exporter/templates/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   {{- with .Values.additionalLabels }}
-    {{- toYaml . | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 data:
     RABBIT_URL: {{ .Values.rabbitmq.url | quote }}


### PR DESCRIPTION
#### What this PR does / why we need it

using `additionalLabels` value causes the rendered `ConfigMap` manifest to be invalid YAML as the rendered labels YAML block is not prepended by a new line (`indent` is used instead of `nindent`)

```console
helm template rmq-test \
  oci://ghcr.io/prometheus-community/charts/prometheus-rabbitmq-exporter \
  --version 2.1.0 \
  --set-json 'additionalLabels={"test":"test"}' \
  --debug

Error: YAML parse error on prometheus-rabbitmq-exporter/templates/configmap.yaml: 
error converting YAML to JSON: yaml: line 9: mapping values are not allowed in this context
```

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
