### PR TITLE
[kube-prometheus-stack] Fix NetworkPolicy for Alertmanager

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -31,7 +31,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 69.5.1
+version: 69.5.2
 appVersion: v0.80.1
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/alertmanager/networkpolicy.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/networkpolicy.yaml
@@ -14,6 +14,7 @@ spec:
   policyTypes:
     {{- toYaml .Values.alertmanager.networkPolicy.policyTypes | nindent 4 }}
   ingress:
+    {{- if and (.Values.alertmanager.networkPolicy.gateway.namespace) (.Values.alertmanager.networkPolicy.gateway.podLabels) }}
     # Allow ingress from gateway
     - from:
         - namespaceSelector:
@@ -27,8 +28,11 @@ spec:
       ports:
         - port: {{ .Values.alertmanager.service.port }}
           protocol: TCP
+        {{- if .Values.alertmanager.service.clusterPort }}
         - port: {{ .Values.alertmanager.service.clusterPort }}
           protocol: TCP
+        {{- end }}
+    {{- end }}
     {{- if .Values.alertmanager.networkPolicy.monitoringRules.prometheus }}
     # Allow ingress from Prometheus
     - from:
@@ -39,17 +43,7 @@ spec:
         - port: {{ .Values.alertmanager.service.port }}
           protocol: TCP
     {{- end }}
-    {{- if .Values.alertmanager.networkPolicy.monitoringRules.loki }}
-    # Allow ingress from Loki
-    - from:
-        - podSelector:
-            matchLabels:
-              app.kubernetes.io/name: loki
-      ports:
-        - port: {{ .Values.alertmanager.service.port }}
-          protocol: TCP
-    {{- end }}
-    {{- if .Values.alertmanager.networkPolicy.enableClusterRules }}
+    {{- if and (.Values.alertmanager.networkPolicy.enableClusterRules) (.Values.alertmanager.service.clusterPort) }}
     # Allow ingress from other Alertmanager pods (for clustering)
     - from:
         - podSelector:

--- a/charts/kube-prometheus-stack/templates/alertmanager/networkpolicy.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/networkpolicy.yaml
@@ -28,10 +28,6 @@ spec:
       ports:
         - port: {{ .Values.alertmanager.service.port }}
           protocol: TCP
-        {{- if .Values.alertmanager.service.clusterPort }}
-        - port: {{ .Values.alertmanager.service.clusterPort }}
-          protocol: TCP
-        {{- end }}
     {{- end }}
     {{- if .Values.alertmanager.networkPolicy.monitoringRules.prometheus }}
     # Allow ingress from Prometheus

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -425,11 +425,11 @@ alertmanager:
     gateway:
       # -- Gateway namespace
       ##
-      namespace: "ingress-nginx"
+      namespace: ""
       # -- Gateway pod labels
       ##
-      podLabels:
-        app.kubernetes.io/name: ingress-nginx
+      podLabels: {}
+      # app.kubernetes.io/name: ingress-nginx
 
     # -- Additional custom ingress rules
     ##
@@ -441,6 +441,13 @@ alertmanager:
     #     podSelector:
     #       matchLabels:
     #         app: another-app
+    # - from:
+    #     - podSelector:
+    #         matchLabels:
+    #           app.kubernetes.io/name: loki
+    #   ports:
+    #     - port: 9093
+    #       protocol: TCP
 
     # -- Configure egress rules
     ##
@@ -470,9 +477,6 @@ alertmanager:
       # -- Enable ingress from Prometheus
       ##
       prometheus: true
-      # -- Enable ingress from Loki
-      ##
-      loki: true
       # -- Enable ingress for config reloader metrics
       ##
       configReloader: true
@@ -727,6 +731,9 @@ alertmanager:
     ## Port for Alertmanager Service to listen on
     ##
     port: 9093
+    ## Port for Alertmanager cluster communication
+    ##
+    # clusterPort: 9094
     ## To be used with a proxy extraContainer port
     ##
     targetPort: 9093


### PR DESCRIPTION
Set gateway/ingress namespace and podLabel selector to an empty string/object in order to not accidentally expose something unexpected. Move the Loki rule to the additionalIngress examples as Loki is not part of the stack. The 'alertmanager.service.clusterPort' was added as it was not declared in the values and now needs to be enabled explicitly.

Issue: #5318

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
