### PR TITLE
[kube-prometheus-stack] fix externalUrl of alertmanager and prometheus when route is configured

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 87.15.2
+version: 87.15.3
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.92.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 87.15.1
+version: 87.15.2
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.92.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 87.15.3
+version: 87.15.2
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.92.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/templates/alertmanager/alertmanager.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/alertmanager.yaml
@@ -43,6 +43,8 @@ spec:
   externalUrl: "{{ tpl .Values.alertmanager.alertmanagerSpec.externalUrl . }}"
 {{- else if and .Values.alertmanager.ingress.enabled .Values.alertmanager.ingress.hosts }}
   externalUrl: "http://{{ tpl (index .Values.alertmanager.ingress.hosts 0) . }}{{ .Values.alertmanager.alertmanagerSpec.routePrefix }}"
+{{- else if and .Values.alertmanager.route.main.enabled .Values.alertmanager.route.main.hostnames }}
+  externalUrl: "http://{{ tpl (index .Values.alertmanager.route.main.hostnames 0) . }}{{ .Values.alertmanager.alertmanagerSpec.routePrefix }}"
 {{- else }}
   externalUrl: http://{{ template "kube-prometheus-stack.fullname" . }}-alertmanager.{{ template "kube-prometheus-stack.namespace" . }}:{{ .Values.alertmanager.service.port }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -82,6 +82,8 @@ spec:
   externalUrl: "{{ tpl .Values.prometheus.prometheusSpec.externalUrl . }}"
 {{- else if and .Values.prometheus.ingress.enabled .Values.prometheus.ingress.hosts }}
   externalUrl: "http://{{ tpl (index .Values.prometheus.ingress.hosts 0) . }}{{ .Values.prometheus.prometheusSpec.routePrefix }}"
+{{- else if and .Values.prometheus.route.main.enabled .Values.prometheus.route.main.hostnames }}
+  externalUrl: "http://{{ tpl (index .Values.prometheus.route.main.hostnames 0) . }}{{ .Values.prometheus.prometheusSpec.routePrefix }}"
 {{- else }}
   externalUrl: http://{{ template "kube-prometheus-stack.fullname" . }}-prometheus.{{ template "kube-prometheus-stack.namespace" . }}:{{ .Values.prometheus.service.port }}
 {{- end }}

--- a/charts/kube-prometheus-stack/unittests/alertmanager/alertmanager_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/alertmanager/alertmanager_test.yaml
@@ -106,5 +106,16 @@ tests:
           path: spec.clusterTLS.server.certSecret.name
           value: am-tls
 
-
-    
+  # 7106
+  - it: should set externalUrl to hostname of main.route
+    set:
+      alertmanager.route.main:
+        enabled: true
+        hostnames:
+          - alertmanager.example.com 
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.externalUrl
+          value: http://alertmanager.example.com/

--- a/charts/kube-prometheus-stack/unittests/alertmanager/alertmanager_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/alertmanager/alertmanager_test.yaml
@@ -107,7 +107,7 @@ tests:
           value: am-tls
 
   # 7106
-  - it: should set externalUrl to hostname of main.route
+  - it: should set externalUrl to hostname of main route
     set:
       alertmanager.route.main:
         enabled: true

--- a/charts/kube-prometheus-stack/unittests/prometheus/prometheus_spec_fields_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/prometheus/prometheus_spec_fields_test.yaml
@@ -112,7 +112,7 @@ tests:
           value: V2.0
 
   # 7106
-  - it: should set externalUrl to hostname of main.route
+  - it: should set externalUrl to hostname of main route
     set:
       prometheus.route.main:
         enabled: true

--- a/charts/kube-prometheus-stack/unittests/prometheus/prometheus_spec_fields_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/prometheus/prometheus_spec_fields_test.yaml
@@ -110,3 +110,17 @@ tests:
       - equal:
           path: spec.remoteWriteReceiverMessageVersions[1]
           value: V2.0
+
+  # 7106
+  - it: should set externalUrl to hostname of main.route
+    set:
+      prometheus.route.main:
+        enabled: true
+        hostnames:
+          - alertmanager.example.com 
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.externalUrl
+          value: http://alertmanager.example.com/


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it
Fix externalUrl in alertmanager chart when main route is configured.

#### Which issue this PR fixes

- fixes #7106

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
- [x] Add an [helm unittest](https://github.com/helm-unittest/helm-unittest) test case to cover this change.
