### PR TITLE
[prometheus-elastcsearch-exporter] allow to disable alias metrics [#5740]

### DIFF
--- a/charts/prometheus-elasticsearch-exporter/Chart.yaml
+++ b/charts/prometheus-elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Elasticsearch stats exporter for Prometheus
 name: prometheus-elasticsearch-exporter
-version: 6.7.2
+version: 6.7.3
 kubeVersion: ">=1.19.0-0"
 appVersion: "v1.9.0"
 home: https://github.com/prometheus-community/elasticsearch_exporter

--- a/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
+++ b/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
@@ -94,8 +94,8 @@ spec:
                     {{- if .Values.es.indices_mappings }}
                     "--es.indices_mappings",
                     {{- end }}
-                    {{- if .Values.es.aliases }}
-                    "--es.aliases",
+                    {{- if not .Values.es.aliases }}
+                    "--no-es.aliases",
                     {{- end }}
                     {{- if .Values.es.shards }}
                     "--es.shards",


### PR DESCRIPTION
#### What this PR does / why we need it
allow to disable alias metrics

they are enabled by default, so need explicit disabling instead of enabling

#### Which issue this PR fixes

- fixes #5740

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
