### PR TITLE
[kube-prometheus-stack]: Update kube-controller-manager and kube-scheduler service selector

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -31,7 +31,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 79.0.1
+version: 79.0.2
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.86.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/service.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/service.yaml
@@ -26,7 +26,7 @@ spec:
     {{- if .Values.kubeControllerManager.service.selector }}
 {{ toYaml .Values.kubeControllerManager.service.selector | indent 4 }}
     {{- else}}
-    component: kube-controller-manager
+    k8s-app: kube-controller-manager
     {{- end}}
 {{- end }}
   type: ClusterIP

--- a/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/service.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/service.yaml
@@ -26,7 +26,7 @@ spec:
     {{- if .Values.kubeScheduler.service.selector }}
 {{ toYaml .Values.kubeScheduler.service.selector | indent 4 }}
     {{- else}}
-    component: kube-scheduler
+    k8s-app: kube-scheduler
     {{- end}}
 {{- end }}
   type: ClusterIP

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1875,7 +1875,7 @@ kubeControllerManager:
       ipFamilies: ["IPv6", "IPv4"]
       ipFamilyPolicy: "PreferDualStack"
     # selector:
-    #   component: kube-controller-manager
+    #   k8s-app: kube-controller-manager
 
   serviceMonitor:
     enabled: true
@@ -1914,7 +1914,7 @@ kubeControllerManager:
     jobLabel: jobLabel
     selector: {}
     #  matchLabels:
-    #    component: kube-controller-manager
+    #    k8s-app: kube-controller-manager
 
     ## Enable scraping kube-controller-manager over https.
     ## Requires proper certs (not self-signed) and delegated authentication/authorization checks.
@@ -2275,7 +2275,7 @@ kubeScheduler:
       ipFamilies: ["IPv6", "IPv4"]
       ipFamilyPolicy: "PreferDualStack"
     # selector:
-    #   component: kube-scheduler
+    #   k8s-app: kube-scheduler
 
   serviceMonitor:
     enabled: true
@@ -2319,7 +2319,7 @@ kubeScheduler:
     jobLabel: jobLabel
     selector: {}
     #  matchLabels:
-    #    component: kube-scheduler
+    #    k8s-app: kube-scheduler
 
     ## Skip TLS certificate validation when scraping
     insecureSkipVerify: null


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR fixes the deployment of the stack to fix scraping from the `kube-controller-manager` and `kube-scheduler`. The key for the selector seems to be an old value based on what I've gathered from [this comment](https://github.com/prometheus-community/helm-charts/issues/3368#issuecomment-1622014574).

Based on what I can tell, this selector is not used anymore in current K8s.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
