### PR TITLE
[prometheus-json-exporter] Document OCI artiacts in README

### DIFF
--- a/charts/prometheus-json-exporter/Chart.yaml
+++ b/charts/prometheus-json-exporter/Chart.yaml
@@ -10,7 +10,7 @@ type: application
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-version: 0.19.0
+version: 0.19.1
 appVersion: "v0.7.0"
 home: https://github.com/prometheus-community/json_exporter
 maintainers:

--- a/charts/prometheus-json-exporter/README.md
+++ b/charts/prometheus-json-exporter/README.md
@@ -9,48 +9,42 @@ This chart bootstraps a [json_exporter](https://github.com/prometheus-community/
 - Kubernetes 1.10+ with Beta APIs enabled
 - Helm 3+
 
-## Get Repository Info
+## Usage
+
+The chart is distributed as an [OCI Artifact](https://helm.sh/docs/topics/registries/) as well as via a traditional [Helm Repository](https://helm.sh/docs/topics/chart_repository/).
+
+- OCI Artifact: `oci://ghcr.io/prometheus-community/charts/prometheus-json-exporter`
+- Helm Repository: `https://prometheus-community.github.io/helm-charts` with chart `prometheus-json-exporter`
+
+The installation instructions use the OCI registry. Refer to the [`helm repo`]([`helm repo`](https://helm.sh/docs/helm/helm_repo/)) command documentation for information on installing charts via the traditional repository.
+
+### Install Chart
 
 ```console
-helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo add stable https://charts.helm.sh/stable
-helm repo update
-```
-
-<!-- textlint-disable -->
-_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
-<!-- textlint-enable -->
-
-## Install Chart
-
-```console
-# Helm
-$ helm install [RELEASE_NAME] prometheus-community/prometheus-json-exporter
+helm install [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/prometheus-json-exporter
 ```
 
 _See [configuration](## Configuring) below._
 
 _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
 
-## Uninstall Chart
+### Uninstall Chart
 
 ```console
-# Helm
-$ helm uninstall [RELEASE_NAME]
+helm uninstall [RELEASE_NAME]
 ```
 
 This removes all the Kubernetes components associated with the chart and deletes the release.
 
 _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
 
-## Upgrading Chart
+### Upgrading Chart
 
 ```console
-# Helm
-$ helm upgrade [RELEASE_NAME] [CHART] --install
+helm upgrade [RELEASE_NAME] [CHART] --install
 ```
 
-### From 0.7.x to 0.8.0
+#### From 0.7.x to 0.8.0
 
 This version fixes configmap name according to the chart standard so that configmap will be recreated with subsequent deployment rollout.
 See [#3926](https://github.com/prometheus-community/helm-charts/pull/3926) for more context.
@@ -60,8 +54,7 @@ See [#3926](https://github.com/prometheus-community/helm-charts/pull/3926) for m
 See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
 
 ```console
-# Helm
-$ helm show values prometheus-community/prometheus-json-exporter
+helm show values oci://ghcr.io/prometheus-community/charts/prometheus-json-exporter
 ```
 
 For more information please refer to the [json_exporter](https://github.com/prometheus-community/json_exporter) documentation.


### PR DESCRIPTION
#### What this PR does / why we need it

OCI artifacts have been distributed for a while now but their usage has never been documented. I have adapted the charts README to add this information.

#### Which issue this PR fixes

- #2454

#### Note to Reviewers

This PR was created as a series of PRs to add information about OCI artifacts to all charts.
Since this involved a lot of repetitive work, please excuse me if I overlooked some usages and ensure that the instructions still make sense.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)