### PR TITLE
[prometheus-json-exporter] Fix YAML indentation issues

### DIFF
--- a/charts/prometheus-json-exporter/Chart.yaml
+++ b/charts/prometheus-json-exporter/Chart.yaml
@@ -10,7 +10,7 @@ type: application
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-version: 0.19.0
+version: 0.19.1
 appVersion: "v0.7.0"
 home: https://github.com/prometheus-community/json_exporter
 maintainers:

--- a/charts/prometheus-json-exporter/templates/deployment.yaml
+++ b/charts/prometheus-json-exporter/templates/deployment.yaml
@@ -48,43 +48,43 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-      - name: {{ .Chart.Name }}
-        {{- with .Values.extraArgs }}
-        args:
-        {{- range . }}
-        - {{ .name | quote }}
-        - {{ .value | quote }}
-        {{- end }}
-        {{- end }}
-        {{- with .Values.environmentVariables }}
-        env:
-          {{- toYaml . | nindent 12}}
-        {{- end }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        ports:
-          - name: http
-            containerPort: 7979
-            protocol: TCP
-        {{- with .Values.livenessProbe }}
-        livenessProbe: {{- toYaml . | nindent 12 }}
-        {{- end }}
-        {{- with .Values.readinessProbe }}
-        readinessProbe: {{- toYaml . | nindent 12 }}
-        {{- end }}
-        resources:
-          {{- toYaml .Values.resources | nindent 12 }}
-        volumeMounts:
-          - name: config-configmap-volume
-            mountPath: /config.yml
-            subPath: config.yml
-        {{- with .Values.additionalVolumeMounts }}
-          {{- toYaml . | nindent 12 }}
-        {{- end  }}
-        securityContext:
-          {{- toYaml .Values.securityContext | nindent 12 }}
+        - name: {{ .Chart.Name }}
+          {{- with .Values.extraArgs }}
+          args:
+          {{- range . }}
+          - {{ .name | quote }}
+          - {{ .value | quote }}
+          {{- end }}
+          {{- end }}
+          {{- with .Values.environmentVariables }}
+          env:
+            {{- toYaml . | nindent 12}}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 7979
+              protocol: TCP
+          {{- with .Values.livenessProbe }}
+          livenessProbe: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: config-configmap-volume
+              mountPath: /config.yml
+              subPath: config.yml
+          {{- with .Values.additionalVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end  }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
       {{- with .Values.extraContainers }}
-      {{- toYaml . | nindent 6 }}
+      {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
       - name: config-configmap-volume


### PR DESCRIPTION
#### What this PR does / why we need it

This PR fixes indentation inconsistencies in the Helm chart YAML templates that were causing template rendering errors and YAML validation failures. Correcting the indentation ensures the chart renders properly and can be deployed without issues. 

#### Special notes for your reviewer

The changes are purely formatting-related; no functional logic was altered. Tested Helm template rendering locally with helm template to confirm no errors. Please verify if there are any other files with similar indentation issues. 

What we experienced in our tf plan:

prometheus-json-exporter
  coalesce.go:237: warning: skipped value for prometheus-json-exporter.nodeSelector: Not a table.
  Error: YAML parse error on prometheus-json-exporter/templates/deployment.yaml: error converting YAML to JSON: yaml: line 55:    did not find expected key

#### Checklist 

- [✓ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [✓] Chart Version bumped
- [✓ ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)