### PR TITLE
[prometheus-node-exporter] allow configuring kube-rbac-proxy listen host

### DIFF
--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - prometheus
   - exporter
 type: application
-version: 4.51.0
+version: 4.51.1
 # renovate: github=prometheus/node_exporter
 appVersion: 1.10.2
 home: https://github.com/prometheus/node_exporter/

--- a/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -193,7 +193,7 @@ spec:
             {{-  if .Values.kubeRBACProxy.extraArgs  }}
             {{- .Values.kubeRBACProxy.extraArgs | toYaml | nindent 12 }}
             {{-  end  }}
-            - --secure-listen-address=:{{ .Values.service.port}}
+            - --secure-listen-address={{ .Values.kubeRBACProxy.listenHost }}{{ .Values.service.port}}
             - --upstream=http://127.0.0.1:{{ $servicePort }}/
             - --proxy-endpoints-port={{ .Values.kubeRBACProxy.proxyEndpointsPort }}
             - --config-file=/etc/kube-rbac-proxy-config/config-file.yaml

--- a/charts/prometheus-node-exporter/unittests/rbac_proxy_listen_host_test.yaml
+++ b/charts/prometheus-node-exporter/unittests/rbac_proxy_listen_host_test.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: kube-rbac-proxy listen host
+templates:
+  - templates/daemonset.yaml
+tests:
+  - it: uses configured listenHost for rbac-proxy
+    set:
+      kubeRBACProxy:
+        enabled: true
+        listenHost: "127.0.0.1:"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: --secure-listen-address=127.0.0.1:9100

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -54,6 +54,9 @@ kubeRBACProxy:
   # all the possible args can be found here: https://github.com/brancz/kube-rbac-proxy#usage
   extraArgs: []
 
+  # Listen address for kube-rbac-proxy. Default is all interfaces.
+  listenHost: ":"
+
   ## Specify security settings for a Container
   ## Allows overrides and additional options compared to (Pod) securityContext
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container


### PR DESCRIPTION
Fixes #6250

- add kubeRBACProxy.listenHost to control secure listen address (default :)
- wire into kube-rbac-proxy args so listen host can be restricted
- add helm-unittest for rendered arg and bump chart to 4.51.1

Tests:
- helm unittest --strict --file 'unittests/**/*.yaml' charts/prometheus-node-exporter