### PR TITLE
[prometheus-smartctl-exporter] add attachMetadata support to ServiceMonitor

### DIFF
--- a/charts/prometheus-smartctl-exporter/Chart.yaml
+++ b/charts/prometheus-smartctl-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.15.4
+version: 0.16.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/prometheus-smartctl-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-smartctl-exporter/templates/servicemonitor.yaml
@@ -12,6 +12,10 @@ metadata:
   namespace: {{ .Values.serviceMonitor.namespace }}
 {{- end }}
 spec:
+{{- with .Values.serviceMonitor.attachMetadata }}
+  attachMetadata:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
   endpoints:
     - interval: {{ .Values.serviceMonitor.interval }}
       path: /metrics

--- a/charts/prometheus-smartctl-exporter/values.yaml
+++ b/charts/prometheus-smartctl-exporter/values.yaml
@@ -34,6 +34,9 @@ serviceMonitor:
   # Set relabel_configs as per https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
   relabelings: []
   metricRelabelings: []
+  ## Attach node metadata to discovered targets. Requires Prometheus v2.35.0 and above.
+  attachMetadata:
+    node: false
 
 prometheusRules:
   enabled: false


### PR DESCRIPTION
## Description
Adds optional `attachMetadata` support to the ServiceMonitor resource.

## Motivation
The `attachMetadata` field allows Prometheus to automatically attach Kubernetes metadata (like node labels) to scraped metrics, which is useful for better observability and filtering.

## Changes
- Added `attachMetadata` field to ServiceMonitor template
- Field is optional and disabled by default (opt-in)
- Added commented example in values.yaml
- Bumped chart version from 0.5.0 to 0.6.0

## Testing
- [x] Rendered template with `helm template` works correctly
- [x] Default behavior unchanged (backward compatible)
- [x] Works when `attachMetadata.node: true` is set

## Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. [prometheus-smartctl-exporter])

## Example Usage
```yaml
serviceMonitor:
  attachMetadata:
    node: true