### PR TITLE
[prometheus-yet-another-cloudwatch-exporter] use configurable portName for service targetPort

### DIFF
--- a/charts/prometheus-yet-another-cloudwatch-exporter/Chart.yaml
+++ b/charts/prometheus-yet-another-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-yet-another-cloudwatch-exporter
 description: Yace - Yet Another CloudWatch Exporter
 type: application
-version: 0.46.0
+version: 0.46.1
 # renovate: github-releases=prometheus-community/yet-another-cloudwatch-exporter
 appVersion: "v0.65.0"
 home: https://github.com/prometheus-community/helm-charts

--- a/charts/prometheus-yet-another-cloudwatch-exporter/templates/service.yaml
+++ b/charts/prometheus-yet-another-cloudwatch-exporter/templates/service.yaml
@@ -13,8 +13,8 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: {{ .Values.portName }}
       protocol: TCP
-      name: http
+      name: {{ .Values.portName }}
   selector:
     {{- include "yet-another-cloudwatch-exporter.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
## What this PR does

The container port name is configurable via `.Values.portName` in the deployment ([`templates/deployment.yaml`](https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus-yet-another-cloudwatch-exporter/templates/deployment.yaml#L104)), but the Service hardcoded both `targetPort` and the port `name` as `http`.

Setting `portName` to anything other than `http` broke the Service → Pod port resolution, since the Service's `targetPort: http` no longer matched the container port name.

This change makes the Service use `.Values.portName` for both `targetPort` and `name`, keeping them in sync with the deployment.

## Backward compatibility

`portName` defaults to `http` in `values.yaml`, so existing installs render identically — no behavior change unless the user has overridden `portName`.

## Checklist
- [x] Chart version bumped (0.46.0 → 0.46.1, patch — backward-compatible)
- [x] DCO sign-off
- [x] Single chart in this PR