### PR TITLE
[prometheus-postgres-exporter] Add metricRelabelings per target

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: v0.18.1
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 7.2.1
+version: 7.2.2
 home: https://github.com/prometheus-community/postgres_exporter
 sources:
   - https://github.com/prometheus-community/postgres_exporter

--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: v0.18.1
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 7.2.2
+version: 7.3.0
 home: https://github.com/prometheus-community/postgres_exporter
 sources:
   - https://github.com/prometheus-community/postgres_exporter

--- a/charts/prometheus-postgres-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-postgres-exporter/templates/servicemonitor.yaml
@@ -40,6 +40,9 @@ spec:
       {{- if $.Values.serviceMonitor.metricRelabelings -}}
         {{ toYaml $.Values.serviceMonitor.metricRelabelings | nindent 8 }}
       {{- end }}
+      {{- if .metricRelabelings -}}
+        {{ toYaml .metricRelabelings | nindent 8 }}
+      {{- end }}
   {{- if $.Values.serviceMonitor.relabelings }}
       relabelings: {{ toYaml $.Values.serviceMonitor.relabelings | nindent 8 }}
   {{- end }}

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -68,6 +68,7 @@ serviceMonitor:
       #   name: pg01 (there needs to exist an authModule with key "client.pg01" if not using sharedAuthModule)
       #   port: default 5432
       #   databaseName: default '' (Set the database name to connect to)
+      #   metricRelabelings: [] (MetricRelabelConfigs to apply to samples from the target before ingestion)
 
 prometheusRule:
   enabled: false


### PR DESCRIPTION
#### What this PR does / why we need it

This commit adds support for adding `metricRelabelings` support per target when using Multi Target in `postgres-exporter`. In a Multi Target environment this can be useful for example for adding labels to a specific target.

For example in my project we have a `postgres-exporter` deployment with several targets using Multi Target support. Each target is owned to a different team, and we plan to use this feature to route alerts to the corresponding team notification channel.

#### Which issue this PR fixes

n/a

#### Special notes for your reviewer

Thanks for your work!!

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
