### PR TITLE
[prometheus-pingmesh-exporter] Document OCI artiacts in README

### DIFF
--- a/charts/prometheus-pingmesh-exporter/Chart.yaml
+++ b/charts/prometheus-pingmesh-exporter/Chart.yaml
@@ -15,4 +15,4 @@ name: prometheus-pingmesh-exporter
 sources:
   - https://github.com/kubeservice-stack/pingmesh-agent
 type: application
-version: 0.4.2
+version: 0.4.3

--- a/charts/prometheus-pingmesh-exporter/README.md
+++ b/charts/prometheus-pingmesh-exporter/README.md
@@ -10,26 +10,26 @@ This chart creates a [Pingmesh Exporter](https://github.com/kubeservice-stack/pi
 
 - Kubernetes 1.8+ with Beta APIs enabled
 
-## Add Helm repository
+## Usage
+
+The chart is distributed as an [OCI Artifact](https://helm.sh/docs/topics/registries/) as well as via a traditional [Helm Repository](https://helm.sh/docs/topics/chart_repository/).
+
+- OCI Artifact: `oci://ghcr.io/prometheus-community/charts/prometheus-pingmesh-exporter`
+- Helm Repository: `https://prometheus-community.github.io/helm-charts` with chart `prometheus-pingmesh-exporter`
+
+The installation instructions use the OCI registry. Refer to the [`helm repo`]([`helm repo`](https://helm.sh/docs/helm/helm_repo/)) command documentation for information on installing charts via the traditional repository.
+
+### Install Chart
 
 ```console
-helm repo add kubeservice-stack https://kubeservice-stack.github.io/kubservice-charts
-helm repo update
-```
-
-_See [`helm repo`](https://helm.sh/docs/helm/helm_repo/) for command documentation._
-
-## Install Chart
-
-```console
-helm install [RELEASE_NAME] prometheus-pingmesh-exporter
+helm install [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/prometheus-pingmesh-exporter
 ```
 
 _See [configuration](#configuration) below._
 
 _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
 
-## Uninstall Chart
+### Uninstall Chart
 
 ```console
 helm uninstall [RELEASE_NAME]
@@ -39,7 +39,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 
 _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
 
-## Upgrading Chart
+### Upgrading Chart
 
 ```console
 helm upgrade [RELEASE_NAME] [CHART] --install
@@ -47,7 +47,7 @@ helm upgrade [RELEASE_NAME] [CHART] --install
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
-## From 0.22.0 to 1.0.1
+#### From 0.22.0 to 1.0.1
 
 ```console
 helm upgrade [RELEASE_NAME] prometheus-pingmesh-exporter --version 1.0.1
@@ -59,10 +59,10 @@ See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_h
 
 ```console
 # Helm 2
-$ helm inspect values prometheus-pingmesh-exporter
+$ helm inspect values oci://ghcr.io/prometheus-community/charts/prometheus-pingmesh-exporter
 
 # Helm 3
-$ helm show values prometheus-pingmesh-exporter
+$ helm show values oci://ghcr.io/prometheus-community/charts/prometheus-pingmesh-exporter
 ```
 
 See [kubeservice-stack/pingmesh-agent/README.md](https://github.com/kubeservice-stack/pingmesh-agent) for further information.


### PR DESCRIPTION
#### What this PR does / why we need it

OCI artifacts have been distributed for a while now but their usage has never been documented. I have adapted the charts README to add this information.

#### Which issue this PR fixes

- #2454

#### Note to Reviewers

This PR was created as a series of PRs to add information about OCI artifacts to all charts.
Since this involved a lot of repetitive work, please excuse me if I overlooked some usages and ensure that the instructions still make sense.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)