### PR TITLE
[prometheus-druid-exporter] Document OCI artiacts in README

### DIFF
--- a/charts/prometheus-druid-exporter/Chart.yaml
+++ b/charts/prometheus-druid-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v0.11.0"
 description: Druid exporter to monitor druid metrics with Prometheus
 name: prometheus-druid-exporter
-version: 1.1.1
+version: 1.1.2
 kubeVersion: ">=1.16.0-0"
 type: application
 home: https://github.com/opstree/druid-exporter

--- a/charts/prometheus-druid-exporter/README.md
+++ b/charts/prometheus-druid-exporter/README.md
@@ -20,26 +20,26 @@ Some of the metrics collections are:-
 
 Helm v2 was no longer supported from chart version 1.0.0.
 
-## Get repository Info
+## Usage
+
+The chart is distributed as an [OCI Artifact](https://helm.sh/docs/topics/registries/) as well as via a traditional [Helm Repository](https://helm.sh/docs/topics/chart_repository/).
+
+- OCI Artifact: `oci://ghcr.io/prometheus-community/charts/prometheus-druid-exporter`
+- Helm Repository: `https://prometheus-community.github.io/helm-charts` with chart `prometheus-druid-exporter`
+
+The installation instructions use the OCI registry. Refer to the [`helm repo`]([`helm repo`](https://helm.sh/docs/helm/helm_repo/)) command documentation for information on installing charts via the traditional repository.
+
+### Install Chart
 
 ```console
-helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo update
-```
-
-_See [`helm repo`](https://helm.sh/docs/helm/helm_repo/) for command documentation._
-
-## Install Chart
-
-```console
-helm install [RELEASE_NAME] prometheus-community/prometheus-druid-exporter
+helm install [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/prometheus-druid-exporter
 ```
 
 _See [configuration](#configuration) below._
 
 _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
 
-## Uninstall Chart
+### Uninstall Chart
 
 ```console
 helm uninstall [RELEASE_NAME]
@@ -49,7 +49,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 
 _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
 
-## Upgrading Chart
+### Upgrading Chart
 
 ```console
 helm upgrade [RELEASE_NAME] [CHART] --install
@@ -57,7 +57,7 @@ helm upgrade [RELEASE_NAME] [CHART] --install
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
-### To 1.0.0
+#### To 1.0.0
 
 Helm v2 was no longer supported from chart version 1.0.0.
 
@@ -68,7 +68,7 @@ _See [Migrating Helm v2 to v3](https://helm.sh/docs/topics/v2_v3_migration/) gui
 See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus-druid-exporter/values.yaml), or run these configuration commands:
 
 ```console
-helm show values prometheus-community/prometheus-druid-exporter
+helm show values oci://ghcr.io/prometheus-community/charts/prometheus-druid-exporter
 ```
 
 ### Druid Server Connection


### PR DESCRIPTION
#### What this PR does / why we need it

OCI artifacts have been distributed for a while now but their usage has never been documented. I have adapted the charts README to add this information.

#### Which issue this PR fixes

- #2454

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)