### PR TITLE
[prometheus-json-exporter] Support full relabeling spec in additionalMetricsRelabels

### DIFF
--- a/charts/prometheus-json-exporter/Chart.yaml
+++ b/charts/prometheus-json-exporter/Chart.yaml
@@ -10,7 +10,7 @@ type: application
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-version: 0.19.2
+version: 0.20.0
 appVersion: "v0.7.0"
 home: https://github.com/prometheus-community/json_exporter
 maintainers:

--- a/charts/prometheus-json-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-json-exporter/templates/servicemonitor.yaml
@@ -25,6 +25,7 @@ spec:
       module:
       - {{ .module }}
       {{- end }}
+    {{- $additionalMetricsRelabels := .additionalMetricsRelabels | default $.Values.serviceMonitor.defaults.additionalMetricsRelabels }}
     metricRelabelings:
       - sourceLabels: [instance]
         targetLabel: instance
@@ -34,11 +35,17 @@ spec:
         targetLabel: target
         replacement: {{ .name }}
         action: replace
-        {{- range $targetLabel, $replacement := .additionalMetricsRelabels | default $.Values.serviceMonitor.defaults.additionalMetricsRelabels }}
+      {{- if kindIs "slice" $additionalMetricsRelabels }}
+      {{- with $additionalMetricsRelabels }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- else }}
+      {{- range $targetLabel, $replacement := $additionalMetricsRelabels }}
       - targetLabel: {{ $targetLabel }}
         replacement: {{ $replacement }}
         action: replace
-        {{- end }}
+      {{- end }}
+      {{- end }}
     {{- with .additionalRelabels | default $.Values.serviceMonitor.defaults.additionalRelabels }}
     relabelings:
     {{- toYaml . | nindent 6 }}

--- a/charts/prometheus-json-exporter/unittests/servicemonitor_test.yaml
+++ b/charts/prometheus-json-exporter/unittests/servicemonitor_test.yaml
@@ -1,0 +1,125 @@
+suite: test servicemonitor
+templates:
+  - servicemonitor.yaml
+tests:
+  - it: should not render when disabled
+    set:
+      serviceMonitor.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render the built-in instance and target relabelings
+    set:
+      serviceMonitor.enabled: true
+      serviceMonitor.targets:
+        - name: example
+          url: http://example.com/healthz
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceMonitor
+      - equal:
+          path: spec.endpoints[0].metricRelabelings
+          value:
+            - sourceLabels: [instance]
+              targetLabel: instance
+              replacement: http://example.com/healthz
+              action: replace
+            - sourceLabels: [target]
+              targetLabel: target
+              replacement: example
+              action: replace
+
+  - it: should render the map form as replace relabelings after the built-ins
+    set:
+      serviceMonitor.enabled: true
+      serviceMonitor.targets:
+        - name: example
+          url: http://example.com/healthz
+          additionalMetricsRelabels:
+            team: backend
+    asserts:
+      - equal:
+          path: spec.endpoints[0].metricRelabelings[2]
+          value:
+            targetLabel: team
+            replacement: backend
+            action: replace
+
+  - it: should render the list form as full relabeling specs after the built-ins
+    set:
+      serviceMonitor.enabled: true
+      serviceMonitor.targets:
+        - name: example
+          url: http://example.com/healthz
+          additionalMetricsRelabels:
+            - sourceLabels: [__name__]
+              regex: 'go_.*'
+              action: drop
+    asserts:
+      - equal:
+          path: spec.endpoints[0].metricRelabelings[2]
+          value:
+            sourceLabels: [__name__]
+            regex: 'go_.*'
+            action: drop
+
+  - it: should render only the built-ins for an empty map
+    set:
+      serviceMonitor.enabled: true
+      serviceMonitor.targets:
+        - name: example
+          url: http://example.com/healthz
+          additionalMetricsRelabels: {}
+    asserts:
+      - lengthEqual:
+          path: spec.endpoints[0].metricRelabelings
+          count: 2
+
+  - it: should render only the built-ins for an empty list
+    set:
+      serviceMonitor.enabled: true
+      serviceMonitor.targets:
+        - name: example
+          url: http://example.com/healthz
+          additionalMetricsRelabels: []
+    asserts:
+      - lengthEqual:
+          path: spec.endpoints[0].metricRelabelings
+          count: 2
+
+  - it: should apply the list form from defaults when the target omits it
+    set:
+      serviceMonitor.enabled: true
+      serviceMonitor.defaults.additionalMetricsRelabels:
+        - sourceLabels: [__name__]
+          regex: 'go_.*'
+          action: drop
+      serviceMonitor.targets:
+        - name: example
+          url: http://example.com/healthz
+    asserts:
+      - equal:
+          path: spec.endpoints[0].metricRelabelings[2]
+          value:
+            sourceLabels: [__name__]
+            regex: 'go_.*'
+            action: drop
+
+  - it: should still render additionalRelabels as relabelings
+    set:
+      serviceMonitor.enabled: true
+      serviceMonitor.targets:
+        - name: example
+          url: http://example.com/healthz
+          additionalRelabels:
+            - sourceLabels: [__meta_kubernetes_pod_node_name]
+              targetLabel: node
+    asserts:
+      - equal:
+          path: spec.endpoints[0].relabelings
+          value:
+            - sourceLabels: [__meta_kubernetes_pod_node_name]
+              targetLabel: node

--- a/charts/prometheus-json-exporter/values.yaml
+++ b/charts/prometheus-json-exporter/values.yaml
@@ -76,6 +76,8 @@ serviceMonitor:
 
   # Default values that will be used for all ServiceMonitors created by `targets`
   defaults:
+    # Either a map of `targetLabel: replacement` pairs, each rendered as a
+    # `replace` metric relabeling, or a list of full Prometheus relabeling specs.
     additionalMetricsRelabels: {}
     additionalRelabels: []
     interval: 10s
@@ -88,7 +90,7 @@ serviceMonitor:
 #      labels: {}                       # Map of labels for ServiceMonitor. Overrides value set in `defaults`
 #      interval: 60s                    # Scraping interval. Overrides value set in `defaults`
 #      scrapeTimeout: 60s               # Scrape timeout. Overrides value set in `defaults`
-#      additionalMetricsRelabels: {}    # Map of metric labels and values to add
+#      additionalMetricsRelabels: {}    # Map of metric labels and values to add, or a list of full relabeling specs. Overrides value set in `defaults`
 #      additionalRelabels: []           # relabelings of metrics
 #      module: example_module           # Name of the module to pick up from `config.yaml` for scraping this target. Optional. Default is `default` provided by the exporter itself.
 


### PR DESCRIPTION
#### What this PR does / why we need it

The `serviceMonitor` `additionalMetricsRelabels` value only accepts a map of
`targetLabel: replacement` pairs, each rendered as a `replace` metric
relabeling. That excludes the rest of the Prometheus relabeling spec (`regex`,
`sourceLabels`, `drop`/`keep`, `labelmap`, and so on).

This change lets `additionalMetricsRelabels` also accept a list of full
relabeling objects, rendered verbatim after the two built-in `instance`/`target`
relabelings. It mirrors how `additionalRelabels` already handles `relabelings`
in the same template. The value type is detected with `kindIs "slice"`, which
is already used elsewhere in the repo (`kube-state-metrics`,
`kube-prometheus-stack`).

```yaml
serviceMonitor:
  targets:
    - name: example
      url: http://example.com/healthz
      # map form (unchanged)
      additionalMetricsRelabels:
        team: backend
    - name: example2
      url: http://example.com/metrics
      # list form (new)
      additionalMetricsRelabels:
        - sourceLabels: [__name__]
          regex: 'go_.*'
          action: drop
```

Both per-target and `serviceMonitor.defaults` accept either form, with the
per-target value taking precedence as before. The map form renders identical
output to today, so this is backward compatible and bumped as a minor version.

A `servicemonitor` unittest suite is added (the chart had none) covering the map
form, the list form, `defaults` precedence, and empty map/list inputs.

#### Which issue this PR fixes

- fixes #6924

#### Special notes for your reviewer

Verified with the pinned CI tooling:

```console
helm unittest --strict --file 'unittests/**/*.yaml' charts/prometheus-json-exporter
ct lint --charts charts/prometheus-json-exporter
```

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
