### PR TITLE
[prometheus-nginx-exporter] Document OCI artiacts in README

### DIFF
--- a/charts/prometheus-nginx-exporter/Chart.yaml
+++ b/charts/prometheus-nginx-exporter/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: A Helm chart for NGINX Prometheus Exporter
 name: prometheus-nginx-exporter
-version: 1.10.0
+version: 1.10.1
 # renovate: github-releases=nginx/nginx-prometheus-exporter
 appVersion: 1.4.2
 home: https://github.com/nginxinc/nginx-prometheus-exporter

--- a/charts/prometheus-nginx-exporter/README.md
+++ b/charts/prometheus-nginx-exporter/README.md
@@ -7,26 +7,26 @@ This chart bootstraps a [NGINX Prometheus Exporter](https://github.com/nginxinc/
 - Kubernetes 1.19+ with Beta APIs enabled
 - Helm 3
 
-## Get Repository Info
-<!-- textlint-disable terminology -->
-```console
-helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo update
-```
+## Usage
 
-_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
-<!-- textlint-enable -->
-## Install Chart
+The chart is distributed as an [OCI Artifact](https://helm.sh/docs/topics/registries/) as well as via a traditional [Helm Repository](https://helm.sh/docs/topics/chart_repository/).
+
+- OCI Artifact: `oci://ghcr.io/prometheus-community/charts/prometheus-nginx-exporter`
+- Helm Repository: `https://prometheus-community.github.io/helm-charts` with chart `prometheus-nginx-exporter`
+
+The installation instructions use the OCI registry. Refer to the [`helm repo`]([`helm repo`](https://helm.sh/docs/helm/helm_repo/)) command documentation for information on installing charts via the traditional repository.
+
+### Install Chart
 
 ```console
-helm install [RELEASE_NAME] prometheus-community/prometheus-nginx-exporter
+helm install [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/prometheus-nginx-exporter
 ```
 
 _See [configuration](#configuring) below._
 
 _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
 
-## Uninstall Chart
+### Uninstall Chart
 
 ```console
 helm uninstall [RELEASE_NAME]
@@ -36,15 +36,15 @@ This removes all the Kubernetes components associated with the chart and deletes
 
 _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
 
-## Upgrading Chart
+### Upgrading Chart
 
 ```console
-helm upgrade [RELEASE_NAME] prometheus-community/prometheus-nginx-exporter --install
+helm upgrade [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/prometheus-nginx-exporter --install
 ```
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
-### To 1.0
+#### To 1.0
 
 Chart release 1.0 reflects a major bump of the default NGINX Exporter image tag from major number 0 to 1.
 
@@ -56,5 +56,5 @@ deprecated format (`-flag`) transparently for NGINX Exporter below release 1.0.0
 See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
 
 ```console
-helm show values prometheus-community/prometheus-nginx-exporter
+helm show values oci://ghcr.io/prometheus-community/charts/prometheus-nginx-exporter
 ```


### PR DESCRIPTION
#### What this PR does / why we need it

OCI artifacts have been distributed for a while now but their usage has never been documented. I have adapted the charts README to add this information.

#### Which issue this PR fixes

- #2454

#### Note to Reviewers

This PR was created as a series of PRs to add information about OCI artifacts to all charts.
Since this involved a lot of repetitive work, please excuse me if I overlooked some usages and ensure that the instructions still make sense.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)