### PR TITLE
[prometheus-cloudwatch-exporter] Add Gateway API HTTPRoute support

### DIFF
--- a/charts/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/charts/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.16.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.28.1
+version: 0.29.0
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
   - https://github.com/prometheus/cloudwatch_exporter

--- a/charts/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/charts/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.16.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.28.2
+version: 0.29.0
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
   - https://github.com/prometheus/cloudwatch_exporter

--- a/charts/prometheus-cloudwatch-exporter/ci/httproute-values.yaml
+++ b/charts/prometheus-cloudwatch-exporter/ci/httproute-values.yaml
@@ -1,0 +1,20 @@
+---
+## Test case: httproute
+route:
+  main:
+    enabled: true
+    hostnames:
+      - "an.example.com"
+    parentRefs:
+      - name: contour
+    filters:
+      - type: RequestHeaderModifier
+        requestHeaderModifier:
+          set:
+            - name: my-header-name
+              value: my-new-header-value
+    additionalRules:
+      - filters:
+          - type: RequestHeaderModifier
+            requestHeaderModifier:
+              remove: ["x-request-id"]

--- a/charts/prometheus-cloudwatch-exporter/templates/route.yaml
+++ b/charts/prometheus-cloudwatch-exporter/templates/route.yaml
@@ -1,0 +1,50 @@
+{{- range $name, $route := .Values.route }}
+{{- if $route.enabled }}
+---
+apiVersion: {{ $route.apiVersion | default "gateway.networking.k8s.io/v1" }}
+kind: {{ $route.kind | default "HTTPRoute" }}
+metadata:
+  {{- with $route.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  name: {{ include "prometheus-cloudwatch-exporter.fullname" $ }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app: {{ template "prometheus-cloudwatch-exporter.name" $ }}
+    chart: {{ template "prometheus-cloudwatch-exporter.chart" $ }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
+    {{- with $route.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with $route.parentRefs }}
+  parentRefs: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $route.hostnames }}
+  hostnames: {{ tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- with $route.additionalRules }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+    {{- if $route.httpsRedirect }}
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+    {{- else }}
+    - name: {{ $route.name | default $name }}
+      backendRefs:
+        - name: {{ include "prometheus-cloudwatch-exporter.fullname" $ }}
+          port: {{ $.Values.service.port }}
+      {{- with $route.filters }}
+      filters: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $route.matches }}
+      matches: {{ toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/prometheus-cloudwatch-exporter/values.yaml
+++ b/charts/prometheus-cloudwatch-exporter/values.yaml
@@ -250,3 +250,54 @@ podDisruptionBudget:
   enabled: false
   maxUnavailable: 1
   # minAvailable: 2
+
+## A HTTPRoute (Gateway API) resource is an alternative to Ingress for routing
+## external HTTP traffic to the cloudwatch exporter Service.
+## ref: https://gateway-api.sigs.k8s.io/api-types/httproute/
+route:
+  main:
+    ## Enable this route
+    enabled: false
+
+    ## ApiVersion set by default to "gateway.networking.k8s.io/v1"
+    apiVersion: ""
+    ## kind set by default to HTTPRoute
+    kind: ""
+
+    ## Optional name for the default rule in the rendered HTTPRoute.
+    name: ""
+
+    ## Annotations to attach to the HTTPRoute resource
+    annotations: {}
+    ## Labels to attach to the HTTPRoute resource
+    labels: {}
+
+    ## ParentRefs refers to resources this HTTPRoute is to be attached to (Gateways)
+    parentRefs: []
+      # - name: contour
+      #   sectionName: http
+
+    ## Hostnames (templated) defines a set of hostnames that should match against the HTTP Host
+    ## header to select a HTTPRoute used to process the request
+    hostnames: []
+      # - my.example.com
+
+    ## additionalRules (templated) allows adding custom rules to the route
+    additionalRules: []
+
+    ## Filters define the filters that are applied to requests that match
+    ## this rule
+    filters: []
+
+    ## Matches define conditions used for matching the rule against incoming
+    ## HTTP requests
+    matches:
+      - path:
+          type: PathPrefix
+          value: /
+
+    ## httpsRedirect adds a filter for redirecting to https (HTTP 301 Moved Permanently).
+    ## To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners.
+    ## Matches and filters do not take effect if enabled.
+    ## Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
+    httpsRedirect: false


### PR DESCRIPTION
Add Gateway API HTTPRoute support to the prometheus-cloudwatch-exporter chart, mirroring the pattern already merged for the prometheus, prometheus-pushgateway, alertmanager, prometheus-blackbox-exporter, and prometheus-json-exporter charts.

The HTTPRoute is opt-in and disabled by default, so the default render is unchanged.

Validation:
- `helm template` renders nothing when `route.main.enabled=false` (default)
- `helm template` renders a valid HTTPRoute with `ci/httproute-values.yaml` (numeric backend port, parentRefs, hostnames, filters, additionalRules)
- `httpsRedirect=true` renders only the RequestRedirect filter
- `ct lint --config .github/linters/ct.yaml` passes
- `helm install --dry-run=server` against a kind cluster with Gateway API CRDs validates the rendered HTTPRoute against the live CRD schema

- [x] DCO signed
