### PR TITLE
[prometheus-node-exporter] make kube-rbac-proxy listen host configurable

### DIFF
--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - prometheus
   - exporter
 type: application
-version: 4.52.0
+version: 4.52.1
 # renovate: github=prometheus/node_exporter
 appVersion: 1.10.2
 home: https://github.com/prometheus/node_exporter/

--- a/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -240,7 +240,7 @@ spec:
             {{-  if .Values.kubeRBACProxy.extraArgs  }}
             {{- .Values.kubeRBACProxy.extraArgs | toYaml | nindent 12 }}
             {{-  end  }}
-            - --secure-listen-address=:{{ .Values.service.port}}
+            - --secure-listen-address={{ .Values.kubeRBACProxy.listenHost }}{{ .Values.service.port}}
             - --upstream=http://127.0.0.1:{{ $servicePort }}/
             - --proxy-endpoints-port={{ .Values.kubeRBACProxy.proxyEndpointsPort }}
             - --config-file=/etc/kube-rbac-proxy-config/config-file.yaml

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -61,6 +61,9 @@ kubeRBACProxy:
 
   # Specify the port used for the Node exporter container (upstream port)
   port: 8100
+  # Host prefix for kube-rbac-proxy secure listen address.
+  # Keep ":" to listen on all interfaces, or set values like "127.0.0.1:" or "$(POD_IP):".
+  listenHost: ":"
   # Specify the name of the container port
   portName: http
   # Configure a hostPort. If true, hostPort will be enabled in the container and set to service.port.


### PR DESCRIPTION
## Summary
This PR makes kube-rbac-proxy listen host configurable in `prometheus-node-exporter` and addresses https://github.com/prometheus-community/helm-charts/issues/6250.

## Problem
When `kubeRBACProxy.enabled=true`, the chart hardcodes `--secure-listen-address=:<port>`, which binds on all interfaces. Users with multi-NIC nodes cannot constrain exposure to a specific interface/IP without post-render patching.

## Root cause
The daemonset template hardcodes `--secure-listen-address` host prefix and does not expose a corresponding value.

## Fix
- Added `kubeRBACProxy.listenHost` in values with default `":"` to preserve existing behavior.
- Updated kube-rbac-proxy args to use `--secure-listen-address={{ .Values.kubeRBACProxy.listenHost }}{{ .Values.service.port }}`.
- Bumped chart version from `4.52.0` to `4.52.1`.

## Validation
- `helm lint charts/prometheus-node-exporter`
- `helm template test charts/prometheus-node-exporter --set kubeRBACProxy.enabled=true --set service.port=9100 --set-string 'kubeRBACProxy.listenHost=$(POD_IP):'`
- Verified rendered arg contains `--secure-listen-address=$(POD_IP):9100`.

## Compatibility
Default behavior remains unchanged because `listenHost` defaults to `":"` (all interfaces).
