### PR TITLE
[kube-state-metrics] fix: kube-state-metrics extraArgs doc link

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - kubernetes
 type: application
-version: 6.1.3
+version: 6.1.4
 # renovate: github-releases=kubernetes/kube-state-metrics
 appVersion: 2.16.0
 home: https://github.com/kubernetes/kube-state-metrics/

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -49,7 +49,7 @@ revisionHistoryLimit: 10
 
 # List of additional cli arguments to configure kube-state-metrics
 # for example: --enable-gzip-encoding, --log-file, etc.
-# all the possible args can be found here: https://github.com/kubernetes/kube-state-metrics/blob/master/docs/cli-arguments.md
+# all the possible args can be found here: https://github.com/kubernetes/kube-state-metrics/blob/main/docs/developer/cli-arguments.md
 extraArgs: []
 
 # If false then the user will opt out of automounting API credentials.


### PR DESCRIPTION
#### What this PR does / why we need it

#### Which issue this PR fixes

- fixes a link in values.yaml for kube-state-metrics

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [x ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
