### PR TITLE
[kube-prometheus-stack] pvc storage alert by percentage

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -31,7 +31,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 77.10.0
+version: 77.11.0
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.85.0
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-storage.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-storage.yaml
@@ -214,4 +214,32 @@ spec:
         {{- end }}
       {{- end }}
 {{- end }}
+{{- if not (.Values.defaultRules.disabled.KubernetesStorageUsage85Percent | default false) }}
+    - alert: KubernetesStorageUsage85Percent
+      annotations:
+{{- if .Values.defaultRules.additionalRuleAnnotations }}
+{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
+{{- end }}
+{{- if .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesStorage }}
+{{ toYaml .Values.defaultRules.additionalRuleGroupAnnotations.kubernetesStorage | indent 8 }}
+{{- end }}
+        description: Storage usage of PVC {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.persistentvolumeclaim {{`}}`}} has exceeded 85% for the last 5 minutes.
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodefilesystemspacefillingup/#:~:text=A%20filesystem%20running%20full%20is%20very%20bad%20for%20any%20process%20in%20need%20to%20write%20to%20the%20filesystem.%20But%20even%20before%20a%20filesystem%20runs%20full%2C%20performance%20is%20usually%20degrading.
+        summary: High storage usage detected (PVC {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.persistentvolumeclaim {{`}}`}})
+      expr: kubelet_volume_stats_used_bytes{job="kubelet", namespace{{ $namespaceOperator }}"{{ $targetNamespace }}", metrics_path="/metrics"} / kubelet_volume_stats_capacity_bytes{job="kubelet", namespace{{ $namespaceOperator }}"{{ $targetNamespace }}", metrics_path="/metrics"} * 100 > 85
+      for: {{ dig "KubernetesStorageUsage85Percent" "for" "5m" .Values.customRules }}
+      {{- with .Values.defaultRules.keepFiringFor }}
+      keep_firing_for: "{{ . }}"
+      {{- end }}
+      labels:
+        severity: {{ dig "KubernetesStorageUsage85Percent" "severity" "warning" .Values.customRules }}
+      {{- if or .Values.defaultRules.additionalRuleLabels .Values.defaultRules.additionalRuleGroupLabels.kubernetesStorage }}
+        {{- with .Values.defaultRules.additionalRuleLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.defaultRules.additionalRuleGroupLabels.kubernetesStorage }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Adds a new alert that shows current storage usage percentage.

**Problem**: The existing KubePersistentVolumeFillingUp alert only says "storage will be full in 4 days" but doesn't tell you how full it is right now. Even after 4 days, it still says 4 days. This makes it hard to know if you need to act immediately.

**Solution**: This new alert fires when storage hits 85% usage. It tells you exactly how much storage is being used right now.

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
