### PR TITLE
`[prometheus-snmp-exporter]` - add security context support for Configmap-reload container at snmp-exporter daemonset and deployment

### DIFF
--- a/charts/prometheus-snmp-exporter/Chart.yaml
+++ b/charts/prometheus-snmp-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus SNMP Exporter
 name: prometheus-snmp-exporter
-version: 7.0.2
+version: 7.0.3
 appVersion: v0.28.0
 home: https://github.com/prometheus/snmp_exporter
 sources:

--- a/charts/prometheus-snmp-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-snmp-exporter/templates/daemonset.yaml
@@ -99,6 +99,10 @@ spec:
             - mountPath: /etc/config
               name: config
               readOnly: true
+{{- if .Values.configmapReload.containerSecurityContext }}
+          securityContext:
+{{ toYaml .Values.configmapReload.containerSecurityContext | indent 12 }}
+        {{- end }}
       {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/prometheus-snmp-exporter/templates/deployment.yaml
+++ b/charts/prometheus-snmp-exporter/templates/deployment.yaml
@@ -106,6 +106,10 @@ spec:
             - mountPath: /etc/config
               name: config
               readOnly: true
+{{- if .Values.configmapReload.containerSecurityContext }}
+          securityContext:
+{{ toYaml .Values.configmapReload.containerSecurityContext | indent 12 }}
+        {{- end }}
       {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/prometheus-snmp-exporter/values.yaml
+++ b/charts/prometheus-snmp-exporter/values.yaml
@@ -160,6 +160,12 @@ configmapReload:
   ##
   resources: {}
 
+  ## configmap-reload container security context
+  containerSecurityContext: {}
+    # runAsNonRoot: true
+    # runAsUser: 1000
+    # readOnlyRootFilesystem: true
+
 # Enable this if you're using https://github.com/prometheus-operator/prometheus-operator
 # A service monitor will be created per each item in serviceMonitor.params[]
 serviceMonitor:


### PR DESCRIPTION
#### What this PR does / why we need it
Add security context support for Configmap-reload container at snmp-exporter daemonset and deployment and set a containerSecurityContext: {} at values.yaml

#### Which issue this PR fixes

- fixes #4996

#### Special notes for your reviewer
Follow the PR @walker-tom
#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
