### PR TITLE
[kube-prometheus-stack]: fix duplicate series in InfoInhibitor

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -31,7 +31,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 75.10.0
+version: 75.10.1
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.83.0
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/general.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/general.rules.yaml
@@ -112,6 +112,7 @@ spec:
         summary: Info-level alert inhibition.
       expr: ALERTS{severity = "info"} == 1 unless on ({{ range $.Values.defaultRules.additionalAggregationLabels }}{{ . }},{{ end }}namespace) ALERTS{alertname != "InfoInhibitor", severity =~ "warning|critical", alertstate="firing"} == 1
       labels:
+        source_alert: '{{ .Labels.alertname }}'
         severity: {{ dig "InfoInhibitor" "severity" "none" .Values.customRules }}
       {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.general }}
         {{- with .Values.defaultRules.additionalRuleLabels }}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
Same as 
https://github.com/prometheus-community/helm-charts/pull/5731/files
#### What this PR does / why we need it
Prevent vector from containing metrics with the same labelset after applying alert labels in InfoInhibitor alert

Problem:
The InfoInhibitor alert was failing to evaluate with the following error in Prometheus:
```
expr:[ALERTS{severity="info"} == 1 unless on (namespace) ALERTS{alertname!="InfoInhibitor",alertstate="firing",severity=~"warning|critical"} == 1
```
`vector contains metrics with the same labelset after applying alert labels`
<img width="276" alt="image" src="https://github.com/user-attachments/assets/56b8ae57-8552-40f6-a0df-2269afac8984" />



Root Cause:
Changed `NodeCPUHighUsage, NodeSystemSaturation` to info
Prometheus saw them as duplicate series with identical labelsets , triggering the vector deduplication error.

Solution:
Added a new label to disambiguate each InfoInhibitor alert based on the originating alert:
```
source_alert: '{{ .Labels.alertname }}'
```



This ensures that each
InfoInhibitor alert includes the alertname of the original info alert that triggered it, resulting in unique labelsets
![image](https://github.com/user-attachments/assets/2b8f7c6e-a88f-4a12-a42f-efcaded5cb48)

The current setup with `unless on (namespace)` works fine for all alerts except those ones related to nodes 

Fixes https://github.com/prometheus-community/helm-charts/issues/1773

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
