### PR TITLE
[prometheus-cloudwatch-exporter] Add commonLabels support

### DIFF
--- a/charts/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/charts/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.16.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.28.1
+version: 0.28.2
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
   - https://github.com/prometheus/cloudwatch_exporter

--- a/charts/prometheus-cloudwatch-exporter/ci/common-labels-values.yaml
+++ b/charts/prometheus-cloudwatch-exporter/ci/common-labels-values.yaml
@@ -1,0 +1,17 @@
+commonLabels:
+  team: observability
+  owner: platform
+
+serviceMonitor:
+  enabled: true
+
+prometheusRule:
+  enabled: true
+  rules:
+    - alert: CloudwatchExporterSample
+      expr: up == 0
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: sample

--- a/charts/prometheus-cloudwatch-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-cloudwatch-exporter/templates/_helpers.tpl
@@ -36,6 +36,19 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Common labels
+*/}}
+{{- define "prometheus-cloudwatch-exporter.labels" -}}
+app: {{ template "prometheus-cloudwatch-exporter.name" . }}
+chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}
+release: {{ .Release.Name }}
+heritage: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Create serviceAccountName for deployment.
 */}}
 {{- define "prometheus-cloudwatch-exporter.serviceAccountName" -}}

--- a/charts/prometheus-cloudwatch-exporter/templates/clusterrole.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/clusterrole.yaml
@@ -4,10 +4,7 @@ kind: ClusterRole
 metadata:
   name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
   labels:
-    app: {{ template "prometheus-cloudwatch-exporter.name" . }}
-    chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "prometheus-cloudwatch-exporter.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""]
     resources: ["secrets","configmap"]

--- a/charts/prometheus-cloudwatch-exporter/templates/clusterrolebinding.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/clusterrolebinding.yaml
@@ -4,10 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
   labels:
-    app: {{ template "prometheus-cloudwatch-exporter.name" . }}
-    chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "prometheus-cloudwatch-exporter.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "prometheus-cloudwatch-exporter.serviceAccountName" . }}

--- a/charts/prometheus-cloudwatch-exporter/templates/configmap.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/configmap.yaml
@@ -4,10 +4,7 @@ metadata:
   name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "prometheus-cloudwatch-exporter.name" . }}
-    chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "prometheus-cloudwatch-exporter.labels" . | nindent 4 }}
 data:
   config.yml: |
     {{ tpl .Values.config . | nindent 4 }}

--- a/charts/prometheus-cloudwatch-exporter/templates/deployment.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/deployment.yaml
@@ -4,10 +4,7 @@ metadata:
   name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "prometheus-cloudwatch-exporter.name" . }}
-    chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "prometheus-cloudwatch-exporter.labels" . | nindent 4 }}
     {{- with .Values.deployment.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -26,6 +23,9 @@ spec:
       labels:
         app: {{ template "prometheus-cloudwatch-exporter.name" . }}
         release: {{ .Release.Name }}
+        {{- with .Values.commonLabels }}
+{{ toYaml . | indent 8 }}
+        {{- end }}
         {{- if .Values.pod.labels }}
 {{ toYaml .Values.pod.labels | indent 8 }}
         {{- end }}

--- a/charts/prometheus-cloudwatch-exporter/templates/ingress.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/ingress.yaml
@@ -9,10 +9,7 @@ metadata:
   name: {{ $fullName }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "prometheus-cloudwatch-exporter.name" . }}
-    chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "prometheus-cloudwatch-exporter.labels" . | nindent 4 }}
 {{- if .Values.ingress.labels }}
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}

--- a/charts/prometheus-cloudwatch-exporter/templates/pdb.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/pdb.yaml
@@ -5,10 +5,7 @@ metadata:
   name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "prometheus-cloudwatch-exporter.name" . }}
-    chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "prometheus-cloudwatch-exporter.labels" . | nindent 4 }}
 spec:
   {{- if .Values.podDisruptionBudget.minAvailable }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}

--- a/charts/prometheus-cloudwatch-exporter/templates/prometheusrule.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/prometheusrule.yaml
@@ -3,10 +3,11 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-{{- if .Values.prometheusRule.labels }}
   labels:
-{{ toYaml .Values.prometheusRule.labels | indent 4}}
-{{- end }}
+    {{- include "prometheus-cloudwatch-exporter.labels" . | nindent 4 }}
+    {{- with .Values.prometheusRule.labels }}
+{{ toYaml . | indent 4}}
+    {{- end }}
   name: {{ $fullName }}
 {{- if .Values.prometheusRule.namespace }}
   namespace: {{ .Values.prometheusRule.namespace }}

--- a/charts/prometheus-cloudwatch-exporter/templates/secrets.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/secrets.yaml
@@ -5,10 +5,7 @@ metadata:
   name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "prometheus-cloudwatch-exporter.name" . }}
-    chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus-cloudwatch-exporter.labels" . | nindent 4 }}
 type: Opaque
 data:
   {{ if .Values.aws.aws_access_key_id }}

--- a/charts/prometheus-cloudwatch-exporter/templates/service.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/service.yaml
@@ -6,10 +6,7 @@ metadata:
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}
   labels:
-    app: {{ template "prometheus-cloudwatch-exporter.name" . }}
-    chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "prometheus-cloudwatch-exporter.labels" . | nindent 4 }}
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4 }}
 {{- end }}

--- a/charts/prometheus-cloudwatch-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/serviceaccount.yaml
@@ -6,10 +6,7 @@ metadata:
   name: {{ template "prometheus-cloudwatch-exporter.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "prometheus-cloudwatch-exporter.name" . }}
-    chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "prometheus-cloudwatch-exporter.labels" . | nindent 4 }}
   {{- if .Values.serviceAccount.annotations }}
   annotations:
     {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}

--- a/charts/prometheus-cloudwatch-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/servicemonitor.yaml
@@ -2,10 +2,11 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-{{- if .Values.serviceMonitor.labels }}
   labels:
-{{ toYaml .Values.serviceMonitor.labels | indent 4}}
-{{- end }}
+    {{- include "prometheus-cloudwatch-exporter.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+{{ toYaml . | indent 4}}
+    {{- end }}
   name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
 {{- if .Values.serviceMonitor.namespace }}
   namespace: {{ .Values.serviceMonitor.namespace }}

--- a/charts/prometheus-cloudwatch-exporter/values.yaml
+++ b/charts/prometheus-cloudwatch-exporter/values.yaml
@@ -4,6 +4,8 @@
 
 replicaCount: 1
 
+commonLabels: {}
+
 image:
   repository: prom/cloudwatch-exporter
   # if not set appVersion field from Chart.yaml is used


### PR DESCRIPTION
## What this PR does
Adds `commonLabels` support to the `prometheus-cloudwatch-exporter` chart and applies those labels to all chart-managed resources.

## Changes
- add `commonLabels` in `values.yaml`
- add reusable labels helper that includes chart labels + `commonLabels`
- apply helper labels to all generated resources (Deployment, Service, ServiceAccount, ConfigMap, Secret, RBAC objects, Ingress, PodDisruptionBudget, ServiceMonitor, PrometheusRule)
- add CI values scenario validating `commonLabels`
- bump chart version `0.28.1` -> `0.28.2`

Closes #6247

## Testing
- `ct lint --config .github/linters/ct.yaml --charts charts/prometheus-cloudwatch-exporter`
- `helm template test charts/prometheus-cloudwatch-exporter -f charts/prometheus-cloudwatch-exporter/ci/common-labels-values.yaml | rg '^\s+team: observability$'`
