### PR TITLE
[prometheus-yet-another-cloudwatch-exporter] Add the ability to set ServiceMonitor `honorTimestamps` parameter

### DIFF
--- a/charts/prometheus-yet-another-cloudwatch-exporter/Chart.yaml
+++ b/charts/prometheus-yet-another-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-yet-another-cloudwatch-exporter
 description: Yace - Yet Another CloudWatch Exporter
 type: application
-version: 0.45.0
+version: 0.46.0
 # renovate: github-releases=prometheus-community/yet-another-cloudwatch-exporter
 appVersion: "v0.65.0"
 home: https://github.com/prometheus-community/helm-charts

--- a/charts/prometheus-yet-another-cloudwatch-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-yet-another-cloudwatch-exporter/templates/servicemonitor.yaml
@@ -23,6 +23,9 @@ spec:
 {{- if .Values.serviceMonitor.timeout }}
     scrapeTimeout: {{ .Values.serviceMonitor.timeout }}
 {{- end }}
+{{- if not (kindIs "invalid" .Values.serviceMonitor.honorTimestamps) }}
+    honorTimestamps: {{ .Values.serviceMonitor.honorTimestamps }}
+{{- end }}
 {{- if .Values.serviceMonitor.relabelings }}
     relabelings:
 {{ toYaml .Values.serviceMonitor.relabelings | indent 6 }}

--- a/charts/prometheus-yet-another-cloudwatch-exporter/values.yaml
+++ b/charts/prometheus-yet-another-cloudwatch-exporter/values.yaml
@@ -162,6 +162,8 @@ serviceMonitor:
   # labels:
   # Set timeout for scrape
   # timeout: 10s
+  # Set honorTimestamps for the ServiceMonitor. Set explicitly to true or false; omit to leave unset
+  # honorTimestamps: true
   # Set relabelings for the ServiceMonitor, use to apply to samples before scraping
   # relabelings: []
   # Set metricRelabelings for the ServiceMonitor, use to apply to samples for ingestion


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR adds a new `.Values.serviceMonitor.honorTimestamps` bool variable, which, if set, is added to the resulting ServiceMonitor manifest. It makes it possible to utilize the YACE's `addCloudwatchTimestamp` feature for those of us who don't have `honorTimestamps` enabled by default/globally in their Prometheus/VictoriaMetrics stacks.

#### Which issue this PR fixes

Fixes https://github.com/prometheus-community/helm-charts/issues/6966

#### Special notes for your reviewer

The `{{- if not (kindIs "invalid" .Values.serviceMonitor.honorTimestamps) }}` is taken from [here](https://github.com/Masterminds/sprig/issues/53#issuecomment-483414063) as a way to both
* preserve the current behaviour - don't set honorTimestamps at all by default 
* make it possible to explicitly set it to either "true" or "false" if needed

`{{- if hasKey .Values.serviceMonitor "honorTimestamps" }}` is one of the alternative approaches that comes to mind, but it has a downside of handling `honorTimestamps: null` ... less elegantly, so I avoided it.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
