### PR TITLE
[kube-prometheus-stack] allow configuring reloader web nodePort + ignore macOS artifacts

### DIFF
--- a/charts/kube-prometheus-stack/.gitignore
+++ b/charts/kube-prometheus-stack/.gitignore
@@ -10,3 +10,4 @@ hack/*.git
 hack/tmp/
 hack/venv/
 hack/pyvenv.cfg
+.DS_Store

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 81.4.2
+version: 81.4.3
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.88.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 81.4.3
+version: 81.4.4
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.88.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/README.md
+++ b/charts/kube-prometheus-stack/README.md
@@ -108,7 +108,7 @@ helm show values oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack
 
 You may also `helm show values` on this chart's [dependencies](#dependencies) for additional options.
 
-For templated Grafana datasource definitions (e.g. when using Helm flow control), use `grafana.additionalDataSourcesString`, which is rendered via `tpl`.
+For templated Grafana datasource definitions (e.g. when using Helm flow control), use `grafana.additionalDataSourcesString`, which is rendered via `tpl`. When exposing Prometheus via a NodePort service, you can pin the reloader web port by setting `prometheus.service.reloaderWebNodePort`.
 
 ### Multiple releases
 

--- a/charts/kube-prometheus-stack/templates/prometheus/service.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/service.yaml
@@ -52,6 +52,9 @@ spec:
     {{- if semverCompare "> 1.20.0-0" $kubeTargetVersion }}
     appProtocol: http
     {{- end }}
+    {{- if and (eq .Values.prometheus.service.type "NodePort") .Values.prometheus.service.reloaderWebNodePort }}
+    nodePort: {{ .Values.prometheus.service.reloaderWebNodePort }}
+    {{- end }}
     port: {{ .Values.prometheus.service.reloaderWebPort }}
     targetPort: reloader-web
   {{- end }}

--- a/charts/kube-prometheus-stack/unittests/prometheus/service_nodeport_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/prometheus/service_nodeport_test.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test prometheus service reloader nodePort
+templates:
+  - prometheus/service.yaml
+tests:
+  - it: sets reloader nodePort when service type is NodePort
+    set:
+      prometheus:
+        service:
+          type: NodePort
+          reloaderWebNodePort: 32100
+    asserts:
+      - equal:
+          path: spec.ports[1].name
+          value: reloader-web
+      - equal:
+          path: spec.ports[1].nodePort
+          value: 32100
+
+  - it: does not set reloader nodePort when service type is not NodePort
+    set:
+      prometheus:
+        service:
+          type: ClusterIP
+          reloaderWebNodePort: 32100
+    asserts:
+      - notExists:
+          path: spec.ports[1].nodePort

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -3583,6 +3583,11 @@ prometheus:
     ##
     reloaderWebPort: 8080
 
+    ## NodePort for Prometheus Reloader to listen on
+    ## Only used if service.type is 'NodePort'
+    ##
+    reloaderWebNodePort:
+
     ## List of IP addresses at which the Prometheus server service is available
     ## Ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips
     ##


### PR DESCRIPTION
Fixes #6327

## What
- add prometheus.service.reloaderWebNodePort value for NodePort services and render nodePort on reloader-web port when provided
- document the option and add helm-unittest coverage; bump chart to 81.4.4 (rebased from earlier 81.2.3)
- ignore .DS_Store inside kube-prometheus-stack chart so macOS Finder files stay out of Git status

## Why
- allow configuring the reloader web UI when Prometheus service runs as NodePort
- keep chart tree clean on macOS; chart-level negate patterns currently re-include .DS_Store under hack/

## Testing
- helm unittest --strict --file 'unittests/**/*.yaml' charts/kube-prometheus-stack
- helm upgrade --install kps-nodeport charts/kube-prometheus-stack --set prometheus.service.type=NodePort,prometheus.service.reloaderWebNodePort=32100,grafana.enabled=false,kubeStateMetrics.enabled=false,nodeExporter.enabled=false,alertmanager.enabled=false,defaultRules.create=false --wait --timeout 10m
- kubectl get svc kps-nodeport-kube-promethe-prometheus -n default -o jsonpath='{range .spec.ports[*]}{.name}:{.port}->{.nodePort} {end}'
- helm lint charts/kube-prometheus-stack