### PR TITLE
[kube-prometheus-stack] add sessionPersistence support to alertm…

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 83.4.3
+version: 83.5.0
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.90.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/templates/alertmanager/route.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/route.yaml
@@ -53,6 +53,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.sessionPersistence }}
+      sessionPersistence:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
   {{- end }}
   {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/route.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/route.yaml
@@ -53,6 +53,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.sessionPersistence }}
+      sessionPersistence:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
   {{- end }}
   {{- end }}

--- a/charts/kube-prometheus-stack/templates/thanos-ruler/route.yaml
+++ b/charts/kube-prometheus-stack/templates/thanos-ruler/route.yaml
@@ -53,6 +53,10 @@ spec:
       matches:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $route.sessionPersistence }}
+      sessionPersistence:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
   {{- end }}
   {{- end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -701,6 +701,14 @@ alertmanager:
       ## Filters define the filters that are applied to requests that match this rule.
       filters: []
 
+      ## Session persistence configuration for the route rule.
+      sessionPersistence: {}
+      # sessionName: route
+      # type: Cookie
+      # absoluteTimeout: 12h
+      # cookieConfig:
+      #   lifetimeType: Permanent
+
       ## Additional custom rules that can be added to the route
       additionalRules: []
 
@@ -3894,6 +3902,14 @@ prometheus:
       ## Filters define the filters that are applied to requests that match this rule.
       filters: []
 
+      ## Session persistence configuration for the route rule.
+      sessionPersistence: {}
+      # sessionName: route
+      # type: Cookie
+      # absoluteTimeout: 12h
+      # cookieConfig:
+      #   lifetimeType: Permanent
+
       ## Additional custom rules that can be added to the route
       additionalRules: []
 
@@ -5129,6 +5145,14 @@ thanosRuler:
 
       ## Filters define the filters that are applied to requests that match this rule.
       filters: []
+
+      ## Session persistence configuration for the route rule.
+      sessionPersistence: {}
+      # sessionName: route
+      # type: Cookie
+      # absoluteTimeout: 12h
+      # cookieConfig:
+      #   lifetimeType: Permanent
 
       ## Additional custom rules that can be added to the route
       additionalRules: []


### PR DESCRIPTION
…anager, prometheus and thanos-ruler routes

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
This PR adds the experimental gateway-api configuration for sessionPersistence.


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
