### PR TITLE
[prometheus-redis-exporter] Add pullSecrets in values

### DIFF
--- a/charts/prometheus-redis-exporter/Chart.yaml
+++ b/charts/prometheus-redis-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.67.0
 description: Prometheus exporter for Redis metrics
 name: prometheus-redis-exporter
-version: 6.9.0
+version: 6.9.1
 home: https://github.com/oliver006/redis_exporter
 sources:
   - https://github.com/oliver006/redis_exporter

--- a/charts/prometheus-redis-exporter/values.yaml
+++ b/charts/prometheus-redis-exporter/values.yaml
@@ -16,6 +16,10 @@ image:
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
+  pullSecrets: []
+  # pullSecrets:
+  #   - docker-secret 
+
 
 command: []
 


### PR DESCRIPTION
#### What this PR does / why we need it

It adds the `pullSecrets` in the values.yaml. This parameter was already available on the Deployment but was not documented in the `values.yaml`

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
