### PR TITLE
[kube-state-metrics] fix fullname with nameOverride

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - kubernetes
 type: application
-version: 7.1.0
+version: 7.1.1
 # renovate: github-releases=kubernetes/kube-state-metrics
 appVersion: 2.18.0
 home: https://github.com/kubernetes/kube-state-metrics/

--- a/charts/kube-state-metrics/templates/_helpers.tpl
+++ b/charts/kube-state-metrics/templates/_helpers.tpl
@@ -16,7 +16,9 @@ If release name contains chart name it will be used as a full name.
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
+{{- if and .Values.nameOverride (contains .Release.Name $name) -}}
+{{- $name | trunc 63 | trimSuffix "-" -}}
+{{- else if contains $name .Release.Name -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}

--- a/charts/kube-state-metrics/unittests/fullname_test.yaml
+++ b/charts/kube-state-metrics/unittests/fullname_test.yaml
@@ -1,0 +1,13 @@
+suite: fullname helper
+templates:
+  - templates/serviceaccount.yaml
+tests:
+  - it: nameOverride containing release name should not double prefix
+    set:
+      nameOverride: ksm-non-pods-foo
+    release:
+      name: ksm-non-pods
+    asserts:
+      - equal:
+          path: metadata.name
+          value: ksm-non-pods-foo


### PR DESCRIPTION
#### What this PR does / why we need it\n- honor nameOverride without duplicating the release name when it already contains the release (prevents names like <release>-<release>-foo)\n- adjust fullname helper logic accordingly and add a unit test\n- bump chart patch version\n\n#### Which issue this PR fixes\n- fixes #6510\n\n#### Checklist\n- [x] DCO signed\n- [x] Chart version bumped (patch)\n- [x] Title of the PR starts with chart name\n- [x] Tests executed: 
### Chart [ kube-state-metrics ] charts/kube-state-metrics

 PASS  fullname helper	charts/kube-state-metrics/unittests/fullname_test.yaml

Charts:      1 passed, 1 total
Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshot:    0 passed, 0 total
Time:        3.202542ms