### PR TITLE
chore(fastly-exporter): add chart icon

### DIFF
--- a/charts/prometheus-fastly-exporter/Chart.yaml
+++ b/charts/prometheus-fastly-exporter/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - fastly
   - monitoring
 home: https://github.com/fastly/fastly-exporter
-icon: https://raw.githubusercontent.com/cncf/artwork/master/prometheus/icon/color/prometheus-icon-color.svg
+icon: https://raw.githubusercontent.com/cncf/artwork/refs/heads/main/projects/prometheus/icon/color/prometheus-icon-color.svg
 maintainers:
   - name: arslanbekov
     email: arslanbekov@gmail.com


### PR DESCRIPTION
## What
- add Prometheus icon to prometheus-fastly-exporter chart metadata
- bump chart version to 0.10.1

## Why
- chart missing icon; adding aligns metadata and clears helm lint warning

## Testing
- helm lint charts/prometheus-fastly-exporter