### PR TITLE
[prometheus-statsd-exporter] fix default liveness/readiness probe path (/health returns 404)

### DIFF
--- a/charts/prometheus-statsd-exporter/Chart.yaml
+++ b/charts/prometheus-statsd-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus-statsd-exporter
 description: A Helm chart for prometheus stats-exporter
-version: 1.0.0
+version: 1.0.1
 appVersion: v0.28.0
 home: https://github.com/prometheus/statsd_exporter
 sources:

--- a/charts/prometheus-statsd-exporter/values.yaml
+++ b/charts/prometheus-statsd-exporter/values.yaml
@@ -55,12 +55,12 @@ statsd:
 
 livenessProbe:
   httpGet:
-    path: /health
+    path: /-/healthy
     port: http
 
 readinessProbe:
   httpGet:
-    path: /health
+    path: /-/healthy
     port: http
 
 prometheus:


### PR DESCRIPTION
## What

The chart's default `livenessProbe`/`readinessProbe` use `httpGet.path: /health`, but `statsd_exporter` returns **HTTP 404** on `/health`. With the chart's default values the pod fails its probes — readiness never goes Ready, and liveness restarts the container.

## Reproduce

```
$ curl -so /dev/null -w '%{http_code}\n' http://<exporter>:9102/health     # 404
$ curl -so /dev/null -w '%{http_code}\n' http://<exporter>:9102/-/healthy   # 200
$ curl -so /dev/null -w '%{http_code}\n' http://<exporter>:9102/-/ready     # 200
```

## Root cause

`/health` was introduced in #2305 on the assumption that the server exposes it. It doesn't have a dedicated `/health` route — statsd_exporter serves `/-/healthy` and `/-/ready` (added in prometheus/statsd_exporter#339).

`/health` returned 200 only *incidentally* up to statsd_exporter **v0.22**, whose `/` handler was a catch-all that returned 200 for any path. In **v0.24.0** (2023-06-02) the exporter adopted exporter-toolkit's `web.NewLandingPage`, which `404`s any path `!= "/"` — silently breaking this probe for every statsd_exporter `>= v0.24`, including this chart's `appVersion: v0.28.0` and the upstream `prom/statsd-exporter` image.

## Fix

Point both probes at **`/-/healthy`** — the canonical lightweight health endpoint. This also satisfies the original intent of #2305 (avoid probing the heavy `/metrics` endpoint). Chart version bumped `1.0.0` → `1.0.1`.
