### PR TITLE
[prometheus-nginx-exporter] Fix custom namespace handling in service monitor

### DIFF
--- a/charts/prometheus-nginx-exporter/Chart.yaml
+++ b/charts/prometheus-nginx-exporter/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for NGINX Prometheus Exporter
 name: prometheus-nginx-exporter
-version: 1.5.0
+version: 1.5.1
 # renovate: github-releases=nginx/nginx-prometheus-exporter
 appVersion: 1.4.2
 home: https://github.com/nginxinc/nginx-prometheus-exporter

--- a/charts/prometheus-nginx-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-nginx-exporter/templates/servicemonitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-nginx-exporter.fullname" .  }}
-  namespace: {{ template "prometheus-nginx-exporter.namespace" . }}
+  namespace: {{ .Values.serviceMonitor.namespace | default (include "prometheus-nginx-exporter.namespace" .) }}
   {{- with .Values.additionalAnnotations }}
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
@@ -34,4 +34,7 @@ spec:
   selector:
     matchLabels:
       {{- include "prometheus-nginx-exporter.selectorLabels" . | indent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ include "prometheus-nginx-exporter.namespace" . }}
 {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Ensure Custom Namespace Is Used in ServiceMonitor
#### Which issue this PR fixes
I have installed prometheus-nginx-exporter in the nginx namespace but I want the service monitor to be installed in the monitoring namespace (different namespace).
And I see there is that option in values.yaml but it doesn't work well.
https://github.com/prometheus-community/helm-charts/blob/5c1972cbc0fcef75802d36d1f9b489f3555d107a/charts/prometheus-nginx-exporter/values.yaml#L77-L81
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
