### PR TITLE
[kube-state-metrics] feat: add option to add aggregationRule

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - kubernetes
 type: application
-version: 8.1.3
+version: 8.2.0
 # renovate: github-releases=kubernetes/kube-state-metrics
 appVersion: 2.19.1
 home: https://github.com/kubernetes/kube-state-metrics/

--- a/charts/kube-state-metrics/templates/role.yaml
+++ b/charts/kube-state-metrics/templates/role.yaml
@@ -15,6 +15,10 @@ metadata:
   namespace: {{ . }}
 {{- end }}
 {{- $activeCollectors := include "kube-state-metrics.collectors" $ | fromYamlArray }}
+{{- if and $.Values.rbac.useClusterRole $.Values.rbac.clusterRoleSelectors }}
+aggregationRule:
+  clusterRoleSelectors: {{- toYaml $.Values.rbac.clusterRoleSelectors | nindent 4 }}
+{{- else }}
 rules:
 {{ if has "certificatesigningrequests" $activeCollectors }}
 - apiGroups: ["certificates.k8s.io"]
@@ -245,5 +249,6 @@ rules:
 {{ if $.Values.rbac.extraRules }}
 {{ toYaml $.Values.rbac.extraRules }}
 {{ end }}
+{{- end }}
 {{- end -}}
 {{- end -}}

--- a/charts/kube-state-metrics/unittests/rbac_aggregation_rule_test.yaml
+++ b/charts/kube-state-metrics/unittests/rbac_aggregation_rule_test.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test rbac aggregationRule
+templates:
+  - role.yaml
+tests:
+  - it: should render aggregationRule and omit rules when clusterRoleSelectors is set
+    set:
+      rbac:
+        useClusterRole: true
+        clusterRoleSelectors:
+          - matchLabels:
+              rbac.example.com/aggregate-to-monitoring: "true"
+    asserts:
+      - equal:
+          path: aggregationRule.clusterRoleSelectors
+          value:
+            - matchLabels:
+                rbac.example.com/aggregate-to-monitoring: "true"
+      - isNull:
+          path: rules
+
+  - it: should render rules and omit aggregationRule when clusterRoleSelectors is empty
+    set:
+      rbac:
+        useClusterRole: true
+        clusterRoleSelectors: []
+    asserts:
+      - isNull:
+          path: aggregationRule
+      - isNotNull:
+          path: rules
+
+  - it: should ignore clusterRoleSelectors and render rules when useClusterRole is false
+    set:
+      rbac:
+        useClusterRole: false
+        namespaces:
+          - default
+        clusterRoleSelectors:
+          - matchLabels:
+              rbac.example.com/aggregate-to-monitoring: "true"
+    asserts:
+      - isNull:
+          path: aggregationRule
+      - isNotNull:
+          path: rules

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -108,6 +108,17 @@ rbac:
   #   verbs: ["list", "watch"]
   extraRules: []
 
+  # Aggregate ClusterRoles using label selectors (only applies when useClusterRole: true).
+  # When set, this ClusterRole aggregates matching ClusterRoles instead of defining rules
+  # directly, so the built-in collector rules above are NOT included. Make sure the
+  # aggregated ClusterRoles grant the permissions kube-state-metrics needs.
+  # ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles
+  # Example:
+  # clusterRoleSelectors:
+  #   - matchLabels:
+  #       rbac.example.com/aggregate-to-monitoring: "true"
+  clusterRoleSelectors: []
+
 # Enable kube-state-metrics native request authn/authz on the metrics endpoints
 # via the `--auth-filter` flag, as an alternative to running kube-rbac-proxy.
 # When enabled, the `create` permissions on `tokenreviews` and


### PR DESCRIPTION
#### What this PR does / why we need it

This PR adds the option to add an aggregation rule to the ClusterRole
used by kube-state-metrics.

That way the user can more easily plug in 3rd party configs, like
<https://github.com/kubernetes-sigs/cluster-api/blob/main/config/metrics/crd-clusterrole.yaml#L6>

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
