### PR TITLE
[prometheus-adapter] fix metrics api in README

### DIFF
--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 4.14.0
+version: 4.14.1
 appVersion: v0.12.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/kubernetes-sigs/prometheus-adapter

--- a/charts/prometheus-adapter/README.md
+++ b/charts/prometheus-adapter/README.md
@@ -136,15 +136,15 @@ rules:
       containerLabel: container
     memory:
       containerQuery: |
-        sum by (<<.GroupBy>>) (
+        round(sum by (<<.GroupBy>>) (
           avg_over_time(container_memory_working_set_bytes{container!="",<<.LabelMatchers>>}[3m])
-        )
+        ))
       nodeQuery: |
-        sum by (<<.GroupBy>>) (
+        round(sum by (<<.GroupBy>>) (
           avg_over_time(node_memory_MemTotal_bytes{<<.LabelMatchers>>}[3m])
           -
           avg_over_time(node_memory_MemAvailable_bytes{<<.LabelMatchers>>}[3m])
-        )
+        ))
       resources:
         overrides:
           node:


### PR DESCRIPTION
When the sum over average values is reported by Metrics API, the result for query consumers is a number of bytes with a decimal point and some precision after it. That's really not good for a number in bytes.

Headlamp UI somehow receives that number re-formatted as millibytes, which its parseRam function does not correctly balk and crash at, so the UI occasionally reports 1000x the actual memory usage, and sometimes flaps back to displaying correctly.

When I add these round wrappers the metric gets reported as a whole number of bytes and that doesn't happen anymore!

No need for a chart rev, I don't know where this query definition comes from and I can find no references to it in any prometheus-adapter docs other than this one README, so I'm fixing it right at the source. (If anyone knows where it comes from, maybe we can cajole them into fixing it in their upstream as well.)

Ref:

* kubernetes-sigs/headlamp#3067