### PR TITLE
[kube-prometheus-stack] avoid duplicate Thanos image key

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 85.0.0
+version: 85.0.1
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.90.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -401,7 +401,7 @@ spec:
 {{- with .Values.prometheus.prometheusSpec.thanos.image }}
     image: {{ . }} 
 {{- end }}
-{{- with (omit .Values.prometheus.prometheusSpec.thanos "objectStorageConfig" "secretProviderClass") }}
+{{- with (omit .Values.prometheus.prometheusSpec.thanos "image" "objectStorageConfig" "secretProviderClass") }}
 {{ toYaml . | indent 4 }}
 {{- end }}
 {{- if ((.Values.prometheus.prometheusSpec.thanos.objectStorageConfig).existingSecret) }}


### PR DESCRIPTION
Fixes #6886.

## What this PR does

This avoids rendering `prometheus.prometheusSpec.thanos.image` twice in the generated Prometheus custom resource.

The template already renders `thanos.image` explicitly. The generic Thanos `toYaml` block now omits `image`, the same way it already omits `objectStorageConfig` and `secretProviderClass`.

## Validation

- Reproduced the duplicate `thanos.image` key with `helm template`
- Verified the rendered Prometheus CR contains a single `thanos.image`
- Verified `objectStorageConfig.existingSecret` still renders under `thanos`
- `helm lint charts/kube-prometheus-stack --kube-version 1.35.4 --set prometheus.prometheusSpec.thanos.image=quay.io/thanos/thanos:v0.41.0 --set grafana.enabled=false --set kubeStateMetrics.enabled=false --set nodeExporter.enabled=false --set windowsMonitoring.enabled=false`
- `git diff --check HEAD~1 HEAD`