### PR TITLE
chore(prometheus-adapter): add chart icon

### DIFF
--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,9 +1,10 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 5.2.0
+version: 5.2.1
 appVersion: v0.12.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/kubernetes-sigs/prometheus-adapter
+icon: https://raw.githubusercontent.com/cncf/artwork/master/prometheus/icon/color/prometheus-icon-color.svg
 keywords:
   - hpa
   - metrics


### PR DESCRIPTION
## What
- add Prometheus icon to prometheus-adapter chart metadata
- bump chart version to 5.2.1

## Why
- chart missing icon; adding aligns metadata and removes lint warning

## Testing
- helm lint charts/prometheus-adapter