### PR TITLE
[prometheus-operator-admission-webhook] tpl affinity

### DIFF
--- a/charts/prometheus-operator-admission-webhook/Chart.yaml
+++ b/charts/prometheus-operator-admission-webhook/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: Prometheus Operator Admission Webhook
 name: prometheus-operator-admission-webhook
-version: 0.20.0
+version: 0.21.0
 appVersion: 0.80.1
 home: https://github.com/prometheus-operator/prometheus-operator
 icon: https://github.com/prometheus-operator/prometheus-operator/raw/main/Documentation/logos/prometheus-operator-logo.png

--- a/charts/prometheus-operator-admission-webhook/Chart.yaml
+++ b/charts/prometheus-operator-admission-webhook/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 description: Prometheus Operator Admission Webhook
 name: prometheus-operator-admission-webhook
 version: 0.21.0
-appVersion: 0.80.1
+appVersion: 0.81.0
 home: https://github.com/prometheus-operator/prometheus-operator
 icon: https://github.com/prometheus-operator/prometheus-operator/raw/main/Documentation/logos/prometheus-operator-logo.png
 keywords:

--- a/charts/prometheus-operator-admission-webhook/ci/affinity-tpl-values.yaml
+++ b/charts/prometheus-operator-admission-webhook/ci/affinity-tpl-values.yaml
@@ -1,0 +1,14 @@
+---
+fullnameOverride: admission-webhook
+
+pod:
+  labels:
+    foo: bar
+    baz: qux
+
+affinity: |
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels: {{ toYaml .Values.pod.labels | nindent 10 }}
+        topologyKey: kubernetes.io/hostname

--- a/charts/prometheus-operator-admission-webhook/ci/affinity-values.yaml
+++ b/charts/prometheus-operator-admission-webhook/ci/affinity-values.yaml
@@ -1,0 +1,16 @@
+---
+fullnameOverride: admission-webhook
+
+pod:
+  labels:
+    foo: bar
+    baz: qux
+
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            foo: bar
+            baz: qux
+        topologyKey: kubernetes.io/hostname

--- a/charts/prometheus-operator-admission-webhook/ci/default-values.yaml
+++ b/charts/prometheus-operator-admission-webhook/ci/default-values.yaml
@@ -1,0 +1,1 @@
+# default values

--- a/charts/prometheus-operator-admission-webhook/ci/deployment-labels-values.yaml
+++ b/charts/prometheus-operator-admission-webhook/ci/deployment-labels-values.yaml
@@ -1,0 +1,6 @@
+---
+fullnameOverride: admission-webhook
+deployment:
+  labels:
+    foo: bar
+    baz: qux

--- a/charts/prometheus-operator-admission-webhook/ci/env-values.yaml
+++ b/charts/prometheus-operator-admission-webhook/ci/env-values.yaml
@@ -1,0 +1,7 @@
+---
+fullnameOverride: admission-webhook
+env:
+  - name: FOO
+    value: bar
+  - name: BAZ
+    value: qux

--- a/charts/prometheus-operator-admission-webhook/ci/extra-args-values.yaml
+++ b/charts/prometheus-operator-admission-webhook/ci/extra-args-values.yaml
@@ -1,0 +1,4 @@
+---
+fullnameOverride: admission-webhook
+extraArgs:
+  - --log-level=debug

--- a/charts/prometheus-operator-admission-webhook/ci/liveness-probe-values.yaml
+++ b/charts/prometheus-operator-admission-webhook/ci/liveness-probe-values.yaml
@@ -1,0 +1,10 @@
+---
+fullnameOverride: admission-webhook
+livenessProbe:
+  tcpSocket: null
+  httpGet:
+    path: /healthz
+    port: https
+    scheme: HTTPS
+  periodSeconds: 5
+  initialDelaySeconds: 1

--- a/charts/prometheus-operator-admission-webhook/ci/pdb-values.yaml
+++ b/charts/prometheus-operator-admission-webhook/ci/pdb-values.yaml
@@ -1,0 +1,4 @@
+---
+fullnameOverride: admission-webhook
+podDisruptionBudget:
+  maxUnavailable: 1

--- a/charts/prometheus-operator-admission-webhook/ci/pod-labels-values.yaml
+++ b/charts/prometheus-operator-admission-webhook/ci/pod-labels-values.yaml
@@ -1,0 +1,6 @@
+---
+fullnameOverride: admission-webhook
+pod:
+  labels:
+    foo: bar
+    baz: qux

--- a/charts/prometheus-operator-admission-webhook/ci/resources-values.yaml
+++ b/charts/prometheus-operator-admission-webhook/ci/resources-values.yaml
@@ -1,0 +1,9 @@
+---
+fullnameOverride: admission-webhook
+resources:
+  limits:
+    cpu: 100m
+    memory: 64Mi
+  requests:
+    cpu: 100m
+    memory: 64Mi

--- a/charts/prometheus-operator-admission-webhook/ci/service-labels-values.yaml
+++ b/charts/prometheus-operator-admission-webhook/ci/service-labels-values.yaml
@@ -1,0 +1,6 @@
+---
+fullnameOverride: admission-webhook
+service:
+  labels:
+    foo: bar
+    baz: qux

--- a/charts/prometheus-operator-admission-webhook/ci/serviceaccount-values.yaml
+++ b/charts/prometheus-operator-admission-webhook/ci/serviceaccount-values.yaml
@@ -1,0 +1,7 @@
+---
+fullnameOverride: admission-webhook
+serviceAccount:
+  name: po-admission-webhook
+  labels:
+    foo: bar
+    baz: qux

--- a/charts/prometheus-operator-admission-webhook/ci/servicemonitor-values.yaml
+++ b/charts/prometheus-operator-admission-webhook/ci/servicemonitor-values.yaml
@@ -1,0 +1,8 @@
+---
+fullnameOverride: admission-webhook
+serviceMonitor:
+  enabled: true
+  jobLabel: app.kubernetes.io/name
+  labels:
+    foo: bar
+    baz: qux

--- a/charts/prometheus-operator-admission-webhook/templates/deployment.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/deployment.yaml
@@ -41,7 +41,11 @@ spec:
     spec:
       {{- with .Values.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- if kindIs "map" . }}
+          {{- toYaml . | nindent 8 }}
+        {{- else }}
+          {{- tpl . $ | nindent 8 }}
+        {{- end }}
       {{- end }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- if .Values.image.pullSecrets }}

--- a/charts/prometheus-operator-admission-webhook/templates/hooks/job-createSecret.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/hooks/job-createSecret.yaml
@@ -73,7 +73,11 @@ spec:
       {{- end }}
       {{- with .Values.jobs.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- if kindIs "map" . }}
+          {{- toYaml . | nindent 8 }}
+        {{- else }}
+          {{- tpl . $ | nindent 8 }}
+        {{- end }}
       {{- end }}
       {{- with .Values.jobs.tolerations }}
       tolerations:

--- a/charts/prometheus-operator-admission-webhook/templates/hooks/job-patchWebhook.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/hooks/job-patchWebhook.yaml
@@ -71,7 +71,11 @@ spec:
       {{- end }}
       {{- with .Values.jobs.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- if kindIs "map" . }}
+          {{- toYaml . | nindent 8 }}
+        {{- else }}
+          {{- tpl . $ | nindent 8 }}
+        {{- end }}
       {{- end }}
       {{- with .Values.jobs.tolerations }}
       tolerations:

--- a/charts/prometheus-operator-admission-webhook/values.schema.json
+++ b/charts/prometheus-operator-admission-webhook/values.schema.json
@@ -3,7 +3,14 @@
     "type": "object",
     "properties": {
         "affinity": {
-            "type": "object"
+            "oneOf": [
+                {
+                    "type": "object"
+                },
+                {
+                    "type": "string"
+                }
+            ]
         },
         "automountServiceAccountToken": {
             "type": "boolean"
@@ -123,7 +130,14 @@
             "type": "object",
             "properties": {
                 "affinity": {
-                    "type": "object"
+                    "oneOf": [
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
                 },
                 "annotations": {
                     "type": "object"

--- a/charts/prometheus-operator-admission-webhook/values.yaml
+++ b/charts/prometheus-operator-admission-webhook/values.yaml
@@ -167,6 +167,13 @@ podDisruptionBudget: {}
 
 ## affinity
 affinity: {}
+# affinity: |
+#   podAntiAffinity:
+#     requiredDuringSchedulingIgnoredDuringExecution:
+#       - labelSelector:
+#           matchLabels:
+#             {{- include "prometheus-operator-admission-webhook.selectorLabels" . | nindent 10 }}
+#         topologyKey: kubernetes.io/hostname
 
 ## automountServiceAccountToken allows mounting the service account token automatically
 ## for other containers to consume


### PR DESCRIPTION
#### What this PR does / why we need it

`tpl` affinity field.  Less hardcoding of values specific to a single release.

#### Which issue this PR fixes

None

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
