### PR TITLE
[prometheus-mysql-exporter] - update exporter to 0.19.0

### DIFF
--- a/charts/prometheus-mysql-exporter/Chart.yaml
+++ b/charts/prometheus-mysql-exporter/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 description: A Helm chart for prometheus mysql exporter with cloudsqlproxy
 name: prometheus-mysql-exporter
-version: 2.12.0
+version: 2.13.0
 home: https://github.com/prometheus/mysqld_exporter
-appVersion: v0.17.2
+appVersion: v0.19.0
 sources:
   - https://github.com/prometheus/mysqld_exporter
 maintainers:


### PR DESCRIPTION
#### What this PR does / why we need it
This updates the `prometheus-mysql-exporter` chart to latest version of the exporter

#### Which issue this PR fixes
None

#### Special notes for your reviewer
@juanchimienti
@monotek

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
