### PR TITLE
kube-state-metrics: fix fullname nameOverride duplication

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - kubernetes
 type: application
-version: 7.1.0
+version: 7.1.1
 # renovate: github-releases=kubernetes/kube-state-metrics
 appVersion: 2.18.0
 home: https://github.com/kubernetes/kube-state-metrics/

--- a/charts/kube-state-metrics/templates/_helpers.tpl
+++ b/charts/kube-state-metrics/templates/_helpers.tpl
@@ -16,10 +16,13 @@ If release name contains chart name it will be used as a full name.
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- $releaseName := .Release.Name -}}
+{{- if contains $name $releaseName -}}
+{{- $releaseName | trunc 63 | trimSuffix "-" -}}
+{{- else if contains $releaseName $name -}}
+{{- $name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" $releaseName $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/kube-state-metrics/unittests/fullname_test.yaml
+++ b/charts/kube-state-metrics/unittests/fullname_test.yaml
@@ -1,0 +1,27 @@
+suite: fullname
+templates:
+  - templates/serviceaccount.yaml
+tests:
+  - it: does not duplicate release name when nameOverride already includes it
+    release:
+      name: ksm-non-pods
+    set:
+      nameOverride: ksm-non-pods-foo
+    asserts:
+      - equal:
+          path: metadata.name
+          value: ksm-non-pods-foo
+  - it: uses release name when it already contains chart name
+    release:
+      name: test-kube-state-metrics
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-kube-state-metrics
+  - it: defaults to release-plus-chart-name
+    release:
+      name: test
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-kube-state-metrics


### PR DESCRIPTION
Fixes #6510

- prevent release name duplication when nameOverride already includes it
- add fullname helm-unittests
- bump chart to 7.1.1

Tests:
- helm unittest --strict --file 'unittests/**/*.yaml' charts/kube-state-metrics
- helm upgrade --install ksm-non-pods charts/kube-state-metrics --set nameOverride=ksm-non-pods-foo --wait
- kubectl get svc -n default ksm-non-pods-foo