### PR TITLE
[kube-state-metrics] align metricAnnotationsAllowlist naming

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - kubernetes
 type: application
-version: 7.2.0
+version: 7.2.1
 # renovate: github-releases=kubernetes/kube-state-metrics
 appVersion: 2.18.0
 home: https://github.com/kubernetes/kube-state-metrics/

--- a/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/kube-state-metrics/templates/deployment.yaml
@@ -96,8 +96,9 @@ spec:
         {{- if .Values.metricLabelsAllowlist }}
         - --metric-labels-allowlist={{ .Values.metricLabelsAllowlist | join "," }}
         {{- end }}
-        {{- if .Values.metricAnnotationsAllowList }}
-        - --metric-annotations-allowlist={{ .Values.metricAnnotationsAllowList | join "," }}
+        {{- $metricAnnotationsAllowlist := .Values.metricAnnotationsAllowlist | default .Values.metricAnnotationsAllowList }}
+        {{- if $metricAnnotationsAllowlist }}
+        - --metric-annotations-allowlist={{ $metricAnnotationsAllowlist | join "," }}
         {{- end }}
         {{- if .Values.metricAllowlist }}
         - --metric-allowlist={{ .Values.metricAllowlist | join "," }}

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -399,8 +399,11 @@ metricLabelsAllowlist: []
 # annotation keys you would like to allow for them (Example: '=namespaces=[kubernetes.io/team,...],pods=[kubernetes.io/team],...)'.
 # A single '*' can be provided per resource instead to allow any annotations, but that has
 # severe performance implications (Example: '=pods=[*]').
-metricAnnotationsAllowList: []
+metricAnnotationsAllowlist: []
   # - pods=[k8s-annotation-1,k8s-annotation-n]
+
+# Deprecated: use metricAnnotationsAllowlist
+metricAnnotationsAllowList: []
 
 # Available collectors for kube-state-metrics.
 # By default, all available resources are enabled, comment out to disable.


### PR DESCRIPTION
## Summary
This PR adds the normalized `metricAnnotationsAllowlist` values key to `kube-state-metrics` while preserving backward compatibility with the existing `metricAnnotationsAllowList` key, addressing https://github.com/prometheus-community/helm-charts/issues/5651.

## Problem
The chart uses `metricAnnotationsAllowList` while related options use the `Allowlist` casing convention. This is inconsistent and causes confusion.

## Root cause
The value and template wiring were implemented only with the older `AllowList` casing.

## Fix
- Added `metricAnnotationsAllowlist` to `values.yaml`.
- Kept `metricAnnotationsAllowList` as a deprecated compatibility alias.
- Updated deployment args rendering to prefer `metricAnnotationsAllowlist` and fall back to `metricAnnotationsAllowList`.
- Bumped chart version from `7.2.0` to `7.2.1`.

## Validation
- `helm lint charts/kube-state-metrics`
- `helm template test charts/kube-state-metrics --set-string 'metricAnnotationsAllowlist[0]=pods=[kubernetes.io/team]'`
- `helm template test charts/kube-state-metrics --set-string 'metricAnnotationsAllowList[0]=pods=[legacy/key]'`
- Verified both render the expected `--metric-annotations-allowlist=...` argument.

## Compatibility
Backward compatible by design: existing users of `metricAnnotationsAllowList` continue to work.
