### PR TITLE
[prometheus-postgres-exporter] Quote namespace in serviceMonitor

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: v0.19.1
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 7.5.1
+version: 7.5.2
 home: https://github.com/prometheus-community/postgres_exporter
 sources:
   - https://github.com/prometheus-community/postgres_exporter

--- a/charts/prometheus-postgres-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-postgres-exporter/templates/servicemonitor.yaml
@@ -8,7 +8,7 @@ metadata:
 {{ toYaml .Values.serviceMonitor.labels | indent 4}}
 {{- end }}
   name: {{ template "prometheus-postgres-exporter.fullname" . }}
-  namespace: {{ .Values.serviceMonitor.namespace | default (include "prometheus-postgres-exporter.namespace" .)  }}
+  namespace: {{ .Values.serviceMonitor.namespace | default (include "prometheus-postgres-exporter.namespace" .) | quote }}
 spec:
 {{- if .Values.serviceMonitor.multipleTarget.enabled }}
   endpoints:
@@ -93,7 +93,7 @@ spec:
   jobLabel: {{ template "prometheus-postgres-exporter.fullname" . }}
   namespaceSelector:
     matchNames:
-    - {{ .Release.Namespace }}
+    - {{ .Release.Namespace | quote }}
   selector:
     matchLabels:
       {{- include "prometheus-postgres-exporter.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
#### What this PR does / why we need it

This fixes ServiceMonitor namespace rendering in the `prometheus-postgres-exporter` chart.

The chart currently renders namespace values without quotes in these fields:

- `metadata.namespace`
- `spec.namespaceSelector.matchNames`

When the namespace is numeric-like, Helm renders it as a YAML number instead of a string, which causes Kubernetes validation/apply failures such as:

- `spec.namespaceSelector.matchNames[0] in body must be of type string: "integer"`
- `cannot unmarshal number into Go struct field ObjectMeta.metadata.namespace of type string`

This PR updates the template to always quote those namespace values and adds coverage for the explicit numeric `serviceMonitor.namespace` case.

#### Which issue this PR fixes

- fixes #6773

#### Special notes for your reviewer

Validated with `helm template` against both repro cases:

1. `--namespace 1234`
2. `--set serviceMonitor.namespace=1234`

Both now render quoted string values in the generated `ServiceMonitor`.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)