### PR TITLE
[prometheus-pingdom-exporter] Document OCI artiacts in README

### DIFF
--- a/charts/prometheus-pingdom-exporter/Chart.yaml
+++ b/charts/prometheus-pingdom-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: prometheus-pingdom-exporter
-version: 3.4.0
+version: 3.4.1
 appVersion: v0.5.0
 home: https://github.com/kokuwaio/pingdom-exporter
 description: A Helm chart for Prometheus Pingdom Exporter

--- a/charts/prometheus-pingdom-exporter/README.md
+++ b/charts/prometheus-pingdom-exporter/README.md
@@ -49,7 +49,7 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 
 #### To version 3.0.0
 
-The docker image has been change too <ghcr.io/monotek/pingdom-exporter>.
+The Docker image has been change too <ghcr.io/monotek/pingdom-exporter>.
 
 The config uses `pingdom.apiToken` only which is used as env var.
 

--- a/charts/prometheus-pingdom-exporter/README.md
+++ b/charts/prometheus-pingdom-exporter/README.md
@@ -53,7 +53,7 @@ The Docker image has been change too <ghcr.io/monotek/pingdom-exporter>.
 
 The config uses `pingdom.apiToken` only which is used as env var.
 
-The docker port changed to `9158`.
+The Docker port changed to `9158`.
 
 ## Configuration
 

--- a/charts/prometheus-pingdom-exporter/README.md
+++ b/charts/prometheus-pingdom-exporter/README.md
@@ -8,19 +8,19 @@ The [prometheus-pingdom-exporter](https://github.com/kokuwaio/pingdom-exporter) 
 
 - Kubernetes 1.16+
 
-## Get Repository Info
+## Usage
+
+The chart is distributed as an [OCI Artifact](https://helm.sh/docs/topics/registries/) as well as via a traditional [Helm Repository](https://helm.sh/docs/topics/chart_repository/).
+
+- OCI Artifact: `oci://ghcr.io/prometheus-community/charts/prometheus-pingdom-exporter`
+- Helm Repository: `https://prometheus-community.github.io/helm-charts` with chart `prometheus-pingdom-exporter`
+
+The installation instructions use the OCI registry. Refer to the [`helm repo`]([`helm repo`](https://helm.sh/docs/helm/helm_repo/)) command documentation for information on installing charts via the traditional repository.
+
+### Install Chart
 
 ```console
-helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo update
-```
-
-_See [`helm install`](https://helm.sh/docs/helm/helm_install/) for command documentation._
-
-## Install Chart
-
-```console
-helm install [RELEASE_NAME] prometheus-community/prometheus-pingdom-exporter
+helm install [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/prometheus-pingdom-exporter
 ```
 
 ```markdown
@@ -29,7 +29,7 @@ _See [configuration](#configuration) below._
 
 _See [`helm install`](https://helm.sh/docs/helm/helm_install/) for command documentation._
 
-## Uninstall Chart
+### Uninstall Chart
 
 ```console
 helm uninstall [RELEASE_NAME]
@@ -39,7 +39,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 
 _See [`helm uninstall`](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
 
-## Upgrading Chart
+### Upgrading Chart
 
 ```console
 helm upgrade [RELEASE_NAME] [CHART] --install
@@ -47,7 +47,7 @@ helm upgrade [RELEASE_NAME] [CHART] --install
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
-### To version 3.0.0
+#### To version 3.0.0
 
 The docker image has been change too <ghcr.io/monotek/pingdom-exporter>.
 
@@ -60,5 +60,5 @@ The docker port changed to `9158`.
 See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
 
 ```console
-helm show values prometheus-community/prometheus-pingdom-exporter
+helm show values oci://ghcr.io/prometheus-community/charts/prometheus-pingdom-exporter
 ```


### PR DESCRIPTION
#### What this PR does / why we need it

OCI artifacts have been distributed for a while now but their usage has never been documented. I have adapted the charts README to add this information.

#### Which issue this PR fixes

- #2454

#### Note to Reviewers

This PR was created as a series of PRs to add information about OCI artifacts to all charts.
Since this involved a lot of repetitive work, please excuse me if I overlooked some usages and ensure that the instructions still make sense.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)