### PR TITLE
[kube-prometheus-stack] Use distroless images by default

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 84.5.1
+version: 85.0.0
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.90.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 84.5.0
+version: 84.5.1
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.90.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/UPGRADE.md
+++ b/charts/kube-prometheus-stack/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade
 
+## From 84.x to 85.x
+
+This version enables the `distroless` variant of both the `prometheus` and `prometheus-node-exporter` images by default
+
 ## From 83.x to 84.x
 
 This version upgrades Grafana to v13.0.0. Please check [What's new in v13.0](https://grafana.com/docs/grafana/latest/whatsnew/whats-new-in-v13-0/)

--- a/charts/kube-prometheus-stack/UPGRADE.md
+++ b/charts/kube-prometheus-stack/UPGRADE.md
@@ -2,7 +2,9 @@
 
 ## From 84.x to 85.x
 
-This version enables the `distroless` variant of both the `prometheus` and `prometheus-node-exporter` images by default
+This version enables the `distroless` variant of both the `prometheus` and `prometheus-node-exporter` images by default.
+
+If you sync images to your private registry, ensure that you also sync image tags with the distroless suffix.
 
 ## From 83.x to 84.x
 

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -51,15 +51,9 @@ spec:
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.image }}
   {{- $registry := .Values.global.imageRegistry | default .Values.prometheus.prometheusSpec.image.registry -}}
-  {{- if and .Values.prometheus.prometheusSpec.image.tag .Values.prometheus.prometheusSpec.image.sha }}
-  image: "{{ $registry }}/{{ .Values.prometheus.prometheusSpec.image.repository }}:{{ .Values.prometheus.prometheusSpec.image.tag }}@sha256:{{ .Values.prometheus.prometheusSpec.image.sha }}"
-  {{- else if .Values.prometheus.prometheusSpec.image.sha }}
-  image: "{{ $registry }}/{{ .Values.prometheus.prometheusSpec.image.repository }}@sha256:{{ .Values.prometheus.prometheusSpec.image.sha }}"
-  {{- else if .Values.prometheus.prometheusSpec.image.tag }}
-  image: "{{ $registry }}/{{ .Values.prometheus.prometheusSpec.image.repository }}:{{ .Values.prometheus.prometheusSpec.image.tag }}"
-  {{- else }}
-  image: "{{ $registry }}/{{ .Values.prometheus.prometheusSpec.image.repository }}"
-  {{- end }}
+  {{- $tag := (.Values.prometheus.prometheusSpec.image.tag | empty | not) | ternary (printf ":%s" .Values.prometheus.prometheusSpec.image.tag) "" -}}
+  {{- $sha := (.Values.prometheus.prometheusSpec.image.sha | empty | not) | ternary (printf "@sha256:%s" .Values.prometheus.prometheusSpec.image.sha) "" }}
+  image: "{{ printf "%s/%s%s%s" $registry .Values.prometheus.prometheusSpec.image.repository $tag $sha }}"
   imagePullPolicy: "{{ .Values.prometheus.prometheusSpec.image.pullPolicy }}"
   version: "{{ default .Values.prometheus.prometheusSpec.image.tag .Values.prometheus.prometheusSpec.version }}"
 {{- end }}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -2628,6 +2628,9 @@ prometheus-node-exporter:
     labels:
       jobLabel: node-exporter
 
+  image:
+    distroless: true
+
   prometheus:
     monitor:
       enabled: true
@@ -4159,7 +4162,7 @@ prometheus:
     image:
       registry: quay.io
       repository: prometheus/prometheus
-      tag: v3.11.3
+      tag: v3.11.3-distroless
       sha: ""
       pullPolicy: IfNotPresent
 


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This MR does two things:
- allows setting the `distroless` variant of the Prometheus image
- changes defaults to use the `distroless` variant for this image and the `prometheus-node-exporter` image by default (see also #6842)

Given the latter change is opinionated, where I personally would consider it a reasonable and more secure default, I've intentionally singled out this change so that it can be extracted to a separate MR or dropped entirely if preferable. 

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

n/a

#### Special notes for your reviewer

n/a

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
