### PR TITLE
[kube-state-metrics] Document OCI artiacts in README

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - kubernetes
 type: application
-version: 6.1.0
+version: 6.1.1
 # renovate: github-releases=kubernetes/kube-state-metrics
 appVersion: 2.16.0
 home: https://github.com/kubernetes/kube-state-metrics/

--- a/charts/kube-state-metrics/README.md
+++ b/charts/kube-state-metrics/README.md
@@ -2,27 +2,26 @@
 
 Installs the [kube-state-metrics agent](https://github.com/kubernetes/kube-state-metrics).
 
-## Get Repository Info
-<!-- textlint-disable -->
+## Usage
+
+The chart is distributed as an [OCI Artifact](https://helm.sh/docs/topics/registries/) as well as via a traditional [Helm Repository](https://helm.sh/docs/topics/chart_repository/).
+
+- OCI Artifact: `oci://ghcr.io/prometheus-community/charts/kube-state-metrics`
+- Helm Repository: `https://prometheus-community.github.io/helm-charts` with chart `kube-state-metrics`
+
+The installation instructions use the OCI registry. Refer to the [`helm repo`]([`helm repo`](https://helm.sh/docs/helm/helm_repo/)) command documentation for information on installing charts via the traditional repository.
+
+### Install Chart
+
 ```console
-helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo update
-```
-
-_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
-<!-- textlint-enable -->
-
-## Install Chart
-
-```console
-helm install [RELEASE_NAME] prometheus-community/kube-state-metrics [flags]
+helm install [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/kube-state-metrics [flags]
 ```
 
 _See [configuration](#configuration) below._
 
 _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
 
-## Uninstall Chart
+### Uninstall Chart
 
 ```console
 helm uninstall [RELEASE_NAME]
@@ -32,19 +31,18 @@ This removes all the Kubernetes components associated with the chart and deletes
 
 _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
 
-## Upgrading Chart
+### Upgrading Chart
 
 ```console
-helm upgrade [RELEASE_NAME] prometheus-community/kube-state-metrics [flags]
+helm upgrade [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/kube-state-metrics [flags]
 ```
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
-### Migrating from stable/kube-state-metrics and kubernetes/kube-state-metrics
+#### Migrating from stable/kube-state-metrics and kubernetes/kube-state-metrics
 
 You can upgrade in-place:
 
-1. [get repository info](#get-repository-info)
 1. [upgrade](#upgrading-chart) your existing release name using the new chart repository
 
 ## Upgrading to v6.0.0
@@ -66,7 +64,7 @@ The upgraded chart now the following changes:
 See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments:
 
 ```console
-helm show values prometheus-community/kube-state-metrics
+helm show values oci://ghcr.io/prometheus-community/charts/kube-state-metrics
 ```
 
 ### kube-rbac-proxy


### PR DESCRIPTION
#### What this PR does / why we need it

OCI artifacts have been distributed for a while now but their usage has never been documented. I have adapted the charts README to add this information.

#### Which issue this PR fixes

- #2454

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)