### PR TITLE
[prometheus-pgbouncer-exporter] Document OCI artiacts in README

### DIFF
--- a/charts/prometheus-pgbouncer-exporter/Chart.yaml
+++ b/charts/prometheus-pgbouncer-exporter/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: "v0.11.0"
 description: A Helm chart for prometheus pgbouncer-exporter
 name: prometheus-pgbouncer-exporter
-version: 0.8.0
+version: 0.8.1
 home: https://github.com/prometheus-community/pgbouncer_exporter
 sources:
   - https://github.com/prometheus-community/pgbouncer_exporter

--- a/charts/prometheus-pgbouncer-exporter/README.md
+++ b/charts/prometheus-pgbouncer-exporter/README.md
@@ -9,26 +9,26 @@ This chart bootstraps a prometheus [pgbouncer exporter](https://github.com/prome
 - Kubernetes 1.16+
 - Helm 3+
 
-## Add Helm Chart Repository
-<!-- textlint-disable terminology -->
-```console
-helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo update
-```
+## Usage
 
-_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
-<!-- textlint-enable -->
-## Install Chart
+The chart is distributed as an [OCI Artifact](https://helm.sh/docs/topics/registries/) as well as via a traditional [Helm Repository](https://helm.sh/docs/topics/chart_repository/).
+
+- OCI Artifact: `oci://ghcr.io/prometheus-community/charts/prometheus-pgbouncer-exporter`
+- Helm Repository: `https://prometheus-community.github.io/helm-charts` with chart `prometheus-pgbouncer-exporter`
+
+The installation instructions use the OCI registry. Refer to the [`helm repo`]([`helm repo`](https://helm.sh/docs/helm/helm_repo/)) command documentation for information on installing charts via the traditional repository.
+
+### Install Chart
 
 ```console
-helm install [RELEASE_NAME] prometheus-community/prometheus-pgbouncer-exporter
+helm install [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/prometheus-pgbouncer-exporter
 ```
 
 _See [configuration](#configuring) below._
 
 _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
 
-## Uninstall Chart
+### Uninstall Chart
 
 ```console
 helm uninstall [RELEASE_NAME]
@@ -38,10 +38,10 @@ This removes all the Kubernetes components associated with the chart and deletes
 
 _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
 
-## Upgrading Chart
+### Upgrading Chart
 
 ```console
-helm upgrade [RELEASE_NAME] prometheus-community/prometheus-pgbouncer-exporter --install
+helm upgrade [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/prometheus-pgbouncer-exporter --install
 ```
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
@@ -51,5 +51,5 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
 
 ```console
-helm show values prometheus-community/prometheus-pgbouncer-exporter
+helm show values oci://ghcr.io/prometheus-community/charts/prometheus-pgbouncer-exporter
 ```


### PR DESCRIPTION
#### What this PR does / why we need it

OCI artifacts have been distributed for a while now but their usage has never been documented. I have adapted the charts README to add this information.

#### Which issue this PR fixes

- #2454

#### Note to Reviewers

This PR was created as a series of PRs to add information about OCI artifacts to all charts.
Since this involved a lot of repetitive work, please excuse me if I overlooked some usages and ensure that the instructions still make sense.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)