### PR TITLE
[kube-prometheus-stack] default HTTPRoute backendRefs

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 81.4.2
+version: 81.4.3
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.88.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 81.4.3
+version: 81.4.4
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.88.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/templates/alertmanager/route.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/route.yaml
@@ -1,8 +1,14 @@
 {{- if .Values.alertmanager.enabled -}}
   {{- $serviceName := printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "alertmanager" }}
   {{- $servicePort := .Values.alertmanager.ingress.servicePort | default .Values.alertmanager.service.port -}}
+  {{- $serviceGroup := "Service" -}}
+  {{- $serviceKind := "Service" -}}
+  {{- $serviceWeight := 1 -}}
   {{- range $name, $route := .Values.alertmanager.route }}
   {{- if $route.enabled }}
+  {{- $serviceGroup = $route.serviceGroup | default "" -}}
+  {{- $serviceKind = $route.serviceKind | default "Service" -}}
+  {{- $serviceWeight = $route.serviceWeight | default 1 -}}
 ---
 apiVersion: {{ $route.apiVersion | default "gateway.networking.k8s.io/v1" }}
 kind: {{ $route.kind | default "HTTPRoute" }}
@@ -40,8 +46,11 @@ spec:
             statusCode: 301
     {{- else }}
     - backendRefs:
-        - name: {{ $serviceName }}
+        - group: {{ $serviceGroup | quote }}
+          kind: {{ $serviceKind }}
+          name: {{ $serviceName }}
           port: {{ $servicePort }}
+          weight: {{ $serviceWeight }}
       {{- with $route.filters }}
       filters:
         {{- toYaml . | nindent 8 }}

--- a/charts/kube-prometheus-stack/templates/prometheus/route.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/route.yaml
@@ -1,8 +1,14 @@
 {{- if .Values.prometheus.enabled -}}
   {{- $serviceName := printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "prometheus" -}}
   {{- $servicePort := .Values.prometheus.ingress.servicePort | default .Values.prometheus.service.port -}}
+  {{- $serviceGroup := "Service" -}} {{/* default group empty string means core */}}
+  {{- $serviceKind := "Service" -}}
+  {{- $serviceWeight := 1 -}}
   {{- range $name, $route := .Values.prometheus.route }}
   {{- if $route.enabled }}
+  {{- $serviceGroup = $route.serviceGroup | default "" -}}
+  {{- $serviceKind = $route.serviceKind | default "Service" -}}
+  {{- $serviceWeight = $route.serviceWeight | default 1 -}}
 ---
 apiVersion: {{ $route.apiVersion | default "gateway.networking.k8s.io/v1" }}
 kind: {{ $route.kind | default "HTTPRoute" }}
@@ -40,8 +46,11 @@ spec:
             statusCode: 301
     {{- else }}
     - backendRefs:
-        - name: {{ $serviceName }}
+        - group: {{ $serviceGroup | quote }}
+          kind: {{ $serviceKind }}
+          name: {{ $serviceName }}
           port: {{ $servicePort }}
+          weight: {{ $serviceWeight }}
       {{- with $route.filters }}
       filters:
         {{- toYaml . | nindent 8 }}

--- a/charts/kube-prometheus-stack/templates/thanos-ruler/route.yaml
+++ b/charts/kube-prometheus-stack/templates/thanos-ruler/route.yaml
@@ -1,8 +1,14 @@
 {{- if .Values.thanosRuler.enabled -}}
   {{- $serviceName := include "kube-prometheus-stack.thanosRuler.name" . }}
   {{- $servicePort := .Values.thanosRuler.service.port -}}
+  {{- $serviceGroup := "Service" -}}
+  {{- $serviceKind := "Service" -}}
+  {{- $serviceWeight := 1 -}}
   {{- range $name, $route := .Values.thanosRuler.route }}
   {{- if $route.enabled }}
+  {{- $serviceGroup = $route.serviceGroup | default "" -}}
+  {{- $serviceKind = $route.serviceKind | default "Service" -}}
+  {{- $serviceWeight = $route.serviceWeight | default 1 -}}
 ---
 apiVersion: {{ $route.apiVersion | default "gateway.networking.k8s.io/v1" }}
 kind: {{ $route.kind | default "HTTPRoute" }}
@@ -40,8 +46,11 @@ spec:
             statusCode: 301
     {{- else }}
     - backendRefs:
-        - name: {{ $serviceName }}
+        - group: {{ $serviceGroup | quote }}
+          kind: {{ $serviceKind }}
+          name: {{ $serviceName }}
           port: {{ $servicePort }}
+          weight: {{ $serviceWeight }}
       {{- with $route.filters }}
       filters:
         {{- toYaml . | nindent 8 }}

--- a/charts/kube-prometheus-stack/unittests/alertmanager/route_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/alertmanager/route_test.yaml
@@ -1,0 +1,18 @@
+suite: alertmanager route backendRefs
+templates:
+  - alertmanager/route.yaml
+tests:
+  - it: includes explicit group kind and weight defaults
+    set:
+      alertmanager.enabled: true
+      alertmanager.route.main.enabled: true
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].group
+          value: ""
+      - equal:
+          path: spec.rules[0].backendRefs[0].kind
+          value: Service
+      - equal:
+          path: spec.rules[0].backendRefs[0].weight
+          value: 1

--- a/charts/kube-prometheus-stack/unittests/prometheus/route_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/prometheus/route_test.yaml
@@ -1,0 +1,18 @@
+suite: prometheus route backendRefs
+templates:
+  - prometheus/route.yaml
+tests:
+  - it: includes explicit group kind and weight defaults
+    set:
+      prometheus.enabled: true
+      prometheus.route.main.enabled: true
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].group
+          value: ""
+      - equal:
+          path: spec.rules[0].backendRefs[0].kind
+          value: Service
+      - equal:
+          path: spec.rules[0].backendRefs[0].weight
+          value: 1

--- a/charts/kube-prometheus-stack/unittests/thanos-ruler/route_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/thanos-ruler/route_test.yaml
@@ -1,0 +1,18 @@
+suite: thanos ruler route backendRefs
+templates:
+  - thanos-ruler/route.yaml
+tests:
+  - it: includes explicit group kind and weight defaults
+    set:
+      thanosRuler.enabled: true
+      thanosRuler.route.main.enabled: true
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].group
+          value: ""
+      - equal:
+          path: spec.rules[0].backendRefs[0].kind
+          value: Service
+      - equal:
+          path: spec.rules[0].backendRefs[0].weight
+          value: 1

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -669,6 +669,21 @@ alertmanager:
       ## Additional custom rules that can be added to the route
       additionalRules: []
 
+      ## Backend reference defaults
+      serviceGroup: ""
+      serviceKind: Service
+      serviceWeight: 1
+
+      ## Backend reference defaults
+      serviceGroup: ""
+      serviceKind: Service
+      serviceWeight: 1
+
+      ## Backend reference defaults
+      serviceGroup: ""
+      serviceKind: Service
+      serviceWeight: 1
+
   ## Configuration for Alertmanager secret
   ##
   secret:

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -674,16 +674,6 @@ alertmanager:
       serviceKind: Service
       serviceWeight: 1
 
-      ## Backend reference defaults
-      serviceGroup: ""
-      serviceKind: Service
-      serviceWeight: 1
-
-      ## Backend reference defaults
-      serviceGroup: ""
-      serviceKind: Service
-      serviceWeight: 1
-
   ## Configuration for Alertmanager secret
   ##
   secret:


### PR DESCRIPTION
#### What this PR does / why we need it\n- explicitly set backendRefs group/kind/weight on HTTPRoute resources (alertmanager/prometheus/thanos-ruler) to match API defaults and avoid GitOps drift\n- expose serviceGroup/serviceKind/serviceWeight values for overriding and document defaults\n- add unit tests covering the rendered backendRefs\n- bump chart patch version\n\n#### Which issue this PR fixes\n- fixes #6441\n\n#### Checklist\n- [x] DCO signed\n- [x] Chart version bumped (patch)\n- [x] Title of the PR starts with chart name\n- [x] Tests executed: 
### Chart [ kube-prometheus-stack ] charts/kube-prometheus-stack

 PASS  test extraManifests	charts/kube-prometheus-stack/unittests/extra-objects_test.yaml
 PASS  test alertmanager	charts/kube-prometheus-stack/unittests/alertmanager/alertmanager_test.yaml
 PASS  test ingress	charts/kube-prometheus-stack/unittests/alertmanager/ingress_test.yaml
 PASS  test networkpolicy	charts/kube-prometheus-stack/unittests/alertmanager/networkpolicy_test.yaml
 PASS  alertmanager route backendRefs	charts/kube-prometheus-stack/unittests/alertmanager/route_test.yaml
 PASS  test grafana additionalDataSourcesString	charts/kube-prometheus-stack/unittests/grafana/additional_datasources_string_test.yaml
 PASS  test grafana operator	charts/kube-prometheus-stack/unittests/grafana/operator_test.yaml
 PASS  test additionalPrometheusRules	charts/kube-prometheus-stack/unittests/prometheus/additionalPrometheusRules_test.yaml
 PASS  test scrapeConfigSelector	charts/kube-prometheus-stack/unittests/prometheus/automountServiceAccountToken_test.yaml
 PASS  prometheus route backendRefs	charts/kube-prometheus-stack/unittests/prometheus/route_test.yaml
 PASS  test ruleSelector	charts/kube-prometheus-stack/unittests/prometheus/rule_selector_test.yaml
 PASS  test scrapeConfigNamespaceSelector	charts/kube-prometheus-stack/unittests/prometheus/scrape_config_namespace_selector_test.yaml
 PASS  test scrapeConfigSelector	charts/kube-prometheus-stack/unittests/prometheus/scrape_config_selector_test.yaml
 PASS  thanos ruler route backendRefs	charts/kube-prometheus-stack/unittests/thanos-ruler/route_test.yaml
 PASS  test rendering	charts/kube-prometheus-stack/charts/crds/unittests/rendering_test.yaml

Charts:      1 passed, 1 total
Test Suites: 15 passed, 15 total
Tests:       59 passed, 59 total
Snapshot:    0 passed, 0 total
Time:        1.169983208s