### PR TITLE
[kube-prometheus-stack] Allow Prometheus ingress to alertmanager reloader metrics port

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 81.5.1
+version: 81.5.2
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.88.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/templates/alertmanager/networkpolicy.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/networkpolicy.yaml
@@ -38,6 +38,10 @@ spec:
       ports:
         - port: {{ .Values.alertmanager.service.port }}
           protocol: TCP
+        {{- if .Values.alertmanager.networkPolicy.monitoringRules.configReloader }}
+        - port: 8080
+          protocol: TCP
+        {{- end }}
     {{- end }}
     {{- if and (.Values.alertmanager.networkPolicy.enableClusterRules) (.Values.alertmanager.service.clusterPort) }}
     # Allow ingress from other Alertmanager pods (for clustering)

--- a/charts/kube-prometheus-stack/unittests/alertmanager/networkpolicy_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/alertmanager/networkpolicy_test.yaml
@@ -59,11 +59,18 @@ tests:
       alertmanager.enabled: true
       alertmanager.networkPolicy.enabled: true
       alertmanager.networkPolicy.monitoringRules.prometheus: true
+      alertmanager.networkPolicy.monitoringRules.configReloader: true
       alertmanager.service.port: 9093
     asserts:
       - equal:
           path: spec.ingress[0].from[0].podSelector.matchLabels["app.kubernetes.io/name"]
           value: prometheus
+      - equal:
+          path: spec.ingress[0].ports[0].port
+          value: 9093
+      - equal:
+          path: spec.ingress[0].ports[1].port
+          value: 8080
 
   - it: should include Alertmanager rules when enabled
     set:
@@ -75,6 +82,18 @@ tests:
       - equal:
           path: spec.ingress[1].from[0].podSelector.matchLabels["app.kubernetes.io/name"]
           value: alertmanager
+
+  - it: should not include reloader port for Prometheus when reloader monitoring is disabled
+    set:
+      alertmanager.enabled: true
+      alertmanager.networkPolicy.enabled: true
+      alertmanager.networkPolicy.monitoringRules.prometheus: true
+      alertmanager.networkPolicy.monitoringRules.configReloader: false
+      alertmanager.service.port: 9093
+    asserts:
+      - lengthEqual:
+          path: spec.ingress[0].ports
+          count: 1
 
   - it: should include cluster rules when enabled
     set:


### PR DESCRIPTION
## Summary
- allow Prometheus ingress on alertmanager reloader-web port (8080) in Alertmanager NetworkPolicy
- keep this gated by monitoringRules.configReloader
- add unit tests for both enabled and disabled reloader-monitoring scenarios
- bump kube-prometheus-stack chart version to 81.5.2

## Related
- Closes #6090

## Testing
- helm lint charts/kube-prometheus-stack
- helm unittest --strict --file 'unittests/**/*.yaml' charts/kube-prometheus-stack
- ct lint --config .github/linters/ct.yaml --charts charts/kube-prometheus-stack