### PR TITLE
chore(ipmi-exporter): add chart icon

### DIFF
--- a/charts/prometheus-ipmi-exporter/Chart.yaml
+++ b/charts/prometheus-ipmi-exporter/Chart.yaml
@@ -2,9 +2,10 @@ apiVersion: v2
 name: prometheus-ipmi-exporter
 description: This is an IPMI exporter for Prometheus.
 type: application
-version: 0.8.0
+version: 0.8.1
 # renovate: github=prometheus-community/ipmi_exporter
 appVersion: "v1.10.1"
+icon: https://raw.githubusercontent.com/cncf/artwork/master/prometheus/icon/color/prometheus-icon-color.svg
 keywords:
   - metrics
   - ipmi


### PR DESCRIPTION
## What
- add Prometheus icon to prometheus-ipmi-exporter chart metadata
- bump chart version to 0.8.1

## Why
- chart missing icon; adding aligns metadata and removes helm lint warning

## Testing
- helm lint charts/prometheus-ipmi-exporter