### PR TITLE
[prom-label-proxy] Document OCI artiacts in README

### DIFF
--- a/charts/prom-label-proxy/Chart.yaml
+++ b/charts/prom-label-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prom-label-proxy
 description: A proxy that enforces a given label in a given PromQL query.
 type: application
-version: 0.13.2
+version: 0.13.3
 # renovate: github=prometheus-community/prom-label-proxy
 appVersion: v0.11.1
 home: "https://github.com/prometheus-community/prom-label-proxy"

--- a/charts/prom-label-proxy/README.md
+++ b/charts/prom-label-proxy/README.md
@@ -2,28 +2,28 @@
 
 A proxy that enforces a given label in a given PromQL query.
 
-**Homepage:** <https://github.com/prometheus-community/prom-label-proxy>
+**Homepage:** <https://github.com/oci://ghcr.io/prometheus-community/charts/prom-label-proxy>
 
-## Get Repository Info
+## Usage
+
+The chart is distributed as an [OCI Artifact](https://helm.sh/docs/topics/registries/) as well as via a traditional [Helm Repository](https://helm.sh/docs/topics/chart_repository/).
+
+- OCI Artifact: `oci://ghcr.io/prometheus-community/charts/prom-label-proxy`
+- Helm Repository: `https://prometheus-community.github.io/helm-charts` with chart `prom-label-proxy`
+
+The installation instructions use the OCI registry. Refer to the [`helm repo`]([`helm repo`](https://helm.sh/docs/helm/helm_repo/)) command documentation for information on installing charts via the traditional repository.
+
+### Install Chart
 
 ```console
-helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo update
-```
-
-_See [`helm repo`](https://helm.sh/docs/helm/helm_repo/) for command documentation._
-
-## Install Chart
-
-```console
-helm install [RELEASE_NAME] prometheus-community/prom-label-proxy
+helm install [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/prom-label-proxy
 ```
 
 _See [configuration](#configuration) below._
 
 _See [`helm install`](https://helm.sh/docs/helm/helm_install/) for command documentation._
 
-## Uninstall Chart
+### Uninstall Chart
 
 ```console
 helm uninstall [RELEASE_NAME]
@@ -33,7 +33,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 
 _See [`helm uninstall`](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
 
-## Upgrading Chart
+### Upgrading Chart
 
 ```console
 helm upgrade [RELEASE_NAME] [CHART] --install
@@ -46,7 +46,7 @@ _See [`helm upgrade`](https://helm.sh/docs/helm/helm_upgrade/) for command docum
 See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
 
 ```console
-helm show values prometheus-community/prom-label-proxy
+helm show values oci://ghcr.io/prometheus-community/charts/prom-label-proxy
 ```
 
 ### kube-rbac-proxy


### PR DESCRIPTION
#### What this PR does / why we need it

OCI artifacts have been distributed for a while now but their usage has never been documented. I have adapted the charts README to add this information.

#### Which issue this PR fixes

- #2454

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)