### PR TITLE
[prometheus-consul-exporter] Document OCI artiacts in README

### DIFF
--- a/charts/prometheus-consul-exporter/Chart.yaml
+++ b/charts/prometheus-consul-exporter/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: "v0.13.0"
 description: A Helm chart for the Prometheus Consul Exporter
 name: prometheus-consul-exporter
-version: 1.1.0
+version: 1.1.1
 keywords:
   - metrics
   - consul

--- a/charts/prometheus-consul-exporter/README.md
+++ b/charts/prometheus-consul-exporter/README.md
@@ -9,28 +9,26 @@ This chart creates a [Consul Exporter](https://github.com/prometheus/consul_expo
 - Kubernetes 1.9+ with Beta APIs enabled
 - Helm 3
 
-## Get Repository Info
+## Usage
 
-<!-- textlint-disable terminology -->
-```console
-helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo update
-```
+The chart is distributed as an [OCI Artifact](https://helm.sh/docs/topics/registries/) as well as via a traditional [Helm Repository](https://helm.sh/docs/topics/chart_repository/).
 
-_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
-<!-- textlint-enable -->
+- OCI Artifact: `oci://ghcr.io/prometheus-community/charts/prometheus-consul-exporter`
+- Helm Repository: `https://prometheus-community.github.io/helm-charts` with chart `prometheus-consul-exporter`
 
-## Install Chart
+The installation instructions use the OCI registry. Refer to the [`helm repo`]([`helm repo`](https://helm.sh/docs/helm/helm_repo/)) command documentation for information on installing charts via the traditional repository.
+
+### Install Chart
 
 ```console
-helm install [RELEASE_NAME] prometheus-community/prometheus-consul-exporter
+helm install [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/prometheus-consul-exporter
 ```
 
 _See [configuration](#configuration) below._
 
 _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
 
-## Uninstall Chart
+### Uninstall Chart
 
 ```console
 helm uninstall [RELEASE_NAME]
@@ -40,7 +38,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 
 _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
 
-## Upgrading Chart
+### Upgrading Chart
 
 ```console
 helm upgrade [RELEASE_NAME] [CHART] --install
@@ -48,7 +46,7 @@ helm upgrade [RELEASE_NAME] [CHART] --install
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
-### From 0.5.x to 1.0.0
+#### From 0.5.x to 1.0.0
 
 Helm `apiVersion` has been increased to `v2` in version 1.0.0. As a result, Helm v3 is required to install the chart. Please, see notes on [migration from Helm v2 to Helm v3](https://helm.sh/docs/topics/v2_v3_migration/).
 
@@ -57,7 +55,7 @@ Helm `apiVersion` has been increased to `v2` in version 1.0.0. As a result, Helm
 See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
 
 ```console
-helm show values prometheus-community/prometheus-consul-exporter
+helm show values oci://ghcr.io/prometheus-community/charts/prometheus-consul-exporter
 ```
 
 ### Consul Server Info


### PR DESCRIPTION
#### What this PR does / why we need it

OCI artifacts have been distributed for a while now but their usage has never been documented. I have adapted the charts README to add this information.

#### Which issue this PR fixes

- #2454

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)