### PR TITLE
[prometheus-rabbitmq-exporter] Fix the issue to add labels to Service

### DIFF
--- a/charts/prometheus-rabbitmq-exporter/Chart.yaml
+++ b/charts/prometheus-rabbitmq-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Rabbitmq metrics exporter for prometheus
 name: prometheus-rabbitmq-exporter
-version: 2.1.1
+version: 2.1.2
 appVersion: 1.0.0
 home: https://github.com/kbudde/rabbitmq_exporter
 sources:

--- a/charts/prometheus-rabbitmq-exporter/templates/service.yaml
+++ b/charts/prometheus-rabbitmq-exporter/templates/service.yaml
@@ -7,9 +7,9 @@ metadata:
     chart: {{ template "prometheus-rabbitmq-exporter.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  {{- with .Values.service.labels }}
-    {{ toYaml . | indent 4 }}
-  {{- end }}
+    {{- with .Values.service.labels -}}
+      {{ toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/prometheus-rabbitmq-exporter/values.yaml
+++ b/charts/prometheus-rabbitmq-exporter/values.yaml
@@ -12,7 +12,9 @@ service:
   type: ClusterIP
   externalPort: 9419
   internalPort: 9419
-  labels: {}
+  labels:
+    foo: bar
+    blah: darh
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
#### What this PR does / why we need it
This PR fix the issue that helm would crash when you define some labels for the _Service_.

#### Which issue this PR fixes
1. Add some labels to the _Service_
```
diff --git a/values.yaml b/values.yaml                                                                                                                                                                             
index 66ceac8..11047b8 100644
--- a/values.yaml
+++ b/values.yaml
@@ -12,7 +12,9 @@ service:
   type: ClusterIP
   externalPort: 9419
   internalPort: 9419
-  labels: {}
+  labels: 
+    foo: bar
+    blah: darh
                                                                                                                                                                                                                 
 resources: {}                                                                                                                                                                                                     
   # We usually recommend not to specify default resources and to leave this as a conscious
```

2. Then  run 
```
$ helm template rabbitmq-exporter . --debug  --version 2.1.1 -f ./values.yaml 
  ...
Error: YAML parse error on prometheus-rabbitmq-exporter/templates/service.yaml: error converting YAML to JSON: yaml: line 10: mapping values are not allowed in this context
helm.go:84: [debug] error converting YAML to JSON: yaml: line 10: mapping values are not allowed in this context
YAML parse error on prometheus-rabbitmq-exporter/templates/service.yaml
```

- fixes # 

```
# git diff 
diff --git a/templates/service.yaml b/templates/service.yaml                                                                                                                                                       
index 394c9cb..447ccf5 100644
--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -7,9 +7,9 @@ metadata:
     chart: {{ template "prometheus-rabbitmq-exporter.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  {{- with .Values.service.labels }}
-    {{ toYaml . | indent 4 }}
-  {{- end }}
+    {{- with .Values.service.labels -}}
+      {{ toYaml . | nindent 4 }}
+    {{- end }}
 spec:
```

#### Special notes for your reviewer

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
