### PR TITLE
[kube-state-metrics] Avoid duplicated release prefix in fullname

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - kubernetes
 type: application
-version: 7.1.0
+version: 7.1.2
 # renovate: github-releases=kubernetes/kube-state-metrics
 appVersion: 2.18.0
 home: https://github.com/kubernetes/kube-state-metrics/

--- a/charts/kube-state-metrics/templates/_helpers.tpl
+++ b/charts/kube-state-metrics/templates/_helpers.tpl
@@ -10,6 +10,7 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
+If nameOverride already contains release name, nameOverride will be used directly.
 */}}
 {{- define "kube-state-metrics.fullname" -}}
 {{- if .Values.fullnameOverride -}}
@@ -18,6 +19,8 @@ If release name contains chart name it will be used as a full name.
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- if contains $name .Release.Name -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else if contains .Release.Name $name -}}
+{{- $name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/charts/kube-state-metrics/unittests/fullname_test.yaml
+++ b/charts/kube-state-metrics/unittests/fullname_test.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test fullname helper behavior
+templates:
+  - serviceaccount.yaml
+tests:
+  - it: should use release name when release already contains chart name
+    release:
+      name: ksm-kube-state-metrics
+    asserts:
+      - equal:
+          path: metadata.name
+          value: ksm-kube-state-metrics
+
+  - it: should use nameOverride directly when it already contains release name
+    release:
+      name: ksm-non-pods
+    set:
+      nameOverride: ksm-non-pods-foo
+    asserts:
+      - equal:
+          path: metadata.name
+          value: ksm-non-pods-foo
+
+  - it: should combine release and nameOverride when names are unrelated
+    release:
+      name: ksm
+    set:
+      nameOverride: metrics
+    asserts:
+      - equal:
+          path: metadata.name
+          value: ksm-metrics


### PR DESCRIPTION
## Summary
- update `kube-state-metrics.fullname` helper to avoid duplicating release name when `nameOverride` already includes it
- preserve existing behavior for the canonical case where release name already includes chart name
- add regression unittest coverage for fullname helper paths
- bump chart version to `7.1.2`

Fixes #6510.

## Testing
- `helm unittest --strict --file 'unittests/**/*.yaml' charts/kube-state-metrics`
- `helm lint charts/kube-state-metrics`
- `ct lint --config .github/linters/ct.yaml --charts charts/kube-state-metrics`
