### PR TITLE
[kube-state-metrics] fix fullname duplication with nameOverride

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - kubernetes
 type: application
-version: 7.2.0
+version: 7.2.1
 # renovate: github-releases=kubernetes/kube-state-metrics
 appVersion: 2.18.0
 home: https://github.com/kubernetes/kube-state-metrics/

--- a/charts/kube-state-metrics/templates/_helpers.tpl
+++ b/charts/kube-state-metrics/templates/_helpers.tpl
@@ -18,6 +18,8 @@ If release name contains chart name it will be used as a full name.
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- if contains $name .Release.Name -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else if contains .Release.Name $name -}}
+{{- $name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}


### PR DESCRIPTION
## Summary
This PR fixes fullname generation for `kube-state-metrics` when `nameOverride` already includes the release name, addressing https://github.com/prometheus-community/helm-charts/issues/6510.

## Problem
With `Release.Name=ksm-non-pods` and `nameOverride=ksm-non-pods-foo`, rendered object names become double-prefixed (`ksm-non-pods-ksm-non-pods-foo`).

## Root cause
The fullname helper only handled the case where release name contains chart/name. It did not handle the inverse case where `nameOverride` already contains release name.

## Fix
Updated `kube-state-metrics.fullname` helper logic to add an inverse containment branch:
- keep existing behavior if release name already contains chart/name
- if `nameOverride` contains release name, use `nameOverride` as fullname
- otherwise keep concatenation behavior

Also bumped chart version from `7.2.0` to `7.2.1`.

## Validation
- `helm lint charts/kube-state-metrics`
- `helm template ksm-non-pods charts/kube-state-metrics --set nameOverride=ksm-non-pods-foo`
- Verified rendered names are `ksm-non-pods-foo` and no `ksm-non-pods-ksm-non-pods-foo` names are produced.

## Compatibility
Existing default naming behavior is preserved unless `nameOverride` already embeds the release name.
