### PR TITLE
[kube-prometheus-stack] Expose additional Prometheus spec fields

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 87.8.0
+version: 87.9.0
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.92.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -474,6 +474,27 @@ spec:
 {{- if .Values.prometheus.prometheusSpec.sampleLimit }}
   sampleLimit: {{ .Values.prometheus.prometheusSpec.sampleLimit }}
 {{- end }}
+{{- if .Values.prometheus.prometheusSpec.targetLimit }}
+  targetLimit: {{ .Values.prometheus.prometheusSpec.targetLimit }}
+{{- end }}
+{{- if .Values.prometheus.prometheusSpec.labelLimit }}
+  labelLimit: {{ .Values.prometheus.prometheusSpec.labelLimit }}
+{{- end }}
+{{- if .Values.prometheus.prometheusSpec.labelNameLengthLimit }}
+  labelNameLengthLimit: {{ .Values.prometheus.prometheusSpec.labelNameLengthLimit }}
+{{- end }}
+{{- if .Values.prometheus.prometheusSpec.labelValueLengthLimit }}
+  labelValueLengthLimit: {{ .Values.prometheus.prometheusSpec.labelValueLengthLimit }}
+{{- end }}
+{{- if .Values.prometheus.prometheusSpec.keepDroppedTargets }}
+  keepDroppedTargets: {{ .Values.prometheus.prometheusSpec.keepDroppedTargets }}
+{{- end }}
+{{- if .Values.prometheus.prometheusSpec.bodySizeLimit }}
+  bodySizeLimit: {{ .Values.prometheus.prometheusSpec.bodySizeLimit }}
+{{- end }}
+{{- if .Values.prometheus.prometheusSpec.enforcedBodySizeLimit }}
+  enforcedBodySizeLimit: {{ .Values.prometheus.prometheusSpec.enforcedBodySizeLimit }}
+{{- end }}
 {{- if .Values.prometheus.prometheusSpec.enforcedKeepDroppedTargets }}
   enforcedKeepDroppedTargets: {{ .Values.prometheus.prometheusSpec.enforcedKeepDroppedTargets }}
 {{- end }}
@@ -528,6 +549,37 @@ spec:
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.serviceDiscoveryRole }}
   serviceDiscoveryRole: {{ .Values.prometheus.prometheusSpec.serviceDiscoveryRole }}
+{{- end }}
+{{- if kindIs "bool" .Values.prometheus.prometheusSpec.enableServiceLinks }}
+  enableServiceLinks: {{ .Values.prometheus.prometheusSpec.enableServiceLinks }}
+{{- end }}
+{{- with .Values.prometheus.prometheusSpec.schedulerName }}
+  schedulerName: {{ . }}
+{{- end }}
+{{- if .Values.prometheus.prometheusSpec.nameEscapingScheme }}
+  nameEscapingScheme: {{ .Values.prometheus.prometheusSpec.nameEscapingScheme }}
+{{- end }}
+{{- if .Values.prometheus.prometheusSpec.reloadStrategy }}
+  reloadStrategy: {{ .Values.prometheus.prometheusSpec.reloadStrategy }}
+{{- end }}
+{{- if .Values.prometheus.prometheusSpec.ruleQueryOffset }}
+  ruleQueryOffset: {{ .Values.prometheus.prometheusSpec.ruleQueryOffset | quote }}
+{{- end }}
+{{- with .Values.prometheus.prometheusSpec.runtime }}
+  runtime:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.prometheus.prometheusSpec.shardingStrategy }}
+  shardingStrategy:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.prometheus.prometheusSpec.shardRetentionPolicy }}
+  shardRetentionPolicy:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.prometheus.prometheusSpec.remoteWriteReceiverMessageVersions }}
+  remoteWriteReceiverMessageVersions:
+{{ toYaml . | indent 4 }}
 {{- end }}
 {{- with .Values.prometheus.prometheusSpec.additionalConfig }}
   {{- tpl (toYaml .) $ | nindent 2 }}

--- a/charts/kube-prometheus-stack/unittests/prometheus/prometheus_spec_fields_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/prometheus/prometheus_spec_fields_test.yaml
@@ -1,0 +1,112 @@
+suite: test prometheus spec fields
+templates:
+  - prometheus/prometheus.yaml
+tests:
+  - it: should not render the new spec fields with default values
+    set:
+      prometheus.enabled: true
+    asserts:
+      - notExists:
+          path: spec.targetLimit
+      - notExists:
+          path: spec.bodySizeLimit
+      - notExists:
+          path: spec.enableServiceLinks
+      - notExists:
+          path: spec.schedulerName
+      - notExists:
+          path: spec.reloadStrategy
+      - notExists:
+          path: spec.runtime
+      - notExists:
+          path: spec.shardingStrategy
+      - notExists:
+          path: spec.remoteWriteReceiverMessageVersions
+
+  - it: should render the global scrape limits
+    set:
+      prometheus.enabled: true
+      prometheus.prometheusSpec.targetLimit: 100
+      prometheus.prometheusSpec.labelLimit: 30
+      prometheus.prometheusSpec.labelNameLengthLimit: 40
+      prometheus.prometheusSpec.labelValueLengthLimit: 50
+      prometheus.prometheusSpec.keepDroppedTargets: 10
+      prometheus.prometheusSpec.bodySizeLimit: 100MB
+      prometheus.prometheusSpec.enforcedBodySizeLimit: 50MB
+    asserts:
+      - equal:
+          path: spec.targetLimit
+          value: 100
+      - equal:
+          path: spec.labelLimit
+          value: 30
+      - equal:
+          path: spec.keepDroppedTargets
+          value: 10
+      - equal:
+          path: spec.bodySizeLimit
+          value: 100MB
+      - equal:
+          path: spec.enforcedBodySizeLimit
+          value: 50MB
+
+  - it: should render enableServiceLinks only when set to a bool
+    set:
+      prometheus.enabled: true
+      prometheus.prometheusSpec.enableServiceLinks: false
+    asserts:
+      - equal:
+          path: spec.enableServiceLinks
+          value: false
+
+  - it: should render schedulerName, nameEscapingScheme and reloadStrategy
+    set:
+      prometheus.enabled: true
+      prometheus.prometheusSpec.schedulerName: my-scheduler
+      prometheus.prometheusSpec.nameEscapingScheme: Underscores
+      prometheus.prometheusSpec.reloadStrategy: ProcessSignal
+    asserts:
+      - equal:
+          path: spec.schedulerName
+          value: my-scheduler
+      - equal:
+          path: spec.nameEscapingScheme
+          value: Underscores
+      - equal:
+          path: spec.reloadStrategy
+          value: ProcessSignal
+
+  - it: should render ruleQueryOffset quoted
+    set:
+      prometheus.enabled: true
+      prometheus.prometheusSpec.ruleQueryOffset: 1m
+    asserts:
+      - equal:
+          path: spec.ruleQueryOffset
+          value: "1m"
+
+  - it: should render runtime, sharding and remoteWriteReceiverMessageVersions
+    set:
+      prometheus.enabled: true
+      prometheus.prometheusSpec.runtime:
+        goGC: 75
+      prometheus.prometheusSpec.shardingStrategy:
+        mode: OnResource
+      prometheus.prometheusSpec.shardRetentionPolicy:
+        whenScaled: Retain
+      prometheus.prometheusSpec.remoteWriteReceiverMessageVersions:
+        - V1.0
+        - V2.0
+    asserts:
+      - equal:
+          path: spec.runtime.goGC
+          value: 75
+      - equal:
+          path: spec.shardingStrategy.mode
+          value: OnResource
+      - equal:
+          path: spec.shardRetentionPolicy.whenScaled
+          value: Retain
+      - equal:
+          path: spec.remoteWriteReceiverMessageVersions[1]
+          value: V2.0

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -4788,6 +4788,28 @@ prometheus:
     # Set to 'false' to disable global sample_limit. or set to a number to override the default value.
     sampleLimit: false
 
+    ## TargetLimit defines a global limit on the number of scraped targets. 0 means no limit.
+    targetLimit: 0
+
+    ## Per-scrape limit on number of labels that will be accepted for a sample. 0 means no limit.
+    labelLimit: 0
+
+    ## Per-scrape limit on length of labels name that will be accepted for a sample. 0 means no limit.
+    labelNameLengthLimit: 0
+
+    ## Per-scrape limit on length of labels value that will be accepted for a sample. 0 means no limit.
+    labelValueLengthLimit: 0
+
+    ## Per-scrape limit on the number of targets dropped by relabeling that will be kept in memory. 0 means no limit.
+    keepDroppedTargets: 0
+
+    ## BodySizeLimit defines a global limit on the size of uncompressed response body that will be accepted. Example: 100MB.
+    bodySizeLimit: ""
+
+    ## EnforcedBodySizeLimit defines the maximum size of uncompressed response body that will be accepted, overriding any
+    ## value set per ServiceMonitor/PodMonitor. Example: 100MB. Empty means no limit.
+    enforcedBodySizeLimit: ""
+
     # EnforcedKeepDroppedTargetsLimit defines on the number of targets dropped by relabeling that will be kept in memory.
     # The value overrides any spec.keepDroppedTargets set by ServiceMonitor, PodMonitor, Probe objects unless spec.keepDroppedTargets
     # is greater than zero and less than spec.enforcedKeepDroppedTargets. 0 means no limit.
@@ -4861,6 +4883,40 @@ prometheus:
     ## Defines the service discovery role used to discover targets from ServiceMonitor objects and Alertmanager endpoints.
     ## If set, the value should be either "Endpoints" or "EndpointSlice". If unset, the operator assumes the "Endpoints" role.
     serviceDiscoveryRole: ""
+
+    ## EnableServiceLinks indicates whether information about services should be injected into the pod's environment
+    ## variables. Uses the operator/Kubernetes default when left unset (~).
+    enableServiceLinks: ~
+
+    ## Set the scheduler name to use for the Prometheus pods.
+    schedulerName: ""
+
+    ## Specifies the character escaping scheme applied to metric and label names.
+    ## Supported values are: AllowUTF8, Underscores, Dots, Values
+    nameEscapingScheme: ""
+
+    ## Defines the strategy used to reload the Prometheus configuration.
+    ## Supported values are: HTTP, ProcessSignal
+    reloadStrategy: ""
+
+    ## Defines the offset the rule evaluation timestamp of the rule evaluation queries is shifted backwards.
+    ## ref: https://github.com/prometheus-community/helm-charts/issues/5843
+    ruleQueryOffset: ""
+
+    ## RuntimeConfig configures the values for the Prometheus process behavior.
+    runtime: {}
+      # goGC: 75
+
+    ## Defines the sharding strategy applied by the operator.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.ShardingStrategy
+    shardingStrategy: {}
+
+    ## Defines the retention policy for the resources of stale shards after a scale-down.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.ShardRetentionPolicy
+    shardRetentionPolicy: {}
+
+    ## List of the protobuf message versions to accept when receiving the remote writes. Example: [V1.0, V2.0].
+    remoteWriteReceiverMessageVersions: []
 
     ## Pod management policy. Kubernetes default is OrderedReady but prometheus-operator default is Parallel.
     ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies


### PR DESCRIPTION
## What this PR does / why we need it

The `Prometheus` CRD supports a number of spec fields the chart's `prometheusSpec` did not expose. This brings `prometheusSpec` to parity with the other operator-managed components (following the recent ThanosRuler #7064 and Alertmanager #7065 work).

Fields added:

- **Global scrape limits**: `targetLimit`, `labelLimit`, `labelNameLengthLimit`, `labelValueLengthLimit`, `keepDroppedTargets`, `bodySizeLimit`, `enforcedBodySizeLimit`
- **`runtime`** (Go runtime / `goGC`), **`shardingStrategy`**, **`shardRetentionPolicy`**
- **`reloadStrategy`**, **`ruleQueryOffset`**, **`nameEscapingScheme`**, **`remoteWriteReceiverMessageVersions`**
- **`enableServiceLinks`** (uses a `kindIs "bool"` guard so the operator/Kubernetes default applies when unset), **`schedulerName`**

### Notes

- All fields are opt-in — the **default render is unchanged**.
- Scalar scrape limits are placed alongside the existing `sampleLimit`/`enforced*` fields; object/array fields render via `toYaml`.
- Adds a `unittests/prometheus/prometheus_spec_fields_test.yaml` suite.

## Which issue this PR fixes

_none_

## Special notes for your reviewer

Verified with `helm template`, `helm lint`, and `helm unittest` (29/29 in the prometheus suite). Default render emits none of the new keys.

## Checklist

- [x] `helm lint` passes
- [x] Chart version bumped (`87.8.0` → `87.9.0`)
- [x] Unit tests added and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)