### PR TITLE
chore(prom-label-proxy): add chart icon

### DIFF
--- a/charts/prom-label-proxy/Chart.yaml
+++ b/charts/prom-label-proxy/Chart.yaml
@@ -2,10 +2,11 @@ apiVersion: v2
 name: prom-label-proxy
 description: A proxy that enforces a given label in a given PromQL query.
 type: application
-version: 0.17.1
+version: 0.17.2
 # renovate: github=prometheus-community/prom-label-proxy
 appVersion: v0.12.1
 home: "https://github.com/prometheus-community/prom-label-proxy"
+icon: https://raw.githubusercontent.com/cncf/artwork/master/prometheus/icon/color/prometheus-icon-color.svg
 keywords:
   - metric
   - monitoring


### PR DESCRIPTION
## What
- add Prometheus icon to prom-label-proxy chart metadata
- bump chart version to 0.17.2

## Why
- helm lint currently reports missing icon metadata; aligning with other charts improves UX in catalog browsers

## Testing
- helm lint charts/prom-label-proxy