### PR TITLE
[kube-prometheus-stack] Allow null value in alertmanagerConfigNamespaceSelector

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -31,7 +31,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 75.3.0
+version: 75.3.1
 
 # Please do not add a renovate hint here, since appVersion updates involves manual tasks
 appVersion: v0.83.0

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -31,7 +31,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 75.3.1
+version: 75.3.2
 
 # Please do not add a renovate hint here, since appVersion updates involves manual tasks
 appVersion: v0.83.0

--- a/charts/kube-prometheus-stack/templates/alertmanager/alertmanager.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/alertmanager.yaml
@@ -75,12 +75,8 @@ spec:
 {{ else }}
   alertmanagerConfigSelector: {}
 {{- end }}
-{{- if .Values.alertmanager.alertmanagerSpec.alertmanagerConfigNamespaceSelector }}
   alertmanagerConfigNamespaceSelector:
-{{ tpl (toYaml .Values.alertmanager.alertmanagerSpec.alertmanagerConfigNamespaceSelector | indent 4) . }}
-{{ else }}
-  alertmanagerConfigNamespaceSelector: {}
-{{- end }}
+{{ tpl (toYaml .Values.alertmanager.alertmanagerSpec.alertmanagerConfigNamespaceSelector | indent 4 | default "null") .  }}
 {{- if .Values.alertmanager.alertmanagerSpec.web }}
   web:
 {{ toYaml .Values.alertmanager.alertmanagerSpec.web | indent 4 }}

--- a/charts/kube-prometheus-stack/unittests/alertmanager/alertmanager_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/alertmanager/alertmanager_test.yaml
@@ -24,3 +24,26 @@ tests:
       - equal:
           path: spec.tolerations[0].key
           value: key1
+  # 5797
+  - it: should be empty value if alertmanagerConfigNamespaceSelector is not set
+    set:
+      alertmanager.alertmanagerSpec.alertmanagerConfigNamespaceSelector: 
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.alertmanagerConfigNamespaceSelector
+          value: null
+
+  - it: should be empty map object if alertmanagerConfigNamespaceSelector is empty map
+    set:
+      alertmanager.alertmanagerSpec.alertmanagerConfigNamespaceSelector: {}
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.alertmanagerConfigNamespaceSelector
+          value: {}
+
+
+    


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
This PR fixes an issue where the `alertmanagerConfigNamespaceSelector` field was intended to be `null` when unspecified, but the chart rendered it as an empty map instead. This caused `Alertmanager` to select resources from all namespaces, rather than restricting discovery to its own namespace.

#### Which issue this PR fixes

- fixes #4704 


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
