### PR TITLE
[prom-label-proxy]: add podDisruptionBudget

### DIFF
--- a/charts/prom-label-proxy/Chart.yaml
+++ b/charts/prom-label-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prom-label-proxy
 description: A proxy that enforces a given label in a given PromQL query.
 type: application
-version: 0.19.0
+version: 0.20.0
 # renovate: github=prometheus-community/prom-label-proxy
 appVersion: v0.13.0
 home: "https://github.com/prometheus-community/prom-label-proxy"

--- a/charts/prom-label-proxy/templates/poddisruptionbudget.yaml
+++ b/charts/prom-label-proxy/templates/poddisruptionbudget.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.podDisruptionBudget -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "prom-label-proxy.fullname" . }}
+  namespace: {{ template "prom-label-proxy.namespace" . }}
+  labels:
+    {{- include "prom-label-proxy.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "prom-label-proxy.selectorLabels" . | nindent 6 }}
+{{ toYaml .Values.podDisruptionBudget | indent 2 }}
+{{- end }}

--- a/charts/prom-label-proxy/values.yaml
+++ b/charts/prom-label-proxy/values.yaml
@@ -91,6 +91,11 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+# -- PodDisruptionBudget configuration. Specify `minAvailable` or `maxUnavailable`.
+podDisruptionBudget: {}
+  # minAvailable: 1
+  # maxUnavailable: 1
+
 # -- Affinity for pod assignment
 affinity: {}
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR introduces the ability to deploy a [podDisruptionBudget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets) for prom-label-proxy. 

#### Special notes for your reviewer

Tested using both the following values:
```
podDisruptionBudget:
  minAvailable: 1
```
```
podDisruptionBudget: {}
```
#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
