### PR TITLE
[kube-prometheus-stack] Document dependency install CRD ordering

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 81.5.0
+version: 81.5.1
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.88.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/README.md
+++ b/charts/kube-prometheus-stack/README.md
@@ -42,6 +42,23 @@ To disable dependencies during installation, see [multiple releases](#multiple-r
 
 _See [helm dependency](https://helm.sh/docs/helm/helm_dependency/) for command documentation._
 
+#### Using as a dependency (umbrella charts)
+
+When `kube-prometheus-stack` is installed as a subchart, first-install runs can fail with errors like:
+
+`no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"`
+
+This happens because CRDs and CRs are created in the same Helm transaction.
+
+Recommended approaches:
+
+1. Manage CRDs separately (recommended):
+   - Install/upgrade `prometheus-operator-crds` first.
+   - Disable CRD management in this chart (`kube-prometheus-stack.crds.enabled=false`).
+2. If you keep CRDs in this chart, run install/upgrade twice:
+   - First run installs CRDs.
+   - Second run creates resources that depend on those CRDs.
+
 #### Grafana Dashboards
 
 This chart provisions a collection of curated Grafana dashboards that are automatically loaded into Grafana via ConfigMaps. These dashboards are rendered into the Helm chart under [`templates/grafana/`](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/templates/grafana/), but **this is not their source of truth**.


### PR DESCRIPTION
## What this PR does
Adds explicit kube-prometheus-stack README guidance for users who consume the chart as a dependency in umbrella charts.

## Why
Users frequently hit first-install failures with missing CRD kinds (`ServiceMonitor`, `PrometheusRule`, etc.) when CRDs and CRs are created in one Helm transaction.

## Changes
- add a new README subsection under **Dependencies**:
  - explains the CRD ordering failure mode
  - recommends managing CRDs separately (`prometheus-operator-crds` + `kube-prometheus-stack.crds.enabled=false`)
  - documents the alternative two-run install workflow
- bump chart version `81.5.0` -> `81.5.1`

Closes #6083

## Testing
- `helm lint charts/kube-prometheus-stack`
- `GITHUB_SHA=$(git rev-parse HEAD) ct lint --config .github/linters/ct.yaml --charts charts/kube-prometheus-stack`
