### PR TITLE
[kube-prometheus-stack] Render webhook matchConditions as list

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 81.5.0
+version: 81.5.1
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.88.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/mutatingWebhookConfiguration.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/mutatingWebhookConfiguration.yaml
@@ -78,8 +78,13 @@ webhooks:
     objectSelector:
       {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- with .Values.prometheusOperator.admissionWebhooks.matchConditions }}
+    {{- $matchConditions := .Values.prometheusOperator.admissionWebhooks.matchConditions }}
+    {{- if $matchConditions }}
     matchConditions:
-      {{- toYaml . | nindent 6 }}
+      {{- if kindIs "slice" $matchConditions }}
+      {{- toYaml $matchConditions | nindent 6 }}
+      {{- else }}
+      {{- toYaml (list $matchConditions) | nindent 6 }}
+      {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/validatingWebhookConfiguration.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/validatingWebhookConfiguration.yaml
@@ -78,9 +78,14 @@ webhooks:
     objectSelector:
       {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- with .Values.prometheusOperator.admissionWebhooks.matchConditions }}
+    {{- $matchConditions := .Values.prometheusOperator.admissionWebhooks.matchConditions }}
+    {{- if $matchConditions }}
     matchConditions:
-      {{- toYaml . | nindent 6 }}
+      {{- if kindIs "slice" $matchConditions }}
+      {{- toYaml $matchConditions | nindent 6 }}
+      {{- else }}
+      {{- toYaml (list $matchConditions) | nindent 6 }}
+      {{- end }}
     {{- end }}
   - name: alertmanagerconfigsvalidate.monitoring.coreos.com
     {{- if eq .Values.prometheusOperator.admissionWebhooks.failurePolicy "IgnoreOnInstallOnly" }}
@@ -148,8 +153,13 @@ webhooks:
     objectSelector:
       {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- with .Values.prometheusOperator.admissionWebhooks.matchConditions }}
+    {{- $matchConditions := .Values.prometheusOperator.admissionWebhooks.matchConditions }}
+    {{- if $matchConditions }}
     matchConditions:
-      {{- toYaml . | nindent 6 }}
+      {{- if kindIs "slice" $matchConditions }}
+      {{- toYaml $matchConditions | nindent 6 }}
+      {{- else }}
+      {{- toYaml (list $matchConditions) | nindent 6 }}
+      {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -2698,7 +2698,11 @@ prometheusOperator:
 
     namespaceSelector: {}
     objectSelector: {}
-    matchConditions: {}
+    # Match conditions for admission webhooks.
+    # Must be a list, for example:
+    # - name: exclude-leases
+    #   expression: '!(request.resource.group == "coordination.k8s.io" && request.resource.resource == "leases")'
+    matchConditions: []
 
     mutatingWebhookConfiguration:
       annotations: {}


### PR DESCRIPTION
## What this PR does
Fixes admission webhook `matchConditions` rendering in `kube-prometheus-stack` so it is always rendered as a list (the Kubernetes API type).

## Changes
- change default `prometheusOperator.admissionWebhooks.matchConditions` from `{}` to `[]`
- update value comment to document list-based usage
- render `matchConditions` as a list in mutating and validating webhook templates
- keep backward compatibility for legacy single-map input by wrapping it as a single list item
- bump chart version `81.5.0` -> `81.5.1`

Closes #6176

## Testing
- `helm lint charts/kube-prometheus-stack`
- `helm template test charts/kube-prometheus-stack --set-json 'prometheusOperator.admissionWebhooks.matchConditions=[{"name":"exclude-leases","expression":"!(request.resource.group == \"coordination.k8s.io\" && request.resource.resource == \"leases\")"}]' | rg 'matchConditions:|name: exclude-leases|expression:'`
- `GITHUB_SHA=$(git rev-parse HEAD) ct lint --config .github/linters/ct.yaml --charts charts/kube-prometheus-stack`
