### PR TITLE
[CI] Allow mend[bot] to run Renovate post job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -138,7 +138,7 @@ jobs:
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository 
       && contains(github.event.pull_request.labels.*.name, 'dependencies/auto-merge') 
-      && (github.actor == 'renovate[bot]' || github.actor == 'helm-charts-renovate-helper[bot]')
+      && (github.actor == 'renovate[bot]' || github.actor == 'mend[bot]' || github.actor == 'helm-charts-renovate-helper[bot]')
     steps:
       # Using a GitHub App token, because GitHub Actions doesn't run on commits from github-actions bot
       # Used App:

--- a/.github/workflows/renovate-custom-hooks.yaml
+++ b/.github/workflows/renovate-custom-hooks.yaml
@@ -11,7 +11,7 @@ jobs:
   renovate-post-run:
     name: Renovate Post Run
     runs-on: ubuntu-latest
-    if: github.actor == 'renovate[bot]'
+    if: github.actor == 'renovate[bot]' || github.actor == 'mend[bot]'
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:


### PR DESCRIPTION
#### What this PR does / why we need it

See:

* https://github.com/renovatebot/renovate/discussions/37842

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
