### PR TITLE
chore(sql-exporter): add chart icon

### DIFF
--- a/charts/prometheus-sql-exporter/Chart.yaml
+++ b/charts/prometheus-sql-exporter/Chart.yaml
@@ -1,12 +1,13 @@
 apiVersion: v2
 description: Prometheus SQL Exporter
 name: prometheus-sql-exporter
-version: 0.4.0
+version: 0.4.1
 appVersion: v0.8
 home: https://github.com/justwatchcom/sql_exporter
 sources:
   - https://github.com/justwatchcom/sql_exporter
   - https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-sql-exporter
+icon: https://raw.githubusercontent.com/cncf/artwork/master/prometheus/icon/color/prometheus-icon-color.svg
 keywords:
   - prometheus
   - sql


### PR DESCRIPTION
## What
- add Prometheus icon to prometheus-sql-exporter chart metadata
- bump chart version to 0.4.1

## Why
- chart missing icon; adding aligns metadata and removes lint warning

## Testing
- helm lint charts/prometheus-sql-exporter