### PR TITLE
[kube-prometheus-stack] fix admission webhook DNS name rendering

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 81.6.7
+version: 81.6.8
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.88.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/templates/_helpers.tpl
+++ b/charts/kube-prometheus-stack/templates/_helpers.tpl
@@ -334,7 +334,7 @@ global:
 {{- $fullname := include "kube-prometheus-stack.operator.fullname" . }}
 {{- $namespace := include "kube-prometheus-stack.namespace" . }}
 {{- $fullname }}
-{{- $fullname }}.{{ $namespace }}.svc
+{{ $fullname }}.{{ $namespace }}.svc
 {{- if .Values.prometheusOperator.admissionWebhooks.deployment.enabled }}
 {{ $fullname }}-webhook
 {{ $fullname }}-webhook.{{ $namespace }}.svc


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR reverts https://github.com/prometheus-community/helm-charts/pull/6629 which incorrectly introduced a [chomp](https://helm.sh/docs/chart_template_guide/control_structures/#controlling-whitespace) which results in errors at deploy time:
```console
x509: certificate is valid for kube-prometheus-stack-operatorkube-prometheus-stack-operator.monitoring.svc, not kube-prometheus-stack-operator
```

Note the way that kube-prometheus-stack-operatorkube-prometheus-stack-operator.monitoring.svc is smushed together rather than two separate names (`kube-prometheus-stack-operator` and `kube-prometheus-stack-operator.monitoring.svc`).

#### Which issue this PR fixes

Haven't opened an issue, but I can.

#### Special notes for your reviewer

The prior PR introduced this issue to resolve a bug, but the problem in that case was related to Windows `^M` (see https://unix.stackexchange.com/questions/32001/what-is-m-and-how-do-i-get-rid-of-it) - cc @vitrix1 

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
