### PR TITLE
[kube-prometheus-stack]  Fix insecure default password in grafana

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -31,7 +31,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 72.6.2
+version: 72.6.3
 # Please do not add a renovate hint here, since appVersion updates involves manual tasks
 appVersion: v0.82.2
 kubeVersion: ">=1.19.0-0"

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1290,8 +1290,16 @@ grafana:
   ##
   defaultDashboardsInterval: 1m
 
+  # Administrator credentials when not using an existing secret (see below)
   adminUser: admin
-  adminPassword: prom-operator
+  # adminPassword: strongpassword
+  
+  # Use an existing secret for the admin user.
+  admin:
+    ## Name of the secret. Can be templated.
+    existingSecret: ""
+    userKey: admin-user
+    passwordKey: admin-password
 
   rbac:
     ## If true, Grafana PSPs will be created


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

As of now, the kubeprometheus-stack chart defines a default admin password for Grafana: "prom-operator". 
By doing so, it's overriding the more secure default default behavior of the upstream Grafana chart, which simply generates a random password when none is set. [1](https://github.com/grafana/helm-charts/blob/8b52cc183bdceb0055085aff585533e88acce65c/charts/grafana/templates/_helpers.tpl#L109)

It's common practice for both bad actors and security scanners to attempt known default passwords on accidentally exposed instances. For example, see this [nuclei template](https://github.com/projectdiscovery/nuclei-templates/blob/main/http/default-logins/grafana/grafana-default-login.yaml), which demonstrates that this default password is well known in security circles.

This PR removes the default password, aligning the default behaviour with upstream Grafana.


#### Which issue this PR fixes


- fixes #4558

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
