### PR TITLE
[prometheus-conntrack-stats-exporter] Document OCI artiacts in README

### DIFF
--- a/charts/prometheus-conntrack-stats-exporter/Chart.yaml
+++ b/charts/prometheus-conntrack-stats-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-conntrack-stats-exporter
 description: A Helm chart for conntrack-stats-exporter
 type: application
-version: 0.5.23
+version: 0.5.24
 # renovate: github=jwkohnen/conntrack-stats-exporter
 appVersion: v0.4.31
 home: https://github.com/jwkohnen/conntrack-stats-exporter

--- a/charts/prometheus-conntrack-stats-exporter/README.md
+++ b/charts/prometheus-conntrack-stats-exporter/README.md
@@ -10,19 +10,19 @@ This chart creates an Conntrack-Stats-Exporter daemonset on a [Kubernetes](http:
 
 - Kubernetes 1.10+
 
-## Get Helm Repository Info
+## Usage
+
+The chart is distributed as an [OCI Artifact](https://helm.sh/docs/topics/registries/) as well as via a traditional [Helm Repository](https://helm.sh/docs/topics/chart_repository/).
+
+- OCI Artifact: `oci://ghcr.io/prometheus-community/charts/prometheus-conntrack-stats-exporter`
+- Helm Repository: `https://prometheus-community.github.io/helm-charts` with chart `prometheus-conntrack-stats-exporter`
+
+The installation instructions use the OCI registry. Refer to the [`helm repo`]([`helm repo`](https://helm.sh/docs/helm/helm_repo/)) command documentation for information on installing charts via the traditional repository.
+
+### Install Chart
 
 ```console
-helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo update
-```
-
-_See [`helm repo`](https://helm.sh/docs/helm/helm_repo/) for command documentation._
-
-## Install Chart
-
-```console
-helm install [RELEASE_NAME] prometheus-community/prometheus-conntrack-stats-exporter
+helm install [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/prometheus-conntrack-stats-exporter
 ```
 
 The command deploys Conntrack-Stats Exporter on the Kubernetes cluster using the default configuration.
@@ -31,7 +31,7 @@ _See [configuration](#configuration) below._
 
 _See [`helm install`](https://helm.sh/docs/helm/helm_install/) for command documentation._
 
-## Uninstall Chart
+### Uninstall Chart
 
 ```console
 helm uninstall [RELEASE_NAME]
@@ -41,7 +41,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 
 _See [`helm uninstall`](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
 
-## Upgrading Chart
+### Upgrading Chart
 
 ```console
 helm upgrade [RELEASE_NAME] [CHART] --install
@@ -53,7 +53,7 @@ See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_h
 To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
 
 ```console
-helm show values prometheus-community/prometheus-conntrack-stats-exporter
+helm show values oci://ghcr.io/prometheus-community/charts/prometheus-conntrack-stats-exporter
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)


### PR DESCRIPTION
#### What this PR does / why we need it

OCI artifacts have been distributed for a while now but their usage has never been documented. I have adapted the charts README to add this information.

#### Which issue this PR fixes

- #2454

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)