### PR TITLE
[prometheus-blackbox-exporter] Allow ServiceMonitor CRD apiVersion override

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 11.8.0
+version: 11.8.1
 # renovate: github=prometheus/blackbox_exporter
 appVersion: v0.28.0
 kubeVersion: ">=1.21.0-0"

--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 11.8.1
+version: 11.9.0
 # renovate: github=prometheus/blackbox_exporter
 appVersion: v0.28.0
 kubeVersion: ">=1.21.0-0"

--- a/charts/prometheus-blackbox-exporter/ci/servicemonitor-apiversion-values.yaml
+++ b/charts/prometheus-blackbox-exporter/ci/servicemonitor-apiversion-values.yaml
@@ -1,6 +1,0 @@
-serviceMonitor:
-  enabled: true
-  apiVersion: azmonitoring.coreos.com/v1
-  targets:
-    - name: example
-      url: https://example.com

--- a/charts/prometheus-blackbox-exporter/ci/servicemonitor-apiversion-values.yaml
+++ b/charts/prometheus-blackbox-exporter/ci/servicemonitor-apiversion-values.yaml
@@ -1,0 +1,6 @@
+serviceMonitor:
+  enabled: true
+  apiVersion: azmonitoring.coreos.com/v1
+  targets:
+    - name: example
+      url: https://example.com

--- a/charts/prometheus-blackbox-exporter/templates/selfservicemonitor.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/selfservicemonitor.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.serviceMonitor.selfMonitor.enabled }}
 ---
-apiVersion: monitoring.coreos.com/v1
+apiVersion: {{ .Values.serviceMonitor.apiVersion }}
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-blackbox-exporter.fullname" $ }}

--- a/charts/prometheus-blackbox-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/servicemonitor.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.serviceMonitor.enabled }}
 {{- range .Values.serviceMonitor.targets }}
 ---
-apiVersion: monitoring.coreos.com/v1
+apiVersion: {{ $.Values.serviceMonitor.apiVersion }}
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-blackbox-exporter.fullname" $ }}-{{ .name }}

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -278,6 +278,10 @@ extraArgs: []
 replicas: 1
 
 serviceMonitor:
+  ## apiVersion to use for ServiceMonitor resources.
+  ##
+  apiVersion: monitoring.coreos.com/v1
+
   ## If true, a ServiceMonitor CRD is created for a prometheus operator
   ## https://github.com/coreos/prometheus-operator for blackbox-exporter itself
   ##


### PR DESCRIPTION
## What this PR does
This change makes the ServiceMonitor CRD API version configurable in the `prometheus-blackbox-exporter` chart.

## Why
Some managed environments use a provider-specific ServiceMonitor API group (for example `azmonitoring.coreos.com/v1`) instead of `monitoring.coreos.com/v1`.

## Changes
- add `serviceMonitor.apiVersion` with default `monitoring.coreos.com/v1`
- use `serviceMonitor.apiVersion` in:
  - `templates/servicemonitor.yaml`
  - `templates/selfservicemonitor.yaml`
- add CI values case to validate override rendering
- bump chart version `11.8.0` -> `11.8.1`

Closes #6086

## Testing
- `ct lint --config .github/linters/ct.yaml --charts charts/prometheus-blackbox-exporter`
- `helm template test charts/prometheus-blackbox-exporter --set serviceMonitor.enabled=true --set-string 'serviceMonitor.targets[0].name=example' --set-string 'serviceMonitor.targets[0].url=https://example.com' --set serviceMonitor.apiVersion=azmonitoring.coreos.com/v1 | rg '^apiVersion: azmonitoring.coreos.com/v1$'`
