### PR TITLE
[kube-prometheus-stack] Make cert-manager private key configurable

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 88.5.4
+version: 88.5.5
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.93.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/certmanager.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/certmanager.yaml
@@ -56,6 +56,10 @@ spec:
     {{- else }}
     name: {{ template "kube-prometheus-stack.fullname" . }}-root-issuer
     {{- end }}
+  {{- if .Values.prometheusOperator.admissionWebhooks.certManager.privateKey }}
+  privateKey:
+    {{- toYaml .Values.prometheusOperator.admissionWebhooks.certManager.privateKey | nindent 4 }}
+  {{- end }}
   dnsNames:
     {{- include "kube-prometheus-stack.operator.admission-webhook.dnsNames" . | splitList "\n" | toYaml | nindent 4 }}
 {{- end -}}

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -3201,6 +3201,13 @@ prometheusOperator:
       #   name: "issuer"
       #   kind: "ClusterIssuer"
 
+      # -- Set the private key algorithm and size for the Certificate. See
+      # https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificatePrivateKey
+      # Defaults to RSA 2048
+      # privateKey:
+      #   algorithm: ECDSA
+      #   size: 384
+
   ## Namespaces to scope the interaction of the Prometheus Operator and the apiserver (allow list).
   ## This is mutually exclusive with denyNamespaces. Setting this to an empty object will disable the configuration
   ##


### PR DESCRIPTION
Summary
Added a configurable `privateKey` option for the cert-manager admission webhook Certificate. Users can now configure the private key algorithm and size, such as `ECDSA` with a `384`-bit key. The chart version was bumped to `88.5.5`.

Motivation
The predefined issuer enforces security policies that reject the default RSA 2048-bit certificate configuration. Making the private key settings configurable allows users to select an algorithm and key size accepted by their issuer while preserving cert-manager’s defaults when no override is provided.