### PR TITLE
[kube-prometheus-stack] Change ingress pathType default from ImplementationSpecific to Prefix

### DIFF
--- a/charts/kube-prometheus-stack/templates/prometheus/ingress.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.prometheus.enabled .Values.prometheus.ingress.enabled -}}
-  {{- $pathType := .Values.prometheus.ingress.pathType | default "ImplementationSpecific" -}}
+  {{- $pathType := .Values.prometheus.ingress.pathType | default "Prefix" -}}
   {{- $serviceName := printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "prometheus" -}}
   {{- $servicePort := .Values.prometheus.ingress.servicePort | default .Values.prometheus.service.port -}}
   {{- $routePrefix := list .Values.prometheus.prometheusSpec.routePrefix -}}


### PR DESCRIPTION

#### What this PR does / why we need it

As per https://github.com/prometheus-community/helm-charts/issues/4228 the default ingress pathType of ImplementationSpecific is not functional on cilium ingress. Changing the default to `pathType: Prefix` is in line with the default setting of `path: /` and fixes the aforementioned issue. 

#### Which issue this PR fixes

- fixes 4228

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
