### PR TITLE
[prometheus-blackbox-exporter] use kubernetes.io/metadata.name in networkPolicy

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 11.8.0
+version: 11.8.1
 # renovate: github=prometheus/blackbox_exporter
 appVersion: v0.28.0
 kubeVersion: ">=1.21.0-0"

--- a/charts/prometheus-blackbox-exporter/templates/networkpolicy.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/networkpolicy.yaml
@@ -15,7 +15,7 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          name: {{ .Values.networkPolicy.monitoringNamespaceName }}
+          kubernetes.io/metadata.name: {{ .Values.networkPolicy.monitoringNamespaceName }}
     ports:
     - port: {{ .Values.service.port }}
       protocol: TCP
@@ -25,4 +25,3 @@ spec:
   policyTypes:
   - Ingress
 {{- end }}
-

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -384,7 +384,8 @@ networkPolicy:
   # Enable network policy and allow access from anywhere
   enabled: false
   # Limit access only from monitoring namespace
-  # Before setting this value to true, you must add the name=monitoring label to the monitoring namespace.  Name can be rewritten by monitoringNamespaceName
+  # Before setting this value to true, the monitoring namespace must exist with
+  # kubernetes.io/metadata.name matching monitoringNamespaceName.
   # Network Policy uses label filtering
   allowMonitoringNamespace: false
   # Rewrite monitoring namespace in network policy (default value monitoring)


### PR DESCRIPTION
## Summary
This PR updates `prometheus-blackbox-exporter` network policy namespace matching to use Kubernetes' well-known namespace label and addresses https://github.com/prometheus-community/helm-charts/issues/6640.

## Problem
When `networkPolicy.allowMonitoringNamespace` is enabled, the chart currently matches on `name=<namespace>`. In many environments, deployers do not control namespace labels and cannot guarantee a custom `name` label exists.

## Root cause
`templates/networkpolicy.yaml` hardcodes the namespace selector key to `name`.

## Fix
- Switched namespace selector label key from `name` to `kubernetes.io/metadata.name`.
- Updated values comment to describe the new expected label semantics.
- Bumped chart version from `11.8.0` to `11.8.1`.

## Validation
- `helm lint charts/prometheus-blackbox-exporter`
- `helm template test charts/prometheus-blackbox-exporter --set networkPolicy.enabled=true --set networkPolicy.allowMonitoringNamespace=true --set networkPolicy.monitoringNamespaceName=observability`
- Verified rendered selector contains `kubernetes.io/metadata.name: observability`.

## Notes
This keeps the same user-facing value (`monitoringNamespaceName`) while aligning selector behavior with a standard Kubernetes label.
