### PR TITLE
[prometheus-pushgateway] Allow existing secret for web config

### DIFF
--- a/charts/prometheus-pushgateway/Chart.yaml
+++ b/charts/prometheus-pushgateway/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: v1.11.2
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 3.6.0
+version: 3.6.1
 home: https://github.com/prometheus/pushgateway
 sources:
   - https://github.com/prometheus/pushgateway

--- a/charts/prometheus-pushgateway/ci/web-config-existing-secret-values.yaml
+++ b/charts/prometheus-pushgateway/ci/web-config-existing-secret-values.yaml
@@ -4,3 +4,16 @@ webConfiguration:
 
 serviceMonitor:
   enabled: true
+  namespace: default
+
+extraManifests:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: pushgateway-web-config
+      namespace: '{{ include "prometheus-pushgateway.namespace" . }}'
+    type: Opaque
+    stringData:
+      web-config.yaml: |
+        basic_auth_users:
+          test: $2y$10$7EqJtq98hPqEX7fNZaFWoOhiP9v0i8YhgdGXNq35p3xNmPR9U1F1W

--- a/charts/prometheus-pushgateway/ci/web-config-existing-secret-values.yaml
+++ b/charts/prometheus-pushgateway/ci/web-config-existing-secret-values.yaml
@@ -2,10 +2,6 @@ webConfiguration:
   existingSecret:
     name: pushgateway-web-config
 
-serviceMonitor:
-  enabled: true
-  namespace: default
-
 extraManifests:
   - apiVersion: v1
     kind: Secret
@@ -15,5 +11,4 @@ extraManifests:
     type: Opaque
     stringData:
       web-config.yaml: |
-        basic_auth_users:
-          test: $2y$10$7EqJtq98hPqEX7fNZaFWoOhiP9v0i8YhgdGXNq35p3xNmPR9U1F1W
+        {}

--- a/charts/prometheus-pushgateway/ci/web-config-existing-secret-values.yaml
+++ b/charts/prometheus-pushgateway/ci/web-config-existing-secret-values.yaml
@@ -1,0 +1,6 @@
+webConfiguration:
+  existingSecret:
+    name: pushgateway-web-config
+
+serviceMonitor:
+  enabled: true

--- a/charts/prometheus-pushgateway/templates/_helpers.tpl
+++ b/charts/prometheus-pushgateway/templates/_helpers.tpl
@@ -87,6 +87,20 @@ basic_auth_users:
 {{- end }}
 
 {{/*
+Return web configuration secret name
+*/}}
+{{- define "prometheus-pushgateway.webConfigurationSecretName" -}}
+{{- $webConfiguration := .Values.webConfiguration | default dict -}}
+{{- $existingSecret := get $webConfiguration "existingSecret" | default dict -}}
+{{- $existingSecretName := get $existingSecret "name" | default "" -}}
+{{- if $existingSecretName -}}
+{{- $existingSecretName -}}
+{{- else -}}
+{{- include "prometheus-pushgateway.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Define Authorization
 */}}
 {{- define "prometheus-pushgateway.Authorization" -}}
@@ -282,7 +296,7 @@ volumes:
   {{- if .Values.webConfiguration }}
   - name: web-config
     secret:
-      secretName: {{ include "prometheus-pushgateway.fullname" . }}
+      secretName: {{ include "prometheus-pushgateway.webConfigurationSecretName" . }}
   {{- end }}
   {{- end }}
   {{- if .Values.extraVolumes }}
@@ -291,7 +305,7 @@ volumes:
   {{- if .Values.webConfiguration }}
   - name: web-config
     secret:
-      secretName: {{ include "prometheus-pushgateway.fullname" . }}
+      secretName: {{ include "prometheus-pushgateway.webConfigurationSecretName" . }}
   {{- else }}
   []
   {{- end }}

--- a/charts/prometheus-pushgateway/templates/secret.yaml
+++ b/charts/prometheus-pushgateway/templates/secret.yaml
@@ -1,4 +1,7 @@
-{{- if .Values.webConfiguration }}
+{{- $webConfiguration := .Values.webConfiguration | default dict -}}
+{{- $existingSecret := get $webConfiguration "existingSecret" | default dict -}}
+{{- $existingSecretName := get $existingSecret "name" | default "" -}}
+{{- if and .Values.webConfiguration (empty $existingSecretName) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,7 +13,7 @@ data:
   web-config.yaml: {{ include "prometheus-pushgateway.webConfiguration" . | b64enc}}
 {{- end }}
 ---
-{{- if and .Values.webConfiguration .Values.serviceMonitor.enabled (empty .Values.serviceMonitor.basicAuth) }}
+{{- if and .Values.webConfiguration.basicAuthUsers .Values.serviceMonitor.enabled (empty .Values.serviceMonitor.basicAuth) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/prometheus-pushgateway/templates/servicemonitor.yaml
+++ b/charts/prometheus-pushgateway/templates/servicemonitor.yaml
@@ -18,7 +18,7 @@ spec:
     {{- with .Values.serviceMonitor.scheme }}
     scheme: {{ . }}
     {{- end }}
-    {{- if and .Values.webConfiguration (empty .Values.serviceMonitor.basicAuth) }}
+    {{- if and .Values.webConfiguration.basicAuthUsers (empty .Values.serviceMonitor.basicAuth) }}
     basicAuth:
       password:
         name: {{ include "prometheus-pushgateway.fullname" . }}-basic-auth

--- a/charts/prometheus-pushgateway/values.yaml
+++ b/charts/prometheus-pushgateway/values.yaml
@@ -123,6 +123,8 @@ resources: {}
 webConfiguration: {}
   # basicAuthUsers:
   #   username: password
+  # existingSecret:
+  #   name: pushgateway-web-config
 
 liveness:
   enabled: true


### PR DESCRIPTION
## What this PR does
- Adds `webConfiguration.existingSecret.name` support so users can provide an existing web config secret.
- Keeps generated secret behavior for inline `webConfiguration.basicAuthUsers`.
- Uses generated secret for ServiceMonitor basic auth only when inline users are provided.
- Adds CI values to validate the new existing-secret path.

Fixes #5979.

## Testing
- helm lint charts/prometheus-pushgateway
- GITHUB_SHA=$(git rev-parse HEAD) ct lint --config .github/linters/ct.yaml --charts charts/prometheus-pushgateway
