### PR TITLE
[prometheus-fastly-exporter] Document OCI artiacts in README

### DIFF
--- a/charts/prometheus-fastly-exporter/Chart.yaml
+++ b/charts/prometheus-fastly-exporter/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: "v9.5.0"
 description: A Helm chart for the Prometheus Fastly Exporter
 name: prometheus-fastly-exporter
-version: 0.9.0
+version: 0.9.1
 keywords:
   - metrics
   - fastly

--- a/charts/prometheus-fastly-exporter/README.md
+++ b/charts/prometheus-fastly-exporter/README.md
@@ -8,26 +8,26 @@ This chart creates a [Fastly Exporter](https://github.com/fastly/fastly-exporter
 
 - Kubernetes 1.8+ with Beta APIs enabled
 
-## Get Repository Info
+## Usage
+
+The chart is distributed as an [OCI Artifact](https://helm.sh/docs/topics/registries/) as well as via a traditional [Helm Repository](https://helm.sh/docs/topics/chart_repository/).
+
+- OCI Artifact: `oci://ghcr.io/prometheus-community/charts/prometheus-fastly-exporter`
+- Helm Repository: `https://prometheus-community.github.io/helm-charts` with chart `prometheus-fastly-exporter`
+
+The installation instructions use the OCI registry. Refer to the [`helm repo`]([`helm repo`](https://helm.sh/docs/helm/helm_repo/)) command documentation for information on installing charts via the traditional repository.
+
+### Install Chart
 
 ```console
-helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo update
-```
-
-_See [`helm repo`](https://helm.sh/docs/helm/helm_repo/) for command documentation._
-
-## Install Chart
-
-```console
-helm install [RELEASE_NAME] prometheus-community/prometheus-fastly-exporter
+helm install [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/prometheus-fastly-exporter
 ```
 
 _See [configuration](#configuration) below._
 
 _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
 
-## Uninstall Chart
+### Uninstall Chart
 
 ```console
 helm uninstall [RELEASE_NAME]
@@ -37,7 +37,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 
 _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
 
-## Upgrading Chart
+### Upgrading Chart
 
 ```console
 helm upgrade [RELEASE_NAME] [CHART] --install
@@ -54,7 +54,7 @@ To use the chart, ensure the `fastly.token` is populated with a valid [Fastly AP
 See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
 
 ```console
-helm show values prometheus-community/prometheus-fastly-exporter
+helm show values oci://ghcr.io/prometheus-community/charts/prometheus-fastly-exporter
 ```
 
 ### Flags


### PR DESCRIPTION
#### What this PR does / why we need it

OCI artifacts have been distributed for a while now but their usage has never been documented. I have adapted the charts README to add this information.

#### Which issue this PR fixes

- #2454

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)