### PR TITLE
[alertmanager] Fix empty object where handler field is required

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 1.19.0
+version: 1.19.1
 # renovate: github-releases=prometheus/alertmanager
 appVersion: v0.28.1
 kubeVersion: ">=1.19.0-0"

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -334,12 +334,12 @@ configmapReload:
   ##
   resources: {}
 
-  livenessProbe: {}
+  #livenessProbe: {}
     # httpGet:
     #   path: /healthz
     #   port: 8080
     #   scheme: HTTP
-  readinessProbe: {}
+  #readinessProbe: {}
     # httpGet:
     #   path: /healthz
     #   port: 8080


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This fixes a regression that was introduced in [PR5635](https://github.com/prometheus-community/helm-charts/pull/5635). The default Alertmanager `values.yaml` file is no longer valid.

Both `livenessProbe` and `readinessProbe` are declared as empty objects {}, but Kubernetes requires at least one handler field inside these probes.

#### Which issue this PR fixes

- fixes #5687

#### Special notes for your reviewer

@monotek 
@naseemkullah 

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
