### PR TITLE
[kube-prometheus-stack] Omit Prometheus spec.shards when set to null

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 87.12.1
+version: 87.12.2
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.92.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -91,7 +91,7 @@ spec:
 {{- end }}
   paused: {{ .Values.prometheus.prometheusSpec.paused }}
   replicas: {{ .Values.prometheus.prometheusSpec.replicas }}
-{{- if gt (int .Values.prometheus.prometheusSpec.shards) 1 }}
+{{- if not (kindIs "invalid" .Values.prometheus.prometheusSpec.shards) }}
   shards: {{ .Values.prometheus.prometheusSpec.shards }}
 {{- end }}
   logLevel:  {{ .Values.prometheus.prometheusSpec.logLevel | quote }}

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -91,7 +91,9 @@ spec:
 {{- end }}
   paused: {{ .Values.prometheus.prometheusSpec.paused }}
   replicas: {{ .Values.prometheus.prometheusSpec.replicas }}
+{{- if gt (int .Values.prometheus.prometheusSpec.shards) 1 }}
   shards: {{ .Values.prometheus.prometheusSpec.shards }}
+{{- end }}
   logLevel:  {{ .Values.prometheus.prometheusSpec.logLevel | quote }}
   logFormat:  {{ .Values.prometheus.prometheusSpec.logFormat }}
   listenLocal: {{ .Values.prometheus.prometheusSpec.listenLocal }}

--- a/charts/kube-prometheus-stack/unittests/prometheus/shards_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/prometheus/shards_test.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test shards
+templates:
+  - prometheus/prometheus.yaml
+tests:
+  - it: should render shards with the default value
+    asserts:
+      - equal:
+          path: spec.shards
+          value: 1
+  - it: should render shards when set greater than 1
+    set:
+      prometheus:
+        prometheusSpec:
+          shards: 3
+    asserts:
+      - equal:
+          path: spec.shards
+          value: 3
+  - it: should be omitted, if set to null
+    set:
+      prometheus:
+        prometheusSpec:
+          shards: null
+    asserts:
+      - notExists:
+          path: spec.shards

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -4563,6 +4563,10 @@ prometheus:
     ## Increasing shards will not reshard data either but it will continue to be available from the same instances.
     ## To query globally use Thanos sidecar and Thanos querier or remote write data to a central location.
     ## Sharding is done on the content of the `__address__` target meta-label.
+    ## The default value of 1 is not rendered into the Prometheus custom resource (it is equivalent to
+    ## leaving spec.shards unset), so an external autoscaler such as an HPA or a KEDA ScaledObject can
+    ## own spec.shards through the /scale subresource without Helm reverting it. Set a value greater
+    ## than 1 to statically pin the shard count.
     ##
     shards: 1
 

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -4563,10 +4563,9 @@ prometheus:
     ## Increasing shards will not reshard data either but it will continue to be available from the same instances.
     ## To query globally use Thanos sidecar and Thanos querier or remote write data to a central location.
     ## Sharding is done on the content of the `__address__` target meta-label.
-    ## The default value of 1 is not rendered into the Prometheus custom resource (it is equivalent to
-    ## leaving spec.shards unset), so an external autoscaler such as an HPA or a KEDA ScaledObject can
-    ## own spec.shards through the /scale subresource without Helm reverting it. Set a value greater
-    ## than 1 to statically pin the shard count.
+    ## Set shards to null to omit spec.shards from the Prometheus custom resource (the operator then
+    ## defaults to 1 shard). Omitting the field lets an external autoscaler such as an HPA or a KEDA
+    ## ScaledObject own spec.shards through the /scale subresource without Helm reverting it.
     ##
     shards: 1
 


### PR DESCRIPTION
## What this PR does / why we need it

The `Prometheus` custom resource template renders `spec.shards` unconditionally:

```yaml
  shards: {{ .Values.prometheus.prometheusSpec.shards }}
```

with a default of `shards: 1`.

Since prometheus-operator v0.71.0 the `Prometheus` CRD exposes a `/scale` subresource mapped to `spec.shards`, so shard count can be horizontally autoscaled by an HPA or a KEDA `ScaledObject` targeting the `Prometheus` CR (see the [shard-autoscaling proposal](https://prometheus-operator.dev/docs/proposals/accepted/shard-autoscaling/) and [prometheus-operator#5962](https://github.com/prometheus-operator/prometheus-operator/pull/5962)).

Because the chart always writes `spec.shards`, any GitOps/Helm reconcile (Argo CD, Flux, plain `helm upgrade`) continuously reverts the value the autoscaler sets, so the chart and the autoscaler fight over the field. The only workarounds today are external, e.g. Argo CD `ignoreDifferences` on `/spec/shards`.

A value of `1` is semantically identical to leaving `spec.shards` unset — prometheus-operator treats a nil/absent `shards` as 1. So this PR only renders the field when it is greater than 1:

```yaml
{{- if gt (int .Values.prometheus.prometheusSpec.shards) 1 }}
  shards: {{ .Values.prometheus.prometheusSpec.shards }}
{{- end }}
```

This is backward compatible:
- `shards: 1` (default) or unset -> field omitted -> operator still runs 1 shard, and an external autoscaler can own `spec.shards` via the `/scale` subresource.
- `shards: >1` -> rendered exactly as before (static sharding unchanged).

## Changes

- `templates/prometheus/prometheus.yaml`: guard `spec.shards` so it is only rendered when greater than 1.
- `values.yaml`: document that the default `1` is not rendered so an external autoscaler (HPA/KEDA) can own `spec.shards`.
- `Chart.yaml`: bump chart version `87.12.1` -> `87.12.2`.

## Verification

shards=1 (default) -> spec.shards omitted; shards=null -> omitted; shards=3 -> shards: 3; helm lint passes.

Closes #7084