### PR TITLE
[kube-prometheus-stack,kube-state-metrics] Add additional labels for Deployments / StatefulSets

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -31,7 +31,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 72.2.0
+version: 72.3.0
 # Please do not add a renovate hint here, since appVersion updates involves manual tasks
 appVersion: v0.82.0
 kubeVersion: ">=1.19.0-0"

--- a/charts/kube-prometheus-stack/templates/alertmanager/alertmanager.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/alertmanager.yaml
@@ -7,6 +7,9 @@ metadata:
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}-alertmanager
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
+{{- if .Values.alertmanager.additionalLabels }}
+{{ toYaml .Values.alertmanager.additionalLabels | indent 4 }}
+{{- end }}
 {{- if .Values.alertmanager.annotations }}
   annotations:
 {{ toYaml .Values.alertmanager.annotations | indent 4 }}

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -11,6 +11,9 @@ metadata:
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
     app: {{ template "kube-prometheus-stack.name" . }}-prometheus
+{{- if .Values.prometheus.additionalLabels }}
+{{ toYaml .Values.prometheus.additionalLabels | indent 4 }}
+{{- end }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 {{- if .Values.prometheus.annotations }}
   annotations:

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -399,6 +399,10 @@ alertmanager:
   ##
   annotations: {}
 
+  ## Additional labels for Alertmanager
+  ##
+  additionalLabels: {}
+
   ## Api that prometheus will use to communicate with alertmanager. Possible values are v1, v2
   ##
   apiVersion: v2
@@ -2379,6 +2383,10 @@ kube-state-metrics:
     create: true
   releaseLabel: true
 
+  ## Additional labels for kube-state-metrics
+  ##
+  additionalLabels: {}
+
   ## Enable scraping via kubernetes-service-endpoints
   ## Disabled by default as we service monitor is enabled below
   ##
@@ -3339,6 +3347,10 @@ prometheus:
   ## Annotations for Prometheus
   ##
   annotations: {}
+
+  ## Additional labels for Prometheus
+  ##
+  additionalLabels: {}
 
   ## Configure network policy for the prometheus
   networkPolicy:

--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - kubernetes
 type: application
-version: 5.33.1
+version: 5.34.0
 # renovate: github-releases=kubernetes/kube-state-metrics
 appVersion: 2.15.0
 home: https://github.com/kubernetes/kube-state-metrics/

--- a/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/kube-state-metrics/templates/deployment.yaml
@@ -9,6 +9,9 @@ metadata:
   namespace: {{ template "kube-state-metrics.namespace" . }}
   labels:
     {{- include "kube-state-metrics.labels" . | indent 4 }}
+  {{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 4 }}
+  {{- end }}
   {{- if .Values.annotations }}
   annotations:
 {{ toYaml .Values.annotations | indent 4 }}

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -366,6 +366,9 @@ topologySpreadConstraints: []
 # Annotations to be added to the deployment/statefulset
 annotations: {}
 
+# Labels to be added to the deployment/statefulset
+labels: {}
+
 # Annotations to be added to the pod
 podAnnotations: {}
 


### PR DESCRIPTION
#### What this PR does / why we need it

This PR adds the option to add additional labels to the `Alertmanager` and `Prometheus` custom resources, resulting in additional labels on the created StatefulSet resources. It also adds the option to add additional labels to the `kube-state-metrics` Deployment/StatefulSet.

This PR makes the same changes as #752, https://github.com/helm/charts/pull/17897, and #2247, but for labels.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
