### PR TITLE
[kube-prometheus-stack] Support kube-scheduler additionalPath scraping

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 81.5.0
+version: 81.5.1
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.88.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/ci/07-kube-scheduler-additional-path-values.yaml
+++ b/charts/kube-prometheus-stack/ci/07-kube-scheduler-additional-path-values.yaml
@@ -1,0 +1,3 @@
+kubeScheduler:
+  serviceMonitor:
+    additionalPath: /metrics/resources

--- a/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -60,4 +60,34 @@ spec:
     relabelings:
 {{ tpl (toYaml .Values.kubeScheduler.serviceMonitor.relabelings | indent 4) . }}
 {{- end }}
+  {{- if .Values.kubeScheduler.serviceMonitor.additionalPath }}
+  - port: {{ .Values.kubeScheduler.serviceMonitor.port }}
+    path: {{ .Values.kubeScheduler.serviceMonitor.additionalPath }}
+    {{- if .Values.kubeScheduler.serviceMonitor.interval }}
+    interval: {{ .Values.kubeScheduler.serviceMonitor.interval }}
+    {{- end }}
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    {{- if .Values.kubeScheduler.serviceMonitor.proxyUrl }}
+    proxyUrl: {{ .Values.kubeScheduler.serviceMonitor.proxyUrl}}
+    {{- end }}
+    {{- if eq (include "kube-prometheus-stack.kubeScheduler.insecureScrape" (list . false true .Values.kubeScheduler.serviceMonitor.https )) "true" }}
+    scheme: https
+    tlsConfig:
+      caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      {{- if eq (include "kube-prometheus-stack.kubeScheduler.insecureScrape" (list . nil true .Values.kubeScheduler.serviceMonitor.insecureSkipVerify)) "true" }}
+      insecureSkipVerify: true
+      {{- end }}
+      {{- if .Values.kubeScheduler.serviceMonitor.serverName }}
+      serverName: {{ .Values.kubeScheduler.serviceMonitor.serverName }}
+      {{- end}}
+    {{- end}}
+{{- if .Values.kubeScheduler.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ tpl (toYaml .Values.kubeScheduler.serviceMonitor.metricRelabelings | indent 4) . }}
+{{- end }}
+{{- if .Values.kubeScheduler.serviceMonitor.relabelings }}
+    relabelings:
+{{ tpl (toYaml .Values.kubeScheduler.serviceMonitor.relabelings | indent 4) . }}
+{{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -2349,6 +2349,11 @@ kubeScheduler:
     ##
     port: http-metrics
 
+    ## Optional additional path to scrape (for example "/metrics/resources").
+    ## When set, the chart creates a second ServiceMonitor endpoint for this path.
+    ##
+    additionalPath: ""
+
     jobLabel: jobLabel
     selector: {}
     #  matchLabels:


### PR DESCRIPTION
## What this PR does
Adds `kubeScheduler.serviceMonitor.additionalPath` to allow scraping an additional kube-scheduler metrics path via a second ServiceMonitor endpoint.

## Changes
- add `kubeScheduler.serviceMonitor.additionalPath` in `values.yaml` (default `""`)
- when set, render an additional endpoint in `templates/exporters/kube-scheduler/servicemonitor.yaml` with the configured path
- add CI values file covering the new option
- bump chart version `81.5.0` -> `81.5.1`

Closes #6334

## Testing
- `helm lint charts/kube-prometheus-stack -f charts/kube-prometheus-stack/ci/07-kube-scheduler-additional-path-values.yaml`
- `helm template test charts/kube-prometheus-stack -f charts/kube-prometheus-stack/ci/07-kube-scheduler-additional-path-values.yaml | rg 'path: /metrics/resources'`
- `GITHUB_SHA=$(git rev-parse HEAD) ct lint --config .github/linters/ct.yaml --charts charts/kube-prometheus-stack`
