### PR TITLE
chore(windows-exporter): add chart icon

### DIFF
--- a/charts/prometheus-windows-exporter/Chart.yaml
+++ b/charts/prometheus-windows-exporter/Chart.yaml
@@ -7,10 +7,11 @@ keywords:
   - prometheus
   - exporter
 type: application
-version: 0.12.2
+version: 0.12.3
 # renovate: github=prometheus-community/windows_exporter
 appVersion: 0.31.3
 home: https://github.com/prometheus-community/windows_exporter/
+icon: https://raw.githubusercontent.com/cncf/artwork/master/prometheus/icon/color/prometheus-icon-color.svg
 sources:
   - https://github.com/prometheus-community/windows_exporter/
 maintainers:


### PR DESCRIPTION
## What
- add Prometheus icon to prometheus-windows-exporter chart metadata
- bump chart version to 0.12.3

## Why
- chart missing icon; adding improves metadata consistency and removes lint warning

## Testing
- helm lint charts/prometheus-windows-exporter