### PR TITLE
[prometheus-kafka-exporter] Enable startup probe by default

### DIFF
--- a/charts/prometheus-kafka-exporter/Chart.yaml
+++ b/charts/prometheus-kafka-exporter/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v1.9.0"
 description: A Helm chart to export metrics from Kafka in Prometheus format using kafka_exporter from https://github.com/danielqsj/kafka_exporter
 name: prometheus-kafka-exporter
 home: https://github.com/danielqsj/kafka_exporter
-version: 3.0.1
+version: 3.0.2
 kubeVersion: ">=1.25.0-0"
 sources:
   - https://github.com/prometheus-community/helm-charts

--- a/charts/prometheus-kafka-exporter/values.yaml
+++ b/charts/prometheus-kafka-exporter/values.yaml
@@ -98,7 +98,7 @@ service:
   loadBalancerIP: null
 
 startup:
-  enabled: false
+  enabled: true
   probe:
     httpGet:
       path: /


### PR DESCRIPTION
## Summary
- enable `startup.enabled` by default for `prometheus-kafka-exporter`
- keep existing startup probe shape/path/port, but ship it enabled out of the box
- bump chart version to `3.0.2`

Closes #5884.

## Testing
- `ct lint --config .github/linters/ct.yaml --charts charts/prometheus-kafka-exporter`
- `helm lint charts/prometheus-kafka-exporter`
- `helm dependency build charts/prometheus-kafka-exporter`
- `helm template pke charts/prometheus-kafka-exporter`
