### PR TITLE
[kube-prometheus-stack] add grafana additionalDataSourcesString

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 81.2.2
+version: 81.2.3
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.88.0
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/README.md
+++ b/charts/kube-prometheus-stack/README.md
@@ -108,6 +108,8 @@ helm show values oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack
 
 You may also `helm show values` on this chart's [dependencies](#dependencies) for additional options.
 
+For templated Grafana datasource definitions (e.g. when using Helm flow control), use `grafana.additionalDataSourcesString`, which is rendered via `tpl`.
+
 ### Multiple releases
 
 The same chart can be used to run multiple Prometheus instances in the same cluster if required. To achieve this, it is necessary to run only one instance of prometheus-operator and a pair of alertmanager pods for an HA configuration, while all other components need to be disabled. To disable a dependency during installation, set `kubeStateMetrics.enabled`, `nodeExporter.enabled` and `grafana.enabled` to `false`.

--- a/charts/kube-prometheus-stack/templates/grafana/configmaps-datasources.yaml
+++ b/charts/kube-prometheus-stack/templates/grafana/configmaps-datasources.yaml
@@ -92,4 +92,7 @@ data:
 {{- if .Values.grafana.additionalDataSources }}
 {{ tpl (toYaml .Values.grafana.additionalDataSources | indent 4) . }}
 {{- end }}
+{{- with .Values.grafana.additionalDataSourcesString }}
+{{ tpl . $ | indent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/unittests/grafana/additional_datasources_string_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/grafana/additional_datasources_string_test.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test grafana additionalDataSourcesString
+templates:
+  - grafana/configmaps-datasources.yaml
+tests:
+  - it: renders templated datasources from string input
+    release:
+      name: kps
+    set:
+      grafana:
+        forceDeployDatasources: true
+        additionalDataSourcesString: |
+          - name: extra-ds
+            type: prometheus
+            url: http://{{ .Release.Name }}-prom
+    asserts:
+      - matchRegex:
+          path: data['datasource.yaml']
+          pattern: "name: extra-ds"
+      - matchRegex:
+          path: data['datasource.yaml']
+          pattern: "url: http://kps-prom"

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1485,6 +1485,10 @@ grafana:
   #   url: https://{{ printf "%s-prometheus.svc" .Release.Name }}:9090
   #   version: 1
 
+  ## Configure additional grafana datasources as a templated string (passed through tpl)
+  ## Useful when you need Helm flow control or templating inside the datasource definition
+  additionalDataSourcesString: ""
+
   # Flag to mark provisioned data sources for deletion if they are no longer configured.
   # It takes no effect if data sources are already listed in the deleteDatasources section.
   # ref: https://grafana.com/docs/grafana/latest/administration/provisioning/#example-data-source-configuration-file


### PR DESCRIPTION
Fixes #6448

- add grafana.additionalDataSourcesString to allow templated datasource definitions
- render string via tpl alongside existing array input
- document option, add helm-unittest, bump chart to 81.2.3

Tests:
- helm unittest --strict --file 'unittests/**/*.yaml' charts/kube-prometheus-stack