### PR TITLE
[prometheus-node-exporter] Add dnsPolicy configuration option

### DIFF
--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - prometheus
   - exporter
 type: application
-version: 4.49.2
+version: 4.50.0
 # renovate: github=prometheus/node_exporter
 appVersion: 1.10.2
 home: https://github.com/prometheus/node_exporter/

--- a/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -270,6 +270,9 @@ spec:
       hostIPC: {{ .Values.hostIPC }}
       affinity:
         {{- include "prometheus-node-exporter.mergedAffinities" . | nindent 8 }}
+      {{- with .Values.dnsPolicy }}
+      dnsPolicy: {{ . }}
+      {{- end }}
       {{- with .Values.dnsConfig }}
       dnsConfig:
         {{- toYaml . | nindent 8 }}

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -435,6 +435,11 @@ daemonsetAnnotations: {}
 ## set to true to add the release label so scraping of the servicemonitor with kube-prometheus-stack works out of the box
 releaseLabel: false
 
+# DNS policy for prometheus-node-exporter pods
+# When hostNetwork is true, you typically want "Default" or "ClusterFirstWithHostNet"
+# Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+dnsPolicy: ""
+
 # Custom DNS configuration to be added to prometheus-node-exporter pods
 dnsConfig: {}
 # nameservers:


### PR DESCRIPTION
## Description

Adds a `dnsPolicy` configuration option to the prometheus-node-exporter chart.

## Problem

When `hostNetwork: true` (the default), Kubernetes defaults to `dnsPolicy: ClusterFirst`, which prepends cluster DNS to the host's DNS servers. If the host has 3 nameservers configured, this results in 4 total nameservers, exceeding the limit and triggering:

```
Nameserver limits were exceeded, some nameservers have been omitted
```

## Solution

Add a `dnsPolicy` value (similar to the existing `dnsConfig`) allowing users to set:
- `Default` - use only host DNS (appropriate when pod doesn't need cluster DNS)
- `ClusterFirstWithHostNet` - prefer cluster DNS with host DNS fallback

## Changes

- `Chart.yaml`: version bump 4.49.2 → 4.50.0
- `values.yaml`: Added `dnsPolicy: ""` with documentation
- `templates/daemonset.yaml`: Added template logic to render `dnsPolicy` when set

## Usage

```yaml
prometheus-node-exporter:
  dnsPolicy: "Default"
```

## Related

- Similar to the fix in prometheus-blackbox-exporter (#48, #42)
- Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy

Signed-off-by: sashanicolas <sasha.nicolas@gmail.com>