### PR TITLE
[prometheus-postgres-exporter] require datasource password explicitly

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: v0.19.1
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 7.5.2
+version: 8.0.0
 home: https://github.com/prometheus-community/postgres_exporter
 sources:
   - https://github.com/prometheus-community/postgres_exporter

--- a/charts/prometheus-postgres-exporter/README.md
+++ b/charts/prometheus-postgres-exporter/README.md
@@ -46,6 +46,19 @@ helm upgrade [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/prometheus
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
+#### To 8.0.0
+
+The hardcoded fallback password previously baked into the generated `Secret` when `config.datasource.password` was unset has been removed. The chart now fails at render time if no password source is configured.
+
+Before upgrading, set exactly one of the following:
+
+- `config.datasource.password` (templated with `tpl`)
+- `config.datasource.passwordFile`
+- `config.datasource.passwordSecret` (reference to an existing `Secret`)
+- `config.datasourceSecret` (reference to an existing `Secret` providing the full data source URI)
+
+Releases that previously installed without a password were producing a `Secret` containing a known plaintext value and an exporter that could not authenticate; configuring one of the options above is required to upgrade.
+
 #### To 7.0.0
 
 Labels and selectors have been replaced following [Helm 3 label and annotation best practices](https://helmsh/docs/chart_best_practices/labels/):

--- a/charts/prometheus-postgres-exporter/ci/config-values.yaml
+++ b/charts/prometheus-postgres-exporter/ci/config-values.yaml
@@ -1,5 +1,7 @@
 ---
 config:
+  datasource:
+    password: testpassword
   logLevel: "debug"
   extraArgs:
     - "--collector.stat_statements"

--- a/charts/prometheus-postgres-exporter/ci/default-values.yaml
+++ b/charts/prometheus-postgres-exporter/ci/default-values.yaml
@@ -1,1 +1,4 @@
 # Default chart values
+config:
+  datasource:
+    password: testpassword

--- a/charts/prometheus-postgres-exporter/ci/deployment-labels-values.yaml
+++ b/charts/prometheus-postgres-exporter/ci/deployment-labels-values.yaml
@@ -1,4 +1,7 @@
 ---
+config:
+  datasource:
+    password: testpassword
 deployment:
   labels:
     foo: "bar"

--- a/charts/prometheus-postgres-exporter/ci/disable-metrics-values.yaml
+++ b/charts/prometheus-postgres-exporter/ci/disable-metrics-values.yaml
@@ -1,5 +1,7 @@
 ---
 config:
+  datasource:
+    password: testpassword
   disableCollectorDatabase: true
   disableCollectorBgwriter: true
   disableDefaultMetrics: true

--- a/charts/prometheus-postgres-exporter/ci/exporter-config-values.yaml
+++ b/charts/prometheus-postgres-exporter/ci/exporter-config-values.yaml
@@ -1,5 +1,7 @@
 ---
 config:
+  datasource:
+    password: testpassword
   postgresExporter: |-
     auth_modules:
       shared:

--- a/charts/prometheus-postgres-exporter/ci/extraenv-values.yaml
+++ b/charts/prometheus-postgres-exporter/ci/extraenv-values.yaml
@@ -1,4 +1,7 @@
 ---
+config:
+  datasource:
+    password: testpassword
 extraEnvs:
   - name: FOO
     value: bar

--- a/charts/prometheus-postgres-exporter/ci/extramanifests-values.yaml
+++ b/charts/prometheus-postgres-exporter/ci/extramanifests-values.yaml
@@ -1,3 +1,6 @@
+config:
+  datasource:
+    password: testpassword
 extraManifests:
 - apiVersion: v1
   kind: ConfigMap

--- a/charts/prometheus-postgres-exporter/ci/pdb-values.yaml
+++ b/charts/prometheus-postgres-exporter/ci/pdb-values.yaml
@@ -1,4 +1,7 @@
 ---
+config:
+  datasource:
+    password: testpassword
 podDisruptionBudget:
   enabled: true
   minAvailable: 1

--- a/charts/prometheus-postgres-exporter/ci/podlabels-values.yaml
+++ b/charts/prometheus-postgres-exporter/ci/podlabels-values.yaml
@@ -1,4 +1,7 @@
 ---
+config:
+  datasource:
+    password: testpassword
 podLabels:
   foo: "bar"
   baz: "qux"

--- a/charts/prometheus-postgres-exporter/ci/serviceaccount-values.yaml
+++ b/charts/prometheus-postgres-exporter/ci/serviceaccount-values.yaml
@@ -1,4 +1,7 @@
 ---
+config:
+  datasource:
+    password: testpassword
 serviceAccount:
   create: true
   name: "postgres-exporter"

--- a/charts/prometheus-postgres-exporter/ci/servicelabels-values.yaml
+++ b/charts/prometheus-postgres-exporter/ci/servicelabels-values.yaml
@@ -1,4 +1,7 @@
 ---
+config:
+  datasource:
+    password: testpassword
 service:
   labels:
     foo: "bar"

--- a/charts/prometheus-postgres-exporter/ci/servicemonitor-values.yaml
+++ b/charts/prometheus-postgres-exporter/ci/servicemonitor-values.yaml
@@ -1,4 +1,7 @@
 ---
+config:
+  datasource:
+    password: testpassword
 serviceMonitor:
   enabled: true
   jobLabel: app.kubernetes.io/name

--- a/charts/prometheus-postgres-exporter/templates/secrets.yaml
+++ b/charts/prometheus-postgres-exporter/templates/secrets.yaml
@@ -1,4 +1,7 @@
 {{- if not (or .Values.config.datasource.passwordSecret .Values.config.datasourceSecret .Values.config.datasource.passwordFile ) -}}
+{{- if not .Values.config.datasource.password }}
+{{- fail "config.datasource.password is required when not using config.datasource.passwordSecret, config.datasource.passwordFile, or config.datasourceSecret" }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,5 +11,5 @@ metadata:
     {{- include "prometheus-postgres-exporter.labels" . | nindent 4 }}
 type: Opaque
 data:
-  data_source_password: {{ tpl (.Values.config.datasource.password | default "somepaswword") . | b64enc }}
+  data_source_password: {{ tpl .Values.config.datasource.password . | b64enc }}
 {{- end -}}

--- a/charts/prometheus-postgres-exporter/templates/secrets.yaml
+++ b/charts/prometheus-postgres-exporter/templates/secrets.yaml
@@ -1,7 +1,4 @@
-{{- if not (or .Values.config.datasource.passwordSecret .Values.config.datasourceSecret .Values.config.datasource.passwordFile ) -}}
-{{- if not .Values.config.datasource.password }}
-{{- fail "config.datasource.password is required when not using config.datasource.passwordSecret, config.datasource.passwordFile, or config.datasourceSecret" }}
-{{- end }}
+{{ $_ := required "config.datasource.password is required when not using config.datasource.passwordSecret, config.datasource.passwordFile, or config.datasourceSecret" .Values.config.datasource.password }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/prometheus-postgres-exporter/templates/secrets.yaml
+++ b/charts/prometheus-postgres-exporter/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if not (or .Values.config.datasource.passwordSecret .Values.config.datasourceSecret .Values.config.datasource.passwordFile ) -}}
 {{ $_ := required "config.datasource.password is required when not using config.datasource.passwordSecret, config.datasource.passwordFile, or config.datasourceSecret" .Values.config.datasource.password }}
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
#### What this PR does / why we need it

Removes the hardcoded `"somepaswword"` (note: also a typo) fallback in the
generated `Secret` and replaces it with an explicit `fail` when none of
`config.datasource.password`, `config.datasource.passwordSecret`,
`config.datasource.passwordFile`, or `config.datasourceSecret` is set.

Previously, forgetting to set a password installed the chart successfully
with a known plaintext value baked into the Secret. The exporter then
failed to authenticate (silent breakage), and the well-known default
risked being copied into a real Postgres account.

After this change, the chart fails at render time with a clear message
pointing the user at the supported password sources.

#### Which issue this PR fixes

- n/a

#### Special notes

This is a behavioral change: installs that today rely on the silent
fallback (and are therefore non-functional anyway) will now fail fast
instead of producing a broken Secret. Per the contributing guide this
is a backwards-incompatible change, so bumping the chart MAJOR version
(7.5.2 --> 8.0.0) and documenting the manual upgrade step in
`charts/prometheus-postgres-exporter/README.md` under `#### To 8.0.0`.

Every file in `charts/prometheus-postgres-exporter/ci/` previously
relied on the silent fallback (no password set). Each is updated to set
`config.datasource.password` so `chart-testing` continues to pass.

Verified locally:

- `helm lint` passes against every CI values file.
- `helm template ... --set config.datasource.password=testpw` renders
  the Secret with the expected b64 value.
- `helm template ...` with no password and no alternative source now
  errors with: `config.datasource.password is required when not using
  config.datasource.passwordSecret, config.datasource.passwordFile, or
  config.datasourceSecret`.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped,  `7.5.2` --> `8.0.0` in `charts/prometheus-postgres-exporter/Chart.yaml`
- [x] Title of the PR starts with chart name

