### PR TITLE
[prometheus-systemd-exporter]  Allow set unit include and bump to v0.7.0

### DIFF
--- a/charts/prometheus-systemd-exporter/Chart.yaml
+++ b/charts/prometheus-systemd-exporter/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: prometheus-systemd-exporter
 description: A Helm chart for prometheus systemd-exporter
 type: application
-version: 1.0.0
-appVersion: "0.7.0"
+version: 0.4.0
+appVersion: "0.6.0"
 home: https://github.com/prometheus-community/systemd_exporter
 sources:
 - https://github.com/prometheus-community/systemd_exporter

--- a/charts/prometheus-systemd-exporter/Chart.yaml
+++ b/charts/prometheus-systemd-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-systemd-exporter
 description: A Helm chart for prometheus systemd-exporter
 type: application
-version: 0.3.0
+version: 1.0.0
 appVersion: "0.6.0"
 home: https://github.com/prometheus-community/systemd_exporter
 sources:

--- a/charts/prometheus-systemd-exporter/Chart.yaml
+++ b/charts/prometheus-systemd-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: prometheus-systemd-exporter
 description: A Helm chart for prometheus systemd-exporter
 type: application
 version: 1.0.0
-appVersion: "0.6.0"
+appVersion: "0.7.0"
 home: https://github.com/prometheus-community/systemd_exporter
 sources:
 - https://github.com/prometheus-community/systemd_exporter

--- a/charts/prometheus-systemd-exporter/README.md
+++ b/charts/prometheus-systemd-exporter/README.md
@@ -40,3 +40,19 @@ See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_h
 ```console
 helm show values prometheus-community/prometheus-systemd-exporter
 ```
+
+### Exported Systemd units
+
+Default values generate metrics for `kubelet.service` and `docker.service` systemd units.
+
+Units to generate metrics for are configurable by means of `config.systemd.collector.unitInclude`.
+
+To generate metrics for all units override default values with:
+
+```yaml
+config:
+  systemd:
+    collector:
+      unitInclude:
+        - '.+'
+```

--- a/charts/prometheus-systemd-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-systemd-exporter/templates/daemonset.yaml
@@ -51,7 +51,6 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - --log.level=info
-          - --systemd.collector.unit-include=kubelet.service|docker.service
           {{- with .Values.extraArgs }}
           {{- toYaml . | nindent 10 }}
           {{- end }}

--- a/charts/prometheus-systemd-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-systemd-exporter/templates/daemonset.yaml
@@ -50,7 +50,8 @@ spec:
           image: {{ include "prometheus-systemd-exporter.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-          - --log.level=info
+          - --log.level={{ .Values.config.log.level }}
+          - --systemd.collector.unit-include={{ join "|" .Values.config.systemd.collector.unitInclude }}
           {{- with .Values.extraArgs }}
           {{- toYaml . | nindent 10 }}
           {{- end }}

--- a/charts/prometheus-systemd-exporter/values.yaml
+++ b/charts/prometheus-systemd-exporter/values.yaml
@@ -51,7 +51,8 @@ env: {}
 ##    VARIABLE: value
 
 # extraArgs allows to pass command line arguments, as described on https://github.com/prometheus-community/systemd_exporter?tab=readme-ov-file#configuration
-extraArgs: []
+extraArgs:
+  - --systemd.collector.unit-include=kubelet.service|docker.service
 # - --systemd.collector.enable-resolved
 
 prometheus:

--- a/charts/prometheus-systemd-exporter/values.yaml
+++ b/charts/prometheus-systemd-exporter/values.yaml
@@ -50,9 +50,19 @@ env: {}
 ##  env:
 ##    VARIABLE: value
 
+config:
+  log:
+    # Log level
+    level: info
+  systemd:
+    collector:
+      # Systemd units to include (regexp allowed)
+      unitInclude:
+        - kubelet.service
+        - docker.service
+
 # extraArgs allows to pass command line arguments, as described on https://github.com/prometheus-community/systemd_exporter?tab=readme-ov-file#configuration
-extraArgs:
-  - --systemd.collector.unit-include=kubelet.service|docker.service
+extraArgs: []
 # - --systemd.collector.enable-resolved
 
 prometheus:


### PR DESCRIPTION
#### What this PR does / why we need it

Allows setting `systemd.collector.unit-include` argument, which was hardcoded.
This allows the user to select the systemd units he is interested into.

#### Which issue this PR fixes

- fixes #4879 

#### Special notes for your reviewer

~I have leveraged existing `extraArgs` for this. The exporter itself has a default value of `.+` for included units, but I have kept current behaviour not to do a breaking change.~

I have also:

~- Bumped exporter version to [v0.7.0](https://github.com/prometheus-community/systemd_exporter/releases/tag/v0.7.0) which has been recently released~ -> will do under separate PR
- Bumped the Chart version to ~`1.0.0`~ `0.4.0`
  ~- This is not a breaking change, so might be confusing. But according to https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md?plain=1#L51 charts should start at `1.0.0`~

I can undo any of those change, or do them in a separate PR if preferred.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
