### PR TITLE
chore(rabbitmq-exporter): add chart icon

### DIFF
--- a/charts/prometheus-rabbitmq-exporter/Chart.yaml
+++ b/charts/prometheus-rabbitmq-exporter/Chart.yaml
@@ -1,9 +1,10 @@
 apiVersion: v1
 description: Rabbitmq metrics exporter for prometheus
 name: prometheus-rabbitmq-exporter
-version: 2.1.1
+version: 2.1.2
 appVersion: 1.0.0
 home: https://github.com/kbudde/rabbitmq_exporter
+icon: https://raw.githubusercontent.com/cncf/artwork/master/prometheus/icon/color/prometheus-icon-color.svg
 sources:
   - https://github.com/kbudde/rabbitmq_exporter
 maintainers:


### PR DESCRIPTION
## What
- add Prometheus icon to prometheus-rabbitmq-exporter chart metadata
- bump chart version to 2.1.2

## Why
- chart missing icon; adding improves metadata quality and removes lint warning

## Testing
- helm lint charts/prometheus-rabbitmq-exporter