### PR TITLE
[prometheus-operator-admission-webhook] feat(chart): add support for revisionHistoryLimit on the cert

### DIFF
--- a/charts/prometheus-operator-admission-webhook/Chart.yaml
+++ b/charts/prometheus-operator-admission-webhook/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: Prometheus Operator Admission Webhook
 name: prometheus-operator-admission-webhook
-version: 0.19.2
+version: 0.20.0
 appVersion: 0.80.1
 home: https://github.com/prometheus-operator/prometheus-operator
 icon: https://github.com/prometheus-operator/prometheus-operator/raw/main/Documentation/logos/prometheus-operator-logo.png

--- a/charts/prometheus-operator-admission-webhook/Chart.yaml
+++ b/charts/prometheus-operator-admission-webhook/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: Prometheus Operator Admission Webhook
 name: prometheus-operator-admission-webhook
-version: 0.19.1
+version: 0.19.2
 appVersion: 0.80.1
 home: https://github.com/prometheus-operator/prometheus-operator
 icon: https://github.com/prometheus-operator/prometheus-operator/raw/main/Documentation/logos/prometheus-operator-logo.png

--- a/charts/prometheus-operator-admission-webhook/templates/certmanager.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/certmanager.yaml
@@ -19,6 +19,9 @@ metadata:
 spec:
   secretName: {{ template "prometheus-operator-admission-webhook.fullname" . }}-root-cert
   duration: {{ .Values.certManager.rootCert.duration | default "43800h0m0s" | quote }}
+  {{- with .Values.certManager.rootCert.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
   issuerRef:
     name: {{ template "prometheus-operator-admission-webhook.fullname" . }}-self-signed-issuer
   commonName: "ca.webhook.prometheus-operator-admission-webhook"
@@ -44,6 +47,9 @@ metadata:
 spec:
   secretName: {{ template "prometheus-operator-admission-webhook.fullname" . }}-cert
   duration: {{ .Values.certManager.webhookCert.duration | default "8760h0m0s" | quote }}
+  {{- with .Values.certManager.webhookCert.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
   issuerRef:
     {{- if .Values.certManager.issuerRef }}
     {{- toYaml .Values.certManager.issuerRef | nindent 4 }}

--- a/charts/prometheus-operator-admission-webhook/values.yaml
+++ b/charts/prometheus-operator-admission-webhook/values.yaml
@@ -113,14 +113,14 @@ certManager:
     # -- Set the revisionHistoryLimit on the Certificate. See
     # https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec
     # Defaults to nil.
-    # revisionHistoryLimit: ""
+    # revisionHistoryLimit:
   ## webhookCert allows setting webhook certificate's lifetime, defaults to 1y
   webhookCert: {}
     # duration: "8760h0m0s"
     # -- Set the revisionHistoryLimit on the Certificate. See
     # https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec
     # Defaults to nil.
-    # revisionHistoryLimit: ""
+    # revisionHistoryLimit:
 
 ## caBundle allows inserting a CA bundle in webhook configurations
 ## (PEM format, base64-encoded) if that CA is unknown at the API server.

--- a/charts/prometheus-operator-admission-webhook/values.yaml
+++ b/charts/prometheus-operator-admission-webhook/values.yaml
@@ -110,9 +110,17 @@ certManager:
   ## rootCert allows setting certificate's lifetime when creating an issuer, defaults to 5y
   rootCert: {}
     # duration: "43800h0m0s"
+    # -- Set the revisionHistoryLimit on the Certificate. See
+    # https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec
+    # Defaults to nil.
+    # revisionHistoryLimit: ""
   ## webhookCert allows setting webhook certificate's lifetime, defaults to 1y
   webhookCert: {}
     # duration: "8760h0m0s"
+    # -- Set the revisionHistoryLimit on the Certificate. See
+    # https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec
+    # Defaults to nil.
+    # revisionHistoryLimit: ""
 
 ## caBundle allows inserting a CA bundle in webhook configurations
 ## (PEM format, base64-encoded) if that CA is unknown at the API server.


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

#### Which issue this PR fixes

Seeing lots of rotations on the certificate for the webhook. So want to mitigate the problem first by providing a revisionHistoryLimit on the cert according to https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec

- replaces https://github.com/prometheus-community/helm-charts/pull/5379

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
