### PR TITLE
[prometheus-fastly-exporter] Add extraManifests support

### DIFF
--- a/charts/prometheus-fastly-exporter/Chart.yaml
+++ b/charts/prometheus-fastly-exporter/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: "v10.2.0"
 description: A Helm chart for the Prometheus Fastly Exporter
 name: prometheus-fastly-exporter
-version: 0.12.0
+version: 0.13.0
 keywords:
   - metrics
   - fastly

--- a/charts/prometheus-fastly-exporter/ci/extramanifests-values.yaml
+++ b/charts/prometheus-fastly-exporter/ci/extramanifests-values.yaml
@@ -1,0 +1,13 @@
+extraManifests:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: '{{ include "prometheus-fastly-exporter.fullname" . }}-extra-cm1'
+  data:
+    extra-data: "value1"
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: '{{ include "prometheus-fastly-exporter.fullname" . }}-extra-secret1'
+  stringData:
+    secret: "value"

--- a/charts/prometheus-fastly-exporter/templates/extra-manifests.yaml
+++ b/charts/prometheus-fastly-exporter/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/prometheus-fastly-exporter/values.yaml
+++ b/charts/prometheus-fastly-exporter/values.yaml
@@ -32,6 +32,24 @@ existingSecret:
 nameOverride: ""
 fullnameOverride: ""
 
+## Extra manifests to deploy as an array
+extraManifests: []
+  # - apiVersion: external-secrets.io/v1
+  #   kind: ExternalSecret
+  #   metadata:
+  #     name: fastly-exporter-token
+  #   spec:
+  #     refreshInterval: 1h
+  #     secretStoreRef:
+  #       name: example-store
+  #       kind: ClusterSecretStore
+  #     target:
+  #       name: fastly-exporter-token
+  #     data:
+  #       - secretKey: token
+  #         remoteRef:
+  #           key: fastly-api-token
+
 # Flags - for a list visit https://github.com/fastly/fastly-exporter#filtering-services
 # Repeatable flags accept a list to generate multiple args with the same key.
 options:


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

Adds an `extraManifests` value to allow users to deploy additional manifests alongside the chart (e.g. `ExternalSecret`, custom `ConfigMap`).

Currently the chart does not provide an extension point for related resources, making it awkward to manage e.g. an ESO `ExternalSecret` that provisions the Fastly API token in the same Helm release.

Default is an empty list, so existing users are unaffected.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
