### PR TITLE
chore(memcached-exporter): add chart icon

### DIFF
--- a/charts/prometheus-memcached-exporter/Chart.yaml
+++ b/charts/prometheus-memcached-exporter/Chart.yaml
@@ -2,10 +2,11 @@ apiVersion: v2
 name: prometheus-memcached-exporter
 description: Prometheus exporter for Memcached metrics
 type: application
-version: 0.4.5
+version: 0.4.6
 # renovate: github=prometheus/memcached_exporter
 appVersion: "v0.15.5"
 home: https://github.com/prometheus/memcached_exporter
+icon: https://raw.githubusercontent.com/cncf/artwork/master/prometheus/icon/color/prometheus-icon-color.svg
 sources:
   - https://github.com/prometheus/memcached_exporter
 keywords:


### PR DESCRIPTION
## What
- add Prometheus icon to prometheus-memcached-exporter chart metadata
- bump chart version to 0.4.6

## Why
- chart missing icon; adding aligns metadata and removes lint warning

## Testing
- helm lint charts/prometheus-memcached-exporter