### PR TITLE
[alertmanager] Fix outdated Kubernetes version in Prerequisites

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 1.39.0
+version: 1.39.1
 # renovate: github-releases=prometheus/alertmanager
 appVersion: v0.33.0
 kubeVersion: ">=1.25.0-0"

--- a/charts/alertmanager/README.md
+++ b/charts/alertmanager/README.md
@@ -8,7 +8,7 @@ As per [prometheus.io documentation](https://prometheus.io/docs/alerting/latest/
 
 ## Prerequisites
 
-Kubernetes 1.14+
+Kubernetes 1.25+
 
 ## Usage
 


### PR DESCRIPTION
<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Updates the `Prerequisites` section in alertmanager `README.md` :
https://github.com/prometheus-community/helm-charts/blob/4b0a86a7ff70fe5f1ebe11b4267c7624e21c09c5/charts/alertmanager/README.md?plain=1#L11

To match the `kubeVersion` constraint defined in `Chart.yaml` :
https://github.com/prometheus-community/helm-charts/blob/4b0a86a7ff70fe5f1ebe11b4267c7624e21c09c5/charts/alertmanager/Chart.yaml#L12

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer
This is misleading for users, since Helm will actually reject installation on clusters below 1.25, regardless of what the README claims. This change brings the documented prerequisite in line with the enforced kubeVersion.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
