### PR TITLE
[kube-state-metrics] Add RBAC for admission policy collectors

### DIFF
--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - prometheus
   - kubernetes
 type: application
-version: 8.4.0
+version: 8.4.1
 # renovate: github-releases=kubernetes/kube-state-metrics
 appVersion: 2.20.0
 home: https://github.com/kubernetes/kube-state-metrics/

--- a/charts/kube-state-metrics/README.md
+++ b/charts/kube-state-metrics/README.md
@@ -72,6 +72,34 @@ See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_h
 helm show values oci://ghcr.io/prometheus-community/charts/kube-state-metrics
 ```
 
+### Admission policy collectors
+
+kube-state-metrics v2.20.0 and later supports the following admission policy collectors.
+They use the `admissionregistration.k8s.io/v1` API and are opt-in in this chart to preserve compatibility with older Kubernetes versions and image overrides.
+
+| Collectors | Required Kubernetes version |
+| --- | --- |
+| `validatingadmissionpolicies`, `validatingadmissionpolicybindings` | [v1.30 or later](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/) |
+| `mutatingadmissionpolicies`, `mutatingadmissionpolicybindings` | [v1.36 or later](https://kubernetes.io/docs/reference/access-authn-authz/mutating-admission-policy/) |
+
+Enable only the collectors supported by your cluster through `collectorsExtra` or `collectors`.
+For example, on Kubernetes v1.36 or later:
+
+```yaml
+collectorsExtra:
+  - mutatingadmissionpolicies
+  - mutatingadmissionpolicybindings
+  - validatingadmissionpolicies
+  - validatingadmissionpolicybindings
+```
+
+On Kubernetes v1.30 through v1.35, enable only the two validating admission policy collectors.
+Do not enable these collectors when overriding the image to a kube-state-metrics version older than v2.20.0.
+
+These resources are cluster-scoped and require cluster-wide RBAC permissions.
+With the default RBAC settings, the chart adds `list` and `watch` permissions only for the selected collectors.
+If you manage RBAC separately, grant those permissions on the selected resources in the `admissionregistration.k8s.io` API group.
+
 ### kube-rbac-proxy
 
 You can enable `kube-state-metrics` endpoint protection using `kube-rbac-proxy`. By setting `kubeRBACProxy.enabled: true`, this chart will deploy one RBAC proxy container per endpoint (metrics & telemetry).

--- a/charts/kube-state-metrics/templates/role.yaml
+++ b/charts/kube-state-metrics/templates/role.yaml
@@ -92,6 +92,18 @@ rules:
   - limitranges
   verbs: ["list", "watch"]
 {{ end -}}
+{{ if has "mutatingadmissionpolicies" $activeCollectors }}
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+    - mutatingadmissionpolicies
+  verbs: ["list", "watch"]
+{{ end -}}
+{{ if has "mutatingadmissionpolicybindings" $activeCollectors }}
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+    - mutatingadmissionpolicybindings
+  verbs: ["list", "watch"]
+{{ end -}}
 {{ if has "mutatingwebhookconfigurations" $activeCollectors }}
 - apiGroups: ["admissionregistration.k8s.io"]
   resources:
@@ -216,6 +228,18 @@ rules:
 - apiGroups: ["storage.k8s.io"]
   resources:
     - storageclasses
+  verbs: ["list", "watch"]
+{{ end -}}
+{{ if has "validatingadmissionpolicies" $activeCollectors }}
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+    - validatingadmissionpolicies
+  verbs: ["list", "watch"]
+{{ end -}}
+{{ if has "validatingadmissionpolicybindings" $activeCollectors }}
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+    - validatingadmissionpolicybindings
   verbs: ["list", "watch"]
 {{ end -}}
 {{ if has "validatingwebhookconfigurations" $activeCollectors }}

--- a/charts/kube-state-metrics/unittests/collectors_test.yaml
+++ b/charts/kube-state-metrics/unittests/collectors_test.yaml
@@ -228,3 +228,161 @@ tests:
             verbs:
               - list
               - watch
+
+  - it: should not grant admission policy permissions by default
+    template: role.yaml
+    asserts:
+      - notContains:
+          path: rules[*].resources
+          content: mutatingadmissionpolicies
+      - notContains:
+          path: rules[*].resources
+          content: mutatingadmissionpolicybindings
+      - notContains:
+          path: rules[*].resources
+          content: validatingadmissionpolicies
+      - notContains:
+          path: rules[*].resources
+          content: validatingadmissionpolicybindings
+
+  - it: should grant only mutating admission policy permissions when selected
+    template: role.yaml
+    set:
+      rbac.useClusterRole: true
+      collectors:
+        - mutatingadmissionpolicies
+    asserts:
+      - equal:
+          path: rules
+          value:
+            - apiGroups:
+                - admissionregistration.k8s.io
+              resources:
+                - mutatingadmissionpolicies
+              verbs:
+                - list
+                - watch
+
+  - it: should grant only mutating admission policy binding permissions when selected
+    template: role.yaml
+    set:
+      rbac.useClusterRole: true
+      collectors:
+        - mutatingadmissionpolicybindings
+    asserts:
+      - equal:
+          path: rules
+          value:
+            - apiGroups:
+                - admissionregistration.k8s.io
+              resources:
+                - mutatingadmissionpolicybindings
+              verbs:
+                - list
+                - watch
+
+  - it: should grant only validating admission policy permissions when selected
+    template: role.yaml
+    set:
+      rbac.useClusterRole: true
+      collectors:
+        - validatingadmissionpolicies
+    asserts:
+      - equal:
+          path: rules
+          value:
+            - apiGroups:
+                - admissionregistration.k8s.io
+              resources:
+                - validatingadmissionpolicies
+              verbs:
+                - list
+                - watch
+
+  - it: should grant only validating admission policy binding permissions when selected
+    template: role.yaml
+    set:
+      rbac.useClusterRole: true
+      collectors:
+        - validatingadmissionpolicybindings
+    asserts:
+      - equal:
+          path: rules
+          value:
+            - apiGroups:
+                - admissionregistration.k8s.io
+              resources:
+                - validatingadmissionpolicybindings
+              verbs:
+                - list
+                - watch
+
+  - it: should add admission policy RBAC and resources through collectorsExtra
+    set:
+      rbac.useClusterRole: true
+      collectors:
+        - pods
+      collectorsExtra:
+        - mutatingadmissionpolicies
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: --resources=pods,mutatingadmissionpolicies
+      - template: role.yaml
+        lengthEqual:
+          path: rules
+          count: 2
+      - template: role.yaml
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - pods
+            verbs:
+              - list
+              - watch
+      - template: role.yaml
+        contains:
+          path: rules
+          content:
+            apiGroups:
+              - admissionregistration.k8s.io
+            resources:
+              - mutatingadmissionpolicies
+            verbs:
+              - list
+              - watch
+
+  - it: should omit admission policy RBAC and resources when collectors are excluded
+    set:
+      rbac.useClusterRole: true
+      collectors:
+        - pods
+        - mutatingadmissionpolicies
+        - mutatingadmissionpolicybindings
+        - validatingadmissionpolicies
+        - validatingadmissionpolicybindings
+      collectorsExclude:
+        - mutatingadmissionpolicies
+        - mutatingadmissionpolicybindings
+        - validatingadmissionpolicies
+        - validatingadmissionpolicybindings
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: --resources=pods
+      - template: role.yaml
+        equal:
+          path: rules
+          value:
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+              verbs:
+                - list
+                - watch

--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -425,8 +425,8 @@ metricLabelsAllowlist: []
 metricAnnotationsAllowList: []
   # - pods=[k8s-annotation-1,k8s-annotation-n]
 
-# Available collectors for kube-state-metrics.
-# By default, all available resources are enabled, comment out to disable.
+# Collectors enabled by default. Comment out entries to disable them.
+# Additional opt-in collectors are listed below.
 collectors:
   - certificatesigningrequests
   - configmaps
@@ -462,6 +462,13 @@ collectors:
   # - roles
   # - rolebindings
   # - serviceaccounts
+  # Admission policy collectors require kube-state-metrics v2.20.0 or later.
+  # These validating admission policy collectors require Kubernetes v1.30+.
+  # - validatingadmissionpolicies
+  # - validatingadmissionpolicybindings
+  # These mutating admission policy collectors require Kubernetes v1.36+.
+  # - mutatingadmissionpolicies
+  # - mutatingadmissionpolicybindings
 
 # collectorsExclude / collectorsExtra tweak the default `collectors` list above
 # without redefining it. Both operate on `.Values.collectors` (not on KSM's


### PR DESCRIPTION
#### What this PR does / why we need it

kube-state-metrics v2.20.0 adds four admission policy collectors, but enabling them through `collectors` or `collectorsExtra` currently does not generate the required RBAC permissions.

This PR adds conditional `list`/`watch` rules for the admission policy and binding resources in `admissionregistration.k8s.io`, with documentation and regression tests. Default collectors remain unchanged.

#### Which issue this PR fixes

Refs #7198 (admission policy collector/RBAC support only).

#### Special notes for your reviewer

These collectors require kube-state-metrics v2.20.0+, with Kubernetes v1.30+ for validating policies and v1.36+ for mutating policies. Keeping them opt-in preserves compatibility with older clusters and image overrides.

Local checks with Helm v4.2.4 and helm-unittest v1.1.2:

- 39 unit tests passed; five new cases fail against the original RBAC template.
- `helm lint --strict` passed for default values, all four CI values files, and both documented examples.
- `helm template` checks passed for both examples. Default output and an `image.tag=v2.19.1` override are unchanged apart from chart version labels.

Kubernetes installation tests were not run locally because Docker Desktop could not start.

AI disclosure: OpenAI Codex prepared the changes and ran the local checks.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[kube-state-metrics]`)
- [x] Add an [helm unittest](https://github.com/helm-unittest/helm-unittest) test case to cover this change.
