### PR TITLE
[prometheus-pushgateway] allow for global.image.registry and global.imagePullSecrets overrides

### DIFF
--- a/charts/prometheus-pushgateway/Chart.yaml
+++ b/charts/prometheus-pushgateway/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: v1.11.1
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 3.1.3
+version: 3.1.4
 home: https://github.com/prometheus/pushgateway
 sources:
   - https://github.com/prometheus/pushgateway

--- a/charts/prometheus-pushgateway/Chart.yaml
+++ b/charts/prometheus-pushgateway/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: v1.11.1
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 3.1.4
+version: 3.2.0
 home: https://github.com/prometheus/pushgateway
 sources:
   - https://github.com/prometheus/pushgateway

--- a/charts/prometheus-pushgateway/templates/_helpers.tpl
+++ b/charts/prometheus-pushgateway/templates/_helpers.tpl
@@ -143,6 +143,20 @@ password: {{ $password | b64enc | quote }}
 {{- end }}
 
 {{/*
+Set the image with or without the registry
+*/}}
+{{- define "prometheus-pushgateway.image" -}}
+{{- $registry := default .Values.image.registry (.Values.global).imageRegistry }}
+{{- $repository := .Values.image.repository }}
+{{- $tag := default .Chart.AppVersion .Values.image.tag }}
+{{- if $registry }}
+    {{- printf "%s/%s:%s" $registry $repository $tag -}}
+{{- else -}}
+    {{- printf "%s:%s"  $repository $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Returns pod spec
 */}}
 {{- define "prometheus-pushgateway.podSpec" -}}
@@ -155,7 +169,7 @@ priorityClassName: {{ . | quote }}
 hostAliases:
 {{- toYaml . | nindent 2 }}
 {{- end }}
-{{- with .Values.imagePullSecrets }}
+{{- with .Values.global.imagePullSecrets | default .Values.imagePullSecrets }}
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}
 {{- end }}
@@ -168,7 +182,7 @@ containers:
   {{- toYaml . | nindent 2 }}
   {{- end }}
   - name: pushgateway
-    image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+    image: {{ include "prometheus-pushgateway.image" . }}
     imagePullPolicy: {{ .Values.image.pullPolicy }}
     {{- with .Values.extraVars }}
     env:

--- a/charts/prometheus-pushgateway/templates/_helpers.tpl
+++ b/charts/prometheus-pushgateway/templates/_helpers.tpl
@@ -146,7 +146,7 @@ password: {{ $password | b64enc | quote }}
 Set the image with or without the registry
 */}}
 {{- define "prometheus-pushgateway.image" -}}
-{{- $registry := default (.Values.global).imageRegistry .Values.image.registry }}
+{{- $registry := default .Values.image.registry (.Values.global).imageRegistry }}
 {{- $repository := .Values.image.repository }}
 {{- $tag := default .Chart.AppVersion .Values.image.tag }}
 {{- if $registry }}
@@ -169,7 +169,7 @@ priorityClassName: {{ . | quote }}
 hostAliases:
 {{- toYaml . | nindent 2 }}
 {{- end }}
-{{- with .Values.imagePullSecrets | default (.Values.global).imagePullSecrets }}
+{{- with (.Values.global).imagePullSecrets | default .Values.imagePullSecrets }}
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}
 {{- end }}

--- a/charts/prometheus-pushgateway/templates/_helpers.tpl
+++ b/charts/prometheus-pushgateway/templates/_helpers.tpl
@@ -146,7 +146,7 @@ password: {{ $password | b64enc | quote }}
 Set the image with or without the registry
 */}}
 {{- define "prometheus-pushgateway.image" -}}
-{{- $registry := default .Values.image.registry (.Values.global).imageRegistry }}
+{{- $registry := default (.Values.global).imageRegistry .Values.image.registry }}
 {{- $repository := .Values.image.repository }}
 {{- $tag := default .Chart.AppVersion .Values.image.tag }}
 {{- if $registry }}
@@ -169,7 +169,7 @@ priorityClassName: {{ . | quote }}
 hostAliases:
 {{- toYaml . | nindent 2 }}
 {{- end }}
-{{- with .Values.global.imagePullSecrets | default .Values.imagePullSecrets }}
+{{- with .Values.imagePullSecrets | default (.Values.global).imagePullSecrets }}
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}
 {{- end }}

--- a/charts/prometheus-pushgateway/values.yaml
+++ b/charts/prometheus-pushgateway/values.yaml
@@ -2,6 +2,10 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+global:
+  imageRegistry: ""
+  imagePullSecrets: []
+
 # Provide a name in place of prometheus-pushgateway for `app:` labels
 nameOverride: ""
 
@@ -12,6 +16,7 @@ fullnameOverride: ""
 namespaceOverride: ""
 
 image:
+  registry: ""
   repository: quay.io/prometheus/pushgateway
   # if not set appVersion field from Chart.yaml is used
   tag: ""


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

allow for global.imageRegistry and global.imagePullSecrets overrides with the local chart settings taking precedence over the global settings.

This is needed to allow users that must host their own registry easily override where the chart pulls from.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)

@gianrubio @cstaud @zeritti 
