### PR TITLE
[alertmanager] Fix VPA namespace to respect namespaceOverride

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 1.38.2
+version: 1.38.3
 # renovate: github-releases=prometheus/alertmanager
 appVersion: v0.32.2
 kubeVersion: ">=1.25.0-0"

--- a/charts/alertmanager/templates/vpa.yaml
+++ b/charts/alertmanager/templates/vpa.yaml
@@ -3,7 +3,7 @@ apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ include "alertmanager.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "alertmanager.namespace" . }}
 spec:
   {{- if .Values.verticalPodAutoscaler.recommenders }}
   recommenders:


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
This PR for fix the VPA in Alertmanager.
The VPA template (`vpa.yaml`) was using `.Release.Namespace` directly :
https://github.com/prometheus-community/helm-charts/blob/f7c44054986435e11c8a032283ea4eddf7967a05/charts/alertmanager/templates/vpa.yaml#L2-L6

Instead of the `alertmanager.namespace` helper template :
https://github.com/prometheus-community/helm-charts/blob/f7c44054986435e11c8a032283ea4eddf7967a05/charts/alertmanager/templates/_helpers.tpl#L72-L80

This means when a user sets `namespaceOverride`, the VPA resource would be created in the wrong namespace (the release namespace instead of the overridden one), while all other resources (StatefulSet, Services, ConfigMap, Ingress, ServiceAccount, PDB, etc.) correctly use the `alertmanager.namespace` helper.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
