### PR TITLE
[alertmanager-snmp-notifier] Add Gateway API HTTPRoute support

### DIFF
--- a/charts/alertmanager-snmp-notifier/Chart.yaml
+++ b/charts/alertmanager-snmp-notifier/Chart.yaml
@@ -5,7 +5,7 @@ home: https://github.com/maxwo/snmp_notifier
 sources:
   - https://github.com/maxwo/snmp_notifier
 type: application
-version: 2.1.0
+version: 2.2.0
 # renovate: github-releases=maxwo/snmp_notifier
 appVersion: v2.1.0
 kubeVersion: ">=1.23.0-0"

--- a/charts/alertmanager-snmp-notifier/Chart.yaml
+++ b/charts/alertmanager-snmp-notifier/Chart.yaml
@@ -5,7 +5,7 @@ home: https://github.com/maxwo/snmp_notifier
 sources:
   - https://github.com/maxwo/snmp_notifier
 type: application
-version: 2.1.1
+version: 2.2.0
 # renovate: github-releases=maxwo/snmp_notifier
 appVersion: v2.1.1
 kubeVersion: ">=1.23.0-0"

--- a/charts/alertmanager-snmp-notifier/ci/httproute-values.yaml
+++ b/charts/alertmanager-snmp-notifier/ci/httproute-values.yaml
@@ -1,5 +1,9 @@
 ---
 ## Test case: httproute
+snmpNotifier:
+  snmpDestinations:
+    - 127.0.0.1:162
+
 route:
   main:
     enabled: true

--- a/charts/alertmanager-snmp-notifier/ci/httproute-values.yaml
+++ b/charts/alertmanager-snmp-notifier/ci/httproute-values.yaml
@@ -1,0 +1,20 @@
+---
+## Test case: httproute
+route:
+  main:
+    enabled: true
+    hostnames:
+      - "an.example.com"
+    parentRefs:
+      - name: contour
+    filters:
+      - type: RequestHeaderModifier
+        requestHeaderModifier:
+          set:
+            - name: my-header-name
+              value: my-new-header-value
+    additionalRules:
+      - filters:
+          - type: RequestHeaderModifier
+            requestHeaderModifier:
+              remove: ["x-request-id"]

--- a/charts/alertmanager-snmp-notifier/templates/_helpers.tpl
+++ b/charts/alertmanager-snmp-notifier/templates/_helpers.tpl
@@ -60,3 +60,14 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Allow the release namespace to be overridden
+*/}}
+{{- define "alertmanager-snmp-notifier.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/alertmanager-snmp-notifier/templates/route.yaml
+++ b/charts/alertmanager-snmp-notifier/templates/route.yaml
@@ -1,0 +1,47 @@
+{{- range $name, $route := .Values.route }}
+{{- if $route.enabled }}
+---
+apiVersion: {{ $route.apiVersion | default "gateway.networking.k8s.io/v1" }}
+kind: {{ $route.kind | default "HTTPRoute" }}
+metadata:
+  {{- with $route.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  name: {{ include "alertmanager-snmp-notifier.fullname" $ }}
+  namespace: {{ include "alertmanager-snmp-notifier.namespace" $ }}
+  labels:
+    {{- include "alertmanager-snmp-notifier.labels" $ | nindent 4 }}
+    {{- with $route.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with $route.parentRefs }}
+  parentRefs: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $route.hostnames }}
+  hostnames: {{ tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- with $route.additionalRules }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+    {{- if $route.httpsRedirect }}
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+    {{- else }}
+    - name: {{ $route.name | default $name }}
+      backendRefs:
+        - name: {{ include "alertmanager-snmp-notifier.fullname" $ }}
+          port: {{ $.Values.service.port }}
+      {{- with $route.filters }}
+      filters: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $route.matches }}
+      matches: {{ toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/alertmanager-snmp-notifier/values.yaml
+++ b/charts/alertmanager-snmp-notifier/values.yaml
@@ -92,6 +92,9 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+## Provide a namespace to substitute for the namespace on resources
+namespaceOverride: ""
+
 service:
   type: ClusterIP
   port: 9464
@@ -115,6 +118,57 @@ ingress:
   #  - secretName: snmp-notifier-tls
   #    hosts:
   #      - snmp-notifier.local
+
+## A HTTPRoute (Gateway API) resource is an alternative to Ingress for routing
+## external HTTP traffic to the SNMP notifier Service.
+## ref: https://gateway-api.sigs.k8s.io/api-types/httproute/
+route:
+  main:
+    ## Enable this route
+    enabled: false
+
+    ## ApiVersion set by default to "gateway.networking.k8s.io/v1"
+    apiVersion: ""
+    ## kind set by default to HTTPRoute
+    kind: ""
+
+    ## Optional name for the default rule in the rendered HTTPRoute.
+    name: ""
+
+    ## Annotations to attach to the HTTPRoute resource
+    annotations: {}
+    ## Labels to attach to the HTTPRoute resource
+    labels: {}
+
+    ## ParentRefs refers to resources this HTTPRoute is to be attached to (Gateways)
+    parentRefs: []
+      # - name: contour
+      #   sectionName: http
+
+    ## Hostnames (templated) defines a set of hostnames that should match against the HTTP Host
+    ## header to select a HTTPRoute used to process the request
+    hostnames: []
+      # - my.example.com
+
+    ## additionalRules (templated) allows adding custom rules to the route
+    additionalRules: []
+
+    ## Filters define the filters that are applied to requests that match
+    ## this rule
+    filters: []
+
+    ## Matches define conditions used for matching the rule against incoming
+    ## HTTP requests
+    matches:
+      - path:
+          type: PathPrefix
+          value: /
+
+    ## httpsRedirect adds a filter for redirecting to https (HTTP 301 Moved Permanently).
+    ## To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners.
+    ## Matches and filters do not take effect if enabled.
+    ## Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
+    httpsRedirect: false
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/alertmanager-snmp-notifier/values.yaml
+++ b/charts/alertmanager-snmp-notifier/values.yaml
@@ -19,7 +19,7 @@ snmpNotifier:
   snmpDestinations:
     - snmp-server:162
 
-  # SNMP authentication secrets, that may be instanciated by the chart, or may use an already created secret
+  # SNMP authentication secrets, that may be instantiated by the chart, or may use an already created secret
   # snmpCommunity: public
   # snmpAuthenticationUsername: my_authentication_username
   # snmpAuthenticationPassword: my_authentication_password


### PR DESCRIPTION
This adds opt-in Gateway API HTTPRoute support to the alertmanager-snmp-notifier
chart, matching the pattern already merged for sibling charts
(prometheus-snmp-exporter #7024, jiralert #7031, prometheus-blackbox-exporter #6961).

A new templates/route.yaml renders an HTTPRoute when route.<name>.enabled is set.
It is disabled by default, so existing installs are unaffected. The backendRef
targets the chart Service on .Values.service.port (9464). This also adds a
namespaceOverride helper (consistent with the sibling charts) and a
ci/httproute-values.yaml test case.

Validation (local):
- helm template: disabled by default renders no HTTPRoute; enabled renders correctly
  across parentRefs / hostnames / filters / additionalRules / httpsRedirect variants
- ct lint: passes across all 5 ci values files (default, httproute, ingress, secret, templates)

Chart version bumped 2.1.0 -> 2.2.0.