### PR TITLE
[prometheus-blackbox-exporter] support tpl in probe target URLs

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 11.13.0
+version: 11.14.0
 # renovate: github=prometheus/blackbox_exporter
 appVersion: v0.28.0
 kubeVersion: ">=1.21.0-0"

--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 11.14.0
+version: 11.15.0
 # renovate: github=prometheus/blackbox_exporter
 appVersion: v0.28.0
 kubeVersion: ">=1.21.0-0"

--- a/charts/prometheus-blackbox-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/servicemonitor.yaml
@@ -29,7 +29,7 @@ spec:
       module:
       - {{ .module | default $.Values.serviceMonitor.defaults.module }}
       target:
-      - {{ .url }}
+      - {{ tpl .url $ }}
       {{- if .hostname }}
       hostname:
       - {{ .hostname }}
@@ -37,7 +37,7 @@ spec:
     metricRelabelings:
       - sourceLabels: [instance]
         targetLabel: instance
-        replacement: {{ .url }}
+        replacement: {{ tpl .url $ }}
         action: replace
       - sourceLabels: [target]
         targetLabel: target


### PR DESCRIPTION
## What this PR does

Wraps `.url` with `tpl` in the ServiceMonitor template so users can use Helm template expressions in probe target URLs.

**Before:**
\`\`\`yaml
target:
- {{ .url }}
\`\`\`

**After:**
\`\`\`yaml
target:
- {{ tpl .url $ }}
\`\`\`

## Motivation

In multi-cluster ArgoCD deployments, users want to define probe targets like:
\`\`\`yaml
url: "grafana.{{ .Values.clusterName }}.org.com"
\`\`\`
Without `tpl`, the expression is passed verbatim to Prometheus instead of being rendered at deploy time. This forces teams to maintain 25+ per-cluster values files just to vary the URL domain.

Closes #6776