### PR TITLE
Add global podTargetLabels to kube-prometheus-stack chart

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -31,7 +31,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 72.0.1
+version: 72.0.2
 # Please do not add a renovate hint here, since appVersion updates involves manual tasks
 appVersion: v0.82.0
 kubeVersion: ">=1.19.0-0"

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -118,6 +118,10 @@ spec:
   scrapeClasses:
     {{- tpl (toYaml . | nindent 4) $ }}
 {{- end }}
+{{- with .Values.prometheus.prometheusSpec.podTargetLabels }}
+  podTargetLabels:
+    {{- tpl (toYaml . | nindent 4) $ }}
+{{- end }}
 {{- if .Values.prometheus.prometheusSpec.scrapeFailureLogFile }}
   scrapeFailureLogFile: {{ .Values.prometheus.prometheusSpec.scrapeFailureLogFile }}
 {{- end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -3900,6 +3900,11 @@ prometheus:
     #     caFile: /etc/prometheus/secrets/istio.default/root-cert.pem
     #     certFile: /etc/prometheus/secrets/istio.default/cert-chain.pem
 
+    ## PodTargetLabels are appended to the `spec.podTargetLabels` field of all PodMonitor and ServiceMonitor objects.
+    ##
+    podTargetLabels: []
+    # - customlabel
+
     ## Interval between consecutive evaluations.
     ##
     evaluationInterval: ""


### PR DESCRIPTION
Add possibility to set global podTargetLabels config in prometheus CRD.