### PR TITLE
[kube-prometheus-stack] fix: render empty ruleSelector when disabled with nil values

### DIFF
--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -279,7 +279,7 @@ spec:
   ruleSelector:
     matchLabels:
       release: {{ $.Release.Name | quote }}
-{{ else if not (kindIs "invalid" .Values.prometheus.prometheusSpec.ruleSelector) }}
+{{- else }}
   ruleSelector: {}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it
This PR fixes an issue where the `ruleSelector` field completely disappears from the generated Prometheus CRD manifest when `ruleSelectorNilUsesHelmValues` is set to `false` and `ruleSelector` is omitted or set to `null`. 

In Prometheus Operator, the absence of `ruleSelector` prevents any rules from being discovered, resulting in an empty `rulefiles-0` configmap. The expected behavior is to render `ruleSelector: {}` so that all rules are matched.

#### Which issue this PR fixes
fixes #7092

#### Special notes for your reviewer
The fix replaces a brittle `kindIs "invalid"` check with a robust `else` fallback block, which guarantees that `ruleSelector: {}` will be rendered when no specific selectors or default helm values are used.

#### Checklist
- [x] DCO signed
- [ ] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
- [ ] Add an helm unittest test case to cover this change.
