### PR TITLE
[prometheus-smartctl-exporter] fix SmartCTLDeviceStatus alert to use renamed smartctl_device_smart_status metric

### DIFF
--- a/charts/prometheus-smartctl-exporter/Chart.yaml
+++ b/charts/prometheus-smartctl-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.17.0
+version: 0.17.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/prometheus-smartctl-exporter/values.yaml
+++ b/charts/prometheus-smartctl-exporter/values.yaml
@@ -79,7 +79,7 @@ prometheusRules:
     smartCTLDeviceStatus:
       enabled: true
       alert: SmartCTLDeviceStatus
-      expr: smartctl_device_status != 1
+      expr: smartctl_device_smart_status != 1
       for: 1m
       annotations:
         summary: Device has bad status


### PR DESCRIPTION
Closes #6949

## Problem
The `SmartCTLDeviceStatus` alert in `charts/prometheus-smartctl-exporter/values.yaml` uses the metric `smartctl_device_status`. The upstream exporter renamed that metric to `smartctl_device_smart_status` and the old name is gone as of the chart's pinned `appVersion: v0.14.0` — so the alert references a metric that no longer exists and can never fire.

Verified against the exporter at tag `v0.14.0`:
- `smartctl_device_status`: **0** occurrences in `metrics.go` (removed).
- `smartctl_device_smart_status`: defined in `metrics.go` (`metricDeviceSmartStatus`, "General smart status").

## Fix
Point the alert at the current metric name. The value semantics are unchanged — `smartctl_device_smart_status` is set from `smart_status.passed` (`1` = passed), exactly like the old metric — so the `!= 1` condition (alert when SMART status is not passing) carries over directly. One-line `expr` change plus the conventional chart `version` patch bump (`0.17.0` → `0.17.1`).

## Verification
- `helm lint` passes.
- `helm template --set prometheusRules.enabled=true` renders `expr: smartctl_device_smart_status != 1`; the old name no longer appears anywhere in the rendered output.