### PR TITLE
[prometheus-kafka-exporter] Escape chart version in Role/RoleBinding labels

### DIFF
--- a/charts/prometheus-kafka-exporter/Chart.yaml
+++ b/charts/prometheus-kafka-exporter/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v1.9.0"
 description: A Helm chart to export metrics from Kafka in Prometheus format using kafka_exporter from https://github.com/danielqsj/kafka_exporter
 name: prometheus-kafka-exporter
 home: https://github.com/danielqsj/kafka_exporter
-version: 3.1.0
+version: 3.1.1
 kubeVersion: ">=1.25.0-0"
 sources:
   - https://github.com/prometheus-community/helm-charts

--- a/charts/prometheus-kafka-exporter/templates/role.yaml
+++ b/charts/prometheus-kafka-exporter/templates/role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "prometheus-kafka-exporter.fullname" . }}
   labels:
     app: {{ template "prometheus-kafka-exporter.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "prometheus-kafka-exporter.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 {{- end }}

--- a/charts/prometheus-kafka-exporter/templates/rolebinding.yaml
+++ b/charts/prometheus-kafka-exporter/templates/rolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "prometheus-kafka-exporter.fullname" . }}
   labels:
     app: {{ template "prometheus-kafka-exporter.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "prometheus-kafka-exporter.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 roleRef:

--- a/charts/prometheus-kafka-exporter/unittests/rbac_test.yaml
+++ b/charts/prometheus-kafka-exporter/unittests/rbac_test.yaml
@@ -1,0 +1,22 @@
+suite: test rbac chart label
+templates:
+  - role.yaml
+  - rolebinding.yaml
+tests:
+  - it: should set the chart label from the chart helper
+    set:
+      rbac.create: true
+    asserts:
+      - matchRegex:
+          path: metadata.labels.chart
+          pattern: ^prometheus-kafka-exporter-[^+]+$
+
+  - it: should escape build metadata in the chart label
+    chart:
+      version: 1.2.3+c4affc05c6f2
+    set:
+      rbac.create: true
+    asserts:
+      - equal:
+          path: metadata.labels.chart
+          value: prometheus-kafka-exporter-1.2.3_c4affc05c6f2


### PR DESCRIPTION
#### What this PR does / why we need it

`templates/role.yaml` and `templates/rolebinding.yaml` interpolate the chart version into the `chart`
label directly:

```yaml
chart: {{ .Chart.Name }}-{{ .Chart.Version }}
```

Every other template in this chart uses the `prometheus-kafka-exporter.chart` helper
(`templates/_helpers.tpl`), which pipes through `replace "+" "_" | trunc 63 | trimSuffix "-"`. This PR
makes those two templates use the same helper. No new helper is introduced.

It matters when the chart version carries SemVer build metadata. Flux CD does exactly that: pulling a
chart through `OCIRepository` + `HelmRelease.spec.chartRef` stamps the version as
`<version>+<digest>`, e.g. `3.0.1+c4affc05c6f2`. `+` is not a legal character in a Kubernetes label
value, so the API server rejects the two RBAC objects and the whole install fails:

```
Helm install failed ... server-side apply failed for object ... Kind=Role:
Role.rbac.authorization.k8s.io "prometheus-kafka-exporter" is invalid: metadata.labels:
Invalid value: "prometheus-kafka-exporter-3.0.1+c4affc05c6f2": a valid label must be an empty string
or consist of alphanumeric characters, '-', '_' or '.' ...
```

The Deployment, Service and ServiceAccount install fine in the same run — they go through the helper
and render `...-3.0.1_c4affc05c6f2`. Only these two objects are affected. Hit on 3.0.1, still present
in 3.1.0.

For plain versions the rendered output is unchanged, since those contain no `+`.

#### Which issue this PR fixes

*(none found open for this — happy to file one if you'd prefer the issue-first flow)*

#### Special notes for your reviewer

Drafted with AI assistance; the diagnosis, the reproduction below and the test were reviewed and run
by me before pushing.

Reproduction, on the packaged chart with the version rewritten the way Flux stamps it
(`version: 3.1.0+c4affc05c6f2`), `helm template x . --set rbac.create=true`:

```
before                                              after
ServiceAccount  ...-3.1.0_c4affc05c6f2              ...-3.1.1_c4affc05c6f2
Role            ...-3.1.0+c4affc05c6f2   <- invalid ...-3.1.1_c4affc05c6f2
RoleBinding     ...-3.1.0+c4affc05c6f2   <- invalid ...-3.1.1_c4affc05c6f2
Service         ...-3.1.0_c4affc05c6f2              ...-3.1.1_c4affc05c6f2
Deployment      ...-3.1.0_c4affc05c6f2              ...-3.1.1_c4affc05c6f2
```

After the change no rendered label contains a `+`. Rendering at a plain version before and after the
change is byte-identical apart from the version bump, confirming the helper swap is a no-op without
build metadata. `helm lint` passes.

The added unittest covers both directions. With the fix applied, using the same invocation as
`.github/linters/ct.yaml` and the same plugin version CI pins (1.1.2):

```
$ helm unittest --strict --file 'unittests/**/*.yaml' charts/prometheus-kafka-exporter
 PASS  test rbac chart label	charts/prometheus-kafka-exporter/unittests/rbac_test.yaml
Charts:      1 passed, 1 total
Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
```

Reverting the two templates to their current form makes it fail, so the test pins the behaviour
rather than merely passing alongside it:

```
Expected to equal:	prometheus-kafka-exporter-1.2.3_c4affc05c6f2
Actual:            	prometheus-kafka-exporter-1.2.3+c4affc05c6f2
Tests:       1 failed, 1 passed, 2 total
```

The test uses helm-unittest's per-test `chart: version:` override to simulate the build-metadata case.
No other chart in this repo uses that feature, so flagging it in case you would rather it were written
differently. I have not run `ct lint` locally (chart-testing not installed), so that one is on CI.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
- [x] Add an [helm unittest](https://github.com/helm-unittest/helm-unittest) test case to cover this change.
