### PR TITLE
[prometheus-operator-admission-webhook]: use httpGet in livenessProbe

### DIFF
--- a/charts/prometheus-operator-admission-webhook/Chart.yaml
+++ b/charts/prometheus-operator-admission-webhook/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: Prometheus Operator Admission Webhook
 name: prometheus-operator-admission-webhook
-version: 0.40.1
+version: 0.40.2
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: 0.91.0
 home: https://github.com/prometheus-operator/prometheus-operator

--- a/charts/prometheus-operator-admission-webhook/Chart.yaml
+++ b/charts/prometheus-operator-admission-webhook/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 description: Prometheus Operator Admission Webhook
 name: prometheus-operator-admission-webhook
-version: 0.40.2
+version: 0.41.0
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: 0.91.0
 home: https://github.com/prometheus-operator/prometheus-operator

--- a/charts/prometheus-operator-admission-webhook/values.schema.json
+++ b/charts/prometheus-operator-admission-webhook/values.schema.json
@@ -242,10 +242,16 @@
                 "periodSeconds": {
                     "type": "integer"
                 },
-                "tcpSocket": {
+                "httpGet": {
                     "type": "object",
                     "properties": {
+                        "path": {
+                            "type": "string"
+                        },
                         "port": {
+                            "type": "string"
+                        },
+                        "scheme": {
                             "type": "string"
                         }
                     }

--- a/charts/prometheus-operator-admission-webhook/values.yaml
+++ b/charts/prometheus-operator-admission-webhook/values.yaml
@@ -272,8 +272,10 @@ containerSecurityContext:
 ## livenessProbe sets liveness probe parameters
 ## Ref. https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 livenessProbe:
-  tcpSocket:
+  httpGet:
+    path: /healthz
     port: https
+    scheme: HTTPS
   periodSeconds: 10
   initialDelaySeconds: 5
 


### PR DESCRIPTION
#### What this PR does / why we need it

Currently, `tcpSocket` is used in the livenessProbe which leads to the error message `caller=/usr/local/go/src/net/http/server.go:3677 msg="http: TLS handshake error from ...: EOF"` every few seconds.
The reason is that tcpSocket doesn't create a valid handshake. `httpGet` should be used instead.


#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
