### PR TITLE
[prometheus-nats-exporter] add configuration option for imagePullSecrets

### DIFF
--- a/charts/prometheus-nats-exporter/Chart.yaml
+++ b/charts/prometheus-nats-exporter/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: 0.17.3
 description: A Helm chart for prometheus-nats-exporter
 name: prometheus-nats-exporter
-version: 2.19.0
+version: 2.20.0
 home: https://github.com/nats-io/prometheus-nats-exporter
 sources:
   - https://github.com/nats-io/prometheus-nats-exporter

--- a/charts/prometheus-nats-exporter/templates/deployment.yaml
+++ b/charts/prometheus-nats-exporter/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
 {{ toYaml .Values.annotations | indent 8 }}
 {{- end}}
     spec:
+{{- if .Values.image.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.image.imagePullSecrets | indent 8 }}
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}
           args:

--- a/charts/prometheus-nats-exporter/values.yaml
+++ b/charts/prometheus-nats-exporter/values.yaml
@@ -8,6 +8,7 @@ image:
   repository: natsio/prometheus-nats-exporter
   tag: ""
   pullPolicy: IfNotPresent
+  imagePullSecrets: []
 
 service:
   labels: {}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This adds a new option to the helm values to allow specifying imagePullSecrets.
The option is `image.imagePullSecrets` and defaults to `[]`.

This is required in our deployment scenario since we use an internal image mirror.

#### Special notes for your reviewer

Existing users will notice no migration changes since the deployment template only adds the relevant blocks to the generated manifest when `image.imagePullSecrets` is set to something sensible.
For this reason, I bumped the minor version since the change adds a new feature but does not break anything.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
