### PR TITLE
[kube-prometheus-stack] skip disabled single-rule groups

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 85.1.2
+version: 85.1.3
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.90.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/hack/sync_prometheus_rules.py
+++ b/charts/kube-prometheus-stack/hack/sync_prometheus_rules.py
@@ -153,11 +153,11 @@ condition_map = {
     'kubernetes-resources': ' .Values.defaultRules.rules.kubernetesResources',
     'kubernetes-storage': ' .Values.defaultRules.rules.kubernetesStorage',
     'kubernetes-system': ' .Values.defaultRules.rules.kubernetesSystem',
-    'kubernetes-system-kube-proxy': ' .Values.kubeProxy.enabled .Values.defaultRules.rules.kubeProxy',
+    'kubernetes-system-kube-proxy': ' .Values.kubeProxy.enabled .Values.defaultRules.rules.kubeProxy (not (.Values.defaultRules.disabled.KubeProxyDown | default false))',
     'kubernetes-system-apiserver': ' .Values.defaultRules.rules.kubernetesSystem', # kubernetes-system was split into more groups in 1.14, one of them is kubernetes-system-apiserver
     'kubernetes-system-kubelet': ' .Values.defaultRules.rules.kubernetesSystem', # kubernetes-system was split into more groups in 1.14, one of them is kubernetes-system-kubelet
-    'kubernetes-system-controller-manager': ' .Values.kubeControllerManager.enabled .Values.defaultRules.rules.kubeControllerManager',
-    'kubernetes-system-scheduler': ' .Values.kubeScheduler.enabled .Values.defaultRules.rules.kubeSchedulerAlerting',
+    'kubernetes-system-controller-manager': ' .Values.kubeControllerManager.enabled .Values.defaultRules.rules.kubeControllerManager (not (.Values.defaultRules.disabled.KubeControllerManagerDown | default false))',
+    'kubernetes-system-scheduler': ' .Values.kubeScheduler.enabled .Values.defaultRules.rules.kubeSchedulerAlerting (not (.Values.defaultRules.disabled.KubeSchedulerDown | default false))',
     'node-exporter.rules': ' .Values.defaultRules.rules.nodeExporterRecording',
     'node-exporter': ' .Values.defaultRules.rules.nodeExporterAlerting',
     'node.rules': ' .Values.defaultRules.rules.node',
@@ -319,10 +319,11 @@ def get_rule_group_condition(group_name, value_key):
     if group_name == '':
         return ''
 
-    if group_name.count(".Values") > 1:
-        group_name = group_name.split(' ')[-1]
+    rule_condition = re.search(r'\.Values\.defaultRules\.rules\.[A-Za-z0-9_]+', group_name)
+    if rule_condition is None:
+        return ''
 
-    return group_name.replace('Values.defaultRules.rules', f"Values.defaultRules.{value_key}").strip()
+    return rule_condition.group(0).replace('Values.defaultRules.rules', f"Values.defaultRules.{value_key}").strip()
 
 
 def add_rules_conditions(rules, rules_map, indent=4):

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-controller-manager.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-controller-manager.yaml
@@ -4,7 +4,7 @@ Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
-{{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.kubeControllerManager.enabled .Values.defaultRules.rules.kubeControllerManager }}
+{{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.kubeControllerManager.enabled .Values.defaultRules.rules.kubeControllerManager (not (.Values.defaultRules.disabled.KubeControllerManagerDown | default false)) }}
 {{- $kubeControllerManagerJob := include "kube-prometheus-stack-kube-controller-manager.name" . }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-kube-proxy.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-kube-proxy.yaml
@@ -4,7 +4,7 @@ Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
-{{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.kubeProxy.enabled .Values.defaultRules.rules.kubeProxy }}
+{{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.kubeProxy.enabled .Values.defaultRules.rules.kubeProxy (not (.Values.defaultRules.disabled.KubeProxyDown | default false)) }}
 {{- $kubeProxyJob := include "kube-prometheus-stack-kube-proxy.name" . }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-scheduler.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/kubernetes-system-scheduler.yaml
@@ -4,7 +4,7 @@ Do not change in-place! In order to change this file first read following link:
 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
-{{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.kubeScheduler.enabled .Values.defaultRules.rules.kubeSchedulerAlerting }}
+{{- if and (semverCompare ">=1.14.0-0" $kubeTargetVersion) (semverCompare "<9.9.9-9" $kubeTargetVersion) .Values.defaultRules.create .Values.kubeScheduler.enabled .Values.defaultRules.rules.kubeSchedulerAlerting (not (.Values.defaultRules.disabled.KubeSchedulerDown | default false)) }}
 {{- $kubeSchedulerJob := include "kube-prometheus-stack-kube-scheduler.name" . }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/charts/kube-prometheus-stack/unittests/prometheus/default_rules_disabled_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/prometheus/default_rules_disabled_test.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test disabled default rules
+templates:
+  - prometheus/rules-1.14/kubernetes-system-controller-manager.yaml
+  - prometheus/rules-1.14/kubernetes-system-kube-proxy.yaml
+  - prometheus/rules-1.14/kubernetes-system-scheduler.yaml
+tests:
+  - it: should not render single-rule groups when their only rule is disabled
+    set:
+      defaultRules.disabled.KubeControllerManagerDown: true
+      defaultRules.disabled.KubeProxyDown: true
+      defaultRules.disabled.KubeSchedulerDown: true
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
#### What this PR does / why we need it

Skips rendering the three generated single-alert PrometheusRule groups when their only alert is disabled via `defaultRules.disabled`.

With Helm 4, disabling `KubeControllerManagerDown`, `KubeProxyDown`, or `KubeSchedulerDown` currently leaves a rendered PrometheusRule with `spec.groups[].rules: null`, which Kubernetes rejects because `rules` must be an array. Since each affected group contains only that one alert, omitting the whole group avoids rendering invalid resources while preserving the default behavior when the alerts are enabled.

The generated templates and `hack/sync_prometheus_rules.py` are updated together so future rule syncs keep the same guards.

#### Which issue this PR fixes

- fixes #6772

#### Special notes for your reviewer

I added a focused helm-unittest case for the disabled single-rule groups. I could not run it locally because the `helm unittest` plugin is not installed in this environment, but the rendered chart was validated with `helm template` and `helm lint`.

#### Validation

- `helm template test charts/kube-prometheus-stack --kube-version 1.35.4 --set defaultRules.disabled.KubeControllerManagerDown=true --set defaultRules.disabled.KubeProxyDown=true --set defaultRules.disabled.KubeSchedulerDown=true --set grafana.enabled=false --set kubeStateMetrics.enabled=false --set nodeExporter.enabled=false --set windowsMonitoring.enabled=false > /tmp/kps-disabled-rules.yaml`
- `rg -n "kubernetes-system-(kube-proxy|controller-manager|scheduler)" /tmp/kps-disabled-rules.yaml` (no matches)
- `helm template test charts/kube-prometheus-stack --kube-version 1.35.4 --show-only templates/prometheus/rules-1.14/kubernetes-system-kube-proxy.yaml --show-only templates/prometheus/rules-1.14/kubernetes-system-controller-manager.yaml --show-only templates/prometheus/rules-1.14/kubernetes-system-scheduler.yaml`
- `helm lint charts/kube-prometheus-stack --kube-version 1.35.4`
- `helm lint charts/kube-prometheus-stack --kube-version 1.35.4 --set defaultRules.disabled.KubeControllerManagerDown=true --set defaultRules.disabled.KubeProxyDown=true --set defaultRules.disabled.KubeSchedulerDown=true --set grafana.enabled=false --set kubeStateMetrics.enabled=false --set nodeExporter.enabled=false --set windowsMonitoring.enabled=false`
- `git diff --check`

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)