### PR TITLE
[kube-prometheus-stack] render containers and initContainers with tpl

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 87.2.1
+version: 87.3.0
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.92.0
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -386,11 +386,11 @@ spec:
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.containers }}
   containers:
-{{ toYaml .Values.prometheus.prometheusSpec.containers | indent 4 }}
+{{ tpl (toYaml .Values.prometheus.prometheusSpec.containers) . | indent 4 }}
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.initContainers }}
   initContainers:
-{{ toYaml .Values.prometheus.prometheusSpec.initContainers | indent 4 }}
+{{ tpl (toYaml .Values.prometheus.prometheusSpec.initContainers) . | indent 4 }}
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.priorityClassName }}
   priorityClassName: {{ .Values.prometheus.prometheusSpec.priorityClassName }}


### PR DESCRIPTION
## What this PR does

Wraps `prometheusSpec.containers` and `prometheusSpec.initContainers` with `tpl` so Helm template expressions are evaluated inside container definitions.

**Before:**
\`\`\`yaml
containers:
{{ toYaml .Values.prometheus.prometheusSpec.containers | indent 4 }}
\`\`\`

**After:**
\`\`\`yaml
containers:
{{ tpl (toYaml .Values.prometheus.prometheusSpec.containers) . | indent 4 }}
\`\`\`

## Motivation

Users running multiple extra containers (e.g., sidecars) need to reference global values like image registry overrides. Without `tpl`, expressions like `"{{ .Values.global.imageRegistry }}/my-sidecar:latest"` are passed verbatim to the Kubernetes API instead of being resolved at deploy time.

This pattern is already used for other fields in the same file (`externalLabels`, `secrets`, `configMaps`, `storageSpec`, `podMetadata`, etc.), making this a natural consistency fix.

Closes #7033