### PR TITLE
[kube-prometheus-stack] Fix indendation of rendered servicemonitor.scrapeLimits for kube-etcd

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -31,7 +31,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 72.5.1
+version: 72.5.2
 # Please do not add a renovate hint here, since appVersion updates involves manual tasks
 appVersion: v0.82.2
 kubeVersion: ">=1.19.0-0"

--- a/charts/kube-prometheus-stack/templates/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-etcd/servicemonitor.yaml
@@ -20,7 +20,7 @@ spec:
   targetLabels:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- include "servicemonitor.scrapeLimits" .Values.kubeEtcd.serviceMonitor | nindent 4 }}
+  {{- include "servicemonitor.scrapeLimits" .Values.kubeEtcd.serviceMonitor | nindent 2 }}
   selector:
     {{- if .Values.kubeEtcd.serviceMonitor.selector }}
     {{ tpl (toYaml .Values.kubeEtcd.serviceMonitor.selector | nindent 4) . }}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Corrects the indentation of the rendered `servicemonitor.scrapeLimits` template for `kube-etcd`, as the rendered properties should be at the same indentation level as the `targetLabels` property per the API for `ServiceMonitor`. Prior to Helm 3.18.0 this appears to have been ignored, but now results in the following error:

```
Error: INSTALLATION FAILED: YAML parse error on kube-prometheus-stack/templates/exporters/kube-etcd/servicemonitor.yaml: error converting YAML to JSON: yaml: line 19: mapping values are not allowed in this context
```

#### Which issue this PR fixes

- fixes #5648 

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
