### PR TITLE
[kube-prometheus-stack] Add HTTPRoute timeout support

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 88.5.4
+version: 88.6.0
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.93.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/README.md
+++ b/charts/kube-prometheus-stack/README.md
@@ -110,6 +110,28 @@ You may also `helm show values` on this chart's [dependencies](#dependencies) fo
 
 For templated Grafana datasource definitions (e.g. when using Helm flow control), use `grafana.additionalDataSourcesString`, which is rendered via `tpl`.
 
+### HTTPRoute timeouts
+
+Set `timeouts` on a route to configure request and backend request timeouts for its generated HTTPRoute rule:
+
+```yaml
+prometheus:
+  route:
+    main:
+      enabled: true
+      parentRefs:
+        - name: gateway
+      timeouts:
+        request: 120s
+        backendRequest: 60s
+```
+
+The same settings are available under `alertmanager.route`, `thanosRuler.route`, and the `routePerReplica` settings for Prometheus and Alertmanager.
+
+Timeouts are only rendered for `kind: HTTPRoute`. They do not apply to generated HTTPS redirect rules or propagate to `additionalRules`; configure timeouts directly on additional rules when needed. Leaving `timeouts` empty preserves the Gateway controller's defaults.
+
+This requires Gateway API CRDs that support HTTPRoute timeouts (available in the Standard channel since v1.2.0) and a Gateway controller that supports the corresponding timeout features. When both values are set, `backendRequest` must not exceed `request`, unless `request` is `"0s"`. See the [Gateway API timeout documentation](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/#timeouts-optional) for duration semantics and controller support requirements.
+
 ### Prometheus High Availability (HA)
 
 For a basic HA setup, run multiple Prometheus replicas:

--- a/charts/kube-prometheus-stack/ci/05-ingress-and-gateway-routes-values.yaml
+++ b/charts/kube-prometheus-stack/ci/05-ingress-and-gateway-routes-values.yaml
@@ -10,6 +10,9 @@ alertmanager:
       enabled: true
       hostnames:
         - "*.example.com"
+      timeouts:
+        request: 120s
+        backendRequest: 60s
       filters:
         - type: RequestHeaderModifier
           requestHeaderModifier:
@@ -36,6 +39,9 @@ alertmanager:
       hostDomain: example.com
       parentRefs:
         - name: gateway
+      timeouts:
+        request: 30s
+        backendRequest: 15s
       filters:
         - type: RequestHeaderModifier
           requestHeaderModifier:
@@ -56,6 +62,9 @@ prometheus:
       enabled: true
       hostnames:
         - "*.example.com"
+      timeouts:
+        request: 120s
+        backendRequest: 60s
       filters:
         - type: RequestHeaderModifier
           requestHeaderModifier:
@@ -82,6 +91,9 @@ prometheus:
       hostDomain: example.com
       parentRefs:
         - name: gateway
+      timeouts:
+        request: 30s
+        backendRequest: 15s
       filters:
         - type: RequestHeaderModifier
           requestHeaderModifier:
@@ -99,6 +111,9 @@ thanosRuler:
       enabled: true
       hostnames:
         - "*.example.com"
+      timeouts:
+        request: 120s
+        backendRequest: 60s
       filters:
         - type: RequestHeaderModifier
           requestHeaderModifier:

--- a/charts/kube-prometheus-stack/templates/_helpers.tpl
+++ b/charts/kube-prometheus-stack/templates/_helpers.tpl
@@ -468,6 +468,12 @@ Expects a dict: { "context": $, "route": <route values>, "serviceName": <string>
   matches:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if eq ($route.kind | default "HTTPRoute") "HTTPRoute" }}
+  {{- with $route.timeouts }}
+  timeouts:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
   {{- with $route.sessionPersistence }}
   sessionPersistence:
     {{- toYaml . | nindent 4 }}

--- a/charts/kube-prometheus-stack/unittests/route_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/route_test.yaml
@@ -1,0 +1,233 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test Gateway API route timeouts
+templates:
+  - prometheus/route.yaml
+  - prometheus/routeperreplica.yaml
+  - alertmanager/route.yaml
+  - alertmanager/routeperreplica.yaml
+  - thanos-ruler/route.yaml
+set:
+  prometheus.enabled: true
+  prometheus.route.main.enabled: true
+  alertmanager.enabled: true
+  alertmanager.route.main.enabled: true
+  thanosRuler.enabled: true
+  thanosRuler.route.main.enabled: true
+tests:
+  - it: should omit timeouts from component routes by default
+    templates:
+      - prometheus/route.yaml
+      - alertmanager/route.yaml
+      - thanos-ruler/route.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - notExists:
+          path: spec.rules[0].timeouts
+
+  - it: should render request and backend timeouts independently for each component
+    templates:
+      - prometheus/route.yaml
+      - alertmanager/route.yaml
+      - thanos-ruler/route.yaml
+    set:
+      prometheus.route.main.timeouts:
+        request: 30s
+      alertmanager.route.main.timeouts:
+        backendRequest: 15s
+      thanosRuler.route.main.timeouts:
+        request: 60s
+        backendRequest: 45s
+    asserts:
+      - template: prometheus/route.yaml
+        equal:
+          path: spec.rules[0].timeouts
+          value:
+            request: 30s
+      - template: alertmanager/route.yaml
+        equal:
+          path: spec.rules[0].timeouts
+          value:
+            backendRequest: 15s
+      - template: thanos-ruler/route.yaml
+        equal:
+          path: spec.rules[0].timeouts
+          value:
+            request: 60s
+            backendRequest: 45s
+
+  - it: should preserve zero-duration timeouts
+    template: prometheus/route.yaml
+    set:
+      prometheus.route.main.timeouts:
+        request: "0s"
+        backendRequest: "0s"
+    asserts:
+      - equal:
+          path: spec.rules[0].timeouts
+          value:
+            request: "0s"
+            backendRequest: "0s"
+
+  - it: should render timeouts on every Prometheus and Alertmanager replica route
+    templates:
+      - prometheus/routeperreplica.yaml
+      - alertmanager/routeperreplica.yaml
+    set:
+      prometheus.servicePerReplica.enabled: true
+      prometheus.prometheusSpec.replicas: 2
+      prometheus.routePerReplica.main.enabled: true
+      prometheus.routePerReplica.main.hostPrefix: prometheus
+      prometheus.routePerReplica.main.hostDomain: example.com
+      prometheus.routePerReplica.main.timeouts:
+        request: 30s
+        backendRequest: 15s
+      alertmanager.servicePerReplica.enabled: true
+      alertmanager.alertmanagerSpec.replicas: 2
+      alertmanager.routePerReplica.main.enabled: true
+      alertmanager.routePerReplica.main.hostPrefix: alertmanager
+      alertmanager.routePerReplica.main.hostDomain: example.com
+      alertmanager.routePerReplica.main.timeouts:
+        request: 10s
+        backendRequest: 5s
+    documentSelector:
+      path: kind
+      value: HTTPRoute
+      matchMany: true
+    asserts:
+      - hasDocuments:
+          count: 2
+          filterAware: true
+      - template: prometheus/routeperreplica.yaml
+        equal:
+          path: spec.rules[0].timeouts
+          value:
+            request: 30s
+            backendRequest: 15s
+      - template: alertmanager/routeperreplica.yaml
+        equal:
+          path: spec.rules[0].timeouts
+          value:
+            request: 10s
+            backendRequest: 5s
+
+  - it: should keep named route timeouts independent and default to HTTPRoute
+    template: prometheus/route.yaml
+    set:
+      prometheus.route.main.timeouts:
+        request: 30s
+      prometheus.route.reports:
+        enabled: true
+        timeouts:
+          request: 60s
+          backendRequest: 45s
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: spec.rules[0].timeouts
+          value:
+            request: 30s
+        documentSelector:
+          path: metadata.name
+          value: RELEASE-NAME-kube-promethe-prometheus
+      - isKind:
+          of: HTTPRoute
+        documentSelector:
+          path: metadata.name
+          value: RELEASE-NAME-kube-promethe-prometheus-reports
+      - equal:
+          path: spec.rules[0].timeouts
+          value:
+            request: 60s
+            backendRequest: 45s
+        documentSelector:
+          path: metadata.name
+          value: RELEASE-NAME-kube-promethe-prometheus-reports
+
+  - it: should preserve additional rules without inheriting the route timeouts
+    template: prometheus/route.yaml
+    set:
+      prometheus.route.main.timeouts:
+        request: 30s
+        backendRequest: 15s
+      prometheus.route.main.additionalRules:
+        - backendRefs:
+            - name: custom-backend
+              port: 8080
+          timeouts:
+            request: 5s
+            backendRequest: 2s
+        - backendRefs:
+            - name: other-backend
+              port: 8081
+    asserts:
+      - lengthEqual:
+          path: spec.rules
+          count: 3
+      - equal:
+          path: spec.rules[0]
+          value:
+            backendRefs:
+              - name: custom-backend
+                port: 8080
+            timeouts:
+              request: 5s
+              backendRequest: 2s
+      - equal:
+          path: spec.rules[1]
+          value:
+            backendRefs:
+              - name: other-backend
+                port: 8081
+      - equal:
+          path: spec.rules[2].timeouts
+          value:
+            request: 30s
+            backendRequest: 15s
+
+  - it: should not add backend timeouts to an HTTPS redirect rule
+    template: prometheus/route.yaml
+    set:
+      prometheus.route.main.httpsRedirect: true
+      prometheus.route.main.timeouts:
+        request: 30s
+        backendRequest: 15s
+    asserts:
+      - equal:
+          path: spec.rules
+          value:
+            - filters:
+                - type: RequestRedirect
+                  requestRedirect:
+                    scheme: https
+                    statusCode: 301
+
+  - it: should not add HTTP timeouts to a GRPCRoute
+    template: prometheus/route.yaml
+    set:
+      prometheus.route.main.kind: GRPCRoute
+      prometheus.route.main.matches: []
+      prometheus.route.main.timeouts:
+        request: 30s
+        backendRequest: 15s
+    asserts:
+      - isKind:
+          of: GRPCRoute
+      - notExists:
+          path: spec.rules[0].timeouts
+
+  - it: should not add HTTP timeouts to a TCPRoute
+    template: prometheus/route.yaml
+    set:
+      prometheus.route.main.apiVersion: gateway.networking.k8s.io/v1alpha2
+      prometheus.route.main.kind: TCPRoute
+      prometheus.route.main.matches: []
+      prometheus.route.main.timeouts:
+        request: 30s
+        backendRequest: 15s
+    asserts:
+      - isKind:
+          of: TCPRoute
+      - notExists:
+          path: spec.rules[0].timeouts

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -711,6 +711,12 @@ alertmanager:
       ## Filters define the filters that are applied to requests that match this rule.
       filters: []
 
+      ## Timeouts for the generated HTTPRoute backend rule.
+      ## Requires Gateway API CRDs and a controller that support HTTPRoute timeouts.
+      timeouts: {}
+      # request: 120s
+      # backendRequest: 60s
+
       ## Session persistence configuration for the route rule.
       sessionPersistence: {}
       # sessionName: route
@@ -809,6 +815,12 @@ alertmanager:
         - path:
             type: PathPrefix
             value: /
+
+      ## Timeouts for the generated HTTPRoute backend rule.
+      ## Requires Gateway API CRDs and a controller that support HTTPRoute timeouts.
+      timeouts: {}
+      # request: 120s
+      # backendRequest: 60s
 
       ## Session persistence configuration for the route rule.
       sessionPersistence: {}
@@ -4040,6 +4052,12 @@ prometheus:
       ## Filters define the filters that are applied to requests that match this rule.
       filters: []
 
+      ## Timeouts for the generated HTTPRoute backend rule.
+      ## Requires Gateway API CRDs and a controller that support HTTPRoute timeouts.
+      timeouts: {}
+      # request: 120s
+      # backendRequest: 60s
+
       ## Session persistence configuration for the route rule.
       sessionPersistence: {}
       # sessionName: route
@@ -4133,6 +4151,12 @@ prometheus:
         - path:
             type: PathPrefix
             value: /
+
+      ## Timeouts for the generated HTTPRoute backend rule.
+      ## Requires Gateway API CRDs and a controller that support HTTPRoute timeouts.
+      timeouts: {}
+      # request: 120s
+      # backendRequest: 60s
 
       ## Session persistence configuration for the route rule.
       sessionPersistence: {}
@@ -5395,6 +5419,12 @@ thanosRuler:
 
       ## Filters define the filters that are applied to requests that match this rule.
       filters: []
+
+      ## Timeouts for the generated HTTPRoute backend rule.
+      ## Requires Gateway API CRDs and a controller that support HTTPRoute timeouts.
+      timeouts: {}
+      # request: 120s
+      # backendRequest: 60s
 
       ## Session persistence configuration for the route rule.
       sessionPersistence: {}


### PR DESCRIPTION
#### What this PR does / why we need it

Adds optional `request` and `backendRequest` timeouts to HTTPRoute rules for Prometheus, Alertmanager and ThanosRuler, including the existing Prometheus and Alertmanager per-replica routes.

Defaults remain unchanged. Timeouts only apply to generated HTTPRoute backend rules; HTTPS redirects, other route kinds and user-provided `additionalRules` are preserved. Includes documentation, CI values and regression tests.

#### Which issue this PR fixes

Fixes #7078

#### Special notes for your reviewer

Requires Gateway API CRDs and a controller that support HTTPRoute timeouts. The fields are available in the Standard channel from Gateway API v1.2.0.

Local checks with Helm v4.2.4 and helm-unittest v1.1.2:

- 107 unit tests passed. Five regression cases fail against the original helper.
- `helm lint --strict` passed for defaults, all five CI values files and the README example.
- Default and original CI values render identically apart from chart version labels with Kubernetes capabilities set to v1.25.0 and v1.36.0. The updated Gateway CI values and README example also render the expected timeouts.

Local Kubernetes installation tests were not run because Docker is unavailable. Actual Gateway request timeout behavior was not tested.

AI assistance: OpenAI Codex prepared the changes and ran the local checks.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[kube-prometheus-stack]`)
- [x] Add an [helm unittest](https://github.com/helm-unittest/helm-unittest) test case to cover this change.
