### PR TITLE
[prometheus-systemd-exporter] Document OCI artiacts in README

### DIFF
--- a/charts/prometheus-systemd-exporter/Chart.yaml
+++ b/charts/prometheus-systemd-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-systemd-exporter
 description: A Helm chart for prometheus systemd-exporter
 type: application
-version: 0.5.0
+version: 0.5.1
 appVersion: "0.7.0"
 home: https://github.com/prometheus-community/systemd_exporter
 sources:

--- a/charts/prometheus-systemd-exporter/README.md
+++ b/charts/prometheus-systemd-exporter/README.md
@@ -4,26 +4,26 @@ Prometheus exporter for systemd units, written in Go.
 
 This chart bootstraps a prometheus [systemd exporter](https://github.com/prometheus-community/systemd_exporter) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
-## Add Helm Chart Repository
+## Usage
+
+The chart is distributed as an [OCI Artifact](https://helm.sh/docs/topics/registries/) as well as via a traditional [Helm Repository](https://helm.sh/docs/topics/chart_repository/).
+
+- OCI Artifact: `oci://ghcr.io/prometheus-community/charts/prometheus-systemd-exporter`
+- Helm Repository: `https://prometheus-community.github.io/helm-charts` with chart `prometheus-systemd-exporter`
+
+The installation instructions use the OCI registry. Refer to the [`helm repo`]([`helm repo`](https://helm.sh/docs/helm/helm_repo/)) command documentation for information on installing charts via the traditional repository.
+
+### Install Chart
 
 ```console
-helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo update
-```
-
-_See [`helm repo`](https://helm.sh/docs/helm/helm_repo/) for command documentation._
-
-## Install Chart
-
-```console
-helm install [RELEASE_NAME] prometheus-community/prometheus-systemd-exporter
+helm install [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/prometheus-systemd-exporter
 ```
 
 _See [configuration](#configuring) below._
 
 _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
 
-## Uninstall Chart
+### Uninstall Chart
 
 ```console
 helm uninstall [RELEASE_NAME]
@@ -38,7 +38,7 @@ _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command doc
 See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
 
 ```console
-helm show values prometheus-community/prometheus-systemd-exporter
+helm show values oci://ghcr.io/prometheus-community/charts/prometheus-systemd-exporter
 ```
 
 ### Exported Systemd units


### PR DESCRIPTION
#### What this PR does / why we need it

OCI artifacts have been distributed for a while now but their usage has never been documented. I have adapted the charts README to add this information.

#### Which issue this PR fixes

- #2454

#### Note to Reviewers

This PR was created as a series of PRs to add information about OCI artifacts to all charts.
Since this involved a lot of repetitive work, please excuse me if I overlooked some usages and ensure that the instructions still make sense.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)