### PR TITLE
[prometheus-pingmesh-exporter] Add Gateway API HTTPRoute support

### DIFF
--- a/charts/prometheus-pingmesh-exporter/Chart.yaml
+++ b/charts/prometheus-pingmesh-exporter/Chart.yaml
@@ -15,4 +15,4 @@ name: prometheus-pingmesh-exporter
 sources:
   - https://github.com/kubeservice-stack/pingmesh-agent
 type: application
-version: 0.4.3
+version: 0.5.0

--- a/charts/prometheus-pingmesh-exporter/ci/httproute-values.yaml
+++ b/charts/prometheus-pingmesh-exporter/ci/httproute-values.yaml
@@ -1,0 +1,20 @@
+---
+## Test case: httproute
+route:
+  main:
+    enabled: true
+    hostnames:
+      - "an.example.com"
+    parentRefs:
+      - name: contour
+    filters:
+      - type: RequestHeaderModifier
+        requestHeaderModifier:
+          set:
+            - name: my-header-name
+              value: my-new-header-value
+    additionalRules:
+      - filters:
+          - type: RequestHeaderModifier
+            requestHeaderModifier:
+              remove: ["x-request-id"]

--- a/charts/prometheus-pingmesh-exporter/templates/route.yaml
+++ b/charts/prometheus-pingmesh-exporter/templates/route.yaml
@@ -1,0 +1,47 @@
+{{- range $name, $route := .Values.route }}
+{{- if $route.enabled }}
+---
+apiVersion: {{ $route.apiVersion | default "gateway.networking.k8s.io/v1" }}
+kind: {{ $route.kind | default "HTTPRoute" }}
+metadata:
+  {{- with $route.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  name: {{ include "prometheus-pingmesh-exporter.fullname" $ }}
+  namespace: {{ include "prometheus-pingmesh-exporter.namespace" $ }}
+  labels:
+    {{- include "prometheus-pingmesh-exporter.labels" $ | nindent 4 }}
+    {{- with $route.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with $route.parentRefs }}
+  parentRefs: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $route.hostnames }}
+  hostnames: {{ tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- with $route.additionalRules }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+    {{- if $route.httpsRedirect }}
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+    {{- else }}
+    - name: {{ $route.name | default $name }}
+      backendRefs:
+        - name: {{ include "prometheus-pingmesh-exporter.fullname" $ }}
+          port: {{ $.Values.service.port }}
+      {{- with $route.filters }}
+      filters: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $route.matches }}
+      matches: {{ toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/prometheus-pingmesh-exporter/values.yaml
+++ b/charts/prometheus-pingmesh-exporter/values.yaml
@@ -199,13 +199,13 @@ config:
       dns:
         transport_protocol: "tcp"
         preferred_ip_protocol: "ip4"
-        query_name: "kubernetes.defalut.svc.cluster.local"
+        query_name: "kubernetes.default.svc.cluster.local"
     dns_ipv6:
       prober: dns
       dns:
         transport_protocol: "tcp"
         preferred_ip_protocol: "ip6"
-        query_name: "kubernetes.defalut.svc.cluster.local"
+        query_name: "kubernetes.default.svc.cluster.local"
 
 pinglistConfig:
   setting:
@@ -403,3 +403,54 @@ dnsConfig:
       value: '3'
     - name: ndots
       value: '3'
+
+## A HTTPRoute (Gateway API) resource is an alternative to Ingress for routing
+## external HTTP traffic to the pingmesh exporter Service.
+## ref: https://gateway-api.sigs.k8s.io/api-types/httproute/
+route:
+  main:
+    ## Enable this route
+    enabled: false
+
+    ## ApiVersion set by default to "gateway.networking.k8s.io/v1"
+    apiVersion: ""
+    ## kind set by default to HTTPRoute
+    kind: ""
+
+    ## Optional name for the default rule in the rendered HTTPRoute.
+    name: ""
+
+    ## Annotations to attach to the HTTPRoute resource
+    annotations: {}
+    ## Labels to attach to the HTTPRoute resource
+    labels: {}
+
+    ## ParentRefs refers to resources this HTTPRoute is to be attached to (Gateways)
+    parentRefs: []
+      # - name: contour
+      #   sectionName: http
+
+    ## Hostnames (templated) defines a set of hostnames that should match against the HTTP Host
+    ## header to select a HTTPRoute used to process the request
+    hostnames: []
+      # - my.example.com
+
+    ## additionalRules (templated) allows adding custom rules to the route
+    additionalRules: []
+
+    ## Filters define the filters that are applied to requests that match
+    ## this rule
+    filters: []
+
+    ## Matches define conditions used for matching the rule against incoming
+    ## HTTP requests
+    matches:
+      - path:
+          type: PathPrefix
+          value: /
+
+    ## httpsRedirect adds a filter for redirecting to https (HTTP 301 Moved Permanently).
+    ## To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners.
+    ## Matches and filters do not take effect if enabled.
+    ## Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
+    httpsRedirect: false


### PR DESCRIPTION
Add Gateway API HTTPRoute support to the prometheus-pingmesh-exporter chart, mirroring the pattern already merged for the prometheus, prometheus-pushgateway, alertmanager, prometheus-blackbox-exporter, and prometheus-json-exporter charts.

The HTTPRoute is opt-in and disabled by default, so the default render is unchanged.

Validation:
- `helm template` renders nothing when `route.main.enabled=false` (default)
- `helm template` renders a valid HTTPRoute with `ci/httproute-values.yaml` (numeric backend port, parentRefs, hostnames, filters, additionalRules)
- `httpsRedirect=true` renders only the RequestRedirect filter
- `ct lint --config .github/linters/ct.yaml` passes
- `helm install --dry-run=server` against a kind cluster with Gateway API CRDs validates the rendered HTTPRoute against the live CRD schema

- [x] DCO signed



Note: also corrected two pre-existing `defalut` -> `default` typos in `values.yaml` (codespell, flagged by the repo CI super-linter once the file was touched).
