### PR TITLE
[prometheus-yet-another-cloudwatch-exporter] Add pod disruption budge…

### DIFF
--- a/charts/prometheus-yet-another-cloudwatch-exporter/Chart.yaml
+++ b/charts/prometheus-yet-another-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-yet-another-cloudwatch-exporter
 description: Yace - Yet Another CloudWatch Exporter
 type: application
-version: 0.42.0
+version: 0.42.1
 # renovate: github-releases=prometheus-community/yet-another-cloudwatch-exporter
 appVersion: "v0.63.0"
 home: https://github.com/prometheus-community/helm-charts

--- a/charts/prometheus-yet-another-cloudwatch-exporter/templates/podDisruptionBudget.yaml
+++ b/charts/prometheus-yet-another-cloudwatch-exporter/templates/podDisruptionBudget.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "yet-another-cloudwatch-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "yet-another-cloudwatch-exporter.labels" . | nindent 4 }}
+spec:
+{{- toYaml (omit .Values.podDisruptionBudget "enabled") | nindent 2 }}
+  selector:
+    matchLabels:
+      {{- include "yet-another-cloudwatch-exporter.selectorLabels" . | nindent 8 }}
+{{- end }}

--- a/charts/prometheus-yet-another-cloudwatch-exporter/values.yaml
+++ b/charts/prometheus-yet-another-cloudwatch-exporter/values.yaml
@@ -96,6 +96,12 @@ tolerations: []
 
 affinity: {}
 
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+  # maxUnavailable: ""
+  unhealthyPodEvictionPolicy: AlwaysAllow
+
 extraEnv: []
   # Define extra environmental variables list as follows
   # - name : key1


### PR DESCRIPTION
…t support

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Adds pod disruption budget support for yet-another-cloudwatch-exporter to support high availability

@cristiangreco @thomaspeitz
#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
