### PR TITLE
[prometheus-ipmi-exporter] Add ScrapeConfig

### DIFF
--- a/charts/prometheus-ipmi-exporter/Chart.yaml
+++ b/charts/prometheus-ipmi-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-ipmi-exporter
 description: This is an IPMI exporter for Prometheus.
 type: application
-version: 0.6.3
+version: 0.7.0
 # renovate: github=prometheus-community/ipmi_exporter
 appVersion: "v1.10.1"
 keywords:

--- a/charts/prometheus-ipmi-exporter/README.md
+++ b/charts/prometheus-ipmi-exporter/README.md
@@ -52,3 +52,36 @@ See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_h
 ```console
 helm show values oci://ghcr.io/prometheus-community/charts/prometheus-ipmi-exporter
 ```
+
+### ScrapeConfig vs ServiceMonitor
+
+This chart supports both ServiceMonitor (v1) and ScrapeConfig (v1alpha1) from prometheus-operator.
+
+**ScrapeConfig** is recommended for:
+
+- Scraping IPMI targets in remote mode (exporter as a proxy)
+- Using file-based service discovery
+- More flexibility with relabeling
+
+**Example - Remote IPMI scraping:**
+
+```yaml
+scrapeConfig:
+  enabled: true
+  mode: remote  # Uses /ipmi endpoint with target relabeling
+  staticConfigs:
+    - targets:
+        - 192.168.1.10
+        - 192.168.1.11
+```
+
+**Example - Local exporter metrics:**
+
+```yaml
+scrapeConfig:
+  enabled: true
+  mode: local  # Uses /metrics endpoint directly
+  staticConfigs:
+    - targets:
+        - ipmi-exporter:9290
+```

--- a/charts/prometheus-ipmi-exporter/templates/scrapeconfig.yaml
+++ b/charts/prometheus-ipmi-exporter/templates/scrapeconfig.yaml
@@ -1,0 +1,72 @@
+{{- if .Values.scrapeConfig }}
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1alpha1" ) ( .Values.scrapeConfig.enabled ) }}
+{{- $hasStatic := .Values.scrapeConfig.staticConfigs }}
+{{- $hasFile := .Values.scrapeConfig.fileSDConfigs }}
+{{- $isRemote := eq .Values.scrapeConfig.mode "remote" }}
+{{- if not (or $hasStatic $hasFile) }}
+{{- fail "scrapeConfig requires either staticConfigs or fileSDConfigs to be defined" }}
+{{- end }}
+{{- if and $hasStatic $hasFile }}
+{{- fail "scrapeConfig cannot have both staticConfigs and fileSDConfigs defined" }}
+{{- end }}
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+{{- if .Values.scrapeConfig.labels }}
+  labels:
+{{- toYaml .Values.scrapeConfig.labels | nindent 4 }}
+{{- end }}
+  name: {{ template "prometheus-ipmi-exporter.fullname" . }}
+{{- if .Values.scrapeConfig.namespace }}
+  namespace: {{ .Values.scrapeConfig.namespace }}
+{{- end }}
+spec:
+  jobName: {{ .Values.scrapeConfig.jobName | default "ipmi-exporter" }}
+{{- if .Values.scrapeConfig.modules }}
+  params:
+    module:
+{{- toYaml .Values.scrapeConfig.modules | nindent 6 }}
+{{- else if $isRemote }}
+  params:
+    module:
+      - default
+{{- end }}
+  scrapeInterval: {{ .Values.scrapeConfig.scrapeInterval | default "1m" }}
+  scrapeTimeout: {{ .Values.scrapeConfig.scrapeTimeout | default "30s" }}
+{{- if .Values.scrapeConfig.metricsPath }}
+  metricsPath: {{ .Values.scrapeConfig.metricsPath }}
+{{- else if $isRemote }}
+  metricsPath: /ipmi
+{{- else }}
+  metricsPath: /metrics
+{{- end }}
+  scheme: {{ .Values.scrapeConfig.scheme | default "HTTP" }}
+{{- if .Values.scrapeConfig.fileSDConfigs }}
+  fileSDConfigs:
+{{- toYaml .Values.scrapeConfig.fileSDConfigs | nindent 4 }}
+{{- end }}
+{{- if .Values.scrapeConfig.staticConfigs }}
+  staticConfigs:
+{{- toYaml .Values.scrapeConfig.staticConfigs | nindent 4 }}
+{{- end }}
+{{- if .Values.scrapeConfig.relabelings }}
+  relabelings:
+{{- toYaml .Values.scrapeConfig.relabelings | nindent 4 }}
+{{- else if $isRemote }}
+  relabelings:
+    - sourceLabels: [__address__]
+      targetLabel: __param_target
+      action: replace
+    - sourceLabels: [__param_target]
+      targetLabel: instance
+      action: replace
+    - targetLabel: __address__
+      replacement: {{ include "prometheus-ipmi-exporter.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+      action: replace
+{{- end }}
+{{- if .Values.scrapeConfig.metricRelabelings }}
+  metricRelabelings:
+{{- toYaml .Values.scrapeConfig.metricRelabelings | nindent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/prometheus-ipmi-exporter/values.yaml
+++ b/charts/prometheus-ipmi-exporter/values.yaml
@@ -61,6 +61,44 @@ serviceMonitor:
   # targetLabels: []
   # metricRelabelings: []
 
+scrapeConfig:
+  # When set true then use a ScrapeConfig to configure scraping
+  enabled: false
+  # Set the namespace the ScrapeConfig should be deployed
+  # namespace: monitoring
+  # Set labels for the ScrapeConfig
+  # labels:
+  # Scraping mode: "local" for direct exporter metrics, "remote" for IPMI target scraping
+  mode: remote
+  # Job name for the scrape config
+  # jobName: ipmi-exporter
+  # Modules list
+  # modules:
+  #   - default
+  #   - dcmi
+  # Set how frequently Prometheus should scrape
+  # scrapeInterval: 1m
+  # Set timeout for scrape
+  # scrapeTimeout: 30s
+  # Metrics path (defaults: /metrics for local mode, /ipmi for remote mode)
+  # metricsPath: /ipmi
+  # Scheme (HTTP or HTTPS)
+  # scheme: HTTP
+  # File service discovery configs
+  # fileSDConfigs:
+  #   - files:
+  #       - /etc/prometheus/secrets/ipmi-exporter/targets.yml
+  #     refreshInterval: 5m
+  # Static configs
+  # staticConfigs:
+  #   - targets:
+  #       - 192.168.1.10
+  #       - 192.168.1.11
+  # Relabelings
+  # relabelings: []
+  # Metric relabelings
+  # metricRelabelings: []
+
   # Configuration file for ipmi_exporter
 
 configSecret:


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Add ScrapeConfig object to be able to scrape multiple targets either locally or remotely. This is needed to avoid having to specify the scrape config separately from this chart.

#### Output

##### Local
```
apiVersion: monitoring.coreos.com/v1alpha1
kind: ScrapeConfig
metadata:
  name: prometheus-ipmi-exporter
spec:
  jobName: ipmi-exporter
  scrapeInterval: 1m
  scrapeTimeout: 30s
  metricsPath: /metrics
  scheme: HTTP
  fileSDConfigs:
    - files:
      - /etc/prometheus/secrets/ipmi-exporter/targets.yml
      refreshInterval: 5m
```

##### Remote
```
apiVersion: monitoring.coreos.com/v1alpha1
kind: ScrapeConfig
metadata:
  name: prometheus-ipmi-exporter
spec:
  jobName: ipmi-exporter
  params:
    module:
      - default
  scrapeInterval: 1m
  scrapeTimeout: 30s
  metricsPath: /ipmi
  scheme: HTTP
  fileSDConfigs:
    - files:
      - /etc/prometheus/secrets/ipmi-exporter/targets.yml
      refreshInterval: 5m
  relabelings:
    - sourceLabels: [__address__]
      targetLabel: __param_target
      action: replace
    - sourceLabels: [__param_target]
      targetLabel: instance
      action: replace
    - targetLabel: __address__
      replacement: prometheus-ipmi-exporter.default.svc.cluster.local:9290
      action: replace
```


#### Special notes for your reviewer
- ref: https://github.com/prometheus-community/ipmi_exporter/blob/61b8d3f2601d85de01a0b157784d73f88973b4dd/docs/configuration.md

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
