### PR TITLE
[prometheus-opencost-exporter] Mark prometheus-opencost-exporter deprecated

### DIFF
--- a/charts/prometheus-opencost-exporter/Chart.yaml
+++ b/charts/prometheus-opencost-exporter/Chart.yaml
@@ -1,5 +1,6 @@
 appVersion: 1.108.0
-version: 0.1.1
+version: 0.1.2
+deprecated: true
 description: Prometheus OpenCost Exporter
 home: https://github.com/opencost/opencost
 name: prometheus-opencost-exporter

--- a/charts/prometheus-opencost-exporter/README.md
+++ b/charts/prometheus-opencost-exporter/README.md
@@ -6,6 +6,10 @@ This chart bootstraps a Prometheus [OpenCost exporter](https://www.opencost.io/d
 
 The original source for this Helm chart is <https://github.com/opencost/opencost-helm-chart>.
 
+## **Deprecated**
+
+**This chart is deprecated in favor of the the [upstream support](https://opencost.io/docs/installation/prometheus/). The chart source code will be removed in 1st Jun 2025.**
+
 ## Prerequisites
 
 - Kubernetes 1.23+


### PR DESCRIPTION
#### What this PR does / why we need it
As the upstream now supports this directly we can deprecate and remove this unmaintained chart.

#### Which issue this PR fixes

Related: https://github.com/prometheus-community/helm-charts/issues/5152

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
