### PR TITLE
[prometheus-adapter] Document OCI artiacts in README

### DIFF
--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 4.14.1
+version: 4.14.2
 appVersion: v0.12.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/kubernetes-sigs/prometheus-adapter

--- a/charts/prometheus-adapter/README.md
+++ b/charts/prometheus-adapter/README.md
@@ -6,26 +6,26 @@ Installs the [Prometheus Adapter](https://github.com/kubernetes-sigs/prometheus-
 
 Kubernetes 1.14+
 
-## Get Helm Repositories Info
+## Usage
+
+The chart is distributed as an [OCI Artifact](https://helm.sh/docs/topics/registries/) as well as via a traditional [Helm Repository](https://helm.sh/docs/topics/chart_repository/).
+
+- OCI Artifact: `oci://ghcr.io/prometheus-community/charts/prometheus-adapter`
+- Helm Repository: `https://prometheus-community.github.io/helm-charts` with chart `prometheus-adapter`
+
+The installation instructions use the OCI registry. Refer to the [`helm repo`]([`helm repo`](https://helm.sh/docs/helm/helm_repo/)) command documentation for information on installing charts via the traditional repository.
+
+### Install Helm Chart
 
 ```console
-helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo update
-```
-
-_See [`helm repo`](https://helm.sh/docs/helm/helm_repo/) for command documentation._
-
-## Install Helm Chart
-
-```console
-helm install [RELEASE_NAME] prometheus-community/prometheus-adapter
+helm install [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/prometheus-adapter
 ```
 
 _See [configuration](#configuration) below._
 
 _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
 
-## Uninstall Helm Chart
+### Uninstall Helm Chart
 
 ```console
 helm uninstall [RELEASE_NAME]
@@ -35,7 +35,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 
 _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
 
-## Upgrading Helm Chart
+### Upgrading Helm Chart
 
 ```console
 helm upgrade [RELEASE_NAME] [CHART] --install
@@ -43,15 +43,15 @@ helm upgrade [RELEASE_NAME] [CHART] --install
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
-### To 4.2.0
+#### To 4.2.0
 
 Readiness and liveness probes are now fully configurable through values `readinessProbe` and `livenessProbe`. The previous values have been kept as defaults.
 
-### To 4.0.0
+#### To 4.0.0
 
 Previously, security context of the container was set directly in the deployment template. This release makes it configurable through the new configuration variable `securityContext` whilst keeping the previously set values as defaults. Furthermore, previous variable `runAsUser` is now set in `securityContext` and is not used any longer. Please, use `securityContext.runAsUser` instead. In the same security context, `seccompProfile` has been enabled and set to type `RuntimeDefault`.
 
-### To 3.0.0
+#### To 3.0.0
 
 Due to a change in deployment labels, the upgrade requires `helm upgrade --force` in order to re-create the deployment.
 
@@ -60,7 +60,7 @@ Due to a change in deployment labels, the upgrade requires `helm upgrade --force
 See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
 
 ```console
-helm show values prometheus-community/prometheus-adapter
+helm show values oci://ghcr.io/prometheus-community/charts/prometheus-adapter
 ```
 
 ### Prometheus Service Endpoint


### PR DESCRIPTION
#### What this PR does / why we need it

OCI artifacts have been distributed for a while now but their usage has never been documented. I have adapted the charts README to add this information.

#### Which issue this PR fixes

- #2454

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)