### PR TITLE
[consul-exporter] Support using environment variables in command args

### DIFF
--- a/charts/prometheus-consul-exporter/Chart.yaml
+++ b/charts/prometheus-consul-exporter/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: "v0.13.0"
 description: A Helm chart for the Prometheus Consul Exporter
 name: prometheus-consul-exporter
-version: 1.1.1
+version: 1.2.0
 keywords:
   - metrics
   - consul

--- a/charts/prometheus-consul-exporter/templates/deployment.yaml
+++ b/charts/prometheus-consul-exporter/templates/deployment.yaml
@@ -31,9 +31,16 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.invokeViaShell }}
+          command: ["/bin/sh"]
+          args:
+            - "-c"
+            - "consul_exporter --consul.server={{ .Values.consulServer }}"
+          {{- else }}
           command: ["consul_exporter"]
           args:
             - "--consul.server={{ .Values.consulServer }}"
+          {{ end }}
             {{- range $key, $value := .Values.options }}
             - "--{{ $key }}{{ if $value }}={{ $value }}{{ end }}"
             {{- end }}

--- a/charts/prometheus-consul-exporter/values.yaml
+++ b/charts/prometheus-consul-exporter/values.yaml
@@ -33,6 +33,12 @@ options: {}
   # no-consul.health-summary:
   # kv.filter=foobar
 
+# By default, consul_exporter is run directly.
+# If you want to use environment variables in `options` or `consulServer`,
+# enable this option to have a shell interpret the command string before
+# `consul_exporter` is executed.
+invokeViaShell: false
+
 service:
   type: ClusterIP
   port: 9107


### PR DESCRIPTION
#### What this PR does / why we need it

To increase the flexibility for options and arguments in the chart, this change adds a flag `invokeViaShell` to the values. When enabled the `consul_exporter` is not directly executed by kubernetes. Instead the same command is passed to `/bin/sh`, which will replace any environment variables.

This allows users to pull in options from secrets on the cluster; kubernetes's downwardApi systems; or other environment ephemera. The option is disabled by default.

This allows for constructs such as

```yaml
invokeViaShell: true
consulServer: "${CONSUL_HOST}:8500"
extraEnv:
  - name: CONSUL_HOST
    valueFrom:
      fieldRef:
        fieldPath: status.hostIP
```

#### Which issue this PR fixes

- fixes #6896 

#### Special notes for your reviewer

This change goes slightly against typical helm conventions of having values for `command` and `args` which can be overridden by the user.

As we have a always present argument specified by `consulServer`, I felt that building up the logic for a more generic solution would overall increase the complexity/confusion for this chart.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
