### PR TITLE
[kube-prometheus-stack] Expose additional Alertmanager spec fields

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 87.7.0
+version: 87.8.0
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.92.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/templates/alertmanager/alertmanager.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/alertmanager.yaml
@@ -215,6 +215,24 @@ spec:
 {{- if .Values.alertmanager.alertmanagerSpec.terminationGracePeriodSeconds }}
   terminationGracePeriodSeconds: {{ .Values.alertmanager.alertmanagerSpec.terminationGracePeriodSeconds }}
 {{- end }}
+{{- if kindIs "bool" .Values.alertmanager.alertmanagerSpec.enableServiceLinks }}
+  enableServiceLinks: {{ .Values.alertmanager.alertmanagerSpec.enableServiceLinks }}
+{{- end }}
+{{- with .Values.alertmanager.alertmanagerSpec.schedulerName }}
+  schedulerName: {{ . }}
+{{- end }}
+{{- with .Values.alertmanager.alertmanagerSpec.hostAliases }}
+  hostAliases:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.alertmanager.alertmanagerSpec.limits }}
+  limits:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.alertmanager.alertmanagerSpec.clusterTLS }}
+  clusterTLS:
+{{ toYaml . | indent 4 }}
+{{- end }}
 {{- with .Values.alertmanager.alertmanagerSpec.additionalConfig }}
   {{- tpl (toYaml .) $ | nindent 2 }}
 {{- end }}

--- a/charts/kube-prometheus-stack/unittests/alertmanager/alertmanager_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/alertmanager/alertmanager_test.yaml
@@ -45,5 +45,66 @@ tests:
           path: spec.alertmanagerConfigNamespaceSelector
           value: {}
 
+  - it: should not render the new spec fields with default values
+    asserts:
+      - notExists:
+          path: spec.enableServiceLinks
+      - notExists:
+          path: spec.schedulerName
+      - notExists:
+          path: spec.hostAliases
+      - notExists:
+          path: spec.limits
+      - notExists:
+          path: spec.clusterTLS
+
+  - it: should render enableServiceLinks only when set to a bool
+    set:
+      alertmanager.alertmanagerSpec.enableServiceLinks: false
+    asserts:
+      - equal:
+          path: spec.enableServiceLinks
+          value: false
+
+  - it: should render schedulerName and hostAliases
+    set:
+      alertmanager.alertmanagerSpec.schedulerName: my-scheduler
+      alertmanager.alertmanagerSpec.hostAliases:
+        - ip: "10.10.0.100"
+          hostnames:
+            - a1.app.local
+    asserts:
+      - equal:
+          path: spec.schedulerName
+          value: my-scheduler
+      - equal:
+          path: spec.hostAliases[0].ip
+          value: "10.10.0.100"
+
+  - it: should render alertmanager silence limits
+    set:
+      alertmanager.alertmanagerSpec.limits:
+        maxSilences: 1000
+        maxPerSilenceBytes: 1MB
+    asserts:
+      - equal:
+          path: spec.limits.maxSilences
+          value: 1000
+      - equal:
+          path: spec.limits.maxPerSilenceBytes
+          value: 1MB
+
+  - it: should render clusterTLS
+    set:
+      alertmanager.alertmanagerSpec.clusterTLS:
+        server:
+          certSecret:
+            name: am-tls
+            key: tls.crt
+    asserts:
+      - equal:
+          path: spec.clusterTLS.server.certSecret.name
+          value: am-tls
+
 
     

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1274,6 +1274,31 @@ alertmanager:
     ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination
     terminationGracePeriodSeconds: ~
 
+    ## EnableServiceLinks indicates whether information about services should be injected into the
+    ## pod's environment variables. Uses the operator/Kubernetes default when left unset (~).
+    enableServiceLinks: ~
+
+    ## Set the scheduler name to use for the Alertmanager pods.
+    schedulerName: ""
+
+    ## Pods' hostAliases configuration
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+    hostAliases: []
+    #  - ip: 10.10.0.100
+    #    hostnames:
+    #      - a1.app.local
+
+    ## Limits defines the Alertmanager limits command line flags. Requires Alertmanager >= v0.28.0.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.AlertmanagerLimitsSpec
+    limits: {}
+      # maxSilences: 1000
+      # maxPerSilenceBytes: 1MB
+
+    ## ClusterTLS defines the mutual TLS configuration for the Alertmanager cluster's gossip protocol.
+    ## Requires Alertmanager >= v0.24.0.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.ClusterTLSConfig
+    clusterTLS: {}
+
     ## Additional configuration which is not covered by the properties above. (passed through tpl)
     additionalConfig: {}
 


### PR DESCRIPTION
## What this PR does / why we need it

The `Alertmanager` CRD supports several spec fields the chart's `alertmanagerSpec` did not expose. This brings `alertmanagerSpec` closer to parity with the other operator-managed components.

Fields added:

- **`limits`** — Alertmanager silence limits (`maxSilences`, `maxPerSilenceBytes`), corresponding to the `--silences.max-silences` / `--silences.max-per-silence-bytes` flags (requires Alertmanager >= v0.28.0).
- **`clusterTLS`** — mutual TLS configuration for the cluster gossip protocol (requires Alertmanager >= v0.24.0).
- **`enableServiceLinks`** — uses a `kindIs "bool"` guard so the operator/Kubernetes default applies when unset.
- **`hostAliases`**
- **`schedulerName`**

### Notes

- All fields are opt-in — the **default render is unchanged**.
- Adds unit tests for each new field to the existing alertmanager suite.

## Which issue this PR fixes

_none_

## Special notes for your reviewer

Verified with `helm template`, `helm lint`, and `helm unittest` (all passing). Default render emits none of the new keys.

## Checklist

- [x] `helm lint` passes
- [x] Chart version bumped (`87.7.0` → `87.8.0`)
- [x] Unit tests added and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)