### PR TITLE
[prometheus-adapter] Render rules.custom with tpl

### DIFF
--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 5.2.0
+version: 5.2.1
 appVersion: v0.12.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/kubernetes-sigs/prometheus-adapter

--- a/charts/prometheus-adapter/templates/configmap.yaml
+++ b/charts/prometheus-adapter/templates/configmap.yaml
@@ -83,7 +83,7 @@ data:
       metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>}[5m])) by (<<.GroupBy>>)
 {{- end -}}
 {{- if .Values.rules.custom }}
-{{ toYaml .Values.rules.custom | indent 4 }}
+{{ tpl (toYaml .Values.rules.custom) . | indent 4 }}
 {{- end -}}
 {{- end -}}
 {{- if .Values.rules.external }}

--- a/charts/prometheus-adapter/values.yaml
+++ b/charts/prometheus-adapter/values.yaml
@@ -129,6 +129,7 @@ startupProbe: {}
 rules:
   default: true
 
+  # Supports templating via tpl.
   custom: []
     # - seriesQuery: '{__name__=~"^some_metric_count$"}'
     #   resources:


### PR DESCRIPTION
## Summary
- render rules.custom via tpl in the generated adapter config
- allow custom metrics rules to reference values dynamically
- document templating support in values comments
- bump prometheus-adapter chart version to 5.2.1

## Related
- Closes #5864

## Testing
- helm lint charts/prometheus-adapter
- ct lint --config .github/linters/ct.yaml --charts charts/prometheus-adapter