### PR TITLE
[prometheus-operator-admission-webhook] selectively disable webhooks

### DIFF
--- a/charts/prometheus-operator-admission-webhook/Chart.yaml
+++ b/charts/prometheus-operator-admission-webhook/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: Prometheus Operator Admission Webhook
 name: prometheus-operator-admission-webhook
-version: 0.22.0
+version: 0.23.0
 appVersion: 0.81.0
 home: https://github.com/prometheus-operator/prometheus-operator
 icon: https://github.com/prometheus-operator/prometheus-operator/raw/main/Documentation/logos/prometheus-operator-logo.png

--- a/charts/prometheus-operator-admission-webhook/templates/mutatingWebhookConfiguration.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/mutatingWebhookConfiguration.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.webhooks.enabled.prometheusrulemutate }}
+{{- if .Values.webhooks.enabled.prometheusruleMutate }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:

--- a/charts/prometheus-operator-admission-webhook/templates/mutatingWebhookConfiguration.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/mutatingWebhookConfiguration.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.webhooks.enabled.prometheusrulemutate }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -48,3 +49,4 @@ webhooks:
     timeoutSeconds: {{ default 10 .Values.webhooks.timeoutSeconds }}
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None
+{{- end }}

--- a/charts/prometheus-operator-admission-webhook/templates/validatingWebhookConfiguration.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/validatingWebhookConfiguration.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.webhooks.enabled.prometheusrulevalidate .Values.webhooks.enabled.alertmanagerconfigsvalidate }}
+{{- if or .Values.webhooks.enabled.prometheusruleValidate .Values.webhooks.enabled.alertmanagerconfigsValidate }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -51,7 +51,7 @@ webhooks:
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None
   {{- end }}
-  {{- if .Values.webhooks.enabled.alertmanagerconfigsvalidate }}
+  {{- if .Values.webhooks.enabled.alertmanagerconfigsValidate }}
   - name: alertmanagerconfigsvalidate.monitoring.coreos.com
     failurePolicy: {{ default "Fail" .Values.webhooks.failurePolicy }}
     {{- with .Values.webhooks.namespaceSelector }}

--- a/charts/prometheus-operator-admission-webhook/templates/validatingWebhookConfiguration.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/validatingWebhookConfiguration.yaml
@@ -22,7 +22,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 webhooks:
-  {{- if .Values.webhooks.enabled.prometheusrulevalidate }}
+  {{- if .Values.webhooks.enabled.prometheusruleValidate }}
   - name: prometheusrulevalidate.monitoring.coreos.com
     failurePolicy: {{ default "Fail" .Values.webhooks.failurePolicy }}
     {{- with .Values.webhooks.namespaceSelector }}

--- a/charts/prometheus-operator-admission-webhook/templates/validatingWebhookConfiguration.yaml
+++ b/charts/prometheus-operator-admission-webhook/templates/validatingWebhookConfiguration.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.webhooks.enabled.prometheusrulevalidate .Values.webhooks.enabled.alertmanagerconfigsvalidate }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -21,6 +22,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 webhooks:
+  {{- if .Values.webhooks.enabled.prometheusrulevalidate }}
   - name: prometheusrulevalidate.monitoring.coreos.com
     failurePolicy: {{ default "Fail" .Values.webhooks.failurePolicy }}
     {{- with .Values.webhooks.namespaceSelector }}
@@ -48,6 +50,8 @@ webhooks:
     timeoutSeconds: {{ default 10 .Values.webhooks.timeoutSeconds }}
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None
+  {{- end }}
+  {{- if .Values.webhooks.enabled.alertmanagerconfigsvalidate }}
   - name: alertmanagerconfigsvalidate.monitoring.coreos.com
     failurePolicy: {{ default "Fail" .Values.webhooks.failurePolicy }}
     {{- with .Values.webhooks.namespaceSelector }}
@@ -75,3 +79,5 @@ webhooks:
     timeoutSeconds: {{ default 10 .Values.webhooks.timeoutSeconds }}
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None
+  {{- end }}
+{{- end }}

--- a/charts/prometheus-operator-admission-webhook/values.yaml
+++ b/charts/prometheus-operator-admission-webhook/values.yaml
@@ -21,6 +21,11 @@ kubeVersionOverride: ""
 ## For info on converting Alertmanagerconfigs,
 ## see https://prometheus-operator.dev/docs/user-guides/webhook/#converting-alertmanagerconfig-resources
 webhooks:
+  enabled:
+    prometheusrulevalidate: true
+    alertmanagerconfigsvalidate: true
+    prometheusrulemutate: true
+
   failurePolicy: Fail
   timeoutSeconds: 10
   namespaceSelector: {}

--- a/charts/prometheus-operator-admission-webhook/values.yaml
+++ b/charts/prometheus-operator-admission-webhook/values.yaml
@@ -22,9 +22,9 @@ kubeVersionOverride: ""
 ## see https://prometheus-operator.dev/docs/user-guides/webhook/#converting-alertmanagerconfig-resources
 webhooks:
   enabled:
-    prometheusrulevalidate: true
-    alertmanagerconfigsvalidate: true
-    prometheusrulemutate: true
+    prometheusruleValidate: true
+    alertmanagerconfigsValidate: true
+    prometheusruleMutate: true
 
   failurePolicy: Fail
   timeoutSeconds: 10


### PR DESCRIPTION
#### What this PR does / why we need it

A [pull request](https://github.com/prometheus-community/helm-charts/issues/3860) to chart/prometheus-operator-crds allowed the ability to selectively disable CRD objects.  In response to that, it's now also necessary to support selective disabling of webhooks.

#### Which issue this PR fixes

None

#### Special notes for your reviewer

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
