### PR TITLE
[kube-state-metrics] Fix missing rolebindings RBAC rule (7.2.1)

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - kubernetes
 type: application
-version: 7.2.0
+version: 7.2.1
 # renovate: github-releases=kubernetes/kube-state-metrics
 appVersion: 2.18.0
 home: https://github.com/kubernetes/kube-state-metrics/

--- a/charts/kube-state-metrics/templates/role.yaml
+++ b/charts/kube-state-metrics/templates/role.yaml
@@ -129,6 +129,12 @@ rules:
   - roles
   verbs: ["list", "watch"]
 {{ end -}}
+{{ if has "rolebindings" $.Values.collectors }}
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources:
+  - rolebindings
+  verbs: ["list", "watch"]
+{{ end -}}
 {{ if has "nodes" $.Values.collectors }}
 - apiGroups: [""]
   resources:

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -437,6 +437,7 @@ collectors:
   # - clusterrolebindings
   # - clusterroles
   # - roles
+  # - rolebindings
 
 # Enabling kubeconfig will pass the --kubeconfig argument to the container
 kubeconfig:


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Fixes a missing `list`/`watch` RBAC rule for the `rolebindings` resource in `role.yaml`. Without this rule, enabling the `rolebindings` collector produces no `kube_rolebinding_info` metrics even though `roles`, `clusterroles`, and `clusterrolebindings` all work correctly.

Also adds `rolebindings` to the commented optional collectors in `values.yaml` for discoverability.

#### Which issue this PR fixes

- fixes #6272

#### Special notes for your reviewer

Simple omission — the `roles` block existed but the corresponding `rolebindings` block was never added.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)