### PR TITLE
[prometheus-kafka-exporter] Add support for deploymentAnnotations

### DIFF
--- a/charts/prometheus-kafka-exporter/Chart.yaml
+++ b/charts/prometheus-kafka-exporter/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v1.9.0"
 description: A Helm chart to export metrics from Kafka in Prometheus format using kafka_exporter from https://github.com/danielqsj/kafka_exporter
 name: prometheus-kafka-exporter
 home: https://github.com/danielqsj/kafka_exporter
-version: 3.0.1
+version: 3.1.0
 kubeVersion: ">=1.25.0-0"
 sources:
   - https://github.com/prometheus-community/helm-charts

--- a/charts/prometheus-kafka-exporter/templates/deployment.yaml
+++ b/charts/prometheus-kafka-exporter/templates/deployment.yaml
@@ -10,6 +10,10 @@ metadata:
     {{- with .Values.deploymentLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/prometheus-kafka-exporter/values.yaml
+++ b/charts/prometheus-kafka-exporter/values.yaml
@@ -16,6 +16,9 @@ hostAliases: []
 # Additional labels for deployment
 deploymentLabels: {}
 
+# Annotations for the Deployment
+deploymentAnnotations: {}
+
 global:
   # To help compatibility with other charts which use global.imagePullSecrets.
   # Allow either an array of {name: pullSecret} maps (k8s-style), or an array of strings (more common helm-style).

--- a/charts/prometheus-kafka-exporter/values.yaml
+++ b/charts/prometheus-kafka-exporter/values.yaml
@@ -64,7 +64,7 @@ serviceAccount:
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
-  # This part is usefull when trying to use an SASL AWS IAM role when connecting to MSK
+  # This part is useful when trying to use an SASL AWS IAM role when connecting to MSK
   annotations: {}
     # eks.amazonaws.com/role-arn: arn:aws:iam::1234567890:role-irsa
     # eks.amazonaws.com/sts-regional-endpoints: "true"


### PR DESCRIPTION
## What this PR does

Adds a new `deploymentAnnotations` value to the `prometheus-kafka-exporter` chart that renders annotations on the Deployment's `metadata.annotations`.

```yaml
deploymentAnnotations: {}
```

## Why

The chart already supports `podAnnotations` (rendered on `spec.template.metadata.annotations`) and `deploymentLabels` (rendered on the Deployment's labels), but there is currently no way to set annotations on the Deployment object itself.

This is needed for tooling that watches **Deployment-level** annotations — most notably [Stakater Reloader](https://github.com/stakater/Reloader), which triggers a rollout when a referenced `Secret`/`ConfigMap` changes. Reloader explicitly does not act on pod template annotations, so `podAnnotations` cannot be used as a workaround.

A real-world case: rotating a TLS client certificate stored in a Kubernetes Secret (e.g. issued by Vault PKI with a TTL) — without the Reloader annotation on the Deployment, the kafka-exporter pod keeps using the old cert until manual restart, and the broker eventually drops the connection.

## How

Follows the existing convention already used in several sibling charts in this repo:

- `charts/prometheus-blackbox-exporter` — `deploymentAnnotations`
- `charts/prometheus-pushgateway` — `deploymentAnnotations`
- `charts/prometheus-adapter` — `deploymentAnnotations`
- `charts/prometheus-json-exporter` — `deploymentAnnotations`
- `charts/prometheus` — `server.deploymentAnnotations`

## Backwards compatibility

Default value is `{}`, so existing installations are unaffected. Minor version bump: `3.0.1` → `3.1.0`.

## Checklist

- [x] DCO sign-off in commit
- [x] Chart `version` bumped (semver minor — additive change)
- [x] No breaking changes
- [x] Default preserves existing behavior