### PR TITLE
[kube-prometheus-stack] Add admission webhook PromQL options

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 85.3.3
+version: 85.4.0
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.90.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/deployment/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/admission-webhooks/deployment/deployment.yaml
@@ -61,6 +61,9 @@ spec:
             {{- if .Values.prometheusOperator.admissionWebhooks.deployment.logLevel }}
             - --log-level={{ .Values.prometheusOperator.admissionWebhooks.deployment.logLevel }}
             {{- end }}
+            {{- with .Values.prometheusOperator.admissionWebhooks.deployment.promqlOptions }}
+            - "--promql-options={{ join "," . }}"
+            {{- end }}
           {{- if .Values.prometheusOperator.admissionWebhooks.deployment.tls.enabled }}
             - "--web.enable-tls=true"
             - "--web.cert-file=/cert/{{ if .Values.prometheusOperator.admissionWebhooks.certManager.enabled }}tls.crt{{ else }}cert{{ end }}"

--- a/charts/kube-prometheus-stack/unittests/prometheus-operator/admission_webhook_deployment_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/prometheus-operator/admission_webhook_deployment_test.yaml
@@ -1,0 +1,14 @@
+suite: admission webhook deployment
+templates:
+  - prometheus-operator/admission-webhooks/deployment/deployment.yaml
+tests:
+  - it: renders PromQL parser options for admission webhook validation
+    set:
+      prometheusOperator.admissionWebhooks.deployment.enabled: true
+      prometheusOperator.admissionWebhooks.deployment.promqlOptions:
+        - extended-range-selectors
+        - experimental-functions
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --promql-options=extended-range-selectors,experimental-functions

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -2914,6 +2914,13 @@ prometheusOperator:
       ## Decrease log verbosity to errors only
       # logLevel: error
 
+      ## PromQL parser options to enable for the admission webhook when validating PrometheusRule resources.
+      ## The options are passed to the prometheus-operator admission-webhook binary as a comma-separated --promql-options value.
+      ## Requires prometheus-operator admission-webhook v0.91.0 or newer.
+      ## Valid values: experimental-functions, duration-expression-parsing, extended-range-selectors, binop-fill-modifiers.
+      ##
+      promqlOptions: []
+
 
       ## Liveness probe
       ##


### PR DESCRIPTION
#### What this PR does / why we need it

Adds `prometheusOperator.admissionWebhooks.deployment.promqlOptions` to `kube-prometheus-stack` and renders it as the `--promql-options` argument on the separate prometheus-operator admission webhook deployment.

This lets users enable PromQL parser options for webhook validation of `PrometheusRule` resources, e.g. `extended-range-selectors`, matching the admission webhook CLI support added in prometheus-operator v0.91.0.

Example:

```yaml
prometheusOperator:
  admissionWebhooks:
    deployment:
      enabled: true
      image:
        tag: v0.91.0
      promqlOptions:
        - extended-range-selectors
```

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer

`promqlOptions` defaults to an empty list. When set, it requires the `prometheus-operator/admission-webhook` image to be v0.91.0 or newer.

Local validation run:

- `helm dependency build charts/kube-prometheus-stack`
- `helm lint charts/kube-prometheus-stack`
- `helm unittest --strict --file 'unittests/**/*.yaml' charts/kube-prometheus-stack`
- `helm template ...` confirmed `--promql-options=extended-range-selectors,experimental-functions` is rendered

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
