### PR TITLE
[kube-state-metrics] added missing rolebindings

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - kubernetes
 type: application
-version: 6.4.2
+version: 6.5.0
 # renovate: github-releases=kubernetes/kube-state-metrics
 appVersion: 2.17.0
 home: https://github.com/kubernetes/kube-state-metrics/

--- a/charts/kube-state-metrics/templates/role.yaml
+++ b/charts/kube-state-metrics/templates/role.yaml
@@ -129,6 +129,12 @@ rules:
   - roles
   verbs: ["list", "watch"]
 {{ end -}}
+{{ if has "rolebindings" $.Values.collectors }}
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources:
+    - rolebindings
+  verbs: ["list", "watch"]
+{{ end -}}
 {{ if has "nodes" $.Values.collectors }}
 - apiGroups: [""]
   resources:

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -437,6 +437,7 @@ collectors:
   # - clusterrolebindings
   # - clusterroles
   # - roles
+  # - rolebindings
 
 # Enabling kubeconfig will pass the --kubeconfig argument to the container
 kubeconfig:


### PR DESCRIPTION
#### What this PR does / why we need it

#### Which issue this PR fixes
- fixes #6272

#### Checklist
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
