### PR TITLE
[prometheus-blackbox-exporter] use kubernetes.io/metadata.name in NetworkPolicy

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 11.13.0
+version: 11.14.0
 # renovate: github=prometheus/blackbox_exporter
 appVersion: v0.28.0
 kubeVersion: ">=1.21.0-0"

--- a/charts/prometheus-blackbox-exporter/templates/networkpolicy.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/networkpolicy.yaml
@@ -15,7 +15,7 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          name: {{ .Values.networkPolicy.monitoringNamespaceName }}
+          kubernetes.io/metadata.name: {{ .Values.networkPolicy.monitoringNamespaceName }}
     ports:
     - port: {{ .Values.service.port }}
       protocol: TCP

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -435,7 +435,7 @@ networkPolicy:
   # Enable network policy and allow access from anywhere
   enabled: false
   # Limit access only from monitoring namespace
-  # Before setting this value to true, you must add the name=monitoring label to the monitoring namespace.  Name can be rewritten by monitoringNamespaceName
+  # Before setting this value to true, the monitoring namespace must exist. Kubernetes automatically sets the kubernetes.io/metadata.name label on all namespaces. The namespace name can be configured via monitoringNamespaceName
   # Network Policy uses label filtering
   allowMonitoringNamespace: false
   # Rewrite monitoring namespace in network policy (default value monitoring)


### PR DESCRIPTION
## What this PR does

Replaces the custom `name:` label with the well-known `kubernetes.io/metadata.name` label in the NetworkPolicy `namespaceSelector`.

**Before:**
\`\`\`yaml
namespaceSelector:
  matchLabels:
    name: monitoring
\`\`\`

**After:**
\`\`\`yaml
namespaceSelector:
  matchLabels:
    kubernetes.io/metadata.name: monitoring
\`\`\`

## Motivation

The previous implementation required users to manually add a `name=monitoring` label to their monitoring namespace before enabling `networkPolicy.allowMonitoringNamespace`. This is fragile: many users don't control the monitoring namespace (e.g., it's managed by a platform team or a third-party operator).

Kubernetes automatically sets `kubernetes.io/metadata.name` on every namespace as a [well-known label](https://kubernetes.io/docs/reference/labels-annotations-taints/#kubernetes-io-metadata-name), so no manual labeling is needed. This is also the recommended approach per Kubernetes docs.

Closes #6640