### PR TITLE
[prometheus-yet-another-cloudwatch-exporter] Update maintainers list for yet-another-cloudwatch-exporter

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,5 +51,5 @@
 /charts/prometheus-systemd-exporter/ @maxime1907
 /charts/prometheus-to-sd/ @acondrat
 /charts/prometheus-windows-exporter/ @jkroepke
-/charts/prometheus-yet-another-cloudwatch-exporter/ @cristiangreco @thomaspeitz
+/charts/prometheus-yet-another-cloudwatch-exporter/ @andriikushch @cristiangreco @thomaspeitz @tristanburgess
 /charts/prometheus/ @Xtigyro @gianrubio @naseemkullah @zanhsieh @zeritti

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -228,9 +228,9 @@
 
 ### prometheus-yet-another-cloudwatch-exporter
 
+- Andrii Kushch (<andrii.kushch@grafana.com> / @andriikushch)
 - Cristian Greco (<cristian.greco@grafana.com> / @cristiangreco)
 - Thomas Peitz (<info@thomas-peitz.de> / @thomaspeitz)
-- Andrii Kushch (<andrii.kushch@grafana.com> / @andriikushch)
 - Tristan Burgess (<tristan.burgess@grafana.com> / @tristanburgess)
 
 ### prometheus

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -228,8 +228,10 @@
 
 ### prometheus-yet-another-cloudwatch-exporter
 
-- cristiangreco (<cristian.greco@grafana.com> / @cristiangreco)
-- thomaspeitz (<info@thomas-peitz.de> / @thomaspeitz)
+- Cristian Greco (<cristian.greco@grafana.com> / @cristiangreco)
+- Thomas Peitz (<info@thomas-peitz.de> / @thomaspeitz)
+- Andrii Kushch (<andrii.kushch@grafana.com> / @andriikushch)
+- Tristan Burgess (<tristan.burgess@grafana.com> / @tristanburgess)
 
 ### prometheus
 

--- a/charts/prometheus-yet-another-cloudwatch-exporter/Chart.yaml
+++ b/charts/prometheus-yet-another-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-yet-another-cloudwatch-exporter
 description: Yace - Yet Another CloudWatch Exporter
 type: application
-version: 0.43.0
+version: 0.44.0
 # renovate: github-releases=prometheus-community/yet-another-cloudwatch-exporter
 appVersion: "v0.64.0"
 home: https://github.com/prometheus-community/helm-charts
@@ -16,9 +16,15 @@ keywords:
   - yet-another-cloudwatch-exporter
   - yace
 maintainers:
-  - name: cristiangreco
+  - name: Cristian Greco
     email: cristian.greco@grafana.com
     url: https://github.com/cristiangreco
-  - name: thomaspeitz
+  - name: Thomas Peitz
     email: info@thomas-peitz.de
     url: https://github.com/thomaspeitz
+  - name: Andrii Kushch
+    email: andrii.kushch@grafana.com
+    url: https://github.com/andriikushch
+  - name: Tristan Burgess
+    email: tristan.burgess@grafana.com
+    url: https://github.com/tristanburgess


### PR DESCRIPTION
#### What this PR does / why we need it
Add:
- Andrii Kushch (andrii.kushch@grafana.com / @andriikushch)
- Tristan Burgess (tristan.burgess@grafana.com / @tristanburgess)

They're both maintainer of the upstream project already.

#### Which issue this PR fixes
n.a.

#### Special notes for your reviewer

#### Checklist

