### PR TITLE
[prometheus-adapter] Add schedulerName and runtimeClassName support

### DIFF
--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 5.3.0
+version: 5.4.0
 appVersion: v0.12.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/kubernetes-sigs/prometheus-adapter

--- a/charts/prometheus-adapter/templates/deployment.yaml
+++ b/charts/prometheus-adapter/templates/deployment.yaml
@@ -122,6 +122,12 @@ spec:
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with .Values.schedulerName }}
+      schedulerName: {{ . }}
+      {{- end }}
+      {{- with .Values.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       {{- if .Values.podSecurityContext }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/charts/prometheus-adapter/values.yaml
+++ b/charts/prometheus-adapter/values.yaml
@@ -26,6 +26,12 @@ nodeSelector: {}
 
 priorityClassName: ""
 
+## Set the schedulerName for prometheus-adapter pods
+schedulerName: ""
+
+## Set the runtimeClassName for prometheus-adapter pods
+runtimeClassName: ""
+
 ## Override the release namespace (for multi-namespace deployments in combined charts)
 namespaceOverride: ""
 


### PR DESCRIPTION
#### What this PR does / why we need it

Adds optional `schedulerName` and `runtimeClassName` fields to the prometheus-adapter Deployment, completing the pod scheduling/runtime knobs the chart already exposes (`nodeSelector`, `affinity`, `tolerations`, `topologySpreadConstraints`, `priorityClassName`). This lets users on multi-scheduler clusters pin the adapter to a specific scheduler, and users running sandboxed runtimes (gVisor, Kata) select a RuntimeClass for the metrics-adapter pod. Both default to `""`, so rendered output is unchanged unless set. The sibling `alertmanager` chart in this repo already ships `schedulerName`.

#### Which issue this PR fixes

- fixes # (none)

#### Special notes for your reviewer

Both fields are gated with `{{- with .Values.X }}`, mirroring the existing `priorityClassName` block, so they render only when set. Default `helm template` output is byte-identical to 5.3.0 apart from the chart-version label. `ct lint` passes locally against both ci value files. No `ci/` scenario was added since the fields are default-off, so `ct install` exercises nothing new. The chart ships no helm-unittests (the sibling scheduling fields have none either), so none were added.

#### Checklist

- [x] DCO signed

---

I am an AI agent (Claude Code, Opus 4.8) contributing on behalf of @somaz94, who reviewed and approved this change.
