### PR TITLE
[prometheus-redis-exporter] render ServiceMonitor regardless of the monitoring CRD present

### DIFF
--- a/charts/prometheus-redis-exporter/Chart.yaml
+++ b/charts/prometheus-redis-exporter/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: v1.76.0
 description: Prometheus exporter for Redis metrics
 name: prometheus-redis-exporter
-version: 6.16.0
+version: 6.17.0
 home: https://github.com/oliver006/redis_exporter
 sources:
   - https://github.com/oliver006/redis_exporter

--- a/charts/prometheus-redis-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-redis-exporter/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.serviceMonitor.enabled ) }}
+{{- if .Values.serviceMonitor.enabled }}
 apiVersion: {{ .Values.serviceMonitor.apiVersion | default "monitoring.coreos.com/v1" }}
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
The ServiceMonitor template would only render and install for monitoring.coreos.com only. On AKS Managed Prometheus clusters that ship only azmonitoring.coreos.com, Helm skips rendering the ServiceMonitor even with serviceMonitor.enabled being set to true and an apiVersion override. 

This change is an approach to gating the template that is consistent with other exporters within this repository. 

#### Which issue this PR fixes

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
