### PR TITLE
[prometheus-kafka-exporter] Add Startup Probe

### DIFF
--- a/charts/prometheus-kafka-exporter/Chart.yaml
+++ b/charts/prometheus-kafka-exporter/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v1.9.0"
 description: A Helm chart to export the metrics from Kafka in Prometheus format using the kafka-exporter from https://github.com/danielqsj/kafka_exporter
 name: prometheus-kafka-exporter
 home: https://github.com/danielqsj/kafka_exporter
-version: 2.16.0
+version: 2.17.0
 kubeVersion: ">=1.19.0-0"
 sources:
   - https://gkarthiks.github.io/helm-charts/charts/prometheus-kafka-exporter

--- a/charts/prometheus-kafka-exporter/templates/deployment.yaml
+++ b/charts/prometheus-kafka-exporter/templates/deployment.yaml
@@ -127,6 +127,10 @@ spec:
             - name: exporter-port
               containerPort: 9308
               protocol: TCP
+{{- if .Values.startup.enabled }}
+          startupProbe:
+{{- toYaml .Values.startup.probe | trim | nindent 12 }}
+{{- end }}
 {{- if .Values.liveness.enabled }}
           livenessProbe:
 {{- toYaml .Values.liveness.probe | trim | nindent 12 }}

--- a/charts/prometheus-kafka-exporter/values.yaml
+++ b/charts/prometheus-kafka-exporter/values.yaml
@@ -99,6 +99,13 @@ service:
   # The field is deprecated, implementation-specific annotations should be set instead.
   loadBalancerIP: null
 
+startup:
+  enabled: false
+  probe:
+    httpGet:
+      path: /
+      port: exporter-port
+
 liveness:
   enabled: false
   probe:


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Added startup probe for prometheus-kafka-exporter chart which was missing.

#### Which issue this PR fixes
#5884 

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
