### PR TITLE
[kube-prometheus-stack] Make CRDs upgrade Job pod-level automountServiceAccountToken configurable

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 82.16.0
+version: 82.16.1
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.89.0
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/charts/crds/templates/upgrade/job.yaml
+++ b/charts/kube-prometheus-stack/charts/crds/templates/upgrade/job.yaml
@@ -33,6 +33,7 @@ spec:
       imagePullSecrets:
         {{- include "kube-prometheus-stack.imagePullSecrets" . | indent 8 }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.upgradeJob.automountServiceAccountToken }}
       serviceAccountName: {{ include "kube-prometheus-stack.crd.upgradeJob.serviceAccountName" . }}
       initContainers:
         - name: busybox

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -132,6 +132,10 @@ crds:
       labels: {}
       automountServiceAccountToken: true
 
+    ## Automounting API credentials for upgrade crd job pod.
+    ##
+    automountServiceAccountToken: true
+
     ## Container-specific security context configuration
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
     ##


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR is a follow-up to https://github.com/prometheus-community/helm-charts/pull/5175 which introduced upgrading CRDs using Helm. While trying to upgrade a kube-prometheus-stack helm release from old 5x to 82.14.1 chart, and to enable the CRDs upgrade Job, I ran into issue - CRDs upgrade Job Pod submission was being rejected by a custom (Kyverno) policy requiring service account auto mounting to be disabled on Pod. Unfortunately the policy is on Pod level only, isn't able to validate ServiceAccount of the Job Pod, that auto mounting is disabled there via already supported flag.

As alternative I've tried using kustomize post renderer patch, to add automountServiceAccountToken to the upgrade CRDs Job Pod template, but even that is failing, the target Job resource can't be found even though patch is valid (suspecting due to a bug at least in Flux+helm+kustomize versions used, which are failing to deal with subcharts and pre-upgrade hooks like the case of this Job).

Another alternative would be to add policy exception, or make policy more complex to validate referenced ServiceAccount too.

Yet another alternative would be not to enable the Job, to manage CRDs outside of the helm release.

Upgrading+debugging Flux is another option but a lenghty process.

Having chart improved is preferred over all of these alternatives.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
