### PR TITLE
[prometheus-yet-another-cloudwatch-exporter] Allow to override image registry

### DIFF
--- a/charts/prometheus-yet-another-cloudwatch-exporter/Chart.yaml
+++ b/charts/prometheus-yet-another-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-yet-another-cloudwatch-exporter
 description: Yace - Yet Another CloudWatch Exporter
 type: application
-version: 0.39.5
+version: 0.40.0
 appVersion: "v0.62.1"
 home: https://github.com/prometheus-community/helm-charts
 sources:

--- a/charts/prometheus-yet-another-cloudwatch-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-yet-another-cloudwatch-exporter/templates/_helpers.tpl
@@ -59,3 +59,15 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Return the correct image registry.
+*/}}
+{{- define "yet-another-cloudwatch-exporter.image.repository" -}}
+  {{- $registry := .Values.image.registry -}}
+  {{- if $registry -}}
+    {{- printf "%s/%s" $registry .Values.image.repository -}}
+  {{- else -}}
+    {{- printf "%s" .Values.image.repository -}}
+  {{- end }}
+{{- end -}}

--- a/charts/prometheus-yet-another-cloudwatch-exporter/templates/deployment.yaml
+++ b/charts/prometheus-yet-another-cloudwatch-exporter/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{- include "yet-another-cloudwatch-exporter.image.repository" . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - "yace"


### PR DESCRIPTION
What this PR does / why we need it
For those using some private image repositories, the current configuration always adds / even if the repository is empty.

Which issue this PR fixes
This PR add helper and global configuration for the repository but allows to work with both private repositories or public quai.io.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
