### PR TITLE
- Collector values restructured based on https://github.com/kubernete…

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - kubernetes
 type: application
-version: 6.1.0
+version: 6.1.1
 # renovate: github-releases=kubernetes/kube-state-metrics
 appVersion: 2.16.0
 home: https://github.com/kubernetes/kube-state-metrics/

--- a/charts/kube-state-metrics/templates/role.yaml
+++ b/charts/kube-state-metrics/templates/role.yaml
@@ -21,10 +21,22 @@ rules:
   - certificatesigningrequests
   verbs: ["list", "watch"]
 {{ end -}}
+{{ if has "clusterroles" $.Values.collectors }}
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources:
+  - clusterroles
+  verbs: ["list", "watch"]
+{{ end -}}
 {{ if has "configmaps" $.Values.collectors }}
 - apiGroups: [""]
   resources:
   - configmaps
+  verbs: ["list", "watch"]
+{{ end -}}
+{{ if has "clusterrolebindings" $.Values.collectors }}
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources:
+  - clusterrolebindings
   verbs: ["list", "watch"]
 {{ end -}}
 {{ if has "cronjobs" $.Values.collectors }}
@@ -69,6 +81,12 @@ rules:
   - ingresses
   verbs: ["list", "watch"]
 {{ end -}}
+{{ if has "ingressclasses" $.Values.collectors }}
+- apiGroups: ["networking.k8s.io"]
+  resources:
+  - ingressclasses
+  verbs: ["list", "watch"]
+{{ end -}}
 {{ if has "jobs" $.Values.collectors }}
 - apiGroups: ["batch"]
   resources:
@@ -103,30 +121,6 @@ rules:
 - apiGroups: ["networking.k8s.io"]
   resources:
   - networkpolicies
-  verbs: ["list", "watch"]
-{{ end -}}
-{{ if has "ingressclasses" $.Values.collectors }}
-- apiGroups: ["networking.k8s.io"]
-  resources:
-  - ingressclasses
-  verbs: ["list", "watch"]
-{{ end -}}
-{{ if has "clusterrolebindings" $.Values.collectors }}
-- apiGroups: ["rbac.authorization.k8s.io"]
-  resources:
-  - clusterrolebindings
-  verbs: ["list", "watch"]
-{{ end -}}
-{{ if has "clusterroles" $.Values.collectors }}
-- apiGroups: ["rbac.authorization.k8s.io"]
-  resources:
-  - clusterroles
-  verbs: ["list", "watch"]
-{{ end -}}
-{{ if has "roles" $.Values.collectors }}
-- apiGroups: ["rbac.authorization.k8s.io"]
-  resources:
-  - roles
   verbs: ["list", "watch"]
 {{ end -}}
 {{ if has "nodes" $.Values.collectors }}
@@ -177,6 +171,18 @@ rules:
   - resourcequotas
   verbs: ["list", "watch"]
 {{ end -}}
+{{ if has "roles" $.Values.collectors }}
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources:
+  - roles
+  verbs: ["list", "watch"]
+{{ end -}}
+{{ if has "rolebindings" $.Values.collectors }}
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources:
+  - rolebindings
+  verbs: ["list", "watch"]
+{{ end -}}
 {{ if has "secrets" $.Values.collectors }}
 - apiGroups: [""]
   resources:
@@ -193,6 +199,12 @@ rules:
 - apiGroups: ["apps"]
   resources:
   - statefulsets
+  verbs: ["list", "watch"]
+{{ end -}}
+{{ if has "serviceaccounts" $.Values.collectors }}
+- apiGroups: [""]
+  resources:
+  - serviceaccounts
   verbs: ["list", "watch"]
 {{ end -}}
 {{ if has "storageclasses" $.Values.collectors }}

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -396,13 +396,17 @@ metricAnnotationsAllowList: []
 # By default, all available resources are enabled, comment out to disable.
 collectors:
   - certificatesigningrequests
+  # - clusterroles
   - configmaps
+  # - clusterrolebindings
   - cronjobs
   - daemonsets
   - deployments
   - endpoints
+  # - endpointslices
   - horizontalpodautoscalers
   - ingresses
+  # - ingressclasses
   - jobs
   - leases
   - limitranges
@@ -417,16 +421,15 @@ collectors:
   - replicasets
   - replicationcontrollers
   - resourcequotas
+  # - roles
+  # - rolebindings
   - secrets
   - services
+  # - serviceaccounts
   - statefulsets
   - storageclasses
   - validatingwebhookconfigurations
   - volumeattachments
-  # - ingressclasses
-  # - clusterrolebindings
-  # - clusterroles
-  # - roles
 
 # Enabling kubeconfig will pass the --kubeconfig argument to the container
 kubeconfig:


### PR DESCRIPTION
Helm collector values and roles are better aligned with

[builder.go#L326-L360](https://github.com/kubernetes/kube-state-metrics/blob/main/internal/store/builder.go#L326-L360)

- New grants added following https://github.com/prometheus-community/helm-charts/pull/5357/files for rolebindings and serviceaccounts

@dotdc, @mrueg, @tariq1890 


#### What this PR does / why we need it

The serviceaccount and rolebindings collector fails for missing permissions.

#### Which issue this PR fixes

- fixes #

#### Special notes for your reviewer
values.yaml and roles.yaml restructured for easier aligning with the collector source code.