### PR TITLE
[prometheus-postgres-exporter] Allow namespace override

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v0.17.0"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 6.9.0
+version: 6.10.0
 home: https://github.com/prometheus-community/postgres_exporter
 sources:
   - https://github.com/prometheus-community/postgres_exporter

--- a/charts/prometheus-postgres-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-postgres-exporter/templates/_helpers.tpl
@@ -62,6 +62,12 @@ Create the name of the service account to use
 {{- end -}}
 {{- end -}}
 
+{{/*
+Define the prometheus-postgres-exporter.namespace template if set with namespaceOverride or .Release.Namespace is set
+*/}}
+{{- define "prometheus-postgres-exporter.namespace" -}}
+  {{- default .Release.Namespace .Values.namespaceOverride -}}
+{{- end }}
 
 {{/*
 Set DATA_SOURCE_URI environment variable

--- a/charts/prometheus-postgres-exporter/templates/configmap.yaml
+++ b/charts/prometheus-postgres-exporter/templates/configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "prometheus-postgres-exporter.fullname" . }}
+  namespace: {{ include "prometheus-postgres-exporter.namespace" . }}
   labels:
     {{- include "prometheus-postgres-exporter.labels" . | nindent 4 }}
 data:

--- a/charts/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/charts/prometheus-postgres-exporter/templates/deployment.yaml
@@ -5,6 +5,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "prometheus-postgres-exporter.fullname" . }}
+  namespace: {{ include "prometheus-postgres-exporter.namespace" . }}
   labels:
     {{- include "prometheus-postgres-exporter.labels" . | nindent 4 }}
     {{- with .Values.deployment.labels }}

--- a/charts/prometheus-postgres-exporter/templates/networkpolicy.yaml
+++ b/charts/prometheus-postgres-exporter/templates/networkpolicy.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ template "prometheus-postgres-exporter.fullname" . }}
+  namespace: {{ include "prometheus-postgres-exporter.namespace" . }}
   labels:
     {{- include "prometheus-postgres-exporter.labels" . | nindent 4 }}
     {{- if .Values.networkPolicy.labels }}

--- a/charts/prometheus-postgres-exporter/templates/pdb.yaml
+++ b/charts/prometheus-postgres-exporter/templates/pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "prometheus-postgres-exporter.fullname" . }}
+  namespace: {{ include "prometheus-postgres-exporter.namespace" . }}
   labels:
     {{- include "prometheus-postgres-exporter.labels" . | nindent 4 }}
 spec:

--- a/charts/prometheus-postgres-exporter/templates/prometheusrule.yaml
+++ b/charts/prometheus-postgres-exporter/templates/prometheusrule.yaml
@@ -3,9 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ template "prometheus-postgres-exporter.fullname" . }}
-{{- with .Values.prometheusRule.namespace }}
-  namespace: {{ . }}
-{{- end }}
+  namespace: {{ .Values.prometheusRule.namespace | default (include "prometheus-postgres-exporter.namespace" .)  }}
   labels:
     {{- include "prometheus-postgres-exporter.labels" . | nindent 4 }}
 {{- with .Values.prometheusRule.additionalLabels }}

--- a/charts/prometheus-postgres-exporter/templates/role.yaml
+++ b/charts/prometheus-postgres-exporter/templates/role.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "prometheus-postgres-exporter.fullname" . }}
+  namespace: {{ include "prometheus-postgres-exporter.namespace" . }}
   labels:
     {{- include "prometheus-postgres-exporter.labels" . | nindent 4 }}
 {{- end }}

--- a/charts/prometheus-postgres-exporter/templates/rolebinding.yaml
+++ b/charts/prometheus-postgres-exporter/templates/rolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "prometheus-postgres-exporter.fullname" . }}
+  namespace: {{ include "prometheus-postgres-exporter.namespace" . }}
   labels:
     {{- include "prometheus-postgres-exporter.labels" . | nindent 4 }}
 roleRef:

--- a/charts/prometheus-postgres-exporter/templates/secrets.yaml
+++ b/charts/prometheus-postgres-exporter/templates/secrets.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "prometheus-postgres-exporter.fullname" . }}
+  namespace: {{ include "prometheus-postgres-exporter.namespace" . }}
   labels:
     {{- include "prometheus-postgres-exporter.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/prometheus-postgres-exporter/templates/service.yaml
+++ b/charts/prometheus-postgres-exporter/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "prometheus-postgres-exporter.fullname" . }}
+  namespace: {{ include "prometheus-postgres-exporter.namespace" . }}
   {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}

--- a/charts/prometheus-postgres-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-postgres-exporter/templates/serviceaccount.yaml
@@ -4,6 +4,7 @@ kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
 metadata:
   name: {{ template "prometheus-postgres-exporter.serviceAccountName" . }}
+  namespace: {{ include "prometheus-postgres-exporter.namespace" . }}
   labels:
     {{- include "prometheus-postgres-exporter.labels" . | nindent 4 }}
   {{- if .Values.serviceAccount.annotations }}

--- a/charts/prometheus-postgres-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-postgres-exporter/templates/servicemonitor.yaml
@@ -8,9 +8,7 @@ metadata:
 {{ toYaml .Values.serviceMonitor.labels | indent 4}}
 {{- end }}
   name: {{ template "prometheus-postgres-exporter.fullname" . }}
-{{- if .Values.serviceMonitor.namespace }}
-  namespace: {{ .Values.serviceMonitor.namespace }}
-{{- end }}
+  namespace: {{ .Values.serviceMonitor.namespace | default (include "prometheus-postgres-exporter.namespace" .)  }}
 spec:
 {{- if .Values.serviceMonitor.multipleTarget.enabled }}
   endpoints:

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -110,6 +110,9 @@ serviceAccount:
   # Add annotations to the ServiceAccount, useful for EKS IAM Roles for Service Accounts or Google Workload Identity.
   annotations: {}
 
+# Force namespace of namespaced resources
+namespaceOverride: ""
+
 # Add a default ingress to allow namespace access to service.targetPort
 # Helpful if other NetworkPolicies are configured in the namespace
 networkPolicy:


### PR DESCRIPTION
this is done in accordance with other charts in this repo, e.g. prometheus

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

The change allows to override the Namespace of namespaced resources using values, like is common practice in [other charts in this repo](https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/values.yaml#L1242).
This also prevents faulty helm implementations ([ref](https://github.com/helm/helm/issues/9256)) from installing resources in the wrong namespace.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
