### PR TITLE
[kube-prometheus-stack] Update securityContext to podSecurityContext for upgradeJob

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -31,7 +31,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 69.7.2
+version: 69.7.3
 appVersion: v0.80.1
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -146,7 +146,7 @@ crds:
     ## This defaults to non root user with uid 1000 and gid 2000. *v1.PodSecurityContext  false
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
     ##
-    securityContext:
+    podSecurityContext:
       fsGroup: 65534
       runAsGroup: 65534
       runAsNonRoot: true


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
This Pull Request updates the `securityContext` to `podSecurityContext` in the `charts/kube-prometheus-stack/values.yaml` file. This change is necessary to align with the configuration in `kube-prometheus-stack/charts/crds/templates/upgrade/job.yaml`, which uses `podSecurityContext`.

The change is required because the upgrade/job.yaml template references .Values.upgradeJob.podSecurityContext, which was previously inconsistent with the values.yaml configuration.


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
