### PR TITLE
[kube-prometheus-stack] Support supplying jsonData on the default datasource

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -31,7 +31,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 77.12.0
+version: 77.12.1
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.85.0
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/templates/grafana/configmaps-datasources.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/configmaps-datasources.yaml
@@ -62,6 +62,9 @@ data:
       access: proxy
       isDefault: false
       jsonData:
+      {{- with $.Values.grafana.sidecar.datasources.extraJsonData -}}
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
         timeInterval: {{ $scrapeInterval }}
 {{- if $.Values.grafana.sidecar.datasources.exemplarTraceIdDestinations }}
         exemplarTraceIdDestinations:

--- a/charts/kube-prometheus-stack/templates/grafana/configmaps-datasources.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/configmaps-datasources.yaml
@@ -36,6 +36,9 @@ data:
       access: proxy
       isDefault: {{ .Values.grafana.sidecar.datasources.isDefaultDatasource }}
       jsonData:
+      {{- if .Values.grafana.sidecar.datasources.extraJsonData -}}
+        {{ tpl (toYaml .Values.grafana.sidecar.datasources.extraJsonData | nindent 8) . }}
+      {{- end }}
         httpMethod: {{ .Values.grafana.sidecar.datasources.httpMethod }}
         timeInterval: {{ $scrapeInterval }}
         {{- if .Values.grafana.sidecar.datasources.timeout }}

--- a/charts/kube-prometheus-stack/templates/grafana/configmaps-datasources.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/configmaps-datasources.yaml
@@ -36,8 +36,8 @@ data:
       access: proxy
       isDefault: {{ .Values.grafana.sidecar.datasources.isDefaultDatasource }}
       jsonData:
-      {{- if .Values.grafana.sidecar.datasources.extraJsonData -}}
-        {{ tpl (toYaml .Values.grafana.sidecar.datasources.extraJsonData | nindent 8) . }}
+      {{- with .Values.grafana.sidecar.datasources.extraJsonData -}}
+        {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
         httpMethod: {{ .Values.grafana.sidecar.datasources.httpMethod }}
         timeInterval: {{ $scrapeInterval }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1388,6 +1388,10 @@ grafana:
       name: Prometheus
       uid: prometheus
 
+      ## Extra jsonData properties to add to the datasource
+      # extraJsonData:
+      #  prometheusType: Prometheus
+
       ## URL of prometheus datasource
       ##
       # url: http://prometheus-stack-prometheus:9090/


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
This PR allows users to supply arbitrary datasource `jsonData`. Currently, a user cannot change the default datasource's `jsonData` to anything they want (say for example, `prometheusType` which supports [any of these values](https://github.com/grafana/grafana/blob/master/public/app/plugins/datasource/prometheus/types.ts#L31-L36))

This change is opt-in; there is no impact to existing configurations.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
