### PR TITLE
[prometheus-yet-another-cloudwatch-exporter] Add topologySpreadConstraints support

### DIFF
--- a/charts/prometheus-yet-another-cloudwatch-exporter/Chart.yaml
+++ b/charts/prometheus-yet-another-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-yet-another-cloudwatch-exporter
 description: Yace - Yet Another CloudWatch Exporter
 type: application
-version: 0.45.0
+version: 0.46.0
 # renovate: github-releases=prometheus-community/yet-another-cloudwatch-exporter
 appVersion: "v0.65.0"
 home: https://github.com/prometheus-community/helm-charts

--- a/charts/prometheus-yet-another-cloudwatch-exporter/templates/deployment.yaml
+++ b/charts/prometheus-yet-another-cloudwatch-exporter/templates/deployment.yaml
@@ -129,6 +129,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - configMap:
             defaultMode: 420

--- a/charts/prometheus-yet-another-cloudwatch-exporter/values.yaml
+++ b/charts/prometheus-yet-another-cloudwatch-exporter/values.yaml
@@ -96,6 +96,16 @@ tolerations: []
 
 affinity: {}
 
+## Topology spread constraints
+## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: failure-domain.beta.kubernetes.io/zone
+  #   whenUnsatisfiable: DoNotSchedule
+  #   labelSelector:
+  #     matchLabels:
+  #       app.kubernetes.io/instance: <release-name>
+
 podDisruptionBudget:
   enabled: false
   minAvailable: 1


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Adds `topologySpreadConstraints` to the deployment manifest for the `prometheus-yet-another-cloudwatch-exporter` so that it can be run with multiple replicas spread across different nodes/zones. Without topology spread constraints, running multiple replicas for HA provides limited benefit if all pods land on the same node/zone.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
