### PR TITLE
[kube-prometheus-stack] align alertmanager labels with operator

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 81.4.2
+version: 81.4.3
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.88.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/templates/alertmanager/alertmanager.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/alertmanager.yaml
@@ -1,15 +1,19 @@
 {{- if .Values.alertmanager.enabled }}
+{{- $amLabels := include "kube-prometheus-stack.labels" . | fromYaml }}
+{{- if not $amLabels }}{{- $amLabels = dict }}{{- end }}
+{{- $_ := set $amLabels "app" (printf "%s-alertmanager" (include "kube-prometheus-stack.name" .)) }}
+{{- $_ := set $amLabels "app.kubernetes.io/name" "alertmanager" }}
+{{- $_ := set $amLabels "app.kubernetes.io/managed-by" "prometheus-operator" }}
+{{- if .Values.alertmanager.additionalLabels }}
+{{- $amLabels = merge $amLabels .Values.alertmanager.additionalLabels }}
+{{- end }}
 apiVersion: monitoring.coreos.com/v1
 kind: Alertmanager
 metadata:
   name: {{ template "kube-prometheus-stack.alertmanager.crname" . }}
   namespace: {{ template "kube-prometheus-stack-alertmanager.namespace" . }}
   labels:
-    app: {{ template "kube-prometheus-stack.name" . }}-alertmanager
-    {{- include "kube-prometheus-stack.labels" . | nindent 4 }}
-    {{- with .Values.alertmanager.additionalLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+{{ toYaml $amLabels | indent 4 }}
   {{- with .Values.alertmanager.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
#### What this PR does / why we need it\n- set default Alertmanager labels to match Prometheus Operator lookup expectations (app.kubernetes.io/name=alertmanager, app.kubernetes.io/managed-by=prometheus-operator) so existing statefulsets aren\'t recreated after upgrading operator >=0.85\n\n#### Which issue this PR fixes\n- fixes #6547\n\n#### Special notes for your reviewer\n- labels are merged with common/additional labels; user overrides still work but operator defaults now align with upstream selectors\n\n#### Checklist\n- [x] DCO signed\n- [x] Chart version bumped (patch)\n- [x] Title of the PR starts with chart name\n- [x] Tests executed: 
### Chart [ kube-prometheus-stack ] charts/kube-prometheus-stack

 PASS  test alertmanager	charts/kube-prometheus-stack/unittests/alertmanager/alertmanager_test.yaml
 PASS  test ingress	charts/kube-prometheus-stack/unittests/alertmanager/ingress_test.yaml
 PASS  test networkpolicy	charts/kube-prometheus-stack/unittests/alertmanager/networkpolicy_test.yaml

Charts:      1 passed, 1 total
Test Suites: 3 passed, 3 total
Tests:       19 passed, 19 total
Snapshot:    0 passed, 0 total
Time:        314.942083ms