### PR TITLE
[prometheus-pushgateway] Fix the image registry and repository default values

### DIFF
--- a/charts/prometheus-pushgateway/values.yaml
+++ b/charts/prometheus-pushgateway/values.yaml
@@ -16,8 +16,8 @@ fullnameOverride: ""
 namespaceOverride: ""
 
 image:
-  registry: ""
-  repository: quay.io/prometheus/pushgateway
+  registry: quay.io
+  repository: prometheus/pushgateway
   # if not set appVersion field from Chart.yaml is used
   tag: ""
   pullPolicy: IfNotPresent


### PR DESCRIPTION
Fix the image registry and repository values structuring in prometheus-pushgateway to match intuition and all the other charts in this repo.

#### What this PR does / why we need it

#### Which issue this PR fixes

- Fixes an out-of-convention and unintuitive values structuring introduced in https://github.com/prometheus-community/helm-charts/pull/5597

#### Special notes for your reviewer

The registry being bundled into the repository value in the default Helm values is incorrect, and while not strictly a functional bug, it's an unintuitive and out-of-repo-conventions approach. Additionally, the _helper for the registry handling assumes the correct values structuring, so this seems like an initial PR oversight/error rather than a design choice.

Submitting this PR to clean this up. This is not a breaking change if folks are using the default values or the global overrides. It is breaking change if folks are using explicit image (but not global) repository or registry values.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
