### PR TITLE
[alertmanager] Make configmapReload probes really optional

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 1.19.0
+version: 1.19.1
 # renovate: github-releases=prometheus/alertmanager
 appVersion: v0.28.1
 kubeVersion: ">=1.19.0-0"

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -119,10 +119,14 @@ spec:
           ports:
             - containerPort: {{ . }}
           {{- end }}
+          {{- with .Values.configmapReload.livenessProbe }}
           livenessProbe:
-            {{- toYaml .Values.configmapReload.livenessProbe | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.configmapReload.readinessProbe }}
           readinessProbe:
-            {{- toYaml .Values.configmapReload.readinessProbe | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.configmapReload.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
#### What this PR does / why we need it

This PR fixes a regression introduced by me in PR
- #5635

In this PR my intent was to add the probes as an optional piece. Sadly Kubernetes does not accept `{}` for the probes fields like it does for `resources: {}`.

#### Which issue this PR fixes

- fixes #5687

#### Special notes for your reviewer

`---`

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
