### PR TITLE
[prometheus-kafka-exporter] feat: added hostAliases capabilities

### DIFF
--- a/charts/prometheus-kafka-exporter/Chart.yaml
+++ b/charts/prometheus-kafka-exporter/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v1.9.0"
 description: A Helm chart to export the metrics from Kafka in Prometheus format using the kafka-exporter from https://github.com/danielqsj/kafka_exporter
 name: prometheus-kafka-exporter
 home: https://github.com/danielqsj/kafka_exporter
-version: 2.15.0
+version: 2.16.0
 kubeVersion: ">=1.19.0-0"
 sources:
   - https://gkarthiks.github.io/helm-charts/charts/prometheus-kafka-exporter

--- a/charts/prometheus-kafka-exporter/templates/deployment.yaml
+++ b/charts/prometheus-kafka-exporter/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
       {{- toYaml .Values.securityContext | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ template "prometheus-kafka-exporter.serviceAccountName" . }}
+      {{- with .Values.hostAliases }}
+      hostAliases:
+          {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - args:
             - '--verbosity={{ .Values.verbosity }}'

--- a/charts/prometheus-kafka-exporter/values.yaml
+++ b/charts/prometheus-kafka-exporter/values.yaml
@@ -9,6 +9,10 @@ command: []
 
 imagePullSecrets: []
 
+hostAliases: []
+  # - ip: "10.10.10.10"
+  #   hostnames: ["kafka.server"]
+
 # Additional labels for deployment
 deploymentLabels: {}
 


### PR DESCRIPTION
# Description:
This PR introduces support for defining Kubernetes hostAliases via values.yaml in the prometheus-kafka-exporter Helm chart.
hostAliases allow mapping custom hostnames to IP addresses inside the Pod’s /etc/hosts file, which can be useful in environments without DNS records or when static hostname resolution is required.

# Changes:

**charts/prometheus-kafka-exporter/templates/deployment.yaml**

Added a conditional block to render hostAliases if provided in values.yaml.

**charts/prometheus-kafka-exporter/values.yaml**

Added a new hostAliases key with an example configuration (commented out by default).

# Benefits:

Enables optional static hostname resolution for the exporter Pod without requiring external DNS changes.
Fully backwards-compatible: if hostAliases is empty or not set, no changes are applied to the Deployment.

# Version bump:

Chart version updated from 2.15.0 -> **2.16.0**