### PR TITLE
[kube-prometheus-stack] make servicename as tpl

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -31,7 +31,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 70.0.3
+version: 70.0.4
 appVersion: v0.81.0
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/alertmanager/alertmanager.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/alertmanager.yaml
@@ -31,7 +31,7 @@ spec:
   replicas: {{ .Values.alertmanager.alertmanagerSpec.replicas }}
   listenLocal: {{ .Values.alertmanager.alertmanagerSpec.listenLocal }}
   {{- if .Values.alertmanager.alertmanagerSpec.serviceName }}
-  serviceName: {{ .Values.alertmanager.alertmanagerSpec.serviceName }}
+  serviceName: {{ tpl .Values.alertmanager.alertmanagerSpec.serviceName . }}
   {{- end }}
   serviceAccountName: {{ template "kube-prometheus-stack.alertmanager.serviceAccountName" . }}
   automountServiceAccountToken: {{ .Values.alertmanager.alertmanagerSpec.automountServiceAccountToken }}

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -163,7 +163,7 @@ spec:
 {{ tpl (toYaml .Values.prometheus.prometheusSpec.configMaps) . | indent 4 }}
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.serviceName }}
-  serviceName: {{.Values.prometheus.prometheusSpec.serviceName }}
+  serviceName: {{ tpl .Values.prometheus.prometheusSpec.serviceName  .}}
 {{- end }}
   serviceAccountName: {{ template "kube-prometheus-stack.prometheus.serviceAccountName" . }}
 {{- if .Values.prometheus.prometheusSpec.serviceMonitorSelector }}

--- a/charts/kube-prometheus-stack/templates/thanos-ruler/ruler.yaml
+++ b/charts/kube-prometheus-stack/templates/thanos-ruler/ruler.yaml
@@ -30,7 +30,7 @@ spec:
   replicas: {{ .Values.thanosRuler.thanosRulerSpec.replicas }}
   listenLocal: {{ .Values.thanosRuler.thanosRulerSpec.listenLocal }}
   {{- if .Values.thanosRuler.thanosRulerSpec.serviceName }}
-  serviceName: {{.Values.thanosRuler.thanosRulerSpec.serviceName }}
+  serviceName: {{ tpl .Values.thanosRuler.thanosRulerSpec.serviceName . }}
   {{- end }}
   serviceAccountName: {{ template "kube-prometheus-stack.thanosRuler.serviceAccountName" . }}
 {{- if .Values.thanosRuler.thanosRulerSpec.externalPrefix }}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Currently it is not possible to pass templated values as serviceName, fixing alertmanager, prometheus and thanosruler templates to allow to pass helm templates



#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
