### PR TITLE
[prometheus-yet-another-cloudwatch-exporter] remove premetheus checks

### DIFF
--- a/charts/prometheus-yet-another-cloudwatch-exporter/Chart.yaml
+++ b/charts/prometheus-yet-another-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-yet-another-cloudwatch-exporter
 description: Yace - Yet Another CloudWatch Exporter
 type: application
-version: 0.39.3
+version: 0.40.0
 appVersion: "v0.62.1"
 home: https://github.com/prometheus-community/helm-charts
 sources:

--- a/charts/prometheus-yet-another-cloudwatch-exporter/templates/prometheusrule.yaml
+++ b/charts/prometheus-yet-another-cloudwatch-exporter/templates/prometheusrule.yaml
@@ -1,4 +1,4 @@
-{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.prometheusRule.enabled ) }}
+{{- if .Values.prometheusRule.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/charts/prometheus-yet-another-cloudwatch-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-yet-another-cloudwatch-exporter/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.serviceMonitor.enabled ) }}
+{{- if .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
#### What this PR does / why we need it
With these checks is not possible to render manifest via helm template. 
It's not compatible in case where rendering is done in CI and plain manifest is stored in gitops repo

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
