### PR TITLE
[prometheus-cloudwatch-exporter] add chart icon 

### DIFF
--- a/charts/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/charts/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,10 +2,11 @@ apiVersion: v1
 appVersion: "0.16.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.28.1
+version: 0.28.2
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
   - https://github.com/prometheus/cloudwatch_exporter
+icon: https://raw.githubusercontent.com/cncf/artwork/master/prometheus/icon/color/prometheus-icon-color.svg
 keywords:
   - aws
   - cloudwatch

--- a/charts/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/charts/prometheus-cloudwatch-exporter/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.28.2
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
   - https://github.com/prometheus/cloudwatch_exporter
-icon: https://raw.githubusercontent.com/cncf/artwork/master/prometheus/icon/color/prometheus-icon-color.svg
+icon: https://cncf-icons.com/artwork/projects/prometheus/icon/color/prometheus-icon-color.svg
 keywords:
   - aws
   - cloudwatch


### PR DESCRIPTION
## What
- add Prometheus icon to prometheus-cloudwatch-exporter chart metadata
- bump chart version to 0.28.2

## Why
- chart missing icon; adding aligns metadata and removes lint warning

## Testing
- helm lint charts/prometheus-cloudwatch-exporter