### PR TITLE
[prometheus-blackbox-exporter] optional set path per target

### DIFF
--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 11.17.2
+version: 11.18.0
 # renovate: github=prometheus/blackbox_exporter
 appVersion: v0.28.0
 kubeVersion: ">=1.21.0-0"

--- a/charts/prometheus-blackbox-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/servicemonitor.yaml
@@ -22,7 +22,7 @@ spec:
     {{- if $.Values.serviceMonitor.tlsConfig }}
     tlsConfig: {{ toYaml $.Values.serviceMonitor.tlsConfig | nindent 6 }}
     {{- end }}
-    path: {{ $.Values.serviceMonitor.path }}
+    path: {{ .path | default $.Values.serviceMonitor.path }}
     interval: {{ .interval | default $.Values.serviceMonitor.defaults.interval }}
     scrapeTimeout: {{ .scrapeTimeout | default $.Values.serviceMonitor.defaults.scrapeTimeout }}
     honorTimestamps: {{ .honorTimestamps | default $.Values.serviceMonitor.defaults.honorTimestamps }}


### PR DESCRIPTION
#### What this PR does / why we need it

This adds the option to set the path per target if needed when creating service monitors for the blackbox exporter. When testing multiple domains and pathes with one blackbox exporter chart installation this will help.

#### Which issue this PR fixes

none

#### Special notes for your reviewer

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
