### PR TITLE
[kube-state-metrics] Fix duplicated release name with nameOverride

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - kubernetes
 type: application
-version: 7.1.0
+version: 7.1.1
 # renovate: github-releases=kubernetes/kube-state-metrics
 appVersion: 2.18.0
 home: https://github.com/kubernetes/kube-state-metrics/

--- a/charts/kube-state-metrics/templates/_helpers.tpl
+++ b/charts/kube-state-metrics/templates/_helpers.tpl
@@ -16,7 +16,7 @@ If release name contains chart name it will be used as a full name.
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
+{{- if contains .Release.Name $name -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}


### PR DESCRIPTION
## Summary
- fix fullname helper logic to correctly detect when nameOverride already contains the release name
- prevent duplicated names like <release>-<release>-...
- bump kube-state-metrics chart version to 7.1.1

## Related
- Closes #6510

## Testing
- helm lint charts/kube-state-metrics
- ct lint --config .github/linters/ct.yaml --charts charts/kube-state-metrics