### PR TITLE
chore(alertmanager-snmp-notifier): add chart icon

### DIFF
--- a/charts/alertmanager-snmp-notifier/Chart.yaml
+++ b/charts/alertmanager-snmp-notifier/Chart.yaml
@@ -5,10 +5,11 @@ home: https://github.com/maxwo/snmp_notifier
 sources:
   - https://github.com/maxwo/snmp_notifier
 type: application
-version: 2.1.0
+version: 2.1.1
 # renovate: github-releases=maxwo/snmp_notifier
 appVersion: v2.1.0
 kubeVersion: ">=1.23.0-0"
+icon: https://raw.githubusercontent.com/cncf/artwork/master/prometheus/icon/color/prometheus-icon-color.svg
 keywords:
   - prometheus
   - snmp

--- a/charts/alertmanager-snmp-notifier/Chart.yaml
+++ b/charts/alertmanager-snmp-notifier/Chart.yaml
@@ -5,11 +5,11 @@ home: https://github.com/maxwo/snmp_notifier
 sources:
   - https://github.com/maxwo/snmp_notifier
 type: application
-version: 2.1.1
+version: 2.1.2
 # renovate: github-releases=maxwo/snmp_notifier
 appVersion: v2.1.0
 kubeVersion: ">=1.23.0-0"
-icon: https://raw.githubusercontent.com/cncf/artwork/master/prometheus/icon/color/prometheus-icon-color.svg
+icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/prometheus/icon/color/prometheus-icon-color.svg
 keywords:
   - prometheus
   - snmp


### PR DESCRIPTION
## What
- add Prometheus icon to alertmanager-snmp-notifier chart metadata
- bump chart version to 2.1.1

## Why
- chart missing icon; adding aligns metadata and removes lint warning

## Testing
- helm lint charts/alertmanager-snmp-notifier