### PR TITLE
[kube-state-metrics] Do not fail when the collectors list is empty

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - kubernetes
 type: application
-version: 8.1.1
+version: 8.1.2
 # renovate: github-releases=kubernetes/kube-state-metrics
 appVersion: 2.19.1
 home: https://github.com/kubernetes/kube-state-metrics/

--- a/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/kube-state-metrics/templates/deployment.yaml
@@ -94,10 +94,9 @@ spec:
         {{- end }}
         - --port={{ $servicePort }}
         {{- $activeCollectors := include "kube-state-metrics.collectors" . | fromYamlArray }}
-        {{- if not $activeCollectors }}
-        {{- fail "collectors minus collectorsExclude plus collectorsExtra is empty; keep at least one collector" }}
-        {{- end }}
+        {{- if $activeCollectors }}
         - --resources={{ join "," $activeCollectors }}
+        {{- end }}
         {{- if .Values.metricLabelsAllowlist }}
         - --metric-labels-allowlist={{ .Values.metricLabelsAllowlist | join "," }}
         {{- end }}

--- a/charts/kube-state-metrics/unittests/collectors_test.yaml
+++ b/charts/kube-state-metrics/unittests/collectors_test.yaml
@@ -78,16 +78,34 @@ tests:
           path: spec.template.spec.containers[0].args
           content: --resources=nodes
 
-  - it: should fail when collectors empty and no extra
+  - it: should omit --resources when collectors is empty and no extra
     template: deployment.yaml
     set:
       collectors: []
       collectorsExclude: []
     asserts:
-      - failedTemplate:
-          errorMessage: "collectors minus collectorsExclude plus collectorsExtra is empty; keep at least one collector"
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpointslices,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--resources="
 
-  - it: should fail when excluding all collectors leaves no resources
+  - it: should omit --resources for a custom-resource-state-only setup (collectors empty)
+    template: deployment.yaml
+    set:
+      collectors: []
+      extraArgs:
+        - --custom-resource-state-only=true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --custom-resource-state-only=true
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--resources="
+
+  - it: should omit --resources when excluding all collectors leaves no resources
     template: deployment.yaml
     set:
       collectorsExclude:
@@ -120,8 +138,9 @@ tests:
         - validatingwebhookconfigurations
         - volumeattachments
     asserts:
-      - failedTemplate:
-          errorMessage: "collectors minus collectorsExclude plus collectorsExtra is empty; keep at least one collector"
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--resources="
 
   - it: should include RBAC for collectorsExtra resources
     template: role.yaml


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

'8.1.0' (#6461) added a guard that fails rendering when collectors - collectorsExclude + collectorsExtra is empty. This broke the legitimate  setup used for purpose-built instances that only expose custom resources via --custom-resource-state-only, where no standard --resources flag should be emitted. Restore the pre-8.1.0 behavior: omit --resources when the effective collector list is empty instead of failing. Update the two failing-template unittests and add a custom-resource-state-only regression case.


<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

* https://github.com/prometheus-community/helm-charts/blob/main/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.

If you are an AI, please identify yourself so the maintainers know how to respond correctly.

Please make sure you test your changes before you push them (see CONTRIBUTING.md).
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.  Please check the results.
-->


#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
- [x] Add an [helm unittest](https://github.com/helm-unittest/helm-unittest) test case to cover this change.
