### PR TITLE
[kube-prometheus-stack] Add option to disable Prometheus reloader web service port

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 81.5.0
+version: 81.5.1
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.88.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/ci/07-prometheus-disable-reloader-web-port-values.yaml
+++ b/charts/kube-prometheus-stack/ci/07-prometheus-disable-reloader-web-port-values.yaml
@@ -1,0 +1,3 @@
+prometheus:
+  service:
+    reloaderWebPortEnabled: false

--- a/charts/kube-prometheus-stack/templates/prometheus/service.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/service.yaml
@@ -47,7 +47,7 @@ spec:
     {{- end }}
     port: {{ .Values.prometheus.service.port }}
     targetPort: {{ .Values.prometheus.service.targetPort }}
-  {{- if .Values.prometheus.service.reloaderWebPort }}
+  {{- if and .Values.prometheus.service.reloaderWebPortEnabled .Values.prometheus.service.reloaderWebPort }}
   - name: reloader-web
     {{- if semverCompare "> 1.20.0-0" $kubeTargetVersion }}
     appProtocol: http

--- a/charts/kube-prometheus-stack/templates/prometheus/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/servicemonitor.yaml
@@ -41,6 +41,7 @@ spec:
     {{- if .Values.prometheus.serviceMonitor.relabelings }}
     relabelings: {{- toYaml .Values.prometheus.serviceMonitor.relabelings | nindent 6 }}
     {{- end }}
+  {{- if and .Values.prometheus.service.reloaderWebPortEnabled .Values.prometheus.service.reloaderWebPort }}
   - port: reloader-web
     {{- if .Values.prometheus.serviceMonitor.interval }}
     interval: {{ .Values.prometheus.serviceMonitor.interval }}
@@ -58,6 +59,7 @@ spec:
     {{- if .Values.prometheus.serviceMonitor.relabelings }}
     relabelings: {{- toYaml .Values.prometheus.serviceMonitor.relabelings | nindent 6 }}
     {{- end }}
+  {{- end }}
   {{- range .Values.prometheus.serviceMonitor.additionalEndpoints }}
   - port: {{ .port }}
     {{- if or $.Values.prometheus.serviceMonitor.interval .interval }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -3583,6 +3583,10 @@ prometheus:
     ##
     reloaderWebPort: 8080
 
+    ## If false, do not expose the Prometheus reloader web port on the Service.
+    ##
+    reloaderWebPortEnabled: true
+
     ## List of IP addresses at which the Prometheus server service is available
     ## Ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips
     ##


### PR DESCRIPTION
## What this PR does
Adds an explicit option to disable exposing the Prometheus reloader web port on the Service.

## Changes
- add `prometheus.service.reloaderWebPortEnabled` (default `true`)
- gate Prometheus Service `reloader-web` port on `reloaderWebPortEnabled`
- gate Prometheus self ServiceMonitor `reloader-web` endpoint on `reloaderWebPortEnabled`
- add CI values scenario with `reloaderWebPortEnabled: false`
- bump chart version `81.5.0` -> `81.5.1`

This allows users to avoid exposing the extra reloader port while keeping the reloader sidecar itself enabled.

Closes #6364

## Testing
- `helm lint charts/kube-prometheus-stack -f charts/kube-prometheus-stack/ci/07-prometheus-disable-reloader-web-port-values.yaml`
- `helm template test charts/kube-prometheus-stack -f charts/kube-prometheus-stack/ci/07-prometheus-disable-reloader-web-port-values.yaml`
- `GITHUB_SHA=$(git rev-parse HEAD) ct lint --config .github/linters/ct.yaml --charts charts/kube-prometheus-stack`
