### PR TITLE
[prometheus-smartctl-exporter] Allow PodMonitor and PriorityClass configuration

### DIFF
--- a/charts/prometheus-smartctl-exporter/Chart.yaml
+++ b/charts/prometheus-smartctl-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.15.3
+version: 0.15.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/prometheus-smartctl-exporter/Chart.yaml
+++ b/charts/prometheus-smartctl-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.15.1
+version: 0.15.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/prometheus-smartctl-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-smartctl-exporter/templates/daemonset.yaml
@@ -40,6 +40,9 @@ spec:
         - name: {{ $secret }}
         {{- end }}
       {{- end }}
+      {{- if $global.Values.priorityClassName }}
+      priorityClassName: {{ $global.Values.priorityClassName }}
+      {{- end }}
       containers:
       - image: "{{ $global.Values.image.repository }}:{{ $global.Values.image.tag | default $global.Chart.AppVersion }}"
         imagePullPolicy: {{ $global.Values.image.pullPolicy }}

--- a/charts/prometheus-smartctl-exporter/templates/podmonitor.yaml
+++ b/charts/prometheus-smartctl-exporter/templates/podmonitor.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ template "prometheus-smartctl-exporter.fullname" . }}
+  labels:
+    {{- include "prometheus-smartctl-exporter.labels" . | nindent 4 }}
+    {{- with .Values.podMonitor.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- if hasKey .Values.podMonitor "namespace" }}
+  namespace: {{ .Values.podMonitor.namespace }}
+{{- end }}
+spec:
+  podMetricsEndpoints:
+    - interval: {{ .Values.podMonitor.interval }}
+      path: /metrics
+      port: http
+      scheme: http
+      scrapeTimeout: {{ .Values.podMonitor.scrapeTimeout }}
+{{- with .Values.podMonitor.relabelings }}
+      relabelings: {{ toYaml . | nindent 8 }}
+{{- end }}
+{{- with .Values.podMonitor.metricRelabelings }}
+      metricRelabelings: {{ toYaml . | nindent 8 }}
+{{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "prometheus-smartctl-exporter.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/prometheus-smartctl-exporter/templates/service.yaml
+++ b/charts/prometheus-smartctl-exporter/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceMonitor.enabled }}
+{{- if .Values.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/prometheus-smartctl-exporter/templates/service.yaml
+++ b/charts/prometheus-smartctl-exporter/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceMonitor.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,3 +18,4 @@ spec:
       name: http
   selector:
     {{- include "prometheus-smartctl-exporter.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/prometheus-smartctl-exporter/values.yaml
+++ b/charts/prometheus-smartctl-exporter/values.yaml
@@ -31,6 +31,8 @@ serviceMonitor:
   relabelings: []
   metricRelabelings: []
 
+
+
 # PodMonitor may be more appropriate than Service Monitor, especially if more than 1000 Pods
 # background info: https://github.com/prometheus-operator/prometheus-operator/pull/6672, https://github.com/prometheus-operator/prometheus-operator/issues/3119
 # You most likely do not want to use a PodMonitor AND serviceMonitor at the same time.
@@ -169,7 +171,10 @@ tolerations:
 
 affinity: {}
 
+# You probably don't need a Service (or ServiceMonitor), consider using a PodMonitor instead
+# Enabled here for backwards compatibility
 service:
+  enabled: true
   type: ClusterIP
   port: 80
   ipDualStack:

--- a/charts/prometheus-smartctl-exporter/values.yaml
+++ b/charts/prometheus-smartctl-exporter/values.yaml
@@ -31,6 +31,22 @@ serviceMonitor:
   relabelings: []
   metricRelabelings: []
 
+# PodMonitor may be more appropriate than Service Monitor, especially if more than 1000 Pods
+# background info: https://github.com/prometheus-operator/prometheus-operator/pull/6672, https://github.com/prometheus-operator/prometheus-operator/issues/3119
+# You most likely do not want to use a PodMonitor AND serviceMonitor at the same time.
+podMonitor:
+  enabled: false
+  # Specify namespace to load the monitor if not in the same namespace
+  # namespace: prometheus-operator
+  # Add Extra labels if needed. Prometeus operator may need them to find it.
+  extraLabels: {}
+  # release: prometheus-operator
+  interval: 60s
+  scrapeTimeout: 30s
+  # Set relabel_configs as per https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+  relabelings: []
+  metricRelabelings: []
+
 prometheusRules:
   enabled: false
   # Specify namespace to load the rule if not in the same namespace
@@ -111,6 +127,10 @@ updateStrategy:
   rollingUpdate:
     maxUnavailable: 1
   type: RollingUpdate
+
+# optional priority class name
+# If set, the DaemonSet will use this priority class.
+priorityClassName: ""
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

#### Which issue this PR fixes

- Allows use of PodMonitor instead of the traditional ServiceMonitor.  This can be more efficient than creating a Service (unnecessary iptables rules overhead) and avoid ServiceMonitor Endpoint issues with >1000 Pods: 
  - https://github.com/prometheus-operator/prometheus-operator/pull/6672
  - https://github.com/prometheus-operator/prometheus-operator/issues/3119
- Allows setting a priorityClassName
- If ServiceMonitor is not enabled, the Service is not created either

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
