### PR TITLE
[kube-prometheus-stack] add kubeScheduler serviceMonitor additionalPath

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 82.9.0
+version: 82.9.1
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.89.0
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -60,4 +60,34 @@ spec:
     relabelings:
 {{ tpl (toYaml .Values.kubeScheduler.serviceMonitor.relabelings | indent 4) . }}
 {{- end }}
+{{- if .Values.kubeScheduler.serviceMonitor.additionalPath }}
+  - port: {{ .Values.kubeScheduler.serviceMonitor.port }}
+    path: {{ .Values.kubeScheduler.serviceMonitor.additionalPath }}
+    {{- if .Values.kubeScheduler.serviceMonitor.interval }}
+    interval: {{ .Values.kubeScheduler.serviceMonitor.interval }}
+    {{- end }}
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    {{- if .Values.kubeScheduler.serviceMonitor.proxyUrl }}
+    proxyUrl: {{ .Values.kubeScheduler.serviceMonitor.proxyUrl}}
+    {{- end }}
+    {{- if eq (include "kube-prometheus-stack.kubeScheduler.insecureScrape" (list . false true .Values.kubeScheduler.serviceMonitor.https )) "true" }}
+    scheme: https
+    tlsConfig:
+      caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      {{- if eq (include "kube-prometheus-stack.kubeScheduler.insecureScrape" (list . nil true .Values.kubeScheduler.serviceMonitor.insecureSkipVerify)) "true" }}
+      insecureSkipVerify: true
+      {{- end }}
+      {{- if .Values.kubeScheduler.serviceMonitor.serverName }}
+      serverName: {{ .Values.kubeScheduler.serviceMonitor.serverName }}
+      {{- end}}
+    {{- end}}
+{{- if .Values.kubeScheduler.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ tpl (toYaml .Values.kubeScheduler.serviceMonitor.metricRelabelings | indent 4) . }}
+{{- end }}
+{{- if .Values.kubeScheduler.serviceMonitor.relabelings }}
+    relabelings:
+{{ tpl (toYaml .Values.kubeScheduler.serviceMonitor.relabelings | indent 4) . }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1960,6 +1960,11 @@ kubeControllerManager:
     ##
     port: http-metrics
 
+    ## Additional path for a second kube-scheduler endpoint scrape.
+    ## Example: /metrics/resources
+    ##
+    additionalPath: ""
+
     jobLabel: jobLabel
     selector: {}
     #  matchLabels:


### PR DESCRIPTION
## Summary
This PR adds support for an additional kube-scheduler ServiceMonitor path in `kube-prometheus-stack`, addressing https://github.com/prometheus-community/helm-charts/issues/6334.

## Problem
The kube-scheduler ServiceMonitor currently renders a single endpoint scrape. Users who need metrics from additional scheduler paths (for example `/metrics/resources`) cannot configure this without patching manifests externally.

## Root cause
`templates/exporters/kube-scheduler/servicemonitor.yaml` only emits one endpoint and no value exists to configure a second path.

## Fix
- Added `kubeScheduler.serviceMonitor.additionalPath` (default `""`) to values.
- Updated kube-scheduler ServiceMonitor template to render a second endpoint when `additionalPath` is set.
- Reused the same scrape settings (port, interval, auth, TLS, relabelings) for the extra endpoint and set only `path` differently.
- Bumped chart version from `82.9.0` to `82.9.1`.

## Validation
- `helm lint charts/kube-prometheus-stack`
- `helm template test charts/kube-prometheus-stack --set kubeScheduler.serviceMonitor.additionalPath=/metrics/resources`
- Verified rendered kube-scheduler ServiceMonitor includes an additional endpoint with `path: /metrics/resources`.

## Compatibility
No behavior change by default since `additionalPath` is empty unless explicitly configured.
