### PR TITLE
[alertmanager] Allow customizing the name of the container port

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -52,7 +52,7 @@
 
 - hectorj2f (<hfernandez@mesosphere.com> / @hectorj2f)
 - mattiasgees (<mattias.gees@jetstack.io> / @mattiasgees)
-- steven-sheehy (unknown / @steven-sheehy)
+- steven-sheehy (<> / @steven-sheehy)
 
 ### prometheus-blackbox-exporter
 
@@ -199,7 +199,7 @@
 
 ### prometheus-smartctl-exporter
 
-- kfox1111 (unknown / @kfox1111)
+- kfox1111 (<> / @kfox1111)
 - zeritti (<rootsandtrees@posteo.de> / @zeritti)
 
 ### prometheus-snmp-exporter
@@ -209,7 +209,7 @@
 
 ### prometheus-sql-exporter
 
-- wilfriedroset (unknown / @wilfriedroset)
+- wilfriedroset (<> / @wilfriedroset)
 
 ### prometheus-stackdriver-exporter
 

--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 1.17.0
+version: 1.17.1
 # renovate: github-releases=prometheus/alertmanager
 appVersion: v0.28.1
 kubeVersion: ">=1.19.0-0"

--- a/charts/alertmanager/templates/serviceperreplica.yaml
+++ b/charts/alertmanager/templates/serviceperreplica.yaml
@@ -35,7 +35,7 @@ items:
       ports:
         - name: http
           port: {{ $.Values.service.port }}
-          targetPort: http
+          targetPort: {{ $.Values.containerPortName }}
       selector:
         {{- include "alertmanager.selectorLabels" $ | nindent 8 }}
         statefulset.kubernetes.io/pod-name: {{ include "alertmanager.fullname" $ }}-{{ $i }}

--- a/charts/alertmanager/templates/services.yaml
+++ b/charts/alertmanager/templates/services.yaml
@@ -29,7 +29,7 @@ spec:
   {{- end }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: {{ .Values.containerPortName }}
       protocol: TCP
       name: http
       {{- if (and (eq .Values.service.type "NodePort") .Values.service.nodePort) }}
@@ -55,7 +55,7 @@ spec:
   clusterIP: None
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: {{ .Values.containerPortName }}
       protocol: TCP
       name: http
     {{- if or (gt (int .Values.replicaCount) 1) (.Values.additionalPeers) }}

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -177,7 +177,7 @@ spec:
             - --web.external-url={{ .Values.baseURL }}
             {{- end }}
           ports:
-            - name: http
+            - name: {{ .Values.containerPortName }}
               containerPort: 9093
               protocol: TCP
             {{- if or (gt (int .Values.replicaCount) 1) (.Values.additionalPeers) }}

--- a/charts/alertmanager/values.schema.json
+++ b/charts/alertmanager/values.schema.json
@@ -584,6 +584,11 @@
             "description": "Resource limits and requests for the pod.",
             "$ref": "#/definitions/resources"
         },
+        "containerPortName": {
+            "description": "Name of the port for the main container.",
+            "type": "string",
+            "default": "http"
+        },
         "livenessProbe": {
             "description": "Liveness probe configuration.",
             "type": "object"

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -93,15 +93,17 @@ extraInitContainers: []
 ##
 extraContainers: []
 
+containerPortName: &containerPortName http
+
 livenessProbe:
   httpGet:
     path: /
-    port: http
+    port: *containerPortName
 
 readinessProbe:
   httpGet:
     path: /
-    port: http
+    port: *containerPortName
 
 service:
   annotations: {}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
It can be useful to customize the name of Alertmanager's container port in situations where another K8s object is observing new deployments (e.g. Prometheus collector that watches for ports named "metrics"). This PR enables this use case with a new top-level `containerPortName` value, which defaults to the current, hard-coded "http" value.

#### Special notes for your reviewer

I left the name of the Service as-is just to keep the PR small.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
