### PR TITLE
kube-state-metrics: fix probes when RBAC proxy is enabled

### DIFF
--- a/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/kube-state-metrics/templates/deployment.yaml
@@ -86,9 +86,6 @@ spec:
         {{-  if .Values.extraArgs  }}
         {{- .Values.extraArgs | toYaml | nindent 8 }}
         {{-  end  }}
-        {{- if .Values.kubeRBACProxy.enabled }}
-        - --host=127.0.0.1
-        {{- end }}
         - --port={{ $servicePort }}
         {{-  if .Values.collectors  }}
         - --resources={{ .Values.collectors | join "," }}
@@ -128,7 +125,6 @@ spec:
         - --kubeconfig=/opt/k8s/.kube/config
         {{- end }}
         {{- if .Values.kubeRBACProxy.enabled }}
-        - --telemetry-host=127.0.0.1
         - --telemetry-port={{ $telemetryPort }}
         {{- else }}
         {{- if .Values.selfMonitor.telemetryHost }}
@@ -182,8 +178,8 @@ spec:
             {{- end }}
             path: /healthz
             {{- if .Values.kubeRBACProxy.enabled }}
-            port: http
-            scheme: HTTPS
+            port: {{ $servicePort }}
+            scheme: HTTP
             {{- else }}
             port: {{ $servicePort }}
             scheme: {{ upper .Values.startupProbe.httpGet.scheme }}
@@ -206,8 +202,8 @@ spec:
             {{- end }}
             path: /livez
             {{- if .Values.kubeRBACProxy.enabled }}
-            port: http
-            scheme: HTTPS
+            port: {{ $servicePort }}
+            scheme: HTTP
             {{- else }}
             port: {{ $servicePort }}
             scheme: {{ upper .Values.livenessProbe.httpGet.scheme }}
@@ -229,8 +225,8 @@ spec:
             {{- end }}
             path: /readyz
             {{- if .Values.kubeRBACProxy.enabled }}
-            port: metrics
-            scheme: HTTPS
+            port: {{ $telemetryPort }}
+            scheme: HTTP
             {{- else }}
             port: {{ $telemetryPort }}
             scheme: {{ upper .Values.readinessProbe.httpGet.scheme }}
@@ -315,7 +311,7 @@ spec:
         readinessProbe:
           httpGet:
             scheme: HTTPS
-            port: 8889
+            port: metrics-healthz
             path: healthz
           initialDelaySeconds: 5
           timeoutSeconds: 5


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

When installing the kube-state-metrics with RBAC proxy enabled, the pod never reaches a healthy state.

```
> helm install rbac oci://ghcr.io/prometheus-community/charts/kube-state-metrics --set kubeRBACProxy.enabled=true
> kubectl describe pod/rbac-kube-state-metrics-668c776c-7r4vg

[...]
Events:
  Type     Reason     Age               From               Message
  ----     ------     ----              ----               -------
[...]
  Warning  Unhealthy  9s (x2 over 9s)   kubelet            Readiness probe errored and resulted in unknown state: strconv.Atoi: parsing "metrics": invalid syntax
  Warning  Unhealthy  3s (x2 over 13s)  kubelet            Liveness probe errored and resulted in unknown state: strconv.Atoi: parsing "http": invalid syntax
```

This is because the named ports are not created when rbac proxy is enabled. Additionally, having the host set to `127.0.0.1` when rbac proxy is enabled breaks the health check because the check originates from Kubernetes (outside the container) and therefore the connection is refused.

With this fix, the probes work as expected in all scenarios.

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
