### PR TITLE
[kube-state-metrics] Fix probe ports when kubeRBACProxy is enabled

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - kubernetes
 type: application
-version: 7.1.0
+version: 7.1.1
 # renovate: github-releases=kubernetes/kube-state-metrics
 appVersion: 2.18.0
 home: https://github.com/kubernetes/kube-state-metrics/

--- a/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/kube-state-metrics/templates/deployment.yaml
@@ -179,10 +179,11 @@ spec:
               value: {{ $header.value }}
             {{- end }}
             path: /healthz
-            port: http
             {{- if .Values.kubeRBACProxy.enabled }}
+            port: {{ .Values.service.port | default 8080 }}
             scheme: HTTPS
             {{- else }}
+            port: http
             scheme: {{ upper .Values.startupProbe.httpGet.scheme }}
             {{- end }}
           initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
@@ -202,10 +203,11 @@ spec:
               value: {{ $header.value }}
             {{- end }}
             path: /livez
-            port: http
             {{- if .Values.kubeRBACProxy.enabled }}
+            port: {{ .Values.service.port | default 8080 }}
             scheme: HTTPS
             {{- else }}
+            port: http
             scheme: {{ upper .Values.livenessProbe.httpGet.scheme }}
             {{- end }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
@@ -224,10 +226,11 @@ spec:
               value: {{ $header.value }}
             {{- end }}
             path: /readyz
-            port: metrics
             {{- if .Values.kubeRBACProxy.enabled }}
+            port: {{ .Values.service.port | default 8080 }}
             scheme: HTTPS
             {{- else }}
+            port: metrics
             scheme: {{ upper .Values.readinessProbe.httpGet.scheme }}
             {{- end }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}

--- a/charts/kube-state-metrics/unittests/deployment_test.yaml
+++ b/charts/kube-state-metrics/unittests/deployment_test.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test deployment probes
+templates:
+  - deployment.yaml
+tests:
+  - it: should use named probe ports by default
+    set:
+      startupProbe.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.port
+          value: http
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: http
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: metrics
+
+  - it: should use the service port for probes when kube-rbac-proxy is enabled
+    set:
+      startupProbe.enabled: true
+      service.port: 9443
+      kubeRBACProxy.enabled: true
+      kubeRBACProxy.port: 9191
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.port
+          value: 9443
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.scheme
+          value: HTTPS
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 9443
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.scheme
+          value: HTTPS
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 9443
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+          value: HTTPS


### PR DESCRIPTION
## Summary
- fix probe port rendering for the main `kube-state-metrics` container when `kubeRBACProxy.enabled=true`
- use numeric service port for startup/liveness/readiness probes in proxy mode
- add a helm-unittest regression suite covering default and kube-rbac-proxy probe behavior
- bump chart version to `7.1.1`

Closes #6164.

## Testing
- `helm unittest --strict --file 'unittests/**/*.yaml' charts/kube-state-metrics`
- `ct lint --config .github/linters/ct.yaml --charts charts/kube-state-metrics`
- `helm lint charts/kube-state-metrics`
