### PR TITLE
[alertmanager] Add Gateway API HTTPRoute support

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 1.37.0
+version: 1.38.0
 # renovate: github-releases=prometheus/alertmanager
 appVersion: v0.32.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/alertmanager/ci/httproute-values.yaml
+++ b/charts/alertmanager/ci/httproute-values.yaml
@@ -1,0 +1,20 @@
+---
+## Test case: httproute
+route:
+  main:
+    enabled: true
+    hostnames:
+      - "an.example.com"
+    parentRefs:
+      - name: contour
+    filters:
+      - type: RequestHeaderModifier
+        requestHeaderModifier:
+          set:
+            - name: my-header-name
+              value: my-new-header-value
+    additionalRules:
+      - filters:
+          - type: RequestHeaderModifier
+            requestHeaderModifier:
+              remove: ["x-request-id"]

--- a/charts/alertmanager/templates/httproute.yaml
+++ b/charts/alertmanager/templates/httproute.yaml
@@ -1,0 +1,46 @@
+{{- range $name, $route := .Values.route }}
+{{- if $route.enabled }}
+---
+apiVersion: {{ $route.apiVersion | default "gateway.networking.k8s.io/v1" }}
+kind: {{ $route.kind | default "HTTPRoute" }}
+metadata:
+  {{- with $route.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  name: {{ include "alertmanager.fullname" $ }}
+  namespace: {{ include "alertmanager.namespace" $ }}
+  labels:
+    {{- include "alertmanager.labels" $ | nindent 4 }}
+    {{- with $route.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with $route.parentRefs }}
+  parentRefs: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $route.hostnames }}
+  hostnames: {{ tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- with $route.additionalRules }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+    {{- if $route.httpsRedirect }}
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+    {{- else }}
+    - backendRefs:
+        - name: {{ include "alertmanager.fullname" $ }}
+          port: {{ $.Values.service.port }}
+      {{- with $route.filters }}
+      filters: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $route.matches }}
+      matches: {{ toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/alertmanager/unittests/httproute_test.yaml
+++ b/charts/alertmanager/unittests/httproute_test.yaml
@@ -1,0 +1,74 @@
+suite: test httproute
+templates:
+  - httproute.yaml
+tests:
+  - it: should be empty if no route is enabled
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should render an HTTPRoute when enabled
+    set:
+      route.main.enabled: true
+      route.main.parentRefs:
+        - name: my-gateway
+      route.main.hostnames:
+        - alertmanager.example.com
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HTTPRoute
+      - isAPIVersion:
+          of: gateway.networking.k8s.io/v1
+  - it: should default the backendRef to the alertmanager service port
+    set:
+      route.main.enabled: true
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: RELEASE-NAME-alertmanager
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 9093
+  - it: should set parentRefs and hostnames
+    set:
+      route.main.enabled: true
+      route.main.parentRefs:
+        - name: my-gateway
+          namespace: gateway-system
+      route.main.hostnames:
+        - alertmanager.example.com
+    asserts:
+      - equal:
+          path: spec.parentRefs[0].name
+          value: my-gateway
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: gateway-system
+      - equal:
+          path: spec.hostnames[0]
+          value: alertmanager.example.com
+  - it: should allow overriding apiVersion and kind
+    set:
+      route.main.enabled: true
+      route.main.apiVersion: gateway.networking.k8s.io/v1beta1
+      route.main.kind: TLSRoute
+    asserts:
+      - isAPIVersion:
+          of: gateway.networking.k8s.io/v1beta1
+      - isKind:
+          of: TLSRoute
+  - it: should render a RequestRedirect filter when httpsRedirect is enabled
+    set:
+      route.main.enabled: true
+      route.main.httpsRedirect: true
+    asserts:
+      - equal:
+          path: spec.rules[0].filters[0].type
+          value: RequestRedirect
+      - equal:
+          path: spec.rules[0].filters[0].requestRedirect.scheme
+          value: https
+      - equal:
+          path: spec.rules[0].filters[0].requestRedirect.statusCode
+          value: 301

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -225,6 +225,52 @@ ingressPerReplica:
     #
     prefix: "alertmanager"
 
+## route (map) allows configuration of Gateway API HTTPRoute resources
+## Requires Gateway API resources and a suitable controller installed within the cluster
+## Ref. https://gateway-api.sigs.k8s.io/guides/http-routing/
+route:
+  main:
+    ## Enable this route
+    enabled: false
+
+    ## apiVersion set by default to "gateway.networking.k8s.io/v1"
+    apiVersion: ""
+    ## kind set by default to HTTPRoute
+    kind: ""
+
+    ## Annotations to attach to the HTTPRoute resource
+    annotations: {}
+    ## Labels to attach to the HTTPRoute resource
+    labels: {}
+
+    ## ParentRefs references the resources (usually Gateways) this HTTPRoute should be attached to
+    parentRefs: []
+      # - name: contour
+      #   sectionName: http
+
+    ## Hostnames (templated) defines a set of hostnames that should match against the HTTP Host
+    ## header to select an HTTPRoute used to process the request
+    hostnames: []
+      # - alertmanager.domain.com
+
+    ## additionalRules (templated) allows adding custom rules to the route
+    additionalRules: []
+
+    ## Filters define the filters that are applied to requests that match this rule
+    filters: []
+
+    ## Matches define conditions used for matching the rule against incoming HTTP requests
+    matches:
+      - path:
+          type: PathPrefix
+          value: /
+
+    ## httpsRedirect adds a filter for redirecting to https (HTTP 301 Moved Permanently).
+    ## To redirect HTTP traffic to HTTPS, you need a Gateway with both HTTP and HTTPS listeners.
+    ## Matches and filters do not take effect if enabled.
+    ## Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
+    httpsRedirect: false
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
#### What this PR does / why we need it

Adds Gateway API `HTTPRoute` support to the standalone `alertmanager` chart,
mirroring the pattern already established in `kube-prometheus-stack` (#4622)
and the standalone `prometheus` chart.

A new `route` map renders one or more `HTTPRoute` resources when
`route.<name>.enabled` is `true`, letting users expose Alertmanager through the
Kubernetes Gateway API instead of an Ingress without leaving the Helm release
lifecycle. `apiVersion`/`kind` are overridable, and an optional `httpsRedirect`
filter is supported.

#### Which issue this PR fixes

- fixes #6832

#### Special notes for your reviewer

- Follows the `route` schema and template shape used by `charts/prometheus` for
  consistency across the standalone charts.
- Adds `templates/httproute.yaml`, a `route.main` values block (disabled by
  default), a helm-unittest suite, and `ci/httproute-values.yaml` render values.
- Chart version bumped `1.37.0` -> `1.38.0`.
- Validated locally: `ct lint` (all ci values incl. httproute), `helm unittest
  --strict` (13/13), and `helm template` for disabled / enabled / httpsRedirect.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)