### PR TITLE
[alertmanager] chart fix emptyDir option  from prometheus chart

### DIFF
--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -238,6 +238,15 @@ spec:
             optional: {{ . }}
             {{- end }}
         {{- end }}
+        {{- if not .Values.persistence.enabled }}
+        - name: storage
+          {{- with .Values.persistence.emptyDir }}
+          emptyDir:
+            {{- toYaml . | nindent 12 }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- end }}
         {{- if .Values.extraVolumes }}
         {{- toYaml .Values.extraVolumes | nindent 8 }}
         {{- end }}
@@ -261,12 +270,4 @@ spec:
         storageClassName: {{ .Values.persistence.storageClass }}
       {{- end }}
       {{- end }}
-  {{- else }}
-        - name: storage
-            {{- with .Values.persistence.emptyDir }}
-          emptyDir:
-            {{- toYaml . | nindent 12 }}
-            {{- else }}
-          emptyDir: {}
-            {{- end -}}
   {{- end }}


### PR DESCRIPTION

#### What this PR does / why we need it

This PR fix issue of using emptyDir for downstream alertmanager when using prometheus chart


#### Which issue this PR fixes

None

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
