### PR TITLE
[prometheus-postgres-exporter] Document OCI artiacts in README

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: v0.17.1
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 7.0.0
+version: 7.0.1
 home: https://github.com/prometheus-community/postgres_exporter
 sources:
   - https://github.com/prometheus-community/postgres_exporter

--- a/charts/prometheus-postgres-exporter/README.md
+++ b/charts/prometheus-postgres-exporter/README.md
@@ -9,26 +9,26 @@ This chart bootstraps a Prometheus [Postgres exporter](https://github.com/promet
 - Kubernetes 1.16+
 - Helm 3+
 
-## Get Repository Info
-<!-- textlint-disable terminology -->
-```console
-helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo update
-```
+## Usage
 
-_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
-<!-- textlint-enable -->
-## Install Chart
+The chart is distributed as an [OCI Artifact](https://helm.sh/docs/topics/registries/) as well as via a traditional [Helm Repository](https://helm.sh/docs/topics/chart_repository/).
+
+- OCI Artifact: `oci://ghcr.io/prometheus-community/charts/prometheus-postgres-exporter`
+- Helm Repository: `https://prometheus-community.github.io/helm-charts` with chart `prometheus-postgres-exporter`
+
+The installation instructions use the OCI registry. Refer to the [`helm repo`]([`helm repo`](https://helm.sh/docs/helm/helm_repo/)) command documentation for information on installing charts via the traditional repository.
+
+### Install Chart
 
 ```console
-helm install [RELEASE_NAME] prometheus-community/prometheus-postgres-exporter
+helm install [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/prometheus-postgres-exporter
 ```
 
 _See [configuration](#configuration) below._
 
 _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
 
-## Uninstall Chart
+### Uninstall Chart
 
 ```console
 helm uninstall [RELEASE_NAME]
@@ -38,15 +38,15 @@ This removes all the Kubernetes components associated with the chart and deletes
 
 _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
 
-## Upgrading Chart
+### Upgrading Chart
 
 ```console
-helm upgrade [RELEASE_NAME] prometheus-community/prometheus-postgres-exporter --install
+helm upgrade [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/prometheus-postgres-exporter --install
 ```
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
-### To 7.0.0
+#### To 7.0.0
 
 Labels and selectors have been replaced following [Helm 3 label and annotation best practices](https://helmsh/docs/chart_best_practices/labels/):
 
@@ -70,11 +70,11 @@ Once the resources have been deleted, you can upgrade the release:
 helm upgrade -i RELEASE_NAME prometheus-community/prometheus-postgres-exporter
 ```
 
-### To 6.0.0
+#### To 6.0.0
 
 Image repository has been split into two values: the new `image.registry` value and the already existing `image.repository` value. No change is required when using the default for `image.repository`. If you have previously modified field `image.repository`, please, set the two fields accordingly.
 
-### To 5.0.0
+#### To 5.0.0
 
 Deprecated options `auto-discover-databases`, `constantLabels`, `exclude-databases` & `include-databases` has been removed.
 Deprecated custom query config has been removed.
@@ -84,18 +84,18 @@ Labels are templated now.
 Add default securityContext and PodSecurityContext.
 LivenessProbe timeout has been raised to 3.
 
-### To 4.6.0
+#### To 4.6.0
 
 This release adds functionality to template the variables inside `config.datasource` by means of allowing the `tpl` function in the resources that make use of it. This functionality is useful when you want to do sub-charting (e.g. in a postgres chart) and you want to avoid the duplication of variables inside `config.datasource`.
 
 Compared to the previous release (4.5.0) the only thing that changed is the fact that you can no longer leave the `config.datasource.host` variable blank. Leaving it blank could cause errors with the `tpl` function. However, the default value was changed to `''` so this error is not expected to happen.
 
-### To 4.0.0
+#### To 4.0.0
 
 This release removes the `pg_database` query from `config.queries` as it has been converted to a built-in collector
 in postgres_exporter v0.11.0. Any customizations to the removed query are now rendered useless and thus should be removed.
 
-### To 3.0.0
+#### To 3.0.0
 
 This release introduces changes to accommodate Postgres 13 or newer versions by default.
 Older Postgres instances have now to overwrite the `pg_stat_statements` query of `config.queries` with following
@@ -131,7 +131,7 @@ WHERE t2.rolname != 'rdsadmin'
   AND queryid IS NOT NULL `
 ```
 
-### To 2.0.0
+#### To 2.0.0
 
 The primary change in 2.0.0 is the Chart API from v1 to v2. This now requires Helm3.
 Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.
@@ -148,5 +148,5 @@ See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_h
 To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run this command:
 
 ```console
-helm show values prometheus-community/prometheus-postgres-exporter
+helm show values oci://ghcr.io/prometheus-community/charts/prometheus-postgres-exporter
 ```


### PR DESCRIPTION
#### What this PR does / why we need it

OCI artifacts have been distributed for a while now but their usage has never been documented. I have adapted the charts README to add this information.

#### Which issue this PR fixes

- #2454

#### Note to Reviewers

This PR was created as a series of PRs to add information about OCI artifacts to all charts.
Since this involved a lot of repetitive work, please excuse me if I overlooked some usages and ensure that the instructions still make sense.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)