### PR TITLE
[kube-prometheus-stack] Fix operator tls handling when admission webhooks are disabled

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 81.5.0
+version: 81.5.1
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.88.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/README.md
+++ b/charts/kube-prometheus-stack/README.md
@@ -123,6 +123,8 @@ When Google configure the control plane for private clusters, they automatically
 You can read more information on how to add firewall rules for the GKE control plane nodes in the [GKE docs](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules)
 
 Alternatively, you can disable the hooks by setting `prometheusOperator.admissionWebhooks.enabled=false`.
+When hooks are disabled and no TLS secret is configured, the operator endpoint automatically falls back to HTTP.
+To keep TLS enabled without admission webhooks, set `prometheusOperator.tls.secretName` to an existing secret with the expected key names.
 
 ## PrometheusRules Admission Webhooks
 

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/ciliumnetworkpolicy.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/ciliumnetworkpolicy.yaml
@@ -1,4 +1,6 @@
 {{- if and .Values.prometheusOperator.networkPolicy.enabled (eq .Values.prometheusOperator.networkPolicy.flavor "cilium") }}
+{{- $operatorTlsSecretConfigured := ne (default "" .Values.prometheusOperator.tls.secretName) "" }}
+{{- $operatorTlsEnabled := and .Values.prometheusOperator.tls.enabled (or $operatorTlsSecretConfigured .Values.prometheusOperator.admissionWebhooks.enabled .Values.prometheusOperator.admissionWebhooks.certManager.enabled) }}
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -25,13 +27,13 @@ spec:
   ingress:
   - toPorts:
     - ports:
-      {{- if .Values.prometheusOperator.tls.enabled }}
+      {{- if $operatorTlsEnabled }}
       - port: {{ .Values.prometheusOperator.tls.internalPort | quote }}
       {{- else }}
       - port: "8080"
       {{- end }}
         protocol: "TCP"
-      {{- if not .Values.prometheusOperator.tls.enabled }}
+      {{- if not $operatorTlsEnabled }}
       rules:
         http:
         - method: "GET"

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -1,5 +1,8 @@
 {{- $namespace := printf "%s" (include "kube-prometheus-stack.namespace" .) }}
 {{- $defaultKubeletSvcName := printf "%s-kubelet" (include "kube-prometheus-stack.fullname" .) }}
+{{- $operatorTlsSecretConfigured := ne (default "" .Values.prometheusOperator.tls.secretName) "" }}
+{{- $operatorTlsEnabled := and .Values.prometheusOperator.tls.enabled (or $operatorTlsSecretConfigured .Values.prometheusOperator.admissionWebhooks.enabled .Values.prometheusOperator.admissionWebhooks.certManager.enabled) }}
+{{- $operatorTlsSecretName := default (printf "%s-admission" (include "kube-prometheus-stack.fullname" .)) .Values.prometheusOperator.tls.secretName }}
 {{- if .Values.prometheusOperator.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -137,7 +140,7 @@ spec:
             {{- if .Values.prometheusOperator.clusterDomain }}
             - --cluster-domain={{ .Values.prometheusOperator.clusterDomain }}
             {{- end }}
-            {{- if .Values.prometheusOperator.tls.enabled }}
+            {{- if $operatorTlsEnabled }}
             - --web.enable-tls=true
             - --web.cert-file=/cert/{{ if .Values.prometheusOperator.admissionWebhooks.certManager.enabled }}tls.crt{{ else }}cert{{ end }}
             - --web.key-file=/cert/{{ if .Values.prometheusOperator.admissionWebhooks.certManager.enabled }}tls.key{{ else }}key{{ end }}
@@ -153,7 +156,7 @@ spec:
           {{- with .Values.prometheusOperator.lifecycle }}
           lifecycle: {{ toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.prometheusOperator.tls.enabled }}
+          {{- if $operatorTlsEnabled }}
           ports:
             - containerPort: {{ .Values.prometheusOperator.tls.internalPort }}
               name: https
@@ -172,7 +175,7 @@ spec:
           securityContext:
 {{ toYaml .Values.prometheusOperator.containerSecurityContext | indent 12 }}
           volumeMounts:
-          {{- if .Values.prometheusOperator.tls.enabled }}
+          {{- if $operatorTlsEnabled }}
             - name: tls-secret
               mountPath: /cert
               readOnly: true
@@ -184,8 +187,8 @@ spec:
           readinessProbe:
             httpGet:
               path: /healthz
-              port: {{ .Values.prometheusOperator.tls.enabled | ternary "https" "http" }}
-              scheme: {{ .Values.prometheusOperator.tls.enabled | ternary "HTTPS" "HTTP" }}
+              port: {{ $operatorTlsEnabled | ternary "https" "http" }}
+              scheme: {{ $operatorTlsEnabled | ternary "HTTPS" "HTTP" }}
             initialDelaySeconds: {{ .Values.prometheusOperator.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.prometheusOperator.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.prometheusOperator.readinessProbe.timeoutSeconds }}
@@ -196,8 +199,8 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthz
-              port: {{ .Values.prometheusOperator.tls.enabled | ternary "https" "http" }}
-              scheme: {{ .Values.prometheusOperator.tls.enabled | ternary "HTTPS" "HTTP" }}
+              port: {{ $operatorTlsEnabled | ternary "https" "http" }}
+              scheme: {{ $operatorTlsEnabled | ternary "HTTPS" "HTTP" }}
             initialDelaySeconds: {{ .Values.prometheusOperator.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.prometheusOperator.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.prometheusOperator.livenessProbe.timeoutSeconds }}
@@ -205,11 +208,11 @@ spec:
             failureThreshold: {{ .Values.prometheusOperator.livenessProbe.failureThreshold }}
           {{- end }}
       volumes:
-        {{- if .Values.prometheusOperator.tls.enabled }}
+        {{- if $operatorTlsEnabled }}
         - name: tls-secret
           secret:
             defaultMode: 420
-            secretName: {{ template "kube-prometheus-stack.fullname" . }}-admission
+            secretName: {{ $operatorTlsSecretName }}
         {{- end }}
         {{- with .Values.prometheusOperator.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/networkpolicy.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/networkpolicy.yaml
@@ -1,4 +1,6 @@
 {{- if and .Values.prometheusOperator.networkPolicy.enabled (eq .Values.prometheusOperator.networkPolicy.flavor "kubernetes") }}
+{{- $operatorTlsSecretConfigured := ne (default "" .Values.prometheusOperator.tls.secretName) "" }}
+{{- $operatorTlsEnabled := and .Values.prometheusOperator.tls.enabled (or $operatorTlsSecretConfigured .Values.prometheusOperator.admissionWebhooks.enabled .Values.prometheusOperator.admissionWebhooks.certManager.enabled) }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -11,7 +13,7 @@ spec:
     - {}
   ingress:
     - ports:
-      {{- if .Values.prometheusOperator.tls.enabled }}
+      {{- if $operatorTlsEnabled }}
       - port: {{ .Values.prometheusOperator.tls.internalPort }}
       {{- else }}
       - port: 8080

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/service.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/service.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.prometheusOperator.enabled }}
+{{- $operatorTlsSecretConfigured := ne (default "" .Values.prometheusOperator.tls.secretName) "" }}
+{{- $operatorTlsEnabled := and .Values.prometheusOperator.tls.enabled (or $operatorTlsSecretConfigured .Values.prometheusOperator.admissionWebhooks.enabled .Values.prometheusOperator.admissionWebhooks.certManager.enabled) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -38,7 +40,7 @@ spec:
   externalTrafficPolicy: {{ .Values.prometheusOperator.service.externalTrafficPolicy }}
 {{- end }}
   ports:
-  {{- if not .Values.prometheusOperator.tls.enabled }}
+  {{- if not $operatorTlsEnabled }}
   - name: http
     {{- if eq .Values.prometheusOperator.service.type "NodePort" }}
     nodePort: {{ .Values.prometheusOperator.service.nodePort }}
@@ -46,7 +48,7 @@ spec:
     port: 8080
     targetPort: http
   {{- end }}
-  {{- if .Values.prometheusOperator.tls.enabled }}
+  {{- if $operatorTlsEnabled }}
   - name: https
     {{- if eq .Values.prometheusOperator.service.type "NodePort"}}
     nodePort: {{ .Values.prometheusOperator.service.nodePortTls }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/servicemonitor.yaml
@@ -1,4 +1,7 @@
 {{- if and .Values.prometheusOperator.enabled .Values.prometheusOperator.serviceMonitor.selfMonitor }}
+{{- $operatorTlsSecretConfigured := ne (default "" .Values.prometheusOperator.tls.secretName) "" }}
+{{- $operatorTlsEnabled := and .Values.prometheusOperator.tls.enabled (or $operatorTlsSecretConfigured .Values.prometheusOperator.admissionWebhooks.enabled .Values.prometheusOperator.admissionWebhooks.certManager.enabled) }}
+{{- $operatorTlsSecretName := default (printf "%s-admission" (include "kube-prometheus-stack.fullname" .)) .Values.prometheusOperator.tls.secretName }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -12,14 +15,14 @@ metadata:
 spec:
   {{- include "servicemonitor.scrapeLimits" .Values.prometheusOperator.serviceMonitor | nindent 2 }}
   endpoints:
-  {{- if .Values.prometheusOperator.tls.enabled }}
+  {{- if $operatorTlsEnabled }}
   - port: https
     scheme: https
     tlsConfig:
       serverName: {{ template "kube-prometheus-stack.operator.fullname" . }}
       ca:
         secret:
-          name: {{ template "kube-prometheus-stack.fullname" . }}-admission
+          name: {{ $operatorTlsSecretName }}
           key: {{ if .Values.prometheusOperator.admissionWebhooks.certManager.enabled }}ca.crt{{ else }}ca{{ end }}
           optional: false
   {{- else }}

--- a/charts/kube-prometheus-stack/unittests/prometheus-operator/deployment_tls_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/prometheus-operator/deployment_tls_test.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: prometheus operator deployment tls fallback
+templates:
+  - prometheus-operator/deployment.yaml
+tests:
+  - it: falls back to http when admission webhooks are disabled and no tls secret is provided
+    set:
+      prometheusOperator.admissionWebhooks.enabled: false
+      prometheusOperator.tls.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].name
+          value: http
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --web.enable-tls=false
+
+  - it: keeps tls enabled when a custom operator tls secret is configured
+    set:
+      prometheusOperator.admissionWebhooks.enabled: false
+      prometheusOperator.tls.enabled: true
+      prometheusOperator.tls.secretName: custom-operator-tls
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].name
+          value: https
+      - equal:
+          path: spec.template.spec.volumes[0].secret.secretName
+          value: custom-operator-tls
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --web.enable-tls=true

--- a/charts/kube-prometheus-stack/unittests/prometheus-operator/service_tls_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/prometheus-operator/service_tls_test.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: prometheus operator service tls fallback
+templates:
+  - prometheus-operator/service.yaml
+tests:
+  - it: exposes http port when admission webhooks are disabled and no tls secret is provided
+    set:
+      prometheusOperator.admissionWebhooks.enabled: false
+      prometheusOperator.tls.enabled: true
+    asserts:
+      - equal:
+          path: spec.ports[0].name
+          value: http
+      - equal:
+          path: spec.ports[0].port
+          value: 8080
+      - equal:
+          path: spec.ports[0].targetPort
+          value: http
+
+  - it: exposes https port when a custom operator tls secret is configured
+    set:
+      prometheusOperator.admissionWebhooks.enabled: false
+      prometheusOperator.tls.enabled: true
+      prometheusOperator.tls.secretName: custom-operator-tls
+    asserts:
+      - equal:
+          path: spec.ports[0].name
+          value: https
+      - equal:
+          path: spec.ports[0].port
+          value: 443
+      - equal:
+          path: spec.ports[0].targetPort
+          value: https

--- a/charts/kube-prometheus-stack/unittests/prometheus-operator/servicemonitor_tls_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/prometheus-operator/servicemonitor_tls_test.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: prometheus operator servicemonitor tls fallback
+templates:
+  - prometheus-operator/servicemonitor.yaml
+tests:
+  - it: scrapes over http when admission webhooks are disabled and no tls secret is provided
+    set:
+      prometheusOperator.admissionWebhooks.enabled: false
+      prometheusOperator.tls.enabled: true
+      prometheusOperator.serviceMonitor.selfMonitor: true
+    asserts:
+      - equal:
+          path: spec.endpoints[0].port
+          value: http
+      - notExists:
+          path: spec.endpoints[0].tlsConfig
+
+  - it: scrapes over https when a custom operator tls secret is configured
+    set:
+      prometheusOperator.admissionWebhooks.enabled: false
+      prometheusOperator.tls.enabled: true
+      prometheusOperator.tls.secretName: custom-operator-tls
+      prometheusOperator.serviceMonitor.selfMonitor: true
+    asserts:
+      - equal:
+          path: spec.endpoints[0].port
+          value: https
+      - equal:
+          path: spec.endpoints[0].tlsConfig.ca.secret.name
+          value: custom-operator-tls

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -2656,6 +2656,9 @@ prometheusOperator:
     tlsMinVersion: VersionTLS13
     # The default webhook port is 10250 in order to work out-of-the-box in GKE private clusters and avoid adding firewall rules.
     internalPort: 10250
+    # Existing secret containing the web cert/key pair for Prometheus Operator.
+    # If admissionWebhooks are disabled and this is empty, operator TLS is disabled automatically.
+    secretName: ""
 
   ## Liveness probe for the prometheusOperator deployment
   ##


### PR DESCRIPTION
## Summary
- fix Prometheus Operator TLS rendering when `prometheusOperator.admissionWebhooks.enabled=false`
- compute effective operator TLS as enabled only when a certificate source exists:
  - admission webhooks enabled, or
  - cert-manager admission certs enabled, or
  - `prometheusOperator.tls.secretName` explicitly set
- avoid mounting the generated `*-admission` secret when it is not created
- switch operator `Service`, `ServiceMonitor`, and operator network policies to the same effective TLS mode
- add `prometheusOperator.tls.secretName` to values for users who want TLS without admission webhooks
- add regression unit tests for deployment/service/servicemonitor behavior and bump chart version to `81.5.1`

Closes #6586.

## Testing
- `helm unittest --strict --file 'unittests/**/*.yaml' charts/kube-prometheus-stack`
- `helm lint charts/kube-prometheus-stack`
- `GITHUB_SHA=$(git rev-parse HEAD) ct lint --config .github/linters/ct.yaml --charts charts/kube-prometheus-stack`
