### PR TITLE
chore(conntrack-exporter): add chart icon

### DIFF
--- a/charts/prometheus-conntrack-stats-exporter/Chart.yaml
+++ b/charts/prometheus-conntrack-stats-exporter/Chart.yaml
@@ -2,10 +2,11 @@ apiVersion: v2
 name: prometheus-conntrack-stats-exporter
 description: A Helm chart for conntrack-stats-exporter
 type: application
-version: 0.5.31
+version: 0.5.32
 # renovate: github=jwkohnen/conntrack-stats-exporter
 appVersion: v0.4.39
 home: https://github.com/jwkohnen/conntrack-stats-exporter
+icon: https://raw.githubusercontent.com/cncf/artwork/master/prometheus/icon/color/prometheus-icon-color.svg
 sources:
   - https://github.com/jwkohnen/conntrack-stats-exporter
   - https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-conntrack-stats-exporter


### PR DESCRIPTION
## What
- add Prometheus icon to prometheus-conntrack-stats-exporter chart metadata
- bump chart version to 0.5.32

## Why
- chart missing icon; adding aligns metadata and eliminates lint warning

## Testing
- helm lint charts/prometheus-conntrack-stats-exporter