### PR TITLE
[prometheus-statsd-exporter] Add Gateway API HTTPRoute support

### DIFF
--- a/charts/prometheus-statsd-exporter/Chart.yaml
+++ b/charts/prometheus-statsd-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus-statsd-exporter
 description: A Helm chart for prometheus stats-exporter
-version: 1.0.0
+version: 1.1.0
 appVersion: v0.28.0
 home: https://github.com/prometheus/statsd_exporter
 sources:

--- a/charts/prometheus-statsd-exporter/ci/httproute-values.yaml
+++ b/charts/prometheus-statsd-exporter/ci/httproute-values.yaml
@@ -1,0 +1,20 @@
+---
+## Test case: httproute
+route:
+  main:
+    enabled: true
+    hostnames:
+      - "an.example.com"
+    parentRefs:
+      - name: contour
+    filters:
+      - type: RequestHeaderModifier
+        requestHeaderModifier:
+          set:
+            - name: my-header-name
+              value: my-new-header-value
+    additionalRules:
+      - filters:
+          - type: RequestHeaderModifier
+            requestHeaderModifier:
+              remove: ["x-request-id"]

--- a/charts/prometheus-statsd-exporter/templates/route.yaml
+++ b/charts/prometheus-statsd-exporter/templates/route.yaml
@@ -1,0 +1,46 @@
+{{- range $name, $route := .Values.route }}
+{{- if $route.enabled }}
+---
+apiVersion: {{ $route.apiVersion | default "gateway.networking.k8s.io/v1" }}
+kind: {{ $route.kind | default "HTTPRoute" }}
+metadata:
+  {{- with $route.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  name: {{ include "prometheus-statsd-exporter.fullname" $ }}
+  labels:
+    {{- include "prometheus-statsd-exporter.labels" $ | nindent 4 }}
+    {{- with $route.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with $route.parentRefs }}
+  parentRefs: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $route.hostnames }}
+  hostnames: {{ tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- with $route.additionalRules }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+    {{- if $route.httpsRedirect }}
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+    {{- else }}
+    - name: {{ $route.name | default $name }}
+      backendRefs:
+        - name: {{ include "prometheus-statsd-exporter.fullname" $ }}
+          port: {{ $.Values.service.port }}
+      {{- with $route.filters }}
+      filters: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $route.matches }}
+      matches: {{ toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/prometheus-statsd-exporter/values.yaml
+++ b/charts/prometheus-statsd-exporter/values.yaml
@@ -174,3 +174,54 @@ tolerations: []
 affinity: {}
 
 topologySpreadConstraints: []
+
+## A HTTPRoute (Gateway API) resource is an alternative to Ingress for routing
+## external HTTP traffic to the statsd exporter Service.
+## ref: https://gateway-api.sigs.k8s.io/api-types/httproute/
+route:
+  main:
+    ## Enable this route
+    enabled: false
+
+    ## ApiVersion set by default to "gateway.networking.k8s.io/v1"
+    apiVersion: ""
+    ## kind set by default to HTTPRoute
+    kind: ""
+
+    ## Optional name for the default rule in the rendered HTTPRoute.
+    name: ""
+
+    ## Annotations to attach to the HTTPRoute resource
+    annotations: {}
+    ## Labels to attach to the HTTPRoute resource
+    labels: {}
+
+    ## ParentRefs refers to resources this HTTPRoute is to be attached to (Gateways)
+    parentRefs: []
+      # - name: contour
+      #   sectionName: http
+
+    ## Hostnames (templated) defines a set of hostnames that should match against the HTTP Host
+    ## header to select a HTTPRoute used to process the request
+    hostnames: []
+      # - my.example.com
+
+    ## additionalRules (templated) allows adding custom rules to the route
+    additionalRules: []
+
+    ## Filters define the filters that are applied to requests that match
+    ## this rule
+    filters: []
+
+    ## Matches define conditions used for matching the rule against incoming
+    ## HTTP requests
+    matches:
+      - path:
+          type: PathPrefix
+          value: /
+
+    ## httpsRedirect adds a filter for redirecting to https (HTTP 301 Moved Permanently).
+    ## To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners.
+    ## Matches and filters do not take effect if enabled.
+    ## Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
+    httpsRedirect: false


### PR DESCRIPTION
Add Gateway API HTTPRoute support to the prometheus-statsd-exporter chart, mirroring the pattern already merged for the prometheus, prometheus-pushgateway, alertmanager, prometheus-blackbox-exporter, and prometheus-json-exporter charts.

The HTTPRoute is opt-in and disabled by default, so the default render is unchanged.

Validation:
- `helm template` renders nothing when `route.main.enabled=false` (default)
- `helm template` renders a valid HTTPRoute with `ci/httproute-values.yaml` (numeric backend port, parentRefs, hostnames, filters, additionalRules)
- `httpsRedirect=true` renders only the RequestRedirect filter
- `ct lint --config .github/linters/ct.yaml` passes
- `helm install --dry-run=server` against a kind cluster with Gateway API CRDs validates the rendered HTTPRoute against the live CRD schema

- [x] DCO signed
