### PR TITLE
[prometheus-kafka-exporter] Document OCI artiacts in README

### DIFF
--- a/charts/prometheus-kafka-exporter/Chart.yaml
+++ b/charts/prometheus-kafka-exporter/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v1.9.0"
 description: A Helm chart to export the metrics from Kafka in Prometheus format using the kafka-exporter from https://github.com/danielqsj/kafka_exporter
 name: prometheus-kafka-exporter
 home: https://github.com/danielqsj/kafka_exporter
-version: 2.12.1
+version: 2.12.2
 kubeVersion: ">=1.19.0-0"
 sources:
   - https://gkarthiks.github.io/helm-charts/charts/prometheus-kafka-exporter

--- a/charts/prometheus-kafka-exporter/README.md
+++ b/charts/prometheus-kafka-exporter/README.md
@@ -11,27 +11,26 @@ This chart bootstraps a [Kafka Exporter](https://github.com/danielqsj/kafka_expo
 
 Helm v2 is no longer supported from chart version 2.0.0.
 
-## Get Repository Info
-<!-- textlint-disable terminology -->
-```console
-helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo update
-```
+## Usage
 
-_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
-<!-- textlint-enable -->
-## Install Chart
+The chart is distributed as an [OCI Artifact](https://helm.sh/docs/topics/registries/) as well as via a traditional [Helm Repository](https://helm.sh/docs/topics/chart_repository/).
+
+- OCI Artifact: `oci://ghcr.io/prometheus-community/charts/prometheus-kafka-exporter`
+- Helm Repository: `https://prometheus-community.github.io/helm-charts` with chart `prometheus-kafka-exporter`
+
+The installation instructions use the OCI registry. Refer to the [`helm repo`]([`helm repo`](https://helm.sh/docs/helm/helm_repo/)) command documentation for information on installing charts via the traditional repository.
+
+### Install Chart
 
 ```console
-helm dependency build
-helm install [RELEASE_NAME] prometheus-community/prometheus-kafka-exporter
+helm install [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/prometheus-kafka-exporter
 ```
 
 _See [configuration](#configuration) below._
 
 _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
 
-## Uninstall Chart
+### Uninstall Chart
 
 ```console
 helm uninstall [RELEASE_NAME]
@@ -41,10 +40,10 @@ This removes all the Kubernetes components associated with the chart and deletes
 
 _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
 
-## Upgrading Chart
+### Upgrading Chart
 
 ```console
-helm upgrade [RELEASE_NAME] prometheus-community/prometheus-kafka-exporter --install
+helm upgrade [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/prometheus-kafka-exporter --install
 ```
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
@@ -54,5 +53,5 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-kafka-exporter/values.yaml), or run these configuration commands:
 
 ```console
-helm show values prometheus-community/prometheus-kafka-exporter
+helm show values oci://ghcr.io/prometheus-community/charts/prometheus-kafka-exporter
 ```


### PR DESCRIPTION
#### What this PR does / why we need it

OCI artifacts have been distributed for a while now but their usage has never been documented. I have adapted the charts README to add this information.

#### Which issue this PR fixes

- #2454

#### Note to Reviewers

This PR was created as a series of PRs to add information about OCI artifacts to all charts.
Since this involved a lot of repetitive work, please excuse me if I overlooked some usages and ensure that the instructions still make sense.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)