### PR TITLE
prometheus-stackdriver-exporter: add namespace override

### DIFF
--- a/charts/prometheus-stackdriver-exporter/Chart.yaml
+++ b/charts/prometheus-stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: prometheus-stackdriver-exporter
-version: 4.12.2
+version: 4.12.3
 appVersion: v0.18.0
 home: https://www.stackdriver.com/
 sources:

--- a/charts/prometheus-stackdriver-exporter/README.md
+++ b/charts/prometheus-stackdriver-exporter/README.md
@@ -39,6 +39,8 @@ $ helm install [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/promethe
 $ helm install --name [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/prometheus-stackdriver-exporter --set stackdriver.projectId=google-project-name
 ```
 
+To install the chart resources into a namespace other than the Helm release namespace, set `namespaceOverride`.
+
 The command deploys Stackdriver-Exporter on the Kubernetes cluster using the default configuration.
 
 _See [configuration](#configuration) below._

--- a/charts/prometheus-stackdriver-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-stackdriver-exporter/templates/_helpers.tpl
@@ -43,6 +43,17 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
+Allow the release namespace to be overridden
+*/}}
+{{- define "stackdriver-exporter.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Generate basic labels
 */}}
 {{- define "stackdriver-exporter.labels" }}

--- a/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "stackdriver-exporter.fullname" . }}
+  namespace: {{ include "stackdriver-exporter.namespace" . }}
   labels:
     {{- include "stackdriver-exporter.labels" . | indent 4 }}
   {{- with .Values.annotations }}

--- a/charts/prometheus-stackdriver-exporter/templates/prometheusrule.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/prometheusrule.yaml
@@ -3,9 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ template "stackdriver-exporter.fullname" .  }}
-  {{- with .Values.prometheusRule.namespace }}
-  namespace: {{ . }}
-  {{- end }}
+  namespace: {{ default (include "stackdriver-exporter.namespace" .) .Values.prometheusRule.namespace }}
   labels:
     {{- include "stackdriver-exporter.labels" . | indent 4 }}
     {{- with .Values.prometheusRule.additionalLabels -}}

--- a/charts/prometheus-stackdriver-exporter/templates/secret.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "stackdriver-exporter.fullname" . }}
+  namespace: {{ include "stackdriver-exporter.namespace" . }}
   labels:
     {{- include "stackdriver-exporter.labels" . | indent 4 }}
     {{- if .Values.secret.labels }}

--- a/charts/prometheus-stackdriver-exporter/templates/service.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/service.yaml
@@ -2,6 +2,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: {{ template "stackdriver-exporter.fullname" . }}
+  namespace: {{ include "stackdriver-exporter.namespace" . }}
   labels:
     {{- include "stackdriver-exporter.labels" . | indent 4 }}
   {{- if .Values.service.annotations }}

--- a/charts/prometheus-stackdriver-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  namespace: {{ include "stackdriver-exporter.namespace" . }}
   labels:
     {{- include "stackdriver-exporter.labels" . | indent 4 }}
   name: {{ template "stackdriver-exporter.serviceAccountName" . }}

--- a/charts/prometheus-stackdriver-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/servicemonitor.yaml
@@ -3,9 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "stackdriver-exporter.fullname" .  }}
-  {{- if .Values.serviceMonitor.namespace }}
-  namespace: {{ .Values.serviceMonitor.namespace }}
-  {{- end }}
+  namespace: {{ default (include "stackdriver-exporter.namespace" .) .Values.serviceMonitor.namespace }}
   labels:
     {{- include "stackdriver-exporter.labels" . | indent 4 }}
     {{- if .Values.serviceMonitor.additionalLabels }}

--- a/charts/prometheus-stackdriver-exporter/unittests/namespace_override_test.yaml
+++ b/charts/prometheus-stackdriver-exporter/unittests/namespace_override_test.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: namespace override
+templates:
+  - templates/deployment.yaml
+  - templates/service.yaml
+  - templates/serviceaccount.yaml
+  - templates/servicemonitor.yaml
+  - templates/prometheusrule.yaml
+tests:
+  - it: applies namespaceOverride to all resources
+    set:
+      namespaceOverride: custom-ns
+      serviceMonitor:
+        enabled: true
+        namespace: ""
+      prometheusRule:
+        enabled: true
+        rules:
+          - alert: TestAlert
+            expr: vector(1)
+      serviceAccount:
+        create: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+        template: templates/deployment.yaml
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+        template: templates/service.yaml
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+        template: templates/serviceaccount.yaml
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+        template: templates/servicemonitor.yaml
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+        template: templates/prometheusrule.yaml

--- a/charts/prometheus-stackdriver-exporter/values.yaml
+++ b/charts/prometheus-stackdriver-exporter/values.yaml
@@ -4,6 +4,9 @@ nameOverride: ""
 # Provide a name to substitute for the full names of resources
 fullnameOverride: ""
 
+# Override the deployment namespace
+namespaceOverride: ""
+
 # Number of exporters to run
 replicaCount: 1
 


### PR DESCRIPTION
Fixes #6303

- add global namespaceOverride and helper
- apply namespace override to deployment, service, serviceaccount, secret, ServiceMonitor, and PrometheusRule
- document option, bump chart to 4.12.3, and add helm-unittest

Tests:
- helm unittest --strict --file 'unittests/**/*.yaml' charts/prometheus-stackdriver-exporter