### PR TITLE
[kube-prometheus-stack] allow templated slack action URLs

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 81.2.3
+version: 81.2.4
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.88.0
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/charts/crds/crds/crd-alertmanagerconfigs.yaml
+++ b/charts/kube-prometheus-stack/charts/crds/crds/crd-alertmanagerconfigs.yaml
@@ -6453,7 +6453,6 @@ spec:
                                   description: |-
                                     url defines the URL to open when the action is triggered.
                                     Only applicable for button-type actions. When set, clicking the button opens this URL.
-                                  pattern: ^https?://.+$
                                   type: string
                                 value:
                                   description: |-


### PR DESCRIPTION
#### What this PR does / why we need it\n- remove strict https URL regex from AlertmanagerConfig slack action url to allow Go templating (common runbook/dashboard/silence links) while keeping type string\n- bump chart patch version\n\n#### Which issue this PR fixes\n- fixes #6503\n\n#### Checklist\n- [x] DCO signed\n- [x] Chart version bumped (patch)\n- [x] Title of the PR starts with chart name\n- [x] Tests executed: 
### Chart [ kube-prometheus-stack ] charts/kube-prometheus-stack

 PASS  test extraManifests	charts/kube-prometheus-stack/unittests/extra-objects_test.yaml
 PASS  test alertmanager	charts/kube-prometheus-stack/unittests/alertmanager/alertmanager_test.yaml
 PASS  test ingress	charts/kube-prometheus-stack/unittests/alertmanager/ingress_test.yaml
 PASS  test networkpolicy	charts/kube-prometheus-stack/unittests/alertmanager/networkpolicy_test.yaml
 PASS  test grafana additionalDataSourcesString	charts/kube-prometheus-stack/unittests/grafana/additional_datasources_string_test.yaml
 PASS  test grafana operator	charts/kube-prometheus-stack/unittests/grafana/operator_test.yaml
 PASS  test additionalPrometheusRules	charts/kube-prometheus-stack/unittests/prometheus/additionalPrometheusRules_test.yaml
 PASS  test scrapeConfigSelector	charts/kube-prometheus-stack/unittests/prometheus/automountServiceAccountToken_test.yaml
 PASS  test ruleSelector	charts/kube-prometheus-stack/unittests/prometheus/rule_selector_test.yaml
 PASS  test scrapeConfigNamespaceSelector	charts/kube-prometheus-stack/unittests/prometheus/scrape_config_namespace_selector_test.yaml
 PASS  test scrapeConfigSelector	charts/kube-prometheus-stack/unittests/prometheus/scrape_config_selector_test.yaml
 PASS  test rendering	charts/kube-prometheus-stack/charts/crds/unittests/rendering_test.yaml

Charts:      1 passed, 1 total
Test Suites: 12 passed, 12 total
Tests:       56 passed, 56 total
Snapshot:    0 passed, 0 total
Time:        1.091570458s