### PR TITLE
[kube-prometheus-stack] bump Grafana to 8.13.*

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -31,7 +31,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 70.7.0
+version: 70.8.0
 appVersion: v0.81.0
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus
@@ -62,7 +62,7 @@ dependencies:
     repository: https://prometheus-community.github.io/helm-charts
     condition: nodeExporter.enabled
   - name: grafana
-    version: "8.12.*"
+    version: "8.13.*"
     repository: https://grafana.github.io/helm-charts
     condition: grafana.enabled
   - name: prometheus-windows-exporter


### PR DESCRIPTION
#### What this PR does / why we need it

Bump Grafana Helm dependencies to the latest [Chart](https://github.com/grafana/helm-charts/releases/tag/grafana-8.13.1) `8.13.1` to include [Grafana](https://github.com/grafana/grafana/releases/tag/v11.6.1) `11.6.1` , which addresses several CVEs

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

```
Security: Fix CVE-2025-3454
Security: Fix https://github.com/advisories/GHSA-p2mq-5mvf-j4j6
Security: Fix CVE-2025-3260
```

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
