### PR TITLE
[kube-prometheus-stack] add ThanosRuler extraEnv support

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 85.2.1
+version: 85.2.2
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.90.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/templates/thanos-ruler/ruler.yaml
+++ b/charts/kube-prometheus-stack/templates/thanos-ruler/ruler.yaml
@@ -175,6 +175,7 @@ spec:
 {{- if or .Values.thanosRuler.thanosRulerSpec.containers .Values.thanosRuler.thanosRulerSpec.extraEnv }}
   containers:
 {{- if .Values.thanosRuler.thanosRulerSpec.extraEnv }}
+{{/* The operator applies env overrides through a strategic merge patch on the generated thanos-ruler container. */}}
 {{- range .Values.thanosRuler.thanosRulerSpec.containers }}
 {{- if eq .name "thanos-ruler" }}
 {{- fail "thanosRuler.thanosRulerSpec.extraEnv cannot be used together with a thanos-ruler entry in thanosRuler.thanosRulerSpec.containers" }}

--- a/charts/kube-prometheus-stack/templates/thanos-ruler/ruler.yaml
+++ b/charts/kube-prometheus-stack/templates/thanos-ruler/ruler.yaml
@@ -172,9 +172,21 @@ spec:
   imagePullSecrets:
 {{ toYaml .Values.global.imagePullSecrets | indent 4 }}
 {{- end }}
-{{- if .Values.thanosRuler.thanosRulerSpec.containers }}
+{{- if or .Values.thanosRuler.thanosRulerSpec.containers .Values.thanosRuler.thanosRulerSpec.extraEnv }}
   containers:
+{{- if .Values.thanosRuler.thanosRulerSpec.extraEnv }}
+{{- range .Values.thanosRuler.thanosRulerSpec.containers }}
+{{- if eq .name "thanos-ruler" }}
+{{- fail "thanosRuler.thanosRulerSpec.extraEnv cannot be used together with a thanos-ruler entry in thanosRuler.thanosRulerSpec.containers" }}
+{{- end }}
+{{- end }}
+  - name: thanos-ruler
+    env:
+{{ toYaml .Values.thanosRuler.thanosRulerSpec.extraEnv | indent 6 }}
+{{- end }}
+{{- if .Values.thanosRuler.thanosRulerSpec.containers }}
 {{ toYaml .Values.thanosRuler.thanosRulerSpec.containers | indent 4 }}
+{{- end }}
 {{- end }}
 {{- if .Values.thanosRuler.thanosRulerSpec.initContainers }}
   initContainers:

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -5558,6 +5558,13 @@ thanosRuler:
     ##
     containers: []
 
+    ## Additional environment variables to set on the ThanosRuler container.
+    ## This is rendered through the Prometheus Operator strategic merge patch.
+    ##
+    extraEnv: []
+    # - name: EXAMPLE
+    #   value: test
+
     # Additional volumes on the output StatefulSet definition.
     volumes: []
 


### PR DESCRIPTION
#### What this PR does / why we need it

Add `thanosRuler.thanosRulerSpec.extraEnv` so chart users can configure environment variables on the generated Thanos Ruler container.

The Prometheus Operator exposes this through `spec.containers` strategic merge patches rather than a top-level `env` field, so the chart renders a `thanos-ruler` container patch only when `extraEnv` is set. It also fails early if `extraEnv` is combined with a manual `thanos-ruler` entry in `thanosRuler.thanosRulerSpec.containers`, avoiding duplicate list-map keys in the ThanosRuler resource.

#### Which issue this PR fixes

- fixes #6020

#### Special notes for your reviewer

The extraEnv block is rendered as a container patch because the operator applies user-provided container entries by name to the generated container.

#### Validation

- `helm template test charts/kube-prometheus-stack --kube-version 1.30.0 --set thanosRuler.enabled=true --show-only templates/thanos-ruler/ruler.yaml`
- `helm template test charts/kube-prometheus-stack --kube-version 1.30.0 --set thanosRuler.enabled=true --set thanosRuler.thanosRulerSpec.extraEnv[0].name=EXAMPLE --set-string thanosRuler.thanosRulerSpec.extraEnv[0].value=test --show-only templates/thanos-ruler/ruler.yaml`
- `helm template test charts/kube-prometheus-stack --kube-version 1.30.0 --set thanosRuler.enabled=true --set thanosRuler.thanosRulerSpec.containers[0].name=sidecar --set thanosRuler.thanosRulerSpec.containers[0].image=busybox --show-only templates/thanos-ruler/ruler.yaml`
- `helm template test charts/kube-prometheus-stack --kube-version 1.30.0 --set thanosRuler.enabled=true --set thanosRuler.thanosRulerSpec.extraEnv[0].name=EXAMPLE --set-string thanosRuler.thanosRulerSpec.extraEnv[0].value=test --set thanosRuler.thanosRulerSpec.containers[0].name=thanos-ruler --set thanosRuler.thanosRulerSpec.containers[0].image=busybox --show-only templates/thanos-ruler/ruler.yaml` (expected failure)
- `helm lint charts/kube-prometheus-stack --kube-version 1.30.0`
- `git diff --check`

#### Checklist

- [x] DCO signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name