### PR TITLE
[prometheus-operator-admission-webhook] bump  admission webhook to v0.82.0

### DIFF
--- a/charts/prometheus-operator-admission-webhook/Chart.yaml
+++ b/charts/prometheus-operator-admission-webhook/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v2
 description: Prometheus Operator Admission Webhook
 name: prometheus-operator-admission-webhook
-version: 0.23.0
-appVersion: 0.81.0
+version: 0.24.0
+appVersion: 0.82.0
 home: https://github.com/prometheus-operator/prometheus-operator
 icon: https://github.com/prometheus-operator/prometheus-operator/raw/main/Documentation/logos/prometheus-operator-logo.png
 keywords:


### PR DESCRIPTION
#### What this PR does / why we need it

Operator released v0.82.0
https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.82.0

#### Which issue this PR fixes

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
