### PR TITLE
[kube-prometheus-stack] fix: Ensure deduplication of `InfoInhibitor` alerts

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -31,7 +31,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 72.9.1
+version: 72.9.2
 
 # Please do not add a renovate hint here, since appVersion updates involves manual tasks
 appVersion: v0.82.2

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/general.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/general.rules.yaml
@@ -110,7 +110,12 @@ spec:
           '
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/general/infoinhibitor
         summary: Info-level alert inhibition.
-      expr: ALERTS{severity = "info"} == 1 unless on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}namespace) ALERTS{alertname != "InfoInhibitor", severity =~ "warning|critical", alertstate="firing"} == 1
+      expr: >-
+        count by ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}namespace) (
+          ALERTS{severity = "info"} == 1
+          unless on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}namespace)
+          ALERTS{alertname != "InfoInhibitor", severity =~ "warning|critical", alertstate="firing"} == 1
+        ) > 0
       labels:
         severity: {{ dig "InfoInhibitor" "severity" "none" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.general }}


### PR DESCRIPTION
#### What this PR does / why we need it

When two alerts with `info=severity` are raised in the same namespace (or namespace and other matching criteria as defined in `additionalAggregationLabels`), it is possible for the current `InfoInhibitor` rule to create two alerts with exactly the same labels. This results in the error reported in #1773 of duplicate label vectors, and also an increase in the number of rules failures which can lead to the default `PrometheusRuleFailures` alert also firing.

This fix changes the `InfoInhibitor` rule to aggregate its data based on the user's selected aggregation labels (plus the enforced namespace aggregation). This will ensure at most one alert can be created in the aggregation.

#### Which issue this PR fixes

Fixes #1773

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
