### PR TITLE
[prometheus-blackbox-exporter] Document OCI artiacts in README

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 11.1.0
+version: 11.1.1
 appVersion: v0.26.0
 kubeVersion: ">=1.21.0-0"
 home: https://github.com/prometheus/blackbox_exporter

--- a/charts/prometheus-blackbox-exporter/README.md
+++ b/charts/prometheus-blackbox-exporter/README.md
@@ -11,26 +11,26 @@ This chart creates a Blackbox-Exporter deployment on a [Kubernetes](http://kuber
 - Kubernetes 1.8+ with Beta APIs enabled
 - Helm >= 3.0
 
-## Get Repository Info
+## Usage
+
+The chart is distributed as an [OCI Artifact](https://helm.sh/docs/topics/registries/) as well as via a traditional [Helm Repository](https://helm.sh/docs/topics/chart_repository/).
+
+- OCI Artifact: `oci://ghcr.io/prometheus-community/charts/prometheus-blackbox-exporter`
+- Helm Repository: `https://prometheus-community.github.io/helm-charts` with chart `prometheus-blackbox-exporter`
+
+The installation instructions use the OCI registry. Refer to the [`helm repo`]([`helm repo`](https://helm.sh/docs/helm/helm_repo/)) command documentation for information on installing charts via the traditional repository.
+
+### Install Chart
 
 ```console
-helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo update
-```
-
-_See [`helm repo`](https://helm.sh/docs/helm/helm_repo/) for command documentation._
-
-## Install Chart
-
-```console
-helm install [RELEASE_NAME] prometheus-community/prometheus-blackbox-exporter
+helm install [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/prometheus-blackbox-exporter
 ```
 
 _See [configuration](#configuration) below._
 
 _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
 
-## Uninstall Chart
+### Uninstall Chart
 
 ```console
 helm uninstall [RELEASE_NAME]
@@ -40,7 +40,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 
 _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
 
-## Upgrading Chart
+### Upgrading Chart
 
 ```console
 helm upgrade [RELEASE_NAME] [CHART] --install
@@ -48,26 +48,26 @@ helm upgrade [RELEASE_NAME] [CHART] --install
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
-### To 11.0.0
+#### To 11.0.0
 
 This version removes support for the deprecated Kubernetes API `extensions/v1beta1`, `networking.k8s.io/v1beta1`, and `rbac.authorization.k8s.io/v1beta1`. and associated attributes.
 
-### To 10.0.0
+#### To 10.0.0
 
 - `extraEnvFromSecret` got replaced with `extraEnvFrom`
 - `extraEnv` handling got changed to use k8s env definitions as list of maps
 
-### To 9.0.0
+#### To 9.0.0
 
 This version remove pod security policy as it is deprecated.
 
-### To 8.0.0
+#### To 8.0.0
 
 - The default image is set to `quay.io/prometheus/blackbox-exporter` instead `prom/blackbox-exporter`
 - `image.repository` is now split into `image.registry` and `image.repository`.
   For the old behavior, set `image.registry` to an empty string and only use `image.repository`.
 
-### To 7.0.0
+#### To 7.0.0
 
 This version introduces the `securityContext` and `podSecurityContext` and removes `allowICMP`option.
 
@@ -81,20 +81,20 @@ securityContext:
     add: ["NET_RAW"]
 ```
 
-### To 6.0.0
+#### To 6.0.0
 
 This version introduces the relabeling field for the ServiceMonitor.
 All values in the list `additionalRelabeling` will now appear under `relabelings` instead of `metricRelabelings`.
 
-### To 5.0.0
+#### To 5.0.0
 
 This version removes Helm 2 support. Also the ingress config has changed, so you have to adapt to the example in the values.yaml.
 
-### To 4.0.0
+#### To 4.0.0
 
 This version create the service account by default and introduce pod security policy, it can be enabled by setting `pspEnabled: true`.
 
-### To 2.0.0
+#### To 2.0.0
 
 This version removes the `podDisruptionBudget.enabled` parameter and changes the default value of `podDisruptionBudget` to `{}`, in order to fix Helm 3 compatibility.
 
@@ -105,7 +105,7 @@ podDisruptionBudget:
   maxUnavailable: 0
 ```
 
-### To 1.0.0
+#### To 1.0.0
 
 This version introduce the new recommended labels.
 
@@ -122,5 +122,5 @@ Note that this will cause downtime of the blackbox.
 See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
 
 ```console
-helm show values prometheus-community/prometheus-blackbox-exporter
+helm show values oci://ghcr.io/prometheus-community/charts/prometheus-blackbox-exporter
 ```


### PR DESCRIPTION
#### What this PR does / why we need it

OCI artifacts have been distributed for a while now but their usage has never been documented. I have adapted the charts README to add this information.

#### Which issue this PR fixes

- #2454

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)