### PR TITLE
[kube-prometheus-stack] add otlp configuration to prometheus.yaml

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -31,7 +31,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 75.2.1
+version: 75.3.0
 
 # Please do not add a renovate hint here, since appVersion updates involves manual tasks
 appVersion: v0.83.0

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -118,6 +118,10 @@ spec:
   - {{ tpl $enableFeatures $ }}
 {{- end }}
 {{- end }}
+{{- if .Values.prometheus.prometheusSpec.otlp }}
+  otlp:
+{{ toYaml .Values.prometheus.prometheusSpec.otlp | indent 4 }}
+{{- end }}
 {{- with .Values.prometheus.prometheusSpec.scrapeClasses }}
   scrapeClasses:
     {{- tpl (toYaml . | nindent 4) $ }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -3983,6 +3983,7 @@ prometheus:
       # promoteResourceAttributes: []
       # keepIdentifyingResourceAttributes: false
       # translationStrategy: NoUTF8EscapingWithSuffixes
+      # convertHistogramsToNHCB: false
 
     ##
     serviceName:

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -3977,6 +3977,13 @@ prometheus:
     enableFeatures: []
     # - exemplar-storage
 
+    ## https://prometheus.io/docs/guides/opentelemetry
+    ##
+    otlp: {}
+      # promoteResourceAttributes: []
+      # keepIdentifyingResourceAttributes: false
+      # translationStrategy: NoUTF8EscapingWithSuffixes
+
     ##
     serviceName:
 


### PR DESCRIPTION
#### What this PR does / why we need it
To provide supported otlp configuration in the prometheus.yaml configuration file, as described at https://prometheus.io/docs/prometheus/latest/configuration/configuration and https://prometheus.io/docs/guides/opentelemetry.
Addapted to kube-prometheus-stack following the CustomResourceDefinition file helm-charts\charts\kube-prometheus-stack\charts\crds\crds\crd-prometheuses.yaml

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #5080 

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
