### PR TITLE
[jiralert] Add Gateway API HTTPRoute support

### DIFF
--- a/charts/jiralert/Chart.yaml
+++ b/charts/jiralert/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jiralert
 description: A Helm chart for Kubernetes to install jiralert
 type: application
-version: 1.8.2
+version: 1.9.0
 appVersion: "v1.3.0"
 home: "https://github.com/prometheus-community/jiralert"
 icon: https://raw.githubusercontent.com/cncf/artwork/master/prometheus/icon/color/prometheus-icon-color.svg

--- a/charts/jiralert/ci/httproute-values.yaml
+++ b/charts/jiralert/ci/httproute-values.yaml
@@ -1,0 +1,29 @@
+---
+## Test case: httproute
+## jiralert requires at least one receiver for the pod to start, so the
+## install test mirrors ci/test-values.yaml's minimal config.
+config:
+  defaults:
+    user: jiraUser
+    password: jiraToken
+  receivers:
+    - name: 'default'
+      project: EXAMPLE
+route:
+  main:
+    enabled: true
+    hostnames:
+      - "an.example.com"
+    parentRefs:
+      - name: contour
+    filters:
+      - type: RequestHeaderModifier
+        requestHeaderModifier:
+          set:
+            - name: my-header-name
+              value: my-new-header-value
+    additionalRules:
+      - filters:
+          - type: RequestHeaderModifier
+            requestHeaderModifier:
+              remove: ["x-request-id"]

--- a/charts/jiralert/templates/route.yaml
+++ b/charts/jiralert/templates/route.yaml
@@ -1,0 +1,47 @@
+{{- range $name, $route := .Values.route }}
+{{- if $route.enabled }}
+---
+apiVersion: {{ $route.apiVersion | default "gateway.networking.k8s.io/v1" }}
+kind: {{ $route.kind | default "HTTPRoute" }}
+metadata:
+  {{- with $route.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  name: {{ include "jiralert.fullname" $ }}
+  namespace: {{ include "jiralert.namespace" $ }}
+  labels:
+    {{- include "jiralert.labels" $ | nindent 4 }}
+    {{- with $route.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with $route.parentRefs }}
+  parentRefs: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $route.hostnames }}
+  hostnames: {{ tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- with $route.additionalRules }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+    {{- if $route.httpsRedirect }}
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+    {{- else }}
+    - name: {{ $route.name | default $name }}
+      backendRefs:
+        - name: {{ include "jiralert.fullname" $ }}
+          port: 9097
+      {{- with $route.filters }}
+      filters: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $route.matches }}
+      matches: {{ toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/jiralert/values.yaml
+++ b/charts/jiralert/values.yaml
@@ -238,3 +238,54 @@ serviceMonitor:
   #   targetLabel: nodename
   #   replacement: $1
   #   action: replace
+
+## A HTTPRoute (Gateway API) resource is an alternative to Ingress for routing
+## external HTTP traffic to the jiralert Service.
+## ref: https://gateway-api.sigs.k8s.io/api-types/httproute/
+route:
+  main:
+    ## Enable this route
+    enabled: false
+
+    ## ApiVersion set by default to "gateway.networking.k8s.io/v1"
+    apiVersion: ""
+    ## kind set by default to HTTPRoute
+    kind: ""
+
+    ## Optional name for the default rule in the rendered HTTPRoute.
+    name: ""
+
+    ## Annotations to attach to the HTTPRoute resource
+    annotations: {}
+    ## Labels to attach to the HTTPRoute resource
+    labels: {}
+
+    ## ParentRefs refers to resources this HTTPRoute is to be attached to (Gateways)
+    parentRefs: []
+      # - name: contour
+      #   sectionName: http
+
+    ## Hostnames (templated) defines a set of hostnames that should match against the HTTP Host
+    ## header to select a HTTPRoute used to process the request
+    hostnames: []
+      # - my.example.com
+
+    ## additionalRules (templated) allows adding custom rules to the route
+    additionalRules: []
+
+    ## Filters define the filters that are applied to requests that match
+    ## this rule
+    filters: []
+
+    ## Matches define conditions used for matching the rule against incoming
+    ## HTTP requests
+    matches:
+      - path:
+          type: PathPrefix
+          value: /
+
+    ## httpsRedirect adds a filter for redirecting to https (HTTP 301 Moved Permanently).
+    ## To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners.
+    ## Matches and filters do not take effect if enabled.
+    ## Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
+    httpsRedirect: false


### PR DESCRIPTION
Add Gateway API HTTPRoute support to the jiralert chart, mirroring the pattern already merged for the prometheus, prometheus-pushgateway, alertmanager, prometheus-blackbox-exporter, and prometheus-json-exporter charts.

The HTTPRoute is opt-in and disabled by default, so the default render is unchanged.

Validation:
- `helm template` renders nothing when `route.main.enabled=false` (default)
- `helm template` renders a valid HTTPRoute with `ci/httproute-values.yaml` (numeric backend port, parentRefs, hostnames, filters, additionalRules)
- `httpsRedirect=true` renders only the RequestRedirect filter
- `ct lint --config .github/linters/ct.yaml` passes
- `helm install --dry-run=server` against a kind cluster with Gateway API CRDs validates the rendered HTTPRoute against the live CRD schema

- [x] DCO signed
