### PR TITLE
[prometheus-modbus-exporter] fix config-reloader-sidecar deployment

### DIFF
--- a/charts/prometheus-modbus-exporter/Chart.yaml
+++ b/charts/prometheus-modbus-exporter/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
 
 type: application
 
-version: 0.1.4
+version: 0.1.5
 appVersion: "0.4.1"
 
 maintainers:

--- a/charts/prometheus-modbus-exporter/templates/deployment.yaml
+++ b/charts/prometheus-modbus-exporter/templates/deployment.yaml
@@ -54,9 +54,14 @@ spec:
           volumeMounts:
           - name: configfile
             mountPath: /etc/modbus_exporter/
-        {{ if .Values.configReloaderSidecar.enable }}
+        {{- if .Values.configReloaderSidecar.enabled }}
         - name: {{ include "prometheus-modbus-exporter.fullname" . }}-config-reloader-sidecar
           image: "{{ .Values.configReloaderSidecar.image.registry }}/{{ .Values.configReloaderSidecar.image.repository }}:{{ .Values.configReloaderSidecar.image.tag }}"
+          imagePullPolicy: {{ .Values.configReloaderSidecar.image.pullPolicy }}
+          {{- with .Values.configReloaderSidecar.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
           - name: CONFIG_DIR
             value: /etc/modbus_exporter/
@@ -65,7 +70,7 @@ spec:
           volumeMounts:
           - name: configfile
             mountPath: /etc/modbus_exporter/
-        {{- end -}}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/prometheus-modbus-exporter/values.yaml
+++ b/charts/prometheus-modbus-exporter/values.yaml
@@ -110,6 +110,15 @@ configReloaderSidecar:
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
     tag: "20230519_90573b0"
+  # The config-reloader-sidecar image runs as root in order to send signals
+  # to the modbus_exporter process via the shared PID namespace. When the
+  # pod-level podSecurityContext sets runAsNonRoot: true (the default), the
+  # sidecar must declare a container-level securityContext that overrides it,
+  # otherwise kubelet refuses to start the container with
+  # "container has runAsNonRoot and image will run as root".
+  securityContext:
+    runAsNonRoot: false
+    runAsUser: 0
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
## Summary

The `config-reloader-sidecar` has never actually deployed for any chart user since it was added, due to two compounding bugs:

1. **Typo in template gate.** `templates/deployment.yaml:57` reads `.Values.configReloaderSidecar.enable`, but `values.yaml` provides `.enabled` (with a 'd'). Helm silently resolves the missing key to nil, so the sidecar block is always skipped — even with the chart's own default value of `enabled: true`.

2. **Missing securityContext override on the sidecar.** The `openenergyprojects/config-reloader-sidecar` image runs as root in order to send signals to the `modbus_exporter` process via the shared PID namespace. The chart's default `podSecurityContext.runAsNonRoot: true` then causes kubelet to reject the container with:

   ```
   container has runAsNonRoot and image will run as root
   ```

   The chart provided no per-container `securityContext` override for the sidecar, so even if the typo were fixed in isolation, the sidecar would `CreateContainerConfigError` on default chart values.

## Changes

- `templates/deployment.yaml`
  - Rename `.Values.configReloaderSidecar.enable` → `.enabled` to match `values.yaml`.
  - Add `imagePullPolicy` (was previously omitted).
  - Add a templated container-level `securityContext` block, sourced from `configReloaderSidecar.securityContext`.
- `values.yaml`: provide a default `configReloaderSidecar.securityContext` with `runAsNonRoot: false` and `runAsUser: 0`, with a comment explaining why the override is necessary.
- `Chart.yaml`: bump chart version `0.1.4` → `0.1.5`.

The main `modbus_exporter` container's container-level `securityContext.runAsNonRoot: true` is unchanged — only the sidecar gets the explicit root override it needs.

## Test plan

Verified live on a Kubernetes cluster running the chart:

- [x] `helm lint` passes.
- [x] `helm template` renders both containers, with the sidecar block correctly conditional on `.enabled`.
- [x] `helm upgrade` of an existing release: both `modbus_exporter` and `config-reloader-sidecar` containers come up Ready (1/1 → 2/2).
- [x] Editing the referenced ConfigMap and waiting now reloads `modbus_exporter` config without a pod rollout (which is the whole reason the sidecar exists).
- [x] Pre-fix behavior reproduced: with stock `0.1.4`, `helm template` emits no sidecar at all, and explicitly setting `configReloaderSidecar.enable: true` (workaround) makes the sidecar appear but it then fails with `CreateContainerConfigError: container has runAsNonRoot and image will run as root`.