### PR TITLE
[prometheus-snmp-exporter] Remove unresponsive maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,7 +45,7 @@
 /charts/prometheus-rabbitmq-exporter/ @desaintmartin @iamabhishek-dubey @juanchimienti @monotek
 /charts/prometheus-redis-exporter/ @acondrat @zanhsieh
 /charts/prometheus-smartctl-exporter/ @kfox1111 @zeritti
-/charts/prometheus-snmp-exporter/ @miouge1 @walker-tom @xiu
+/charts/prometheus-snmp-exporter/ @walker-tom @xiu
 /charts/prometheus-sql-exporter/ @wilfriedroset
 /charts/prometheus-stackdriver-exporter/ @apenney @rpahli
 /charts/prometheus-statsd-exporter/ @scDisorder

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -205,7 +205,6 @@
 
 ### prometheus-snmp-exporter
 
-- miouge1 (<maxime@root314.com> / @miouge1)
 - walker-tom (<walker.thomas.p@gmail.com> / @walker-tom)
 - xiu (<github@xiu.io> / @xiu)
 

--- a/charts/prometheus-snmp-exporter/Chart.yaml
+++ b/charts/prometheus-snmp-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus SNMP Exporter
 name: prometheus-snmp-exporter
-version: 7.0.0
+version: 7.0.1
 appVersion: v0.28.0
 home: https://github.com/prometheus/snmp_exporter
 sources:
@@ -11,9 +11,6 @@ keywords:
   - snmp
   - monitoring
 maintainers:
-  - name: miouge1
-    email: maxime@root314.com
-    url: https://github.com/miouge1
   - name: xiu
     email: github@xiu.io
     url: https://github.com/xiu


### PR DESCRIPTION
#### What this PR does / why we need it

Remove unresponsive maintainer @miouge1.

#### Which issue this PR fixes

Closes: https://github.com/prometheus-community/helm-charts/issues/5155

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
