### PR TITLE
[prometheus-node-exporter] append extraArgs to default args

### DIFF
--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - prometheus
   - exporter
 type: application
-version: 4.55.0
+version: 4.55.1
 # renovate: github=prometheus/node_exporter
 appVersion: 1.11.1
 home: https://github.com/prometheus/node_exporter/

--- a/charts/prometheus-node-exporter/templates/NOTES.txt
+++ b/charts/prometheus-node-exporter/templates/NOTES.txt
@@ -14,6 +14,17 @@
   kubectl port-forward --namespace {{ template "prometheus-node-exporter.namespace" . }} $POD_NAME 9100
 {{- end }}
 
+{{- if .Values.defaultArgs }}
+
+NOTE: The chart now ships with a `defaultArgs` list containing the standard
+filesystem collector exclusion flags. If you previously set these flags via
+`extraArgs`, remove them from `extraArgs` to avoid duplicate-flag errors on
+startup:
+  --collector.filesystem.ignored-mount-points
+  --collector.filesystem.ignored-fs-types
+Set `defaultArgs: []` to opt out of the built-in defaults entirely.
+{{- end }}
+
 {{- if .Values.kubeRBACProxy.enabled}}
 
 kube-rbac-proxy endpoint protections is enabled:

--- a/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -109,7 +109,7 @@ spec:
             {{- end }}
             {{- end }}
             - --web.listen-address=[$(HOST_IP)]:{{ $servicePort }}
-            {{- with .Values.extraArgs }}
+            {{- with concat (.Values.defaultArgs | default list) (.Values.extraArgs | default list) }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- with .Values.containerSecurityContext }}

--- a/charts/prometheus-node-exporter/unittests/daemonset_args_test.yaml
+++ b/charts/prometheus-node-exporter/unittests/daemonset_args_test.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: daemonset defaultArgs / extraArgs ordering
+templates:
+  - daemonset.yaml
+tests:
+  - it: renders defaultArgs before extraArgs by default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($|/)
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$
+
+  - it: appends extraArgs after defaultArgs
+    set:
+      extraArgs:
+        - --collector.diskstats.ignored-devices=^(ram|loop)\\d+$
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($|/)
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --collector.diskstats.ignored-devices=^(ram|loop)\\d+$
+      - equal:
+          path: spec.template.spec.containers[0].args[-1]
+          value: --collector.diskstats.ignored-devices=^(ram|loop)\\d+$
+
+  - it: omits all defaultArgs when defaultArgs is set to empty list
+    set:
+      defaultArgs: []
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($|/)
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$
+
+  - it: renders only extraArgs when defaultArgs is empty and extraArgs is set
+    set:
+      defaultArgs: []
+      extraArgs:
+        - --collector.textfile.directory=/run/prometheus
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($|/)
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --collector.textfile.directory=/run/prometheus

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -485,7 +485,13 @@ terminationMessageParams:
 ## Assign a PriorityClassName to pods if set
 # priorityClassName: ""
 
-## Additional container arguments
+## Default container arguments
+##
+defaultArgs:
+  - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($|/)
+  - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$
+
+## Additional container arguments appended after defaultArgs
 ##
 extraArgs: []
 #   - --collector.diskstats.ignored-devices=^(ram|loop|fd|(h|s|v)d[a-z]|nvme\\d+n\\d+p)\\d+$

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -485,13 +485,16 @@ terminationMessageParams:
 ## Assign a PriorityClassName to pods if set
 # priorityClassName: ""
 
-## Default container arguments
+## Default container arguments prepended before extraArgs.
+## Set to [] to disable the built-in filesystem collector exclusions.
+## If you previously set these flags via extraArgs, remove them there to
+## avoid duplicate-flag startup errors.
 ##
 defaultArgs:
   - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($|/)
   - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$
 
-## Additional container arguments appended after defaultArgs
+## Additional container arguments appended after defaultArgs.
 ##
 extraArgs: []
 #   - --collector.diskstats.ignored-devices=^(ram|loop|fd|(h|s|v)d[a-z]|nvme\\d+n\\d+p)\\d+$


### PR DESCRIPTION
## Summary
- move the node-exporter filesystem ignore flags into a new `defaultArgs` value
- render container args with `defaultArgs` followed by user-provided `extraArgs`
- bump the prometheus-node-exporter chart patch version

## Why
Previously, users adding one custom `extraArgs` entry had to copy the chart defaults as well or lose the default filesystem ignore rules. Keeping defaults in `defaultArgs` and appending `extraArgs` preserves the default behavior while making custom args additive.

Fixes prometheus-community/helm-charts#6831.

## Validation
- `/tmp/codex-helm/helm template pne charts/prometheus-node-exporter`
- rendered with `extraArgs: [--collector.textfile.directory=/run/prometheus]` and confirmed default filesystem args are still present before the custom arg
- `/tmp/codex-helm/helm lint charts/prometheus-node-exporter`
- `git diff --check`
