### PR TITLE
[prometheus-postgres-exporter] use labels suggested by K8s best practices

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: v0.17.1
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 6.10.2
+version: 7.0.0
 home: https://github.com/prometheus-community/postgres_exporter
 sources:
   - https://github.com/prometheus-community/postgres_exporter

--- a/charts/prometheus-postgres-exporter/README.md
+++ b/charts/prometheus-postgres-exporter/README.md
@@ -46,6 +46,31 @@ helm upgrade [RELEASE_NAME] prometheus-community/prometheus-postgres-exporter --
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
+
+### To 7.0.0
+
+Labels and selectors have been replaced following [Helm 3 label and annotation best practices](https://helmsh/docs/chart_best_practices/labels/):
+
+| Previous            | Current                      |
+|---------------------|------------------------------|
+| app                 | app.kubernetes.io/name       |
+| chart               | helm.sh/chart                |
+| [none]              | app.kubernetes.io/version    |
+| heritage            | [none]                       |
+| release             | app.kubernetes.io/instance   |
+
+As the change is affecting immutable selector labels, the deployment must be deleted before upgrading the release, e.g.:
+
+```console
+kubectl delete deploy -l app=prometheus-postgres-exporter --cascade=orphan
+```
+
+Once the resources have been deleted, you can upgrade the release:
+
+```console
+helm upgrade -i RELEASE_NAME prometheus-community/prometheus-postgres-exporter
+```
+
 ### To 6.0.0
 
 Image repository has been split into two values: the new `image.registry` value and the already existing `image.repository` value. No change is required when using the default for `image.repository`. If you have previously modified field `image.repository`, please, set the two fields accordingly.

--- a/charts/prometheus-postgres-exporter/README.md
+++ b/charts/prometheus-postgres-exporter/README.md
@@ -46,7 +46,6 @@ helm upgrade [RELEASE_NAME] prometheus-community/prometheus-postgres-exporter --
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
-
 ### To 7.0.0
 
 Labels and selectors have been replaced following [Helm 3 label and annotation best practices](https://helmsh/docs/chart_best_practices/labels/):

--- a/charts/prometheus-postgres-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-postgres-exporter/templates/_helpers.tpl
@@ -35,9 +35,11 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "prometheus-postgres-exporter.labels" -}}
-chart: {{ include "prometheus-postgres-exporter.chart" . }}
+helm.sh/chart: {{ include "prometheus-postgres-exporter.chart" . }}
 {{ include "prometheus-postgres-exporter.selectorLabels" . }}
-heritage: {{ .Release.Service }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
 {{- if .Values.commonLabels}}
 {{ toYaml .Values.commonLabels }}
 {{- end }}
@@ -47,8 +49,8 @@ heritage: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "prometheus-postgres-exporter.selectorLabels" -}}
-app: {{ include "prometheus-postgres-exporter.name" . }}
-release: {{ .Release.Name }}
+app.kubernetes.io/name: {{ include "prometheus-postgres-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
CC: @gianrubio @zanhsieh @zeritti 


#### What this PR does / why we need it

The benefit of using those labels, suggested by the https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/ , is that many applications are able to work with them nativeli, generally making thinks easier.

This brings this helm-chart close to the other in this repository.

#### Which issue this PR fixes

No open issue

#### Special notes for your reviewer

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
