### PR TITLE
[prometheus-mysql-exporter] fix environment variables indentation

### DIFF
--- a/charts/prometheus-mysql-exporter/Chart.yaml
+++ b/charts/prometheus-mysql-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for prometheus mysql exporter with cloudsqlproxy
 name: prometheus-mysql-exporter
-version: 2.11.0
+version: 2.11.1
 home: https://github.com/prometheus/mysqld_exporter
 appVersion: v0.17.2
 sources:

--- a/charts/prometheus-mysql-exporter/templates/deployment.yaml
+++ b/charts/prometheus-mysql-exporter/templates/deployment.yaml
@@ -94,12 +94,12 @@ spec:
           {{- with .Values.extraEnvs }}
           {{- if kindIs "map" . }}
           {{- range $name, $value := . }}
-          - name: {{ $name }}
-            value: {{ tpl $value $ | quote }}
+            - name: {{ $name }}
+              value: {{ tpl $value $ | quote }}
           {{- end }}
           {{- end }}
           {{- if kindIs "slice" . -}}
-          {{ toYaml . | nindent 10 }}
+            {{ toYaml . | nindent 12 }}
           {{- end }}
           {{- end }}
           ports:


### PR DESCRIPTION
#### What this PR does / why we need it

Fixes YAML indentation for environment variables in the deployment template to ensure proper formatting when using `extraEnvs` as both map and slice formats.

Changes:
- Fixed indentation for `extraEnvs` when provided as a map (from 10 to 12 spaces)
- Fixed indentation for `extraEnvs` when provided as a slice (from 10 to 12 spaces)
- Ensures consistent YAML formatting with the parent `env:` block

This resolves potential YAML parsing issues and ensures the environment variables are properly nested under the `env:` section.

/cc @juanchimienti @monotek

#### Special notes for your reviewer

The indentation fix ensures that `extraEnvs` variables align correctly with the `MYSQLD_EXPORTER_PASSWORD ` and other env vars defined above them in the template.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped (2.11.0 → 2.11.1)
- [x] Title of the PR starts with chart name (`[prometheus-mysql-exporter]`)
