### PR TITLE
[prometheus-cloudwatch-exporter] add commonLabels support

### DIFF
--- a/charts/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/charts/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.16.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.28.1
+version: 0.28.2
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
   - https://github.com/prometheus/cloudwatch_exporter

--- a/charts/prometheus-cloudwatch-exporter/templates/clusterrole.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/clusterrole.yaml
@@ -8,6 +8,9 @@ metadata:
     chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 rules:
   - apiGroups: [""]
     resources: ["secrets","configmap"]

--- a/charts/prometheus-cloudwatch-exporter/templates/clusterrolebinding.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/clusterrolebinding.yaml
@@ -8,6 +8,9 @@ metadata:
     chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "prometheus-cloudwatch-exporter.serviceAccountName" . }}

--- a/charts/prometheus-cloudwatch-exporter/templates/configmap.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/configmap.yaml
@@ -8,6 +8,9 @@ metadata:
     chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 data:
   config.yml: |
     {{ tpl .Values.config . | nindent 4 }}

--- a/charts/prometheus-cloudwatch-exporter/templates/deployment.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/deployment.yaml
@@ -8,6 +8,9 @@ metadata:
     chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- with .Values.deployment.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -26,6 +29,9 @@ spec:
       labels:
         app: {{ template "prometheus-cloudwatch-exporter.name" . }}
         release: {{ .Release.Name }}
+        {{- with .Values.commonLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- if .Values.pod.labels }}
 {{ toYaml .Values.pod.labels | indent 8 }}
         {{- end }}

--- a/charts/prometheus-cloudwatch-exporter/templates/ingress.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/ingress.yaml
@@ -13,6 +13,9 @@ metadata:
     chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 {{- if .Values.ingress.labels }}
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}

--- a/charts/prometheus-cloudwatch-exporter/templates/pdb.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/pdb.yaml
@@ -9,6 +9,9 @@ metadata:
     chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if .Values.podDisruptionBudget.minAvailable }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}

--- a/charts/prometheus-cloudwatch-exporter/templates/prometheusrule.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/prometheusrule.yaml
@@ -3,9 +3,14 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-{{- if .Values.prometheusRule.labels }}
+{{- if or .Values.prometheusRule.labels .Values.commonLabels }}
   labels:
-{{ toYaml .Values.prometheusRule.labels | indent 4}}
+  {{- with .Values.commonLabels }}
+{{ toYaml . | indent 4 }}
+  {{- end }}
+  {{- with .Values.prometheusRule.labels }}
+{{ toYaml . | indent 4 }}
+  {{- end }}
 {{- end }}
   name: {{ $fullName }}
 {{- if .Values.prometheusRule.namespace }}

--- a/charts/prometheus-cloudwatch-exporter/templates/secrets.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/secrets.yaml
@@ -9,6 +9,9 @@ metadata:
     chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 type: Opaque
 data:
   {{ if .Values.aws.aws_access_key_id }}

--- a/charts/prometheus-cloudwatch-exporter/templates/service.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/service.yaml
@@ -10,6 +10,9 @@ metadata:
     chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4 }}
 {{- end }}

--- a/charts/prometheus-cloudwatch-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/serviceaccount.yaml
@@ -10,6 +10,9 @@ metadata:
     chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- if .Values.serviceAccount.annotations }}
   annotations:
     {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}

--- a/charts/prometheus-cloudwatch-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/servicemonitor.yaml
@@ -2,9 +2,14 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-{{- if .Values.serviceMonitor.labels }}
+{{- if or .Values.serviceMonitor.labels .Values.commonLabels }}
   labels:
-{{ toYaml .Values.serviceMonitor.labels | indent 4}}
+  {{- with .Values.commonLabels }}
+{{ toYaml . | indent 4 }}
+  {{- end }}
+  {{- with .Values.serviceMonitor.labels }}
+{{ toYaml . | indent 4 }}
+  {{- end }}
 {{- end }}
   name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
 {{- if .Values.serviceMonitor.namespace }}

--- a/charts/prometheus-cloudwatch-exporter/values.yaml
+++ b/charts/prometheus-cloudwatch-exporter/values.yaml
@@ -44,6 +44,9 @@ deployment:
   labels: {}
   annotations: {}
 
+# Common labels to attach to all resources
+commonLabels: {}
+
 # Extra environment variables
 extraEnv:
   # - name: foo


### PR DESCRIPTION
## Summary
This PR adds `commonLabels` support to `prometheus-cloudwatch-exporter` resources and addresses https://github.com/prometheus-community/helm-charts/issues/6247.

## Problem
The chart exposes resource-specific label knobs (`service.labels`, `deployment.labels`, etc.) but lacks a global/common label mechanism. Users wanting organization-wide labels on all chart resources must duplicate labels per-resource or patch rendered manifests.

## Root cause
No top-level value exists to inject shared labels into metadata across all templates.

## Fix
- Added `commonLabels: {}` to `values.yaml`.
- Wired `commonLabels` into metadata labels for all chart-rendered resources.
- Included `commonLabels` in deployment pod template labels.
- Ensured `PrometheusRule` and `ServiceMonitor` metadata labels include `commonLabels` even when chart-specific label maps are empty.
- Bumped chart version from `0.28.1` to `0.28.2`.

## Validation
- `helm lint charts/prometheus-cloudwatch-exporter`
- `helm template test charts/prometheus-cloudwatch-exporter --set commonLabels.team=platform --set serviceMonitor.enabled=true --set prometheusRule.enabled=true`
- Verified repeated `team: platform` labels across rendered resources.

## Compatibility
Backward compatible: `commonLabels` defaults to `{}` and does not affect existing installs unless explicitly set.
