### PR TITLE
[kube-prometheus-stack] Add optional PDB for operator

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -31,7 +31,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 71.2.0
+version: 72.0.0
 # Please do not add a renovate hint here, since appVersion updates involves manual tasks
 appVersion: v0.82.0
 kubeVersion: ">=1.19.0-0"

--- a/charts/kube-prometheus-stack/UPGRADE.md
+++ b/charts/kube-prometheus-stack/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade
 
+## From 71.x to 72.x
+
+This version adds an `enabled` flag to the `prometheusOperator.admissionWebhooks.deployment.podDisruptionBudget` settings. Users who want this chart to deploy a `podDisruptionBudget` must now set the flag `podDisruptionBudget.enabled` to `true` for each `podDisruptionBudget` resource to be created.
+
 ## From 70.x to 71.x
 
 This version upgrades Prometheus-Operator to v0.82.0

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/deployment/pdb.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/deployment/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.prometheusOperator.admissionWebhooks.deployment.podDisruptionBudget -}}
+{{- if .Values.prometheusOperator.admissionWebhooks.deployment.podDisruptionBudget.enabled -}}
 apiVersion: {{ include "kube-prometheus-stack.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -11,5 +11,5 @@ spec:
     matchLabels:
       app: {{ template "kube-prometheus-stack.name" . }}-operator-webhook
       release: {{ $.Release.Name | quote }}
-{{ toYaml .Values.prometheusOperator.admissionWebhooks.deployment.podDisruptionBudget | indent 2 }}
+{{ toYaml (omit .Values.prometheusOperator.admissionWebhooks.deployment.podDisruptionBudget "enabled") | indent 2 }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/pdb.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/pdb.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.prometheusOperator.podDisruptionBudget.enabled -}}
+apiVersion: {{ include "kube-prometheus-stack.pdb.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "kube-prometheus-stack.operator.fullname" . }}
+  namespace: {{ template "kube-prometheus-stack.namespace" . }}
+  labels:
+    {{- include "kube-prometheus-stack.prometheus-operator.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "kube-prometheus-stack.name" . }}-operator
+      release: {{ $.Release.Name | quote }}
+{{- toYaml (omit .Values.prometheusOperator.podDisruptionBudget "enabled") | indent 2 }}
+{{- end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -500,6 +500,7 @@ alertmanager:
     enabled: false
     minAvailable: 1
     maxUnavailable: ""
+    unhealthyPodEvictionPolicy: AlwaysAllow
 
   ## Alertmanager configuration directives
   ## ref: https://prometheus.io/docs/alerting/configuration/#configuration-file
@@ -2642,9 +2643,11 @@ prometheusOperator:
       strategy: {}
 
       # Ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
-      podDisruptionBudget: {}
-        # maxUnavailable: 1
-        # minAvailable: 1
+      podDisruptionBudget:
+        enabled: false
+        minAvailable: 1
+        maxUnavailable: ""
+        unhealthyPodEvictionPolicy: AlwaysAllow
 
       ## Number of old replicasets to retain ##
       ## The default value is 10, 0 will garbage-collect old replicasets ##
@@ -3039,6 +3042,14 @@ prometheusOperator:
   ## Annotations to add to the operator pod
   ##
   podAnnotations: {}
+
+  ## Assign a podDisruptionBudget to the operator
+  ##
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    maxUnavailable: ""
+    unhealthyPodEvictionPolicy: AlwaysAllow
 
   ## Assign a PriorityClassName to pods if set
   # priorityClassName: ""
@@ -3582,6 +3593,7 @@ prometheus:
     enabled: false
     minAvailable: 1
     maxUnavailable: ""
+    unhealthyPodEvictionPolicy: AlwaysAllow
 
   # Ingress exposes thanos sidecar outside the cluster
   thanosIngress:
@@ -4804,6 +4816,7 @@ thanosRuler:
     enabled: false
     minAvailable: 1
     maxUnavailable: ""
+    unhealthyPodEvictionPolicy: AlwaysAllow
 
   ingress:
     enabled: false


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
When setting up the availability of your cluster the operator-webhook has a definable PDB, but not the operator itself.

This adds an optional `PodDisruptionBudget` for the operator container itself.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
