### PR TITLE
[kube-prometheus-stack] Pass Grafana ds and dashboard `label` and `labelValue` thru `tpl`

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -31,7 +31,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 77.6.2
+version: 77.6.3
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.85.0
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/hack/sync_grafana_dashboards.py
+++ b/charts/kube-prometheus-stack/hack/sync_grafana_dashboards.py
@@ -132,7 +132,7 @@ metadata:
 {{ toYaml .Values.grafana.sidecar.dashboards.annotations | indent 4 }}
   labels:
     {{- if $.Values.grafana.sidecar.dashboards.label }}
-    {{ $.Values.grafana.sidecar.dashboards.label }}: {{ ternary $.Values.grafana.sidecar.dashboards.labelValue "1" (not (empty $.Values.grafana.sidecar.dashboards.labelValue)) | quote }}
+    {{ tpl $.Values.grafana.sidecar.dashboards.label $ }}: {{ ternary (tpl $.Values.grafana.sidecar.dashboards.labelValue $) "1" (not (empty $.Values.grafana.sidecar.dashboards.labelValue)) | quote }}
     {{- end }}
     app: {{ template "kube-prometheus-stack.name" $ }}-grafana
 {{ include "kube-prometheus-stack.labels" $ | indent 4 }}

--- a/charts/kube-prometheus-stack/templates/grafana/configmaps-datasources.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/configmaps-datasources.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- toYaml .Values.grafana.sidecar.datasources.annotations | nindent 4 }}
 {{- end }}
   labels:
-    {{ $.Values.grafana.sidecar.datasources.label }}: {{ $.Values.grafana.sidecar.datasources.labelValue | quote }}
+    {{ tpl $.Values.grafana.sidecar.datasources.label $ }}: {{ (tpl $.Values.grafana.sidecar.datasources.labelValue $) | quote }}
     app: {{ template "kube-prometheus-stack.name" $ }}-grafana
 {{ include "kube-prometheus-stack.labels" $ | indent 4 }}
 data:


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

According to [Grafana docs](https://github.com/grafana/helm-charts/blob/d73a322972ab1ef4220154199b1e28405b60d53a/charts/grafana/values.yaml#L1005-L1008) datasource sidecar's `label` and `labelValue` can be templated. This commit adds those missing `tpl` functions in default datasource template. Similarly dashboard sidecar `label` and `labelValue` also support [templating](https://github.com/grafana/helm-charts/blob/d73a322972ab1ef4220154199b1e28405b60d53a/charts/grafana/values.yaml#L1087-L1090) which is added in `sync_grafana_dashboards.py` file.

Currently downstream charts that have `kube-prometheus-stack` as dependency do not allow templating of `label` and `labelValues` of the Grafana datasource and dashboard configmaps/secrets due to missing `tpl` functions in templates of Grafana default datasources and dashboards. This PR fixes!

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
