### PR TITLE
[kube-prometheus-stack] Expose prometheus-operator featureGates

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 87.9.0
+version: 87.10.0
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.92.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml
@@ -137,6 +137,13 @@ spec:
             {{- if .Values.prometheusOperator.clusterDomain }}
             - --cluster-domain={{ .Values.prometheusOperator.clusterDomain }}
             {{- end }}
+            {{- with .Values.prometheusOperator.featureGates }}
+            {{- $gates := list }}
+            {{- range $key, $value := . }}
+            {{- $gates = append $gates (printf "%s=%v" $key $value) }}
+            {{- end }}
+            - --feature-gates={{ join "," $gates }}
+            {{- end }}
             {{- if .Values.prometheusOperator.tls.enabled }}
             - --web.enable-tls=true
             - --web.cert-file=/cert/{{ if .Values.prometheusOperator.admissionWebhooks.certManager.enabled }}tls.crt{{ else }}cert{{ end }}

--- a/charts/kube-prometheus-stack/unittests/prometheus-operator/deployment_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/prometheus-operator/deployment_test.yaml
@@ -1,0 +1,28 @@
+suite: test prometheus-operator deployment
+templates:
+  - prometheus-operator/deployment.yaml
+tests:
+  - it: should not render --feature-gates by default
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --feature-gates
+
+  - it: should render --feature-gates as sorted comma-joined key=value pairs
+    set:
+      prometheusOperator.featureGates:
+        StatusForConfigurationResources: true
+        PrometheusAgentDaemonSet: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --feature-gates=PrometheusAgentDaemonSet=true,StatusForConfigurationResources=true
+
+  - it: should render a disabled feature gate as false
+    set:
+      prometheusOperator.featureGates:
+        PrometheusAgentDaemonSet: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --feature-gates=PrometheusAgentDaemonSet=false

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -3506,6 +3506,14 @@ prometheusOperator:
   ##
   secretFieldSelector: "type!=kubernetes.io/dockercfg,type!=kubernetes.io/service-account-token,type!=helm.sh/release.v1"
 
+  ## Feature gates to enable/disable operator features, rendered as --feature-gates=<key>=<value>.
+  ## See https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/feature-gates.md
+  ## Example:
+  ##   featureGates:
+  ##     PrometheusAgentDaemonSet: true
+  ##     StatusForConfigurationResources: true
+  featureGates: {}
+
   ## If false then the user will opt out of automounting API credentials.
   ##
   automountServiceAccountToken: true


### PR DESCRIPTION
## What this PR does / why we need it

The prometheus-operator supports a `--feature-gates` flag to enable/disable operator features (e.g. `PrometheusAgentDaemonSet`, `StatusForConfigurationResources`), but the chart had no first-class value for it — users had to fall back to `prometheusOperator.extraArgs`.

This adds **`prometheusOperator.featureGates`** (a map), rendered as `--feature-gates=<key>=<value>,...` on the operator container. It's the operator-level analogue of the `enableFeatures` support the CRDs already have.

```yaml
prometheusOperator:
  featureGates:
    PrometheusAgentDaemonSet: true
    StatusForConfigurationResources: true
```
renders:
```
- --feature-gates=PrometheusAgentDaemonSet=true,StatusForConfigurationResources=true
```

### Notes

- The map is empty by default, so the flag is **not** rendered and the default output is unchanged.
- Keys are emitted in sorted order (deterministic template output).
- Adds a `unittests/prometheus-operator/deployment_test.yaml` suite.

## Which issue this PR fixes

_none_

## Special notes for your reviewer

Verified with `helm template`, `helm lint`, and `helm unittest` (operator suite green). Flag absent unless `featureGates` is set.

## Checklist

- [x] `helm lint` passes
- [x] Chart version bumped (`87.8.0` → `87.10.0`)
- [x] Unit tests added and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)