### PR TITLE
[prom-label-proxy] When enabling HPA, do not set .spec.replicas on the deployment

### DIFF
--- a/charts/prom-label-proxy/Chart.yaml
+++ b/charts/prom-label-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prom-label-proxy
 description: A proxy that enforces a given label in a given PromQL query.
 type: application
-version: 0.13.1
+version: 0.13.2
 # renovate: github=prometheus-community/prom-label-proxy
 appVersion: v0.11.1
 home: "https://github.com/prometheus-community/prom-label-proxy"

--- a/charts/prom-label-proxy/templates/deployment.yaml
+++ b/charts/prom-label-proxy/templates/deployment.yaml
@@ -6,7 +6,9 @@ metadata:
   labels:
     {{- include "prom-label-proxy.labels" . | nindent 4 }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "prom-label-proxy.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

When using the HPA resource for the prom-label-proxy chart, the `.spec.replicas` is still being set on the deployment. During upgrade the desiredCount is ignored and being reset to the `.spec.replicas` value by default. My change is to not set `.spec.replicas` on the deployment when using the HPA object.

#### Which issue this PR fixes

* `.spec.replicas` being set on the deployment of `prom-label-proxy` when using the HPA object.f


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
