### PR TITLE
[kube-state-metrics] align metricAnnotationsAllowlist

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - kubernetes
 type: application
-version: 6.3.0
+version: 6.3.1
 # renovate: github-releases=kubernetes/kube-state-metrics
 appVersion: 2.17.0
 home: https://github.com/kubernetes/kube-state-metrics/

--- a/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/kube-state-metrics/templates/deployment.yaml
@@ -96,8 +96,10 @@ spec:
         {{- if .Values.metricLabelsAllowlist }}
         - --metric-labels-allowlist={{ .Values.metricLabelsAllowlist | join "," }}
         {{- end }}
-        {{- if .Values.metricAnnotationsAllowList }}
-        - --metric-annotations-allowlist={{ .Values.metricAnnotationsAllowList | join "," }}
+        {{- /* backwards compatibility with metricAnnotationsAllowList */ }}
+        {{- $metricAnnotationsAllowlist := .Values.metricAnnotationsAllowlist | default .Values.metricAnnotationsAllowList }}
+        {{- if $metricAnnotationsAllowlist }}
+        - --metric-annotations-allowlist={{ $metricAnnotationsAllowlist | join "," }}
         {{- end }}
         {{- if .Values.metricAllowlist }}
         - --metric-allowlist={{ .Values.metricAllowlist | join "," }}

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -397,7 +397,7 @@ metricLabelsAllowlist: []
 # annotation keys you would like to allow for them (Example: '=namespaces=[kubernetes.io/team,...],pods=[kubernetes.io/team],...)'.
 # A single '*' can be provided per resource instead to allow any annotations, but that has
 # severe performance implications (Example: '=pods=[*]').
-metricAnnotationsAllowList: []
+metricAnnotationsAllowlist: []
   # - pods=[k8s-annotation-1,k8s-annotation-n]
 
 # Available collectors for kube-state-metrics.


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
The difference in the name of `metricAnnotationsAllowList` and `metricLabelsAllowlist` is confusing and can lead to misktakes when configuring the chart. The names should therefore be aligned. The new name also matches the capitalization in `metricAllowlist` and `metricDenylist`.

#### Which issue this PR fixes

- fixes #5651

#### Special notes for your reviewer

The change could also be made in a backwards-incompatible way to keep the chart cleaner, if you prefer.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
