### PR TITLE
[prometheus-operator-admissions-controller] affinity=null

### DIFF
--- a/charts/prometheus-operator-admission-webhook/Chart.yaml
+++ b/charts/prometheus-operator-admission-webhook/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: Prometheus Operator Admission Webhook
 name: prometheus-operator-admission-webhook
-version: 0.24.0
+version: 0.24.1
 appVersion: 0.82.0
 home: https://github.com/prometheus-operator/prometheus-operator
 icon: https://github.com/prometheus-operator/prometheus-operator/raw/main/Documentation/logos/prometheus-operator-logo.png

--- a/charts/prometheus-operator-admission-webhook/values.schema.json
+++ b/charts/prometheus-operator-admission-webhook/values.schema.json
@@ -5,6 +5,9 @@
         "affinity": {
             "oneOf": [
                 {
+                    "type": "null"
+                },
+                {
                     "type": "object"
                 },
                 {

--- a/charts/prometheus-operator-admission-webhook/values.yaml
+++ b/charts/prometheus-operator-admission-webhook/values.yaml
@@ -171,7 +171,7 @@ podDisruptionBudget: {}
   # maxUnavailable: 0
 
 ## affinity
-affinity: {}
+affinity: null
 # affinity: |
 #   podAntiAffinity:
 #     requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
#### What this PR does / why we need it

Fixes coalesce warning when setting type to string (from default map)

```
coalesce.go:220: warning: cannot overwrite table with non table for affinity (map[])
```

#### Which issue this PR fixes

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
