### PR TITLE
[prometheus-systemd-exporter] bump exporter version to 0.7.0

### DIFF
--- a/charts/prometheus-systemd-exporter/Chart.yaml
+++ b/charts/prometheus-systemd-exporter/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: prometheus-systemd-exporter
 description: A Helm chart for prometheus systemd-exporter
 type: application
-version: 0.4.0
-appVersion: "0.6.0"
+version: 0.5.0
+appVersion: "0.7.0"
 home: https://github.com/prometheus-community/systemd_exporter
 sources:
 - https://github.com/prometheus-community/systemd_exporter


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Bumps the default version of the exporter to [v0.7.0](https://github.com/prometheus-community/systemd_exporter/releases/tag/v0.7.0)

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
