### PR TITLE
[prometheus-ipmi-exporter] Add README

### DIFF
--- a/charts/prometheus-ipmi-exporter/Chart.yaml
+++ b/charts/prometheus-ipmi-exporter/Chart.yaml
@@ -2,7 +2,8 @@ apiVersion: v2
 name: prometheus-ipmi-exporter
 description: This is an IPMI exporter for Prometheus.
 type: application
-version: 0.6.0
+version: 0.6.1
+# renovate: github=prometheus-community/ipmi_exporter
 appVersion: "v1.10.0"
 keywords:
   - metrics

--- a/charts/prometheus-ipmi-exporter/README.md
+++ b/charts/prometheus-ipmi-exporter/README.md
@@ -1,0 +1,54 @@
+# Prometheus IPMI Exporter
+
+A Prometheus exporter for *IP Management Interface* metrics.
+
+This chart creates a [IPMI Exporter](https://github.com/prometheus-community/ipmi_exporter) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.33+
+
+## Usage
+
+The chart is distributed as an [OCI Artifact](https://helm.sh/docs/topics/registries/) as well as via a traditional [Helm Repository](https://helm.sh/docs/topics/chart_repository/).
+
+- OCI Artifact: `oci://ghcr.io/prometheus-community/charts/prometheus-ipmi-exporter`
+- Helm Repository: `https://prometheus-community.github.io/helm-charts` with chart `prometheus-ipmi-exporter`
+
+The installation instructions use the OCI registry. Refer to the [`helm repo`]([`helm repo`](https://helm.sh/docs/helm/helm_repo/)) command documentation for information on installing charts via the traditional repository.
+
+### Install Chart
+
+```console
+helm install [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/prometheus-ipmi-exporter
+```
+
+*See [configuration](#configuration) below.*
+
+*See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation.*
+
+### Uninstall Chart
+
+```console
+helm uninstall [RELEASE_NAME]
+```
+
+This removes all the Kubernetes components associated with the chart and deletes the release.
+
+*See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation.*
+
+### Upgrading Chart
+
+```console
+helm upgrade [RELEASE_NAME] [CHART] --install
+```
+
+*See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation.*
+
+## Configuration
+
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
+
+```console
+helm show values oci://ghcr.io/prometheus-community/charts/prometheus-ipmi-exporter
+```


### PR DESCRIPTION

#### What this PR does / why we need it

The *prometheus-ipmi-exporter* chart did not have a proper README.
This PR adds one which has the same structure as the other charts READMEs.

#### Which issue this PR fixes

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)

