### PR TITLE
[prometheus-smartctl-exporter] Add podLabels support

### DIFF
--- a/charts/prometheus-smartctl-exporter/Chart.yaml
+++ b/charts/prometheus-smartctl-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.16.2
+version: 0.17.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/prometheus-smartctl-exporter/Chart.yaml
+++ b/charts/prometheus-smartctl-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.16.1
+version: 0.16.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/prometheus-smartctl-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-smartctl-exporter/templates/daemonset.yaml
@@ -33,6 +33,9 @@ spec:
       labels:
         {{- include "prometheus-smartctl-exporter.selectorLabels" $global | nindent 8 }}
         idx: i{{ $idx }}
+        {{- with $global.Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- if $global.Values.image.pullSecrets }}
       imagePullSecrets:

--- a/charts/prometheus-smartctl-exporter/values.yaml
+++ b/charts/prometheus-smartctl-exporter/values.yaml
@@ -150,6 +150,9 @@ priorityClassName: ""
 
 annotations: {}
 
+# Additional annotations to add to the exporter pods.
+podAnnotations: {}
+
 # Additional labels to add to the exporter pods.
 podLabels: {}
 

--- a/charts/prometheus-smartctl-exporter/values.yaml
+++ b/charts/prometheus-smartctl-exporter/values.yaml
@@ -150,6 +150,9 @@ priorityClassName: ""
 
 annotations: {}
 
+# Additional labels to add to the exporter pods.
+podLabels: {}
+
 nodeSelector: {}
 
 tolerations:


### PR DESCRIPTION
## What this PR does

Adds a `podLabels` value to the **prometheus-smartctl-exporter** chart and renders it on the DaemonSet pod template, mirroring the existing `podAnnotations` handling.

## Why

The pod template only emitted selector labels, so there was no way to attach custom labels to the exporter pods — commonly needed for GitOps tooling, cost-allocation, and NetworkPolicy pod selectors. Requested in #6909.

## Notes

- `podLabels` defaults to `{}`, so the rendered DaemonSet is unchanged unless set.
- Verified with `helm template --set podLabels.team=storage` (label appears on the pod) and default render (unchanged). `helm lint` passes.
- Chart version bumped 0.16.1 → 0.16.2.

Closes #6909
