### PR TITLE
[prometheus-smartctl-exporter] Mount host /dev directly for live device updates

### DIFF
--- a/charts/prometheus-smartctl-exporter/Chart.yaml
+++ b/charts/prometheus-smartctl-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.16.0
+version: 0.16.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/prometheus-smartctl-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-smartctl-exporter/templates/daemonset.yaml
@@ -71,8 +71,9 @@ spec:
         resources:
 {{ toYaml $item.resources | indent 10 }}
         volumeMounts:
-        - mountPath: /hostdev
+        - mountPath: /dev
           name: dev
+          mountPropagation: HostToContainer
       dnsPolicy: ClusterFirst
       hostNetwork: {{ $item.hostNetwork }}
       {{- if $item.priorityClassName }}


### PR DESCRIPTION
## Summary
- mount host device tree directly at `/dev` instead of `/hostdev`
- set `mountPropagation: HostToContainer` on the `/dev` mount to receive host-side device updates
- bump chart version to `0.16.1`

Closes #6223.

## Testing
- `ct lint --config .github/linters/ct.yaml --charts charts/prometheus-smartctl-exporter`
- `helm lint charts/prometheus-smartctl-exporter`
- `helm template smartctl charts/prometheus-smartctl-exporter`
