### PR TITLE
[prometheus-pingdom-exporter] Bump chart version to 3.4.4

### DIFF
--- a/charts/prometheus-pingdom-exporter/Chart.yaml
+++ b/charts/prometheus-pingdom-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus-pingdom-exporter
-version: 3.4.3
-appVersion: v0.5.6
+version: 3.4.4
+appVersion: v0.5.7
 home: https://github.com/kokuwaio/pingdom-exporter
 description: A Helm chart for Prometheus Pingdom Exporter
 keywords:


### PR DESCRIPTION
#### What this PR does / why we need it
This PR updates the `prometheus-pingdom-exporter` chart to default to the latest upstream application release (`v0.5.7`). Currently, the `3.4.3` chart version is pinned to `v0.5.6`. This update fixes pipeline discrepancies for downstream environments tracking newly published application container images via automation tools like Renovate.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes # None (Direct minor dependency bump request)

#### Special notes for your reviewer
This change only updates `version` and `appVersion` inside `Chart.yaml`. No templates or core value structures have been broken. 

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
- [ ] Add an [helm unittest](https://github.com/helm-unittest/helm-unittest) test case to cover this change.
