### PR TITLE
[prometheus-node-exporter] add chart icon

### DIFF
--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -10,7 +10,7 @@ version: 4.51.1
 # renovate: github=prometheus/node_exporter
 appVersion: 1.10.2
 home: https://github.com/prometheus/node_exporter/
-icon: https://raw.githubusercontent.com/cncf/artwork/master/prometheus/icon/color/prometheus-icon-color.svg
+icon: https://raw.githubusercontent.com/cncf/artwork/refs/heads/main/projects/prometheus/icon/color/prometheus-icon-color.svg
 sources:
   - https://github.com/prometheus/node_exporter/
 maintainers:


### PR DESCRIPTION
## What
- add an icon to the prometheus-node-exporter chart metadata
- bump chart version to 4.51.1

## Why
- helm lint currently reports a warning that the chart is missing an icon; providing the Prometheus icon aligns with other community charts and improves chart metadata quality

## Testing
- helm lint charts/prometheus-node-exporter