### PR TITLE
[prometheus-postgres-exporter] Add podMonitor template

### DIFF
--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: v0.20.1
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 8.1.1
+version: 8.2.0
 home: https://github.com/prometheus-community/postgres_exporter
 sources:
   - https://github.com/prometheus-community/postgres_exporter

--- a/charts/prometheus-postgres-exporter/README.md
+++ b/charts/prometheus-postgres-exporter/README.md
@@ -157,6 +157,8 @@ kubectl patch deployment prometheus-postgres-exporter --type=json -p='[{"op": "r
 
 ## Configuration
 
+This chart can scrape metrics using either a [ServiceMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#servicemonitor) (`serviceMonitor.enabled`) or a [PodMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#podmonitor) (`podMonitor.enabled`) for the Prometheus Operator. Use PodMonitor when scraping pods directly without going through the Kubernetes Service.
+
 See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing).
 To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run this command:
 

--- a/charts/prometheus-postgres-exporter/templates/podmonitor.yaml
+++ b/charts/prometheus-postgres-exporter/templates/podmonitor.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.podMonitor.enabled }}
+apiVersion: {{ .Values.podMonitor.apiVersion | default "monitoring.coreos.com/v1" }}
+kind: PodMonitor
+metadata:
+{{- if .Values.podMonitor.labels }}
+  labels:
+    {{- include "prometheus-postgres-exporter.labels" . | nindent 4 }}
+{{ toYaml .Values.podMonitor.labels | indent 4}}
+{{- end }}
+  name: {{ template "prometheus-postgres-exporter.fullname" . }}
+  namespace: {{ .Values.podMonitor.namespace | default (include "prometheus-postgres-exporter.namespace" .) | quote }}
+spec:
+  podMetricsEndpoints:
+  - port: http
+{{- if .Values.podMonitor.interval }}
+    interval: {{ .Values.podMonitor.interval }}
+{{- end }}
+{{- if .Values.podMonitor.telemetryPath }}
+    path: {{ .Values.podMonitor.telemetryPath }}
+{{- end }}
+{{- if .Values.podMonitor.scheme }}
+    scheme: {{ .Values.podMonitor.scheme }}
+{{- end }}
+{{- if .Values.podMonitor.timeout }}
+    scrapeTimeout: {{ .Values.podMonitor.timeout }}
+{{- end }}
+{{- if .Values.podMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ toYaml .Values.podMonitor.metricRelabelings | indent 4 }}
+{{- end }}
+{{- if .Values.podMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.podMonitor.relabelings | nindent 4 }}
+{{- end }}
+{{- with .Values.podMonitor.tlsConfig }}
+    tlsConfig:
+{{- toYaml . | nindent 6 }}
+{{- end }}
+  jobLabel: {{ template "prometheus-postgres-exporter.fullname" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ include "prometheus-postgres-exporter.namespace" . | quote }}
+  selector:
+    matchLabels:
+      {{- include "prometheus-postgres-exporter.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -70,6 +70,33 @@ serviceMonitor:
       #   databaseName: default '' (Set the database name to connect to)
       #   metricRelabelings: [] (MetricRelabelConfigs to apply to samples from the target before ingestion)
 
+podMonitor:
+  # PodMonitor scrapes pods directly, bypassing the Kubernetes Service.
+  # Useful when a Service isn't desired/available, or you prefer pod-based discovery.
+  # ref. https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#podmonitor
+  # When set true then use a PodMonitor to configure scraping
+  enabled: false
+  # Specify the API version for the PodMonitor
+  apiVersion: "monitoring.coreos.com/v1"
+  # Set the namespace the PodMonitor should be deployed
+  # namespace: monitoring
+  # Set how frequently Prometheus should scrape
+  # interval: 30s
+  # Set path to postgres-exporter telemetry-path
+  # telemetryPath: /metrics
+  # Set labels for the PodMonitor, use this to define your scrape label for Prometheus Operator
+  # labels:
+  # Set timeout for scrape
+  # timeout: 10s
+  # MetricRelabelConfigs to apply to samples before ingestion
+  # metricRelabelings: []
+  # Set relabel_configs as per https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+  # relabelings: []
+  # HTTP scheme to use for scraping. For example `http` or `https`. Default is `http`.
+  # scheme: http
+  # TLS configuration to use when scraping the metric endpoint by Prometheus.
+  # tlsConfig: {}
+
 prometheusRule:
   enabled: false
   additionalLabels: {}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
This adds the ability to use a `podMonitor` directly rather than a `serviceMonitor`. This is most useful with multiple read-only replicas behind a single service (CNPG).

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
- [-] Add an [helm unittest](https://github.com/helm-unittest/helm-unittest) test case to cover this change.

This chart doesn't have unit tests yet.