### PR TITLE
[prometheus-nats-exporter] - Add healthz flag to metrics configuration

### DIFF
--- a/charts/prometheus-nats-exporter/Chart.yaml
+++ b/charts/prometheus-nats-exporter/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: 0.18.0
 description: A Helm chart for prometheus-nats-exporter
 name: prometheus-nats-exporter
-version: 2.21.0
+version: 2.21.1
 home: https://github.com/nats-io/prometheus-nats-exporter
 sources:
   - https://github.com/nats-io/prometheus-nats-exporter

--- a/charts/prometheus-nats-exporter/templates/deployment.yaml
+++ b/charts/prometheus-nats-exporter/templates/deployment.yaml
@@ -53,6 +53,9 @@ spec:
             {{- if .Values.config.metrics.gatewayz }}
             - "-gatewayz"
             {{- end }}
+            {{- if .Values.config.metrics.healthz }}
+            - "-healthz"
+            {{- end }}
             {{- if .Values.config.metrics.jsz }}
             - "-jsz=all"
             {{- end }}

--- a/charts/prometheus-nats-exporter/values.yaml
+++ b/charts/prometheus-nats-exporter/values.yaml
@@ -56,6 +56,7 @@ config:
     connz_detailed: true
     jsz: true
     gatewayz: true
+    healthz: true
     leafz: true
     routez: true
     subz: true


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR adds the possibility to expose prometheus nats exporter healthz metrics:

https://github.com/nats-io/prometheus-nats-exporter?tab=readme-ov-file#usage

#### Special notes for your reviewer

Double check if want this healthz flag enabled by default in the chart itself

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
