### PR TITLE
[kube-prometheus-stack] Document Grafana dashboard folder options

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 88.5.4
+version: 88.5.5
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.93.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1547,6 +1547,13 @@ grafana:
       ## Annotations for Grafana dashboard configmaps
       ##
       annotations: {}
+
+      ## Annotation the sidecar reads to decide in which Grafana folder a dashboard
+      ## is stored. Requires `provider.foldersFromFilesStructure` to be enabled.
+      ## ref: https://github.com/grafana/helm-charts/tree/main/charts/grafana#sidecar-for-dashboards
+      ##
+      # folderAnnotation: grafana_folder
+
       multicluster:
         global:
           enabled: false
@@ -1554,6 +1561,12 @@ grafana:
           enabled: false
       provider:
         allowUiUpdates: false
+
+        ## Let Grafana replicate the dashboard folder structure created by the sidecar,
+        ## so dashboards are grouped into folders instead of the default one.
+        ## Required when using `folderAnnotation` above.
+        ##
+        # foldersFromFilesStructure: true
     datasources:
       enabled: true
       defaultDatasourceEnabled: true


### PR DESCRIPTION
#### What this PR does / why we need it

`grafana.sidecar.dashboards` in this chart is passed straight to the Grafana subchart, which supports grouping dashboards into Grafana folders via `folderAnnotation` + `provider.foldersFromFilesStructure`. Neither key appears in this chart's `values.yaml`, so users have no way to discover the feature without digging into the Grafana chart.

This adds both as commented examples next to the keys they belong to:

```yaml
grafana:
  sidecar:
    dashboards:
      folderAnnotation: grafana_folder
      provider:
        foldersFromFilesStructure: true
```

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer

Comments only — no change to rendered output with default values. Verified that setting both values renders the expected `FOLDER_ANNOTATION` env var on the dashboard sidecar and `options.foldersFromFilesStructure: true` in the dashboard provider configmap.

#### Checklist

- [x] DCO signed
- [x] Chart Version bumped (88.5.4 -> 88.5.5)
- [x] Variables are documented in `values.yaml` (this chart does not keep a values table in README.md)
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
