### PR TITLE
chore(prometheus-adapter): add nameOverride and fullnameOverride values

### DIFF
--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 5.2.1
+version: 5.3.0
 appVersion: v0.12.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/kubernetes-sigs/prometheus-adapter

--- a/charts/prometheus-adapter/values.yaml
+++ b/charts/prometheus-adapter/values.yaml
@@ -2,6 +2,12 @@ affinity: {}
 
 topologySpreadConstraints: []
 
+# Override the name of the chart
+nameOverride: ""
+
+# Override the full name of the release
+fullnameOverride: ""
+
 image:
   repository: registry.k8s.io/prometheus-adapter/prometheus-adapter
   # if not set appVersion field from Chart.yaml is used


### PR DESCRIPTION
## Summary
- Add `nameOverride` and `fullnameOverride` values to `prometheus-adapter` chart
- The `_helpers.tpl` template already supports these values but they were not exposed in `values.yaml`
- Bump chart version from 5.2.0 to 5.3.0

## Motivation
Users need to override deployment names when deploying multiple instances or integrating with existing naming conventions. Without these values exposed, customizing resource names was not possible through standard Helm value overrides.

## Changes
- `charts/prometheus-adapter/values.yaml`: Added `nameOverride` and `fullnameOverride` with empty string defaults
- `charts/prometheus-adapter/Chart.yaml`: Bumped version to 5.3.0

Signed-off-by: Yuan Chen <yuanchen97@gmail.com>