### PR TITLE
[kube-state-metrics] Probes use ports by name rather than number

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - kubernetes
 type: application
-version: 7.0.0
+version: 7.0.1
 # renovate: github-releases=kubernetes/kube-state-metrics
 appVersion: 2.17.0
 home: https://github.com/kubernetes/kube-state-metrics/

--- a/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/kube-state-metrics/templates/deployment.yaml
@@ -163,10 +163,8 @@ spec:
         ports:
         - containerPort: {{ .Values.service.port | default 8080}}
           name: http
-        {{- if .Values.selfMonitor.enabled }}
         - containerPort: {{ $telemetryPort }}
           name: metrics
-        {{- end }}
         {{- end }}
         {{- if .Values.startupProbe.enabled }}
         startupProbe:
@@ -181,11 +179,10 @@ spec:
               value: {{ $header.value }}
             {{- end }}
             path: /healthz
-            {{- if .Values.kubeRBACProxy.enabled }}
             port: http
+            {{- if .Values.kubeRBACProxy.enabled }}
             scheme: HTTPS
             {{- else }}
-            port: {{ $servicePort }}
             scheme: {{ upper .Values.startupProbe.httpGet.scheme }}
             {{- end }}
           initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
@@ -205,11 +202,10 @@ spec:
               value: {{ $header.value }}
             {{- end }}
             path: /livez
-            {{- if .Values.kubeRBACProxy.enabled }}
             port: http
+            {{- if .Values.kubeRBACProxy.enabled }}
             scheme: HTTPS
             {{- else }}
-            port: {{ $servicePort }}
             scheme: {{ upper .Values.livenessProbe.httpGet.scheme }}
             {{- end }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
@@ -228,11 +224,10 @@ spec:
               value: {{ $header.value }}
             {{- end }}
             path: /readyz
-            {{- if .Values.kubeRBACProxy.enabled }}
             port: metrics
+            {{- if .Values.kubeRBACProxy.enabled }}
             scheme: HTTPS
             {{- else }}
-            port: {{ $telemetryPort }}
             scheme: {{ upper .Values.readinessProbe.httpGet.scheme }}
             {{- end }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
@@ -315,7 +310,7 @@ spec:
         readinessProbe:
           httpGet:
             scheme: HTTPS
-            port: 8889
+            port: metrics-healthz
             path: healthz
           initialDelaySeconds: 5
           timeoutSeconds: 5


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

The linter I'm running (popeyecli.io) reported that:
* the probes are using port numbers rather than names
* the probes are using a port that is not defined by the container

when installed not using the RBAC mode, but not self-monitor. This shifts to name based mappings.

#### Special notes for your reviewer

https://popeyecli.io/

I view this as really a bugfix since the port isn't listed currently.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
