### PR TITLE
 promtheus-adapter: add configurable revisonHistoryLimit to deployment

### DIFF
--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 5.1.1
+version: 5.2.0
 appVersion: v0.12.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/kubernetes-sigs/prometheus-adapter

--- a/charts/prometheus-adapter/templates/deployment.yaml
+++ b/charts/prometheus-adapter/templates/deployment.yaml
@@ -16,9 +16,7 @@ metadata:
   namespace: {{ include "k8s-prometheus-adapter.namespace" . }}
 spec:
   replicas: {{ .Values.replicas }}
-  {{- if .Values.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-  {{- end }}
   strategy: {{ toYaml .Values.strategy | nindent 4 }}
   selector:
     matchLabels:

--- a/charts/prometheus-adapter/values.yaml
+++ b/charts/prometheus-adapter/values.yaml
@@ -307,4 +307,4 @@ extraManifests: []
   #     extra-data: "value"
 
 # Optional: set revisionHistoryLimit for the Deployment
-revisionHistoryLimit: null
+revisionHistoryLimit: 10


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

#### Which issue this PR fixes

This PR introduces a new optional value to the `prometheus-adapter` Helm chart to allow users to configure the `revisionHistoryLimit` field on the Deployment resource.
By default, Kubernetes sets `revisionHistoryLimit` to `10`. However, users may wish to increase or decrease this number to suit their rollback or resource retention strategies.

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
