### PR TITLE
[prometheus-elasticsearch-exporter] Remove whitespace from metricRelabelings

### DIFF
--- a/charts/prometheus-elasticsearch-exporter/Chart.yaml
+++ b/charts/prometheus-elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Elasticsearch stats exporter for Prometheus
 name: prometheus-elasticsearch-exporter
-version: 6.7.0
+version: 6.7.1
 kubeVersion: ">=1.19.0-0"
 appVersion: "v1.9.0"
 home: https://github.com/prometheus-community/elasticsearch_exporter

--- a/charts/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
@@ -28,7 +28,7 @@ spec:
     {{- end }}
     {{- if .Values.serviceMonitor.metricRelabelings }}
     metricRelabelings:
-    {{ toYaml .Values.serviceMonitor.metricRelabelings | nindent 4 }}
+    {{- toYaml .Values.serviceMonitor.metricRelabelings | nindent 4 }}
     {{- end }}
   jobLabel: {{ default .Release.Name .Values.serviceMonitor.jobLabel }}
   selector:


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This changes the rendering of the chart with the following values.yml:

```yaml
serviceMonitor:
  enabled: true
  metricRelabelings:
    - sourceLabels: [foo]
      targetLabel: bar
```

from producing

```yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
spec:
  endpoints:
  - interval: 10s
    scrapeTimeout: 10s
    honorLabels: true
    port: http
    path: /metrics
    scheme: http
    metricRelabelings:

    - sourceLabels:
      - foo
      targetLabel: bar
```

to producing

```yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
spec:
  endpoints:
  - interval: 10s
    scrapeTimeout: 10s
    honorLabels: true
    port: http
    path: /metrics
    scheme: http
    metricRelabelings:
    - sourceLabels:
      - foo
      targetLabel: bar
```

#### Which issue this PR fixes

I didn't create an issue for this PR.

#### Special notes for your reviewer

I created this issue when I was having an unrelated issue to an invalid `metricRelabelings` field. (I had `source_labels` where I should have had `sourceLabels`, but I think it's still a good change, so I'm leaving the PR for your hands. However, this wasn't the actual _bug_ that I thought it was.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
