### PR TITLE
chore(jiralert): add chart icon

### DIFF
--- a/charts/jiralert/Chart.yaml
+++ b/charts/jiralert/Chart.yaml
@@ -2,9 +2,10 @@ apiVersion: v2
 name: jiralert
 description: A Helm chart for Kubernetes to install jiralert
 type: application
-version: 1.8.1
+version: 1.8.2
 appVersion: "v1.3.0"
 home: "https://github.com/prometheus-community/jiralert"
+icon: https://raw.githubusercontent.com/cncf/artwork/master/prometheus/icon/color/prometheus-icon-color.svg
 keywords:
   - monitoring
   - prometheus


### PR DESCRIPTION
## What
- add Prometheus icon to jiralert chart metadata
- bump chart version to 1.8.2

## Why
- chart missing icon; adding aligns metadata and removes lint warning

## Testing
- helm lint charts/jiralert