### PR TITLE
[prometheus-druid-exporter] add ability to specify custom env vars

### DIFF
--- a/charts/prometheus-druid-exporter/Chart.yaml
+++ b/charts/prometheus-druid-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v0.11.0"
 description: Druid exporter to monitor druid metrics with Prometheus
 name: prometheus-druid-exporter
-version: 1.1.2
+version: 1.2.0
 kubeVersion: ">=1.16.0-0"
 type: application
 home: https://github.com/opstree/druid-exporter

--- a/charts/prometheus-druid-exporter/templates/deployment.yaml
+++ b/charts/prometheus-druid-exporter/templates/deployment.yaml
@@ -46,6 +46,9 @@ spec:
           value: {{ .Values.logLevel }}
         - name: LOG_FORMAT
           value: {{ .Values.logFormat }}
+        {{- if .Values.env }}
+          {{- toYaml .Values.env | nindent 8 }}
+        {{- end }}
         image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: {{ include "prometheus-druid-exporter.fullname" . }}

--- a/charts/prometheus-druid-exporter/values.yaml
+++ b/charts/prometheus-druid-exporter/values.yaml
@@ -12,6 +12,11 @@ annotations: {}
 
 podAnnotations: {}
 
+# Additional Environment variables
+env: []
+  # - name: NO_HISTOGRAM
+  #   value: "true"
+
 druidURL: http://druid.opstreelabs.in
 logLevel: info
 logFormat: json


### PR DESCRIPTION
#### What this PR does / why we need it

Add ability to specify envvars for configuration of druid-exporter.

#### Which issue this PR fixes

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
