### PR TITLE
[alertmanager] Ability to add probes for reloader sidercar

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 1.17.3
+version: 1.18.0
 # renovate: github-releases=prometheus/alertmanager
 appVersion: v0.28.1
 kubeVersion: ">=1.19.0-0"

--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 1.17.2
+version: 1.17.3
 # renovate: github-releases=prometheus/alertmanager
 appVersion: v0.28.1
 kubeVersion: ">=1.19.0-0"

--- a/charts/alertmanager/ci/config-reload-values.yaml
+++ b/charts/alertmanager/ci/config-reload-values.yaml
@@ -1,2 +1,16 @@
 configmapReload:
   enabled: true
+
+  extraArgs:
+    listen-address: ":8080"
+
+  livenessProbe:
+    httpGet:
+      path: /healthz
+      port: 8080
+      scheme: HTTP
+  readinessProbe:
+    httpGet:
+      path: /healthz
+      port: 8080
+      scheme: HTTP

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -119,6 +119,10 @@ spec:
           ports:
             - containerPort: {{ . }}
           {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.configmapReload.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.configmapReload.readinessProbe | nindent 12 }}
           {{- with .Values.configmapReload.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -334,6 +334,17 @@ configmapReload:
   ##
   resources: {}
 
+  livenessProbe: {}
+    # httpGet:
+    #   path: /healthz
+    #   port: 8080
+    #   scheme: HTTP
+  readinessProbe: {}
+    # httpGet:
+    #   path: /healthz
+    #   port: 8080
+    #   scheme: HTTP
+
   extraArgs: {}
 
   ## Optionally specify extra list of additional volumeMounts


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
The alertmanager chart misses the probes for the optional sidecar.
The reloader sidecar is present in multiple charts already and there it includes the probes. E.g.:
- blackbox exporter
  https://github.com/prometheus-community/helm-charts/blob/c12280491748258ffd573a5af53bda6d811f6bed/charts/prometheus-blackbox-exporter/values.yaml#L463-L472
- kube-prometheus-stack (via Operator):
  https://github.com/prometheus-operator/prometheus-operator/blob/b2f9aacee4c8812928626210572e2e998425f492/pkg/operator/config_reloader.go#L321-L339
- prometheus:
  https://github.com/prometheus-community/helm-charts/blob/c12280491748258ffd573a5af53bda6d811f6bed/charts/prometheus/values.yaml#L101-L114

maybe also other charts (didn't check all)

FYI @PatMis16

#### Which issue this PR fixes
<!--
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
-->

`---`

#### Special notes for your reviewer

I noticed that there was a discussion about defining the containerPort for the reloader in the past:
- https://github.com/prometheus-community/helm-charts/pull/1915

Since we wanted 100% backward compat back then, I also implemented the probes to be fully optional.

If you would be okay to have a (theoretical) breaking change, it can be simplified by using the parameter `.Values.configmapReload.containerPort` as the listen address argument. Then I can implement it identical with the blackbox-exporter chart.

```yaml
# ..
  args:
    # ..
    - --listen-address=:{{ .Values.configReloader.containerPort }}
    #..
  ports:
    - name: reloader-web # use a named port
      containerPort: {{ .Values.configReloader.containerPort }}
      protocol: TCP
  # ..
  livenessProbe:
    httpGet:
      path: /healthz
      port: reloader-web # use a named port
      scheme: HTTP
# Source: https://github.com/prometheus-community/helm-charts/blob/c12280491748258ffd573a5af53bda6d811f6bed/charts/prometheus-blackbox-exporter/values.yaml#L463-L472
```

/cc @monotek @naseemkullah

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
