### PR TITLE
[kube-state-metrics] Add RBAC rule for serviceaccounts collector

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - kubernetes
 type: application
-version: 7.7.0
+version: 7.8.0
 # renovate: github-releases=kubernetes/kube-state-metrics
 appVersion: 2.19.1
 home: https://github.com/kubernetes/kube-state-metrics/

--- a/charts/kube-state-metrics/templates/role.yaml
+++ b/charts/kube-state-metrics/templates/role.yaml
@@ -189,6 +189,12 @@ rules:
   - secrets
   verbs: ["list", "watch"]
 {{ end -}}
+{{ if has "serviceaccounts" $.Values.collectors }}
+- apiGroups: [""]
+  resources:
+  - serviceaccounts
+  verbs: ["list", "watch"]
+{{ end -}}
 {{ if has "services" $.Values.collectors }}
 - apiGroups: [""]
   resources:

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -451,6 +451,7 @@ collectors:
   # - clusterroles
   # - roles
   # - rolebindings
+  # - serviceaccounts
 
 # Enabling kubeconfig will pass the --kubeconfig argument to the container
 kubeconfig:


### PR DESCRIPTION
## What this PR does / why we need it

The `serviceaccounts` collector (shipping in the pinned `appVersion` 2.19.1) had no RBAC rule in `role.yaml`. Enabling it via `collectors` produced **no metrics**, since the ServiceAccount was never granted `list`/`watch` on `serviceaccounts` — the user had to hand-write `rbac.extraRules`.

This wires it in like every other per-collector rule and adds it as an opt-in entry in the default `collectors` list. The `apiGroups`/`resources` match the [upstream kube-state-metrics ClusterRole](https://github.com/kubernetes/kube-state-metrics/blob/main/examples/standard/cluster-role.yaml).

### Notes

- The rule is **opt-in** (commented in the `collectors` list), so the **default render is unchanged** — no new permissions are granted unless the collector is enabled.
- **Scope narrowed:** this PR originally also added `validatingadmissionpolicies` / `validatingadmissionpolicybindings`. Per @mrueg those collectors are only in KSM `master` and land in the next release, so they are no-ops against the chart's current `appVersion` (2.19.1). They're deferred to a follow-up once the chart bumps to a KSM release that includes them.

## Special notes for your reviewer

Verified with `helm template` (the rule renders only when the collector is enabled; absent by default) and `helm lint`.

## Checklist

- [x] `helm lint` passes
- [x] Chart version bumped (`7.7.0` → `7.8.0`)
- [x] Default render unchanged (collector is opt-in)
- [x] DCO sign-off

🤖 Generated with [Claude Code](https://claude.com/claude-code)