### PR TITLE
[kube-state-metrics] add deployment labels to kube-state-metrics

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - kubernetes
 type: application
-version: 5.34.1
+version: 5.35.0
 # renovate: github-releases=kubernetes/kube-state-metrics
 appVersion: 2.15.0
 home: https://github.com/kubernetes/kube-state-metrics/

--- a/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/kube-state-metrics/templates/deployment.yaml
@@ -9,9 +9,12 @@ metadata:
   namespace: {{ template "kube-state-metrics.namespace" . }}
   labels:
     {{- include "kube-state-metrics.labels" . | indent 4 }}
-  {{- if .Values.annotations }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.annotations }}
   annotations:
-{{ toYaml .Values.annotations | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   selector:

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -366,6 +366,9 @@ topologySpreadConstraints: []
 # Annotations to be added to the deployment/statefulset
 annotations: {}
 
+# Labels to be added to the deployment/statefulset
+labels: {}
+
 # Annotations to be added to the pod
 podAnnotations: {}
 


### PR DESCRIPTION
#### What this PR does / why we need it

Follow-up on #5624. Adds the option to add custom labels to the kube-state-metrics deployment.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
