### PR TITLE
[prometheus] Allow statefulset without persistent volume

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus
 # renovate: github=prometheus/prometheus
 appVersion: v3.5.0
-version: 27.28.0
+version: 27.28.1
 kubeVersion: ">=1.19.0-0"
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/templates/deploy.yaml
+++ b/charts/prometheus/templates/deploy.yaml
@@ -298,7 +298,7 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config
-            - name: {{ ternary .Values.server.persistentVolume.statefulSetNameOverride "storage-volume" (and .Values.server.persistentVolume.enabled (not (empty .Values.server.persistentVolume.statefulSetNameOverride))) }}
+            - name: {{ ternary .Values.server.persistentVolume.statefulSetNameOverride "storage-volume" (and .Values.server.persistentVolume.enabled .Values.server.statefulSet.enabled (not (empty .Values.server.persistentVolume.statefulSetNameOverride))) }}
               mountPath: {{ .Values.server.persistentVolume.mountPath }}
               subPath: "{{ .Values.server.persistentVolume.subPath }}"
           {{- range .Values.server.extraHostPathMounts }}
@@ -437,12 +437,13 @@ spec:
 {{- if .Values.server.extraVolumes }}
 {{ toYaml .Values.server.extraVolumes | indent 8}}
 {{- end }}
-      {{- if not .Values.server.statefulSet.enabled }}
-        - name: {{ .Values.server.persistentVolume.statefulSetNameOverride | default "storage-volume" }}
-        {{- if .Values.server.persistentVolume.enabled }}
+        {{- if and .Values.server.persistentVolume.enabled (not .Values.server.statefulSet.enabled) }}
+        - name: "storage-volume"
           persistentVolumeClaim:
             claimName: {{ if .Values.server.persistentVolume.existingClaim }}{{ .Values.server.persistentVolume.existingClaim }}{{- else }}{{ template "prometheus.server.fullname" . }}{{- end }}
-        {{- else }}
+        {{- end }}
+        {{- if not .Values.server.persistentVolume.enabled }}
+        - name: "storage-volume"
           emptyDir:
           {{- if or .Values.server.emptyDir.sizeLimit .Values.server.emptyDir.medium }}
           {{- if .Values.server.emptyDir.medium }}
@@ -455,24 +456,23 @@ spec:
             {}
           {{- end -}}
         {{- end -}}
-      {{- end -}}
   {{- if and .Values.server.statefulSet.enabled .Values.server.persistentVolume.enabled }}
   volumeClaimTemplates:
     - apiVersion: v1
       kind: PersistentVolumeClaim
       metadata:
         name: {{ .Values.server.persistentVolume.statefulSetNameOverride | default "storage-volume" }}
-        {{- if .Values.server.persistentVolume.annotations }}
+        {{- with .Values.server.persistentVolume.annotations }}
         annotations:
-{{ toYaml .Values.server.persistentVolume.annotations | indent 10 }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{- if .Values.server.persistentVolume.labels }}
+        {{- with .Values.server.persistentVolume.labels }}
         labels:
-{{ toYaml .Values.server.persistentVolume.labels | indent 10 }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
       spec:
         accessModes:
-{{ toYaml .Values.server.persistentVolume.accessModes | indent 10 }}
+          {{- toYaml .Values.server.persistentVolume.accessModes | nindent 10 }}
         resources:
           requests:
             storage: "{{ .Values.server.persistentVolume.size }}"

--- a/charts/prometheus/templates/deploy.yaml
+++ b/charts/prometheus/templates/deploy.yaml
@@ -295,10 +295,11 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- $storageVolumeName := ternary .Values.server.persistentVolume.statefulSetNameOverride "storage-volume" (and .Values.server.persistentVolume.enabled .Values.server.statefulSet.enabled (not (empty .Values.server.persistentVolume.statefulSetNameOverride))) }}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config
-            - name: {{ ternary .Values.server.persistentVolume.statefulSetNameOverride "storage-volume" (and .Values.server.persistentVolume.enabled .Values.server.statefulSet.enabled (not (empty .Values.server.persistentVolume.statefulSetNameOverride))) }}
+            - name: {{ $storageVolumeName }}
               mountPath: {{ .Values.server.persistentVolume.mountPath }}
               subPath: "{{ .Values.server.persistentVolume.subPath }}"
           {{- range .Values.server.extraHostPathMounts }}
@@ -438,12 +439,11 @@ spec:
 {{ toYaml .Values.server.extraVolumes | indent 8}}
 {{- end }}
         {{- if and .Values.server.persistentVolume.enabled (not .Values.server.statefulSet.enabled) }}
-        - name: "storage-volume"
+        - name: {{ $storageVolumeName }}
           persistentVolumeClaim:
             claimName: {{ if .Values.server.persistentVolume.existingClaim }}{{ .Values.server.persistentVolume.existingClaim }}{{- else }}{{ template "prometheus.server.fullname" . }}{{- end }}
-        {{- end }}
-        {{- if not .Values.server.persistentVolume.enabled }}
-        - name: "storage-volume"
+        {{- else if not .Values.server.persistentVolume.enabled }}
+        - name: {{ $storageVolumeName }}
           emptyDir:
           {{- if or .Values.server.emptyDir.sizeLimit .Values.server.emptyDir.medium }}
           {{- if .Values.server.emptyDir.medium }}
@@ -461,7 +461,7 @@ spec:
     - apiVersion: v1
       kind: PersistentVolumeClaim
       metadata:
-        name: {{ .Values.server.persistentVolume.statefulSetNameOverride | default "storage-volume" }}
+        name: {{ $storageVolumeName }}
         {{- with .Values.server.persistentVolume.annotations }}
         annotations:
           {{- toYaml . | nindent 10 }}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR restores support for configuring a statefulset without a persistent volume, i.e. with an _emptyDir_ volume.

#### Which issue this PR fixes

- fixes #5962

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
