### PR TITLE
[alertmanager] fix YAML parsing error by moving conditional emptyDir templating in StatefulSet template

### DIFF
--- a/charts/alertmanager/Chart.yaml
+++ b/charts/alertmanager/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/a
 sources:
   - https://github.com/prometheus/alertmanager
 type: application
-version: 1.40.2
+version: 1.40.3
 # renovate: github-releases=prometheus/alertmanager
 appVersion: v0.33.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/alertmanager/templates/statefulset.yaml
+++ b/charts/alertmanager/templates/statefulset.yaml
@@ -238,6 +238,15 @@ spec:
             optional: {{ . }}
             {{- end }}
         {{- end }}
+        {{- if not .Values.persistence.enabled }}
+        - name: storage
+          {{- with .Values.persistence.emptyDir }}
+          emptyDir:
+            {{- toYaml . | nindent 12 }}
+          {{- else }}
+          emptyDir: {}
+          {{- end -}}
+        {{- end }}
         {{- if .Values.extraVolumes }}
         {{- toYaml .Values.extraVolumes | nindent 8 }}
         {{- end }}
@@ -269,12 +278,4 @@ spec:
         storageClassName: {{ .Values.persistence.storageClass }}
       {{- end }}
       {{- end }}
-  {{- else }}
-        - name: storage
-            {{- with .Values.persistence.emptyDir }}
-          emptyDir:
-            {{- toYaml . | nindent 12 }}
-            {{- else }}
-          emptyDir: {}
-            {{- end -}}
-  {{- end }}
+  {{- end -}}

--- a/charts/alertmanager/unittests/persistence_test.yaml
+++ b/charts/alertmanager/unittests/persistence_test.yaml
@@ -1,0 +1,106 @@
+suite: test statefulset persistence
+templates:
+  - statefulset.yaml
+  - configmap.yaml
+tests:
+  - it: should use a volumeClaimTemplate and no emptyDir storage volume with default values
+    template: statefulset.yaml
+    asserts:
+      # First two assertions check that with persistence, volumeClaimTemplates gets rendered
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.name
+          value: storage
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
+          value: 50Mi
+      # Next two assertions check that 'config' is the only volume that gets rendered
+      - lengthEqual:
+          path: spec.template.spec.volumes
+          count: 1
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: config
+            configMap:
+              name: RELEASE-NAME-alertmanager
+
+  - it: should mount an empty emptyDir storage volume when persistence is disabled
+    template: statefulset.yaml
+    set:
+      persistence.enabled: false
+    asserts:
+      - notExists:
+          path: spec.volumeClaimTemplates
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: storage
+            emptyDir: {}
+      # The storage mount must still resolve to a volume that exists.
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="alertmanager")].volumeMounts
+          content:
+            name: storage
+            mountPath: /alertmanager
+
+  - it: should render configured emptyDir values when persistence is disabled
+    template: statefulset.yaml
+    set:
+      persistence.enabled: false
+      persistence.emptyDir:
+        medium: Memory
+        sizeLimit: 100Mi
+    asserts:
+      - notExists:
+          path: spec.volumeClaimTemplates
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: storage
+            emptyDir:
+              medium: Memory
+              sizeLimit: 100Mi
+
+  - it: should render both the emptyDir storage volume and extraPodConfigs when persistence is disabled
+    template: statefulset.yaml
+    set:
+      persistence.enabled: false
+      persistence.emptyDir:
+        sizeLimit: 100Mi
+      extraPodConfigs:
+        hostNetwork: true
+        dnsPolicy: ClusterFirstWithHostNet
+    asserts:
+      - notExists:
+          path: spec.volumeClaimTemplates
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: storage
+            emptyDir:
+              sizeLimit: 100Mi
+      # extraPodConfigs must be rendered at pod-spec level, alongside the volume.
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+      - equal:
+          path: spec.template.spec.dnsPolicy
+          value: ClusterFirstWithHostNet
+
+  - it: should keep the volumeClaimTemplate and render extraPodConfigs when persistence is enabled
+    template: statefulset.yaml
+    set:
+      extraPodConfigs:
+        hostNetwork: true
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.name
+          value: storage
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: storage
+            emptyDir: {}
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

This PR fixes a YAML parse error when trying to install the `alertmanager` chart with those two conditions being true:

- `persistence.enabled` being set to `false`
- _any_ key-value pairs present in `extraPodConfigs`, e.g. `hostNetwork: true`

This is due to the `emptyDir` templating that happens when `persistence` is disabled not living within the `volumes` part of the STS template; it's separated from its theoretical parent by whatever gets configured through `extraPodConfigs` in the STS template, resulting in an orphaned list item, and thus a YAML parse error.

More details can be found in #7113 including steps for reproducing the bug.

#### Which issue this PR fixes

- fixes #7113

#### Special notes for your reviewer

This PR is based on the work of @i-yevtushenko in PR #6063. Since the PR seemed stale and there was no documenting issue, I created both from scratch.

`unittests/persistence_test.yaml` was co-authored by Claude Code, since I don't have much experience with Helm's `unittest` plugin (yet). I designed the test cases, proofread them, and made sure they fail in the chart's current version and pass after applying the fix in this PR.

Let me know if there's refactoring or adjustments to be done for the tests.

#### Checklist

- [X] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
- [X] Add an [helm unittest](https://github.com/helm-unittest/helm-unittest) test case to cover this change.
