### PR TITLE
[prometheus-pushgateway] Add Istio Gateway/VirtualService support

### DIFF
--- a/charts/prometheus-pushgateway/Chart.yaml
+++ b/charts/prometheus-pushgateway/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: v1.11.2
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 3.6.0
+version: 3.7.0
 home: https://github.com/prometheus/pushgateway
 sources:
   - https://github.com/prometheus/pushgateway

--- a/charts/prometheus-pushgateway/ci/istio-gateway-values.yaml
+++ b/charts/prometheus-pushgateway/ci/istio-gateway-values.yaml
@@ -1,0 +1,27 @@
+---
+## Test case: Istio Gateway/VirtualService
+istioGateway:
+  enabled: true
+  gateway: istio-system/my-gateway
+  hosts:
+    - pushgateway.example.com
+  match:
+    - uri:
+        prefix: /metrics
+  rewrite:
+    uri: /
+  timeout: 30s
+  retries:
+    attempts: 3
+    perTryTimeout: 10s
+  corsPolicy:
+    allowOrigins:
+      - exact: https://example.com
+    allowMethods:
+      - GET
+      - POST
+  annotations:
+    test-annotation: test-value
+  labels:
+    test-label: test-value
+

--- a/charts/prometheus-pushgateway/templates/virtualservice.yaml
+++ b/charts/prometheus-pushgateway/templates/virtualservice.yaml
@@ -1,0 +1,82 @@
+{{- if .Values.istioGateway.enabled }}
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: {{ include "prometheus-pushgateway.fullname" . }}
+  namespace: {{ include "prometheus-pushgateway.namespace" . }}
+  labels:
+    {{- include "prometheus-pushgateway.defaultLabels" . | nindent 4 }}
+    {{- with .Values.istioGateway.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.istioGateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.istioGateway.hosts }}
+  hosts:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  gateways:
+  {{- if kindIs "string" .Values.istioGateway.gateway }}
+    - {{ .Values.istioGateway.gateway }}
+  {{- else }}
+    {{- toYaml .Values.istioGateway.gateway | nindent 4 }}
+  {{- end }}
+  http:
+    - {{- with .Values.istioGateway.match }}
+      match:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.istioGateway.rewrite }}
+      rewrite:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.istioGateway.redirect }}
+      redirect:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.istioGateway.timeout }}
+      timeout: {{ . }}
+      {{- end }}
+      {{- with .Values.istioGateway.retries }}
+      retries:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.istioGateway.fault }}
+      fault:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.istioGateway.mirror }}
+      mirror:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.istioGateway.mirrorPercentage }}
+      mirrorPercentage:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.istioGateway.corsPolicy }}
+      corsPolicy:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.istioGateway.headers }}
+      headers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if not .Values.istioGateway.redirect }}
+      route:
+        {{- if .Values.istioGateway.route }}
+        {{- toYaml .Values.istioGateway.route | nindent 8 }}
+        {{- else }}
+        - destination:
+            host: {{ include "prometheus-pushgateway.fullname" . }}
+            port:
+              number: {{ .Values.istioGateway.port | default .Values.service.port }}
+            {{- with .Values.istioGateway.subset }}
+            subset: {{ . }}
+            {{- end }}
+        {{- end }}
+      {{- end }}
+{{- end }}
+

--- a/charts/prometheus-pushgateway/values.yaml
+++ b/charts/prometheus-pushgateway/values.yaml
@@ -191,6 +191,150 @@ ingress:
   #     hosts:
   #       - pushgateway.domain.com
 
+## Configure Istio Gateway/VirtualService resource that allow you to access the
+## pushgateway installation. Set up the URL
+## ref: https://istio.io/latest/docs/reference/config/networking/virtual-service/
+##
+istioGateway:
+  ## Enable Istio Gateway/VirtualService.
+  ##
+  enabled: false
+
+  ## Istio Gateway reference (namespace/gateway-name or just gateway-name for same namespace).
+  ## Can be a string or a list for multiple gateways.
+  ##
+  # gateway: istio-system/my-gateway
+  ## Or for multiple gateways:
+  # gateway:
+  #   - istio-system/external-gateway
+  #   - istio-system/internal-gateway
+
+  ## Hostnames for the VirtualService.
+  ## Must be provided if istioGateway is enabled.
+  ##
+  # hosts:
+  #   - pushgateway.domain.com
+
+  ## HTTP match conditions (must be a list).
+  ## ref: https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPMatchRequest
+  ##
+  match:
+    - uri:
+        prefix: /
+  ## Example with multiple match conditions:
+  # match:
+  #   - uri:
+  #       prefix: /metrics
+  #   - uri:
+  #       prefix: /api
+
+  ## Rewrite the URI before forwarding to the destination.
+  ## Useful when migrating from Ingress with rewrite-target annotation.
+  ##
+  # rewrite:
+  #   uri: /
+
+  ## HTTP redirect configuration.
+  ## Note: redirect and route are mutually exclusive.
+  ##
+  # redirect:
+  #   uri: /new-path
+  #   authority: new-host.example.com
+  #   redirectCode: 301
+
+  ## HTTP route destination port (defaults to service.port).
+  ##
+  # port: 9091
+
+  ## Destination subset (for use with DestinationRule).
+  ##
+  # subset: v1
+
+  ## Custom route configuration for advanced use cases (canary, traffic splitting).
+  ## If specified, overrides the default route to the service.
+  ##
+  # route:
+  #   - destination:
+  #       host: pushgateway-canary
+  #       port:
+  #         number: 9091
+  #       subset: canary
+  #     weight: 10
+  #   - destination:
+  #       host: pushgateway
+  #       port:
+  #         number: 9091
+  #       subset: stable
+  #     weight: 90
+
+  ## Request timeout.
+  ##
+  # timeout: 30s
+
+  ## Retry policy.
+  ##
+  # retries:
+  #   attempts: 3
+  #   perTryTimeout: 10s
+
+  ## Fault injection for testing resilience (chaos engineering).
+  ## ref: https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPFaultInjection
+  ##
+  # fault:
+  #   delay:
+  #     percentage:
+  #       value: 10
+  #     fixedDelay: 5s
+  #   abort:
+  #     percentage:
+  #       value: 5
+  #     httpStatus: 503
+
+  ## Traffic mirroring configuration.
+  ## ref: https://istio.io/latest/docs/tasks/traffic-management/mirroring/
+  ##
+  # mirror:
+  #   host: pushgateway-shadow
+  #   port:
+  #     number: 9091
+  # mirrorPercentage:
+  #   value: 100
+
+  ## Header manipulation rules.
+  ## ref: https://istio.io/latest/docs/reference/config/networking/virtual-service/#Headers
+  ##
+  # headers:
+  #   request:
+  #     set:
+  #       x-custom-header: "value"
+  #     add:
+  #       x-request-id: "123"
+  #     remove:
+  #       - x-unwanted-header
+  #   response:
+  #     set:
+  #       x-response-header: "value"
+
+  ## CORS policy configuration.
+  ##
+  # corsPolicy:
+  #   allowOrigins:
+  #     - exact: https://example.com
+  #   allowMethods:
+  #     - GET
+  #     - POST
+  #   allowHeaders:
+  #     - content-type
+  #   maxAge: 24h
+
+  ## Annotations for VirtualService.
+  ##
+  annotations: {}
+
+  ## Labels for VirtualService.
+  ##
+  labels: {}
+
 ## route (map) allows configuration of HTTPRoute resources
 ## Requires Gateway API resources and suitable controller installed within the cluster
 ## Ref. https://gateway-api.sigs.k8s.io/guides/http-routing/


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Adds support for Istio Gateway/VirtualService as an alternative to Ingress and HTTPRoute for exposing Pushgateway.

This allows users running Istio service mesh to configure traffic routing using native Istio resources.

**Changes:**
- Added `istioGateway` section in `values.yaml` with configuration options (gateway, hosts, match, timeout, retries, tls, annotations, labels)
- Created `templates/virtualservice.yaml` template
- Added CI test file `ci/istio-gateway-values.yaml`
- Bumped chart version from 3.6.0 to 3.7.0

**Example usage:**
```yaml
istioGateway:
  enabled: true
  gateway: istio-system/my-gateway
  hosts:
    - pushgateway.example.com
```

#### Which issue this PR fixes

With the [upcoming retirement of Ingress NGINX](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/) announced by Kubernetes SIG Network and the Security Response Committee, best-effort maintenance will continue only until March 2026. After that, there will be no further releases, bugfixes, or security updates.

This PR provides an alternative ingress solution for users who need to migrate away from Ingress NGINX to Istio service mesh.


#### Special notes for your reviewer
The implementation follows the same pattern as existing ingress and route (HTTPRoute) configurations
All existing CI tests pass
Tested with helm template and helm lint

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
