### PR TITLE
[kube-prometheus-stack] handling scrapeProtocols as an array

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -31,7 +31,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 75.3.0
+version: 75.3.1
 
 # Please do not add a renovate hint here, since appVersion updates involves manual tasks
 appVersion: v0.83.0

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -136,8 +136,9 @@ spec:
 {{- if .Values.prometheus.prometheusSpec.scrapeInterval }}
   scrapeInterval: {{ .Values.prometheus.prometheusSpec.scrapeInterval }}
 {{- end }}
-{{- if .Values.prometheus.prometheusSpec.scrapeProtocols }}
-  scrapeProtocols: {{ .Values.prometheus.prometheusSpec.scrapeProtocols }}
+{{- with .Values.prometheus.prometheusSpec.scrapeProtocols }}
+  scrapeProtocols:
+    {{- tpl (toYaml . | nindent 4) $ }}
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.scrapeTimeout }}
   scrapeTimeout: {{ .Values.prometheus.prometheusSpec.scrapeTimeout }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -3491,9 +3491,6 @@ prometheus:
     ## relabel configs to apply to samples before ingestion.
     relabelings: []
 
-    ## Set default scrapeProtocols for Prometheus instances
-    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#scrapeprotocolstring-alias
-    scrapeProtocols: []
   # Service for external access to sidecar
   # Enabling this creates a service to expose thanos-sidecar outside the cluster.
   thanosServiceExternal:
@@ -4647,6 +4644,10 @@ prometheus:
     ## greater than 60 (seconds). Otherwise it will be equal to 900 seconds (15
     ## minutes).
     maximumStartupDurationSeconds: 0
+
+    ## Set default scrapeProtocols for Prometheus instances
+    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#scrapeprotocolstring-alias
+    scrapeProtocols: []
 
   additionalRulesForClusterRole: []
   #  - apiGroups: [ "" ]


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
The PR fixes Handling of `scrapeProtocols` in prometheus CR. As the values are an array, they need to be templated as such. Previously using an array for this values threw following error
```
Error: UPGRADE FAILED: cannot patch "prom-stack-kube-prometheus-prometheus" with kind Prometheus: Prometheus.monitoring.coreos.com "prom-stack-kube-prometheus-prometheus" is invalid: spec.scrapeProtocols[0]: Unsupported value: "OpenMetricsText1.0.0 OpenMetricsText0.0.1 PrometheusText0.0.4 PrometheusText1.0.0": supported values: "PrometheusProto", "OpenMetricsText0.0.1", "OpenMetricsText1.0.0", "PrometheusText0.0.4", "PrometheusText1.0.0"
```

Also the scrape protocol configuration seems to have been misplaced in the default values files - I moved it to the correct section in the yaml file

Tested locally using values
```yaml
prometheus:
  prometheusSpec:
    ## Set default scrapeProtocols for Prometheus instances
    ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#scrapeprotocolstring-alias
    scrapeProtocols: [ "OpenMetricsText1.0.0", "OpenMetricsText0.0.1", "PrometheusText0.0.4", "PrometheusText1.0.0" ]
```

results before the change:
```
▶ helm template . -s templates/prometheus/prometheus.yaml -f testing.values.yaml | grep scrapeProtocols

scrapeProtocols: [OpenMetricsText1.0.0 OpenMetricsText0.0.1 PrometheusText0.0.4 PrometheusText1.0.0]
```

results after the change:
```
▶ helm template . -s templates/prometheus/prometheus.yaml -f testing.values.yaml | grep scrapeProtocols -a5

1042:  scrapeProtocols:
1061-    - OpenMetricsText1.0.0
1088-    - OpenMetricsText0.0.1
1115-    - PrometheusText0.0.4
1141-    - PrometheusText1.0.0
```

#### Which issue this PR fixes
Didn't find any issue - rather than opening an issue, I opened a PR

#### Special notes for your reviewer
N/A

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
