### PR TITLE
[prometheus-operator-admission-webhook] Document OCI artiacts in README

### DIFF
--- a/charts/prometheus-operator-admission-webhook/Chart.yaml
+++ b/charts/prometheus-operator-admission-webhook/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: Prometheus Operator Admission Webhook
 name: prometheus-operator-admission-webhook
-version: 0.29.0
+version: 0.29.1
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: 0.84.0
 home: https://github.com/prometheus-operator/prometheus-operator

--- a/charts/prometheus-operator-admission-webhook/README.md
+++ b/charts/prometheus-operator-admission-webhook/README.md
@@ -13,26 +13,26 @@ For more info, please, see the [Prometheus Operator](https://prometheus-operator
 - Kubernetes 1.13+ with Beta APIs enabled
 - Helm 3
 
-## Get Repository Info
-<!-- textlint-disable terminology -->
-```console
-helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo update
-```
+## Usage
 
-_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
-<!-- textlint-enable -->
-## Install Chart
+The chart is distributed as an [OCI Artifact](https://helm.sh/docs/topics/registries/) as well as via a traditional [Helm Repository](https://helm.sh/docs/topics/chart_repository/).
+
+- OCI Artifact: `oci://ghcr.io/prometheus-community/charts/prometheus-operator-admission-webhook`
+- Helm Repository: `https://prometheus-community.github.io/helm-charts` with chart `prometheus-operator-admission-webhook`
+
+The installation instructions use the OCI registry. Refer to the [`helm repo`]([`helm repo`](https://helm.sh/docs/helm/helm_repo/)) command documentation for information on installing charts via the traditional repository.
+
+### Install Chart
 
 ```console
-helm install [RELEASE_NAME] prometheus-community/prometheus-operator-admission-webhook
+helm install [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/prometheus-operator-admission-webhook
 ```
 
 _See [configuration](#configuration) below._
 
 _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
 
-## Uninstall Chart
+### Uninstall Chart
 
 ```console
 helm uninstall [RELEASE_NAME]
@@ -42,10 +42,10 @@ This removes all the Kubernetes components associated with the chart and deletes
 
 _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
 
-## Upgrading Chart
+### Upgrading Chart
 
 ```console
-helm upgrade [RELEASE_NAME] prometheus-community/prometheus-operator-admission-webhook --install
+helm upgrade [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/prometheus-operator-admission-webhook --install
 ```
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
@@ -57,5 +57,5 @@ See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_h
 To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
 
 ```console
-helm show values prometheus-community/prometheus-operator-admission-webhook
+helm show values oci://ghcr.io/prometheus-community/charts/prometheus-operator-admission-webhook
 ```


### PR DESCRIPTION
#### What this PR does / why we need it

OCI artifacts have been distributed for a while now but their usage has never been documented. I have adapted the charts README to add this information.

#### Which issue this PR fixes

- #2454

#### Note to Reviewers

This PR was created as a series of PRs to add information about OCI artifacts to all charts.
Since this involved a lot of repetitive work, please excuse me if I overlooked some usages and ensure that the instructions still make sense.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)