### PR TITLE
[kube-prometheus-stack] Add the possibility to specify matchConditions for admissionWebhooks objects

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -31,7 +31,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 72.9.0
+version: 72.9.1
 
 # Please do not add a renovate hint here, since appVersion updates involves manual tasks
 appVersion: v0.82.2

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/mutatingWebhookConfiguration.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/mutatingWebhookConfiguration.yaml
@@ -78,4 +78,8 @@ webhooks:
     objectSelector:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.prometheusOperator.admissionWebhooks.matchConditions }}
+    matchConditions:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/validatingWebhookConfiguration.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/validatingWebhookConfiguration.yaml
@@ -78,4 +78,8 @@ webhooks:
     objectSelector:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.prometheusOperator.admissionWebhooks.matchConditions }}
+    matchConditions:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -2668,6 +2668,7 @@ prometheusOperator:
 
     namespaceSelector: {}
     objectSelector: {}
+    matchConditions: {}
 
     mutatingWebhookConfiguration:
       annotations: {}


### PR DESCRIPTION
#### What this PR does / why we need it

Add the possibility to specify `matchConditions` for admissionWebhooks objects. We have a use case where we don't want validation for some of our Prometheus rules. Currently, `matchLabels` allows filtering based on label presence, but there is no built-in way to exclude certain labels. Adding `matchConditions` would solve this problem by letting us define more flexible filtering logic.

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer

N/A

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
