### PR TITLE
[prometheus-snmp-exporter] Add podLabels support

### DIFF
--- a/charts/prometheus-snmp-exporter/Chart.yaml
+++ b/charts/prometheus-snmp-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus SNMP Exporter
 name: prometheus-snmp-exporter
-version: 9.14.0
+version: 9.14.1
 # renovate: github=prometheus/snmp_exporter
 appVersion: v0.30.1
 home: https://github.com/prometheus/snmp_exporter

--- a/charts/prometheus-snmp-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-snmp-exporter/templates/daemonset.yaml
@@ -14,6 +14,9 @@ spec:
     metadata:
       labels:
         {{- include "prometheus-snmp-exporter.labels" . | indent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
 {{ toYaml .Values.podAnnotations | indent 8 }}
     spec:

--- a/charts/prometheus-snmp-exporter/templates/deployment.yaml
+++ b/charts/prometheus-snmp-exporter/templates/deployment.yaml
@@ -17,6 +17,9 @@ spec:
     metadata:
       labels:
         {{- include "prometheus-snmp-exporter.labels" . | indent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
 {{ toYaml .Values.podAnnotations | indent 8 }}
     spec:

--- a/charts/prometheus-snmp-exporter/values.yaml
+++ b/charts/prometheus-snmp-exporter/values.yaml
@@ -134,6 +134,9 @@ ingress:
 
 podAnnotations: {}
 
+# Additional labels to add to the exporter pods.
+podLabels: {}
+
 extraArgs: []
 # - --history.limit=1000
 


### PR DESCRIPTION
## What this PR does

Adds a `podLabels` value to the **prometheus-snmp-exporter** chart and renders it on both the Deployment and DaemonSet pod templates (the chart renders one or the other via `.Values.kind`), mirroring the existing `podAnnotations` handling.

## Why

The pod templates only emitted the chart labels, so there was no way to attach custom labels to the exporter pods — commonly needed for GitOps tooling, cost-allocation, and NetworkPolicy pod selectors.

## Notes

- `podLabels` defaults to `{}` (guarded with `{{- with }}`), so the rendered workload is unchanged unless set.
- Verified with `helm template --set podLabels.team=neteng` for both `kind: Deployment` (default) and `kind: DaemonSet` (label appears on the pod in both), and default render unchanged. `helm lint` passes.
- Chart version bumped 9.14.0 → 9.14.1.
