### PR TITLE
[prometheus-couchdb-exporter] add chart icon

### DIFF
--- a/charts/prometheus-couchdb-exporter/Chart.yaml
+++ b/charts/prometheus-couchdb-exporter/Chart.yaml
@@ -3,11 +3,12 @@ appVersion: "1.0"
 description: A Helm chart to export the metrics from couchdb in Prometheus format.
 name: prometheus-couchdb-exporter
 home: https://github.com/gesellix/couchdb-prometheus-exporter
-version: 1.0.1
+version: 1.0.2
 keywords:
 - couchdb-exporter
 sources:
   - https://github.com/gesellix/couchdb-prometheus-exporter
+icon: https://raw.githubusercontent.com/cncf/artwork/master/prometheus/icon/color/prometheus-icon-color.svg
 maintainers:
 - name: gkarthiks
   email: github.gkarthiks@gmail.com

--- a/charts/prometheus-couchdb-exporter/Chart.yaml
+++ b/charts/prometheus-couchdb-exporter/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
 - couchdb-exporter
 sources:
   - https://github.com/gesellix/couchdb-prometheus-exporter
-icon: https://raw.githubusercontent.com/cncf/artwork/master/prometheus/icon/color/prometheus-icon-color.svg
+icon: https://cncf-icons.com/artwork/projects/prometheus/icon/color/prometheus-icon-color.svg
 maintainers:
 - name: gkarthiks
   email: github.gkarthiks@gmail.com


### PR DESCRIPTION
## What
- add Prometheus icon to prometheus-couchdb-exporter chart metadata
- bump chart version to 1.0.2

## Why
- chart missing icon; adding aligns metadata and removes lint warning

## Testing
- helm lint charts/prometheus-couchdb-exporter