### PR TITLE
[kube-state-metrics] Only set NodePort on valid service type

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - kubernetes
 type: application
-version: 5.36.0
+version: 5.37.0
 # renovate: github-releases=kubernetes/kube-state-metrics
 appVersion: 2.15.0
 home: https://github.com/kubernetes/kube-state-metrics/

--- a/charts/kube-state-metrics/templates/service.yaml
+++ b/charts/kube-state-metrics/templates/service.yaml
@@ -22,7 +22,7 @@ spec:
   - name: "http"
     protocol: TCP
     port: {{ .Values.service.port | default 8080}}
-  {{- if .Values.service.nodePort }}
+  {{- if ( and (eq .Values.service.type "NodePort" ) (not (empty .Values.service.nodePort)) ) }}
     nodePort: {{ .Values.service.nodePort }}
   {{- end }}
     targetPort: {{ .Values.service.port | default 8080}}
@@ -31,7 +31,7 @@ spec:
     protocol: TCP
     port: {{ .Values.selfMonitor.telemetryPort | default 8081 }}
     targetPort: {{ .Values.selfMonitor.telemetryPort | default 8081 }}
-  {{- if .Values.selfMonitor.telemetryNodePort }}
+  {{- if ( and (eq .Values.service.type "NodePort" ) (not (empty .Values.service.nodePort)) ) }}
     nodePort: {{ .Values.selfMonitor.telemetryNodePort }}
   {{- end }}
   {{ end }}


### PR DESCRIPTION
#### What this PR does / why we need it

The nodeport field on a service is only valid on Services of type NodePort.
Other charts in this repo handle this correctly, so adding the same if statement in kube-state-metrics chart.

#### Which issue this PR fixes

#### Special notes for your reviewer

Thanks in advance :)

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
