### PR TITLE
[prometheus-kafka-exporter] Add new values to set TLS file names

### DIFF
--- a/charts/prometheus-kafka-exporter/Chart.yaml
+++ b/charts/prometheus-kafka-exporter/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v1.9.0"
 description: A Helm chart to export the metrics from Kafka in Prometheus format using the kafka-exporter from https://github.com/danielqsj/kafka_exporter
 name: prometheus-kafka-exporter
 home: https://github.com/danielqsj/kafka_exporter
-version: 2.17.0
+version: 2.18.0
 kubeVersion: ">=1.19.0-0"
 sources:
   - https://gkarthiks.github.io/helm-charts/charts/prometheus-kafka-exporter

--- a/charts/prometheus-kafka-exporter/Chart.yaml
+++ b/charts/prometheus-kafka-exporter/Chart.yaml
@@ -1,12 +1,13 @@
 apiVersion: v2
 appVersion: "v1.9.0"
-description: A Helm chart to export the metrics from Kafka in Prometheus format using the kafka-exporter from https://github.com/danielqsj/kafka_exporter
+description: A Helm chart to export metrics from Kafka in Prometheus format using kafka_exporter from https://github.com/danielqsj/kafka_exporter
 name: prometheus-kafka-exporter
 home: https://github.com/danielqsj/kafka_exporter
 version: 2.18.0
 kubeVersion: ">=1.19.0-0"
 sources:
-  - https://gkarthiks.github.io/helm-charts/charts/prometheus-kafka-exporter
+  - https://github.com/prometheus-community/helm-charts
+  - https://github.com/danielqsj/kafka_exporter
 keywords:
   - prometheus
   - kafka
@@ -20,6 +21,7 @@ maintainers:
   - name: zeritti
     email: rootsandtrees@posteo.de
     url: https://github.com/zeritti
+type: application
 annotations:
   "artifacthub.io/links": |
     - name: Chart Source

--- a/charts/prometheus-kafka-exporter/templates/deployment.yaml
+++ b/charts/prometheus-kafka-exporter/templates/deployment.yaml
@@ -88,12 +88,12 @@ spec:
             - '--sasl.keytab-path={{ .Values.sasl.kerberos.mountPath }}/kerberos.keytab'
             - '--sasl.kerberos-auth-type={{ .Values.sasl.kerberos.kerberosAuthType }}'
           {{- end }}
+          {{- end }}
           {{- if .Values.server.tls.enabled }}
             - '--server.tls.ca-file={{ .Values.server.tls.mountPath }}/{{ .Values.server.tls.caFile }}'
             - '--server.tls.cert-file={{ .Values.server.tls.mountPath }}/{{ .Values.server.tls.certFile }}'
             - '--server.tls.key-file={{ .Values.server.tls.mountPath }}/{{ .Values.server.tls.keyFile }}'
             - '--server.tls.mutual-auth-enabled={{ .Values.server.tls.mutualAuthEnabled }}'
-          {{- end }}
           {{- end }}
           {{- if .Values.extraArgs }}
           {{- range .Values.extraArgs  }}
@@ -146,7 +146,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if or (.Values.tls.mountPath) (.Values.sasl.kerberos.mountPath) }}
+          {{- if or (.Values.tls.mountPath) (.Values.sasl.kerberos.mountPath) (.Values.server.tls.mountPath) }}
           volumeMounts:
             {{- if .Values.tls.mountPath }}
             - mountPath: {{ .Values.tls.mountPath }}
@@ -176,7 +176,7 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
-      {{- if or (.Values.tls.mountPath) (.Values.sasl.kerberos.mountPath) }}
+      {{- if or (.Values.tls.mountPath) (.Values.sasl.kerberos.mountPath) (.Values.server.tls.mountPath) }}
       volumes:
         {{- if .Values.tls.mountPath }}
         - name: kafka-certs

--- a/charts/prometheus-kafka-exporter/templates/deployment.yaml
+++ b/charts/prometheus-kafka-exporter/templates/deployment.yaml
@@ -55,9 +55,9 @@ spec:
           {{- if .Values.tls.enabled }}
             - '--tls.enabled'
           {{- if .Values.tls.mountPath }}
-            - '--tls.ca-file={{ .Values.tls.mountPath }}/ca.crt'
-            - '--tls.cert-file={{ .Values.tls.mountPath }}/tls.crt'
-            - '--tls.key-file={{ .Values.tls.mountPath }}/tls.key'
+            - '--tls.ca-file={{ .Values.tls.mountPath }}/{{ .Values.tls.caFile }}'
+            - '--tls.cert-file={{ .Values.tls.mountPath }}/{{ .Values.tls.certFile }}'
+            - '--tls.key-file={{ .Values.tls.mountPath }}/{{ .Values.tls.keyFile }}'
           {{- end }}
           {{- if .Values.tls.insecureSkipVerify }}
             - '--tls.insecure-skip-tls-verify'
@@ -89,9 +89,9 @@ spec:
             - '--sasl.kerberos-auth-type={{ .Values.sasl.kerberos.kerberosAuthType }}'
           {{- end }}
           {{- if .Values.server.tls.enabled }}
-            - '--server.tls.ca-file={{ .Values.server.tls.mountPath }}/ca.crt'
-            - '--server.tls.cert-file={{ .Values.server.tls.mountPath }}/tls.crt'
-            - '--server.tls.key-file={{ .Values.server.tls.mountPath }}/tls.key'
+            - '--server.tls.ca-file={{ .Values.server.tls.mountPath }}/{{ .Values.server.tls.caFile }}'
+            - '--server.tls.cert-file={{ .Values.server.tls.mountPath }}/{{ .Values.server.tls.certFile }}'
+            - '--server.tls.key-file={{ .Values.server.tls.mountPath }}/{{ .Values.server.tls.keyFile }}'
             - '--server.tls.mutual-auth-enabled={{ .Values.server.tls.mutualAuthEnabled }}'
           {{- end }}
           {{- end }}

--- a/charts/prometheus-kafka-exporter/values.yaml
+++ b/charts/prometheus-kafka-exporter/values.yaml
@@ -178,10 +178,6 @@ tolerations: []
 affinity: {}
 
 # this allows the usage of tls connection to your kafka cluster based on a secret in tls format
-# mandatory keys:
-# ca.crt
-# tls.crt
-# tls.key
 tls:
   enabled: false
   insecureSkipVerify: false

--- a/charts/prometheus-kafka-exporter/values.yaml
+++ b/charts/prometheus-kafka-exporter/values.yaml
@@ -189,6 +189,9 @@ tls:
   serverName: ""
   # mountPath: /secret/certs
   # secretName: <name of an existing secret>
+  caFile: ca.crt
+  certFile: tls.crt
+  keyFile: tls.key
 
 sasl:
   enabled: false
@@ -226,8 +229,11 @@ server:
   tls:
     enabled: false
     mutualAuthEnabled: false
-  # mountPath: /secret/certs
-  # secretName: <name of an existing secret>
+    # mountPath: /secret/certs
+    # secretName: <name of an existing secret>
+    caFile: ca.crt
+    certFile: tls.crt
+    keyFile: tls.key
 
 # If enabled Kafka dependency chart will be used.
 # This is only needed for the CI job so it should always be disabled.


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR updates the **prometheus-kafka-exporter** Helm chart to allow users to specify custom TLS file names via new values:  
```yaml
tls:
  ...
  # secretName: <name of an existing secret>
  caFile: ca.crt
  certFile: tls.crt
  keyFile: tls.key

server:
  tls:
    ...
    # secretName: <name of an existing secret>
    caFile: ca.crt
    certFile: tls.crt
    keyFile: tls.key
```

The deployment template has been updated to use these values for both the main and server TLS configuration, replacing previously hardcoded file names.  

Default values are set to:
- `ca.crt`
- `tls.crt`
- `tls.key`

This change makes the chart more flexible when working with secrets created by tools like the [Strimzi Kafka Operator](https://strimzi.io/), which names secret keys differently.

#### Special notes for your reviewer

- The change is backward compatible, since defaults align with existing behavior.  
- No changes are required for existing users unless they want to override the file names.  

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-kafka-exporter]`)
