### PR TITLE
[kube-prometheus-stack] Expose additional ThanosRuler spec fields

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 87.6.0
+version: 87.7.0
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.92.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/templates/thanos-ruler/ruler.yaml
+++ b/charts/kube-prometheus-stack/templates/thanos-ruler/ruler.yaml
@@ -219,6 +219,96 @@ spec:
 {{- if .Values.thanosRuler.thanosRulerSpec.terminationGracePeriodSeconds }}
   terminationGracePeriodSeconds: {{ .Values.thanosRuler.thanosRulerSpec.terminationGracePeriodSeconds }}
 {{- end }}
+{{- if .Values.thanosRuler.thanosRulerSpec.version }}
+  version: {{ .Values.thanosRuler.thanosRulerSpec.version }}
+{{- end }}
+{{- if .Values.thanosRuler.thanosRulerSpec.imagePullPolicy }}
+  imagePullPolicy: {{ .Values.thanosRuler.thanosRulerSpec.imagePullPolicy }}
+{{- end }}
+{{- if .Values.thanosRuler.thanosRulerSpec.enableFeatures }}
+  enableFeatures:
+{{- range $enableFeatures := .Values.thanosRuler.thanosRulerSpec.enableFeatures }}
+  - {{ tpl $enableFeatures $ }}
+{{- end }}
+{{- end }}
+{{- if kindIs "bool" .Values.thanosRuler.thanosRulerSpec.enableServiceLinks }}
+  enableServiceLinks: {{ .Values.thanosRuler.thanosRulerSpec.enableServiceLinks }}
+{{- end }}
+{{- if .Values.thanosRuler.thanosRulerSpec.minReadySeconds }}
+  minReadySeconds: {{ .Values.thanosRuler.thanosRulerSpec.minReadySeconds }}
+{{- end }}
+{{- if .Values.thanosRuler.thanosRulerSpec.dnsConfig }}
+  dnsConfig:
+{{ toYaml .Values.thanosRuler.thanosRulerSpec.dnsConfig | indent 4 }}
+{{- end }}
+{{- if .Values.thanosRuler.thanosRulerSpec.dnsPolicy }}
+  dnsPolicy: {{ .Values.thanosRuler.thanosRulerSpec.dnsPolicy }}
+{{- end }}
+{{- if .Values.thanosRuler.thanosRulerSpec.hostAliases }}
+  hostAliases:
+{{ toYaml .Values.thanosRuler.thanosRulerSpec.hostAliases | indent 4 }}
+{{- end }}
+{{- if .Values.thanosRuler.thanosRulerSpec.remoteWrite }}
+  remoteWrite:
+{{ tpl (toYaml .Values.thanosRuler.thanosRulerSpec.remoteWrite | indent 4) . }}
+{{- end }}
+{{- if .Values.thanosRuler.thanosRulerSpec.tracingConfig.existingSecret }}
+  tracingConfig:
+    key: "{{ .Values.thanosRuler.thanosRulerSpec.tracingConfig.existingSecret.key }}"
+    name: "{{ .Values.thanosRuler.thanosRulerSpec.tracingConfig.existingSecret.name }}"
+{{- else if .Values.thanosRuler.thanosRulerSpec.tracingConfig.secret }}
+  tracingConfig:
+    key: tracing-configs.yaml
+    name: {{ template "kube-prometheus-stack.thanosRuler.name" . }}
+{{- end }}
+{{- if .Values.thanosRuler.thanosRulerSpec.tracingConfigFile }}
+  tracingConfigFile: "{{ .Values.thanosRuler.thanosRulerSpec.tracingConfigFile }}"
+{{- end }}
+{{- if .Values.thanosRuler.thanosRulerSpec.alertRelabelConfigs.existingSecret }}
+  alertRelabelConfigs:
+    key: "{{ .Values.thanosRuler.thanosRulerSpec.alertRelabelConfigs.existingSecret.key }}"
+    name: "{{ .Values.thanosRuler.thanosRulerSpec.alertRelabelConfigs.existingSecret.name }}"
+{{- else if .Values.thanosRuler.thanosRulerSpec.alertRelabelConfigs.secret }}
+  alertRelabelConfigs:
+    key: alert-relabel-configs.yaml
+    name: {{ template "kube-prometheus-stack.thanosRuler.name" . }}
+{{- end }}
+{{- if .Values.thanosRuler.thanosRulerSpec.alertRelabelConfigFile }}
+  alertRelabelConfigFile: "{{ .Values.thanosRuler.thanosRulerSpec.alertRelabelConfigFile }}"
+{{- end }}
+{{- if .Values.thanosRuler.thanosRulerSpec.grpcServerTlsConfig }}
+  grpcServerTlsConfig:
+{{ toYaml .Values.thanosRuler.thanosRulerSpec.grpcServerTlsConfig | indent 4 }}
+{{- end }}
+{{- if .Values.thanosRuler.thanosRulerSpec.objectStorageConfigFile }}
+  objectStorageConfigFile: "{{ .Values.thanosRuler.thanosRulerSpec.objectStorageConfigFile }}"
+{{- end }}
+{{- if .Values.thanosRuler.thanosRulerSpec.ruleConcurrentEval }}
+  ruleConcurrentEval: {{ .Values.thanosRuler.thanosRulerSpec.ruleConcurrentEval }}
+{{- end }}
+{{- if .Values.thanosRuler.thanosRulerSpec.ruleOutageTolerance }}
+  ruleOutageTolerance: {{ .Values.thanosRuler.thanosRulerSpec.ruleOutageTolerance | quote }}
+{{- end }}
+{{- if .Values.thanosRuler.thanosRulerSpec.ruleGracePeriod }}
+  ruleGracePeriod: {{ .Values.thanosRuler.thanosRulerSpec.ruleGracePeriod | quote }}
+{{- end }}
+{{- if .Values.thanosRuler.thanosRulerSpec.ruleQueryOffset }}
+  ruleQueryOffset: {{ .Values.thanosRuler.thanosRulerSpec.ruleQueryOffset | quote }}
+{{- end }}
+{{- if .Values.thanosRuler.thanosRulerSpec.resendDelay }}
+  resendDelay: {{ .Values.thanosRuler.thanosRulerSpec.resendDelay | quote }}
+{{- end }}
+{{- if .Values.thanosRuler.thanosRulerSpec.enforcedNamespaceLabel }}
+  enforcedNamespaceLabel: {{ .Values.thanosRuler.thanosRulerSpec.enforcedNamespaceLabel }}
+{{- if .Values.thanosRuler.thanosRulerSpec.excludedFromEnforcement }}
+  excludedFromEnforcement:
+  {{- if kindIs "string" .Values.thanosRuler.thanosRulerSpec.excludedFromEnforcement }}
+{{ tpl .Values.thanosRuler.thanosRulerSpec.excludedFromEnforcement . | indent 4 }}
+  {{- else }}
+{{ tpl (toYaml .Values.thanosRuler.thanosRulerSpec.excludedFromEnforcement | indent 4) . }}
+  {{- end }}
+{{- end }}
+{{- end }}
 {{- with .Values.thanosRuler.thanosRulerSpec.additionalConfig }}
   {{- tpl (toYaml .) $ | nindent 2 }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/thanos-ruler/secret.yaml
+++ b/charts/kube-prometheus-stack/templates/thanos-ruler/secret.yaml
@@ -23,4 +23,14 @@ data:
   query-configs.yaml: {{ toYaml .secret | b64enc | quote }}
   {{- end }}
   {{- end }}
+  {{- with .Values.thanosRuler.thanosRulerSpec.tracingConfig }}
+  {{- if and .secret (not .existingSecret) }}
+  tracing-configs.yaml: {{ toYaml .secret | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+  {{- with .Values.thanosRuler.thanosRulerSpec.alertRelabelConfigs }}
+  {{- if and .secret (not .existingSecret) }}
+  alert-relabel-configs.yaml: {{ toYaml .secret | b64enc | quote }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/kube-prometheus-stack/unittests/thanos-ruler/ruler_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/thanos-ruler/ruler_test.yaml
@@ -1,0 +1,126 @@
+suite: test thanos ruler
+templates:
+  - thanos-ruler/ruler.yaml
+tests:
+  - it: should be empty if thanosRuler is not enabled
+    set:
+      thanosRuler.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render the new spec fields with default values
+    set:
+      thanosRuler.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - notExists:
+          path: spec.enableFeatures
+      - notExists:
+          path: spec.enableServiceLinks
+      - notExists:
+          path: spec.remoteWrite
+      - notExists:
+          path: spec.tracingConfig
+      - notExists:
+          path: spec.alertRelabelConfigs
+      - notExists:
+          path: spec.ruleQueryOffset
+
+  - it: should render enableFeatures as a list
+    set:
+      thanosRuler.enabled: true
+      thanosRuler.thanosRulerSpec.enableFeatures:
+        - promql-experimental-functions
+    asserts:
+      - equal:
+          path: spec.enableFeatures[0]
+          value: promql-experimental-functions
+
+  - it: should render enableServiceLinks only when set to a bool
+    set:
+      thanosRuler.enabled: true
+      thanosRuler.thanosRulerSpec.enableServiceLinks: false
+    asserts:
+      - equal:
+          path: spec.enableServiceLinks
+          value: false
+
+  - it: should render rule evaluation tuning and duration fields quoted
+    set:
+      thanosRuler.enabled: true
+      thanosRuler.thanosRulerSpec.ruleConcurrentEval: 4
+      thanosRuler.thanosRulerSpec.ruleOutageTolerance: 1h
+      thanosRuler.thanosRulerSpec.ruleGracePeriod: 10m
+      thanosRuler.thanosRulerSpec.ruleQueryOffset: 30s
+      thanosRuler.thanosRulerSpec.resendDelay: 1m
+    asserts:
+      - equal:
+          path: spec.ruleConcurrentEval
+          value: 4
+      - equal:
+          path: spec.ruleOutageTolerance
+          value: "1h"
+      - equal:
+          path: spec.ruleQueryOffset
+          value: "30s"
+
+  - it: should render remoteWrite
+    set:
+      thanosRuler.enabled: true
+      thanosRuler.thanosRulerSpec.remoteWrite:
+        - url: http://remote/api/v1/write
+    asserts:
+      - equal:
+          path: spec.remoteWrite[0].url
+          value: http://remote/api/v1/write
+
+  - it: should render tracingConfig from an existing secret
+    set:
+      thanosRuler.enabled: true
+      thanosRuler.thanosRulerSpec.tracingConfig.existingSecret.name: my-tracing
+      thanosRuler.thanosRulerSpec.tracingConfig.existingSecret.key: tracing.yaml
+    asserts:
+      - equal:
+          path: spec.tracingConfig.name
+          value: my-tracing
+      - equal:
+          path: spec.tracingConfig.key
+          value: tracing.yaml
+
+  - it: should render tracingConfig pointing at the chart-managed secret
+    set:
+      thanosRuler.enabled: true
+      thanosRuler.thanosRulerSpec.tracingConfig.secret:
+        type: JAEGER
+    asserts:
+      - equal:
+          path: spec.tracingConfig.key
+          value: tracing-configs.yaml
+
+  - it: should render alertRelabelConfigs from an existing secret
+    set:
+      thanosRuler.enabled: true
+      thanosRuler.thanosRulerSpec.alertRelabelConfigs.existingSecret.name: my-relabel
+      thanosRuler.thanosRulerSpec.alertRelabelConfigs.existingSecret.key: relabel.yaml
+    asserts:
+      - equal:
+          path: spec.alertRelabelConfigs.name
+          value: my-relabel
+
+  - it: should render excludedFromEnforcement only alongside enforcedNamespaceLabel
+    set:
+      thanosRuler.enabled: true
+      thanosRuler.thanosRulerSpec.enforcedNamespaceLabel: namespace
+      thanosRuler.thanosRulerSpec.excludedFromEnforcement:
+        - namespace: kube-system
+          resource: prometheusrules
+          name: my-rule
+    asserts:
+      - equal:
+          path: spec.enforcedNamespaceLabel
+          value: namespace
+      - equal:
+          path: spec.excludedFromEnforcement[0].namespace
+          value: kube-system

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -5608,6 +5608,102 @@ thanosRuler:
     # rollingUpdate:
     #   maxUnavailable: 1
 
+    ## Version of Thanos Ruler to deploy. Overrides the version derived from the image tag when set.
+    version: ""
+
+    ## Image pull policy for the Thanos Ruler container.
+    imagePullPolicy: ""
+
+    ## EnableFeatures API enables access to Thanos Ruler disabled features.
+    enableFeatures: []
+
+    ## EnableServiceLinks indicates whether information about services should be injected into the
+    ## pod's environment variables. Uses the operator/Kubernetes default when left unset (~).
+    enableServiceLinks: ~
+
+    ## Minimum number of seconds for which a newly created pod should be ready without any of its
+    ## containers crashing/restarting for it to be considered available.
+    minReadySeconds: ~
+
+    ## Defines the DNS configuration for the pods.
+    dnsConfig: {}
+      # nameservers:
+      #   - 1.2.3.4
+      # searches:
+      #   - ns1.svc.cluster-domain.example
+      # options:
+      #   - name: ndots
+      #     value: "2"
+
+    ## Defines the DNS policy for the pods.
+    dnsPolicy: ""
+
+    ## Pods' hostAliases configuration
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+    hostAliases: []
+    #  - ip: 10.10.0.100
+    #    hostnames:
+    #      - a1.app.local
+
+    ## Defines the list of remote write configurations. When not empty, the Thanos Ruler operates in stateless mode.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.RemoteWriteSpec
+    remoteWrite: []
+
+    ## Configures tracing for Thanos Ruler. Maps to the tracing.config CLI argument.
+    tracingConfig:
+      # use existing secret, if configured, tracingConfig.secret will not be used
+      existingSecret: {}
+        # name: ""
+        # key: ""
+      # render tracingConfig secret data and configure it to be used by Thanos Ruler custom resource, ignored when tracingConfig.existingSecret is set
+      secret: {}
+
+    ## Path to a tracing configuration file on disk (e.g. mounted through a volume). Takes precedence over tracingConfig.
+    tracingConfigFile: ""
+
+    ## Configures alert relabeling for Thanos Ruler. Maps to the alert.relabel-config CLI argument.
+    alertRelabelConfigs:
+      # use existing secret, if configured, alertRelabelConfigs.secret will not be used
+      existingSecret: {}
+        # name: ""
+        # key: ""
+      # render alertRelabelConfigs secret data and configure it to be used by Thanos Ruler custom resource, ignored when alertRelabelConfigs.existingSecret is set
+      secret: {}
+
+    ## Path to an alert relabel configuration file on disk. Takes precedence over alertRelabelConfigs.
+    alertRelabelConfigFile: ""
+
+    ## Configures the gRPC server TLS for Thanos Ruler.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.TLSConfig
+    grpcServerTlsConfig: {}
+
+    ## Path to an object storage configuration file on disk. Takes precedence over objectStorageConfig.
+    objectStorageConfigFile: ""
+
+    ## Number of concurrent rule evaluations.
+    ruleConcurrentEval: ~
+
+    ## Maximum time to tolerate outage for restoring "for" state of alert.
+    ruleOutageTolerance: ""
+
+    ## Minimum duration between alert and restored "for" state. Maintained only for alerts with a configured "for"
+    ## time greater than the grace period.
+    ruleGracePeriod: ""
+
+    ## The default rule group's query offset duration to shift the evaluation time of rules backwards.
+    ## ref: https://github.com/prometheus-community/helm-charts/issues/5843
+    ruleQueryOffset: ""
+
+    ## Minimum amount of time to wait before resending an alert to Alertmanager.
+    resendDelay: ""
+
+    ## EnforcedNamespaceLabel enforces adding a namespace label of origin for each alert and metric.
+    enforcedNamespaceLabel: ""
+
+    ## List of references to PrometheusRule objects to be excluded from enforcement (requires enforcedNamespaceLabel).
+    ## Can be a list of objects, or a string that is passed through tpl.
+    excludedFromEnforcement: []
+
     ## Additional configuration which is not covered by the properties above. (passed through tpl)
     additionalConfig: {}
 


### PR DESCRIPTION
## What this PR does / why we need it

The `ThanosRuler` CRD supports a number of spec fields that the chart's `thanosRulerSpec` did not expose. This brings `thanosRulerSpec` to parity with the other operator-managed components (Prometheus / Alertmanager), so users no longer have to fall back to `additionalConfig` for common configuration.

Fields added:

- **Capabilities**: `enableFeatures`, `remoteWrite`, `tracingConfig` (+`tracingConfigFile`), `alertRelabelConfigs` (+`alertRelabelConfigFile`), `grpcServerTlsConfig`, `objectStorageConfigFile`
- **Rule evaluation tuning**: `ruleConcurrentEval`, `ruleOutageTolerance`, `ruleGracePeriod`, `ruleQueryOffset`, `resendDelay`
- **Pod/meta**: `enableServiceLinks`, `dnsConfig`, `dnsPolicy`, `hostAliases`, `minReadySeconds`, `imagePullPolicy`, `version`
- **Enforcement**: `enforcedNamespaceLabel`, `excludedFromEnforcement`

### Notes

- `tracingConfig` and `alertRelabelConfigs` follow the existing `objectStorageConfig` `existingSecret`/`secret` idiom and are wired into `secret.yaml`.
- `enableServiceLinks` uses a `kindIs "bool"` guard so the operator/Kubernetes default applies when unset.
- `excludedFromEnforcement` nests under `enforcedNamespaceLabel` and accepts a list or a templated string, matching the Prometheus template.
- All fields are opt-in — the **default render is unchanged**.
- Adds a new `unittests/thanos-ruler/ruler_test.yaml` suite (10 tests).

Fixes #5843

## Which issue this PR fixes

Fixes #5843

## Special notes for your reviewer

Verified with `helm template`, `helm lint`, and `helm unittest` (10/10 passing). Default render emits none of the new keys.

## Checklist

- [x] `helm lint` passes
- [x] Chart version bumped (`87.6.0` → `87.7.0`)
- [x] Unit tests added and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)