### PR TITLE
[kube-state-metrics] Use scrapeConfig to have HA

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - kubernetes
 type: application
-version: 5.31.0
+version: 5.32.0
 appVersion: 2.15.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -8,6 +8,7 @@ keywords:
   - kubernetes
 type: application
 version: 5.32.0
+# renovate: github-releases=kubernetes/kube-state-metrics
 appVersion: 2.15.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/charts/kube-state-metrics/templates/_helpers.tpl
+++ b/charts/kube-state-metrics/templates/_helpers.tpl
@@ -104,6 +104,25 @@ labelValueLengthLimit: {{ . }}
 {{- end }}
 {{- end -}}
 
+{{/* Sets default scrape limits for scrapeconfig */}}
+{{- define "scrapeconfig.scrapeLimits" -}}
+{{- with .sampleLimit }}
+sampleLimit: {{ . }}
+{{- end }}
+{{- with .targetLimit }}
+targetLimit: {{ . }}
+{{- end }}
+{{- with .labelLimit }}
+labelLimit: {{ . }}
+{{- end }}
+{{- with .labelNameLengthLimit }}
+labelNameLengthLimit: {{ . }}
+{{- end }}
+{{- with .labelValueLengthLimit }}
+labelValueLengthLimit: {{ . }}
+{{- end }}
+{{- end -}}
+
 {{/*
 Formats imagePullSecrets. Input is (dict "Values" .Values "imagePullSecrets" .{specific imagePullSecrets})
 */}}

--- a/charts/kube-state-metrics/templates/scrapeconfig.yaml
+++ b/charts/kube-state-metrics/templates/scrapeconfig.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.prometheus.scrapeconfig.enabled }}
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: {{ template "kube-state-metrics.fullname" . }}
+  namespace: {{ template "kube-state-metrics.namespace" . }}
+  labels:
+    {{- include "kube-state-metrics.labels" . | indent 4 }}
+  {{- with .Values.prometheus.scrapeconfig.additionalLabels }}
+    {{- tpl (toYaml . | nindent 4) $ }}
+  {{- end }}
+  {{- with .Values.prometheus.scrapeconfig.annotations }}
+  annotations:
+    {{- tpl (toYaml . | nindent 4) $ }}
+  {{- end }}
+spec:
+  {{- include "scrapeconfig.scrapeLimits" .Values.prometheus.scrapeconfig | indent 2 }}
+  staticConfigs:
+    - targets:
+        - {{ template "kube-state-metrics.fullname" . }}.{{ template "kube-state-metrics.namespace" . }}.svc:{{ .Values.service.port }}
+    {{- if .Values.prometheus.scrapeconfig.staticConfigLabels}}
+      labels:
+      {{- with .Values.prometheus.scrapeconfig.staticConfigLabels }}
+        {{- tpl (toYaml . | nindent 8) $ }}
+      {{- end }}
+    {{- end }}
+{{- if .Values.prometheus.scrapeconfig.jobName }}
+  jobName: {{ .Values.prometheus.scrapeconfig.jobName }}
+{{- end }}
+{{- if .Values.prometheus.scrapeconfig.honorLabels }}
+  honorLabels: true
+{{- end }}
+{{- if .Values.prometheus.scrapeconfig.scrapeInterval }}
+  scrapeInterval: {{ .Values.prometheus.scrapeconfig.scrapeInterval }}
+{{- end }}
+{{- if .Values.prometheus.scrapeconfig.scrapeTimeout }}
+  scrapeTimeout: {{ .Values.prometheus.scrapeconfig.scrapeTimeout }}
+{{- end }}
+{{- if .Values.prometheus.scrapeconfig.proxyUrl }}
+  proxyUrl: {{ .Values.prometheus.scrapeconfig.proxyUrl }}
+{{- end }}
+{{- if .Values.prometheus.scrapeconfig.enableHttp2 }}
+  enableHttp2: {{ .Values.prometheus.scrapeconfig.enableHttp2 }}
+{{- end }}
+{{- if .Values.prometheus.scrapeconfig.metricRelabelings }}
+  metricRelabelings:
+    {{- toYaml .Values.prometheus.scrapeconfig.metricRelabelings | nindent 4 }}
+{{- end }}
+{{- if .Values.prometheus.scrapeconfig.relabelings }}
+  relabelings:
+    {{- toYaml .Values.prometheus.scrapeconfig.relabelings | nindent 4 }}
+{{- end }}
+{{- if .Values.prometheus.scrapeconfig.scheme  }}
+  scheme: {{ .Values.prometheus.scrapeconfig.scheme }}
+{{- end }}
+{{- if .Values.prometheus.scrapeconfig.tlsConfig }}
+  tlsConfig:
+    {{- toYaml (.Values.prometheus.scrapeconfig.tlsConfig ) | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -239,6 +239,46 @@ prometheus:
         # name: secret-name
         # key:  key-name
       tlsConfig: {}
+  ## Create a scrapeConfig resource for scraping the kube-state-metrics service. Use this instead of serviceMonitor
+  ## to have more instances of kube-state-metrics safety.
+  scrapeconfig:
+    ## To avoid duplicate metrics, first disable the serviveMonitor creation via prometheus.monitor.enabled=false
+    enabled: false
+    annotations: {}
+    additionalLabels: {}
+    jobName: kube-state-metrics
+    ## SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.
+    ##
+    sampleLimit: 0
+
+    ## TargetLimit defines a limit on the number of scraped targets that will be accepted.
+    ##
+    targetLimit: 0
+
+    ## Per-scrape limit on number of labels that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+    ##
+    labelLimit: 0
+
+    ## Per-scrape limit on length of labels name that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+    ##
+    labelNameLengthLimit: 0
+
+    ## Per-scrape limit on length of labels value that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+    ##
+    labelValueLengthLimit: 0
+
+    ## StaticConfigLabels defines the labels to be used in the Prometheus static configuration for scraping.
+    staticConfigLabels: {}
+    scrapeInterval: ""
+    scrapeTimeout: ""
+    proxyUrl: ""
+    ## Whether to enable HTTP2 for scrapeconfig
+    enableHttp2: false
+    honorLabels: true
+    metricRelabelings: []
+    relabelings: []
+    scheme: ""
+    tlsConfig: {}
 
 ## Specify if a Pod Security Policy for kube-state-metrics must be created
 ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -242,7 +242,7 @@ prometheus:
   ## Create a scrapeConfig resource for scraping the kube-state-metrics service. Use this instead of serviceMonitor
   ## to have more instances of kube-state-metrics safety.
   scrapeconfig:
-    ## To avoid duplicate metrics, first disable the serviveMonitor creation via prometheus.monitor.enabled=false
+    ## To avoid duplicate metrics, first disable the serviceMonitor creation via prometheus.monitor.enabled=false
     enabled: false
     annotations: {}
     additionalLabels: {}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR enables scrapeConfig to be used as alternative to serviceMonitor for kube-state-metrics.

We want to have a way to configure the kube-state-metrics in High Availiability. The simple way to do it is increasing the number of `replicas` to 2. However, it duplicates the kube-state-metrics metrics. 

With the use of scrapeConfig resource instead of serviceMonitor, you can scrape the kube-state-metrics as a traditional kubernetes services where each replica will expose its endpoint port giving high availability 


#### Which issue this PR fixes

- https://github.com/kubernetes/kube-state-metrics/issues/611

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
