### PR TITLE
[prometheus-stackdriver-exporter] Clean up deprecated config and add descriptor cache TTL

### DIFF
--- a/charts/prometheus-stackdriver-exporter/Chart.yaml
+++ b/charts/prometheus-stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: prometheus-stackdriver-exporter
-version: 4.13.0
+version: 5.0.0
 appVersion: v0.19.0
 home: https://www.stackdriver.com/
 sources:

--- a/charts/prometheus-stackdriver-exporter/README.md
+++ b/charts/prometheus-stackdriver-exporter/README.md
@@ -33,10 +33,10 @@ The installation instructions use the OCI registry. Refer to the [`helm repo`]([
 
 ```console
 # Helm 3
-$ helm install [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/prometheus-stackdriver-exporter --set stackdriver.projectId=google-project-name
+$ helm install [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/prometheus-stackdriver-exporter --set 'stackdriver.projectIds[0]=google-project-name'
 
 # Helm 2
-$ helm install --name [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/prometheus-stackdriver-exporter --set stackdriver.projectId=google-project-name
+$ helm install --name [RELEASE_NAME] oci://ghcr.io/prometheus-community/charts/prometheus-stackdriver-exporter --set 'stackdriver.projectIds[0]=google-project-name'
 ```
 
 The command deploys Stackdriver-Exporter on the Kubernetes cluster using the default configuration.
@@ -71,6 +71,30 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 #### Upgrading an existing Release to a new major version
 
 A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an incompatible breaking change needing manual actions.
+
+##### 4.x to 5.x
+
+The deprecated `stackdriver.projectId` and
+`stackdriver.metrics.typePrefixes` parameters have been removed.
+
+Replace:
+
+```yaml
+stackdriver:
+  projectId: my-project
+  metrics:
+    typePrefixes: compute.googleapis.com/instance/cpu
+```
+with:
+
+```yaml
+stackdriver:
+  projectIds:
+    - my-project
+  metrics:
+    prefixes:
+      - compute.googleapis.com/instance/cpu
+```
 
 ##### 3.x to 4.x
 
@@ -141,7 +165,7 @@ $ helm inspect values oci://ghcr.io/prometheus-community/charts/prometheus-stack
 $ helm show values oci://ghcr.io/prometheus-community/charts/prometheus-stackdriver-exporter
 ```
 
-> **Tip**: You can use the default [values.yaml](values.yaml), as long as you provide a value for stackdriver.projectId
+> **Tip**: You can use the default [values.yaml](values.yaml), as long as you provide a value for stackdriver.projectIds.
 
 ## Google Storage Metrics
 

--- a/charts/prometheus-stackdriver-exporter/ci/descriptor-cache-values.yaml
+++ b/charts/prometheus-stackdriver-exporter/ci/descriptor-cache-values.yaml
@@ -1,0 +1,19 @@
+---
+stackdriver:
+  projectIds:
+    - dummy-project
+  metrics:
+    descriptorCacheTTL: 10m
+  serviceAccountKey: |
+    {
+      "type": "service_account",
+      "project_id": "dummy-acc",
+      "private_key_id": "00000000000000000000000000000000000",
+      "private_key": "",
+      "client_email": "dummy@dummy-acc.iam.gserviceaccount.com",
+      "client_id": "0000000000000000000000000",
+      "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+      "token_uri": "https://oauth2.googleapis.com/token",
+      "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+      "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/dummy%dummy-acc.iam.gserviceaccount.com"
+    }

--- a/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
@@ -79,24 +79,17 @@ spec:
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
           {{- end }}
           args:
-            {{- if .Values.stackdriver.projectIds }}
             {{- range .Values.stackdriver.projectIds }}
             - --google.project-ids={{ . }}
-            {{- end }}
-            {{- else }}
-            - --google.project-id={{ .Values.stackdriver.projectId }}
             {{- end }}
             {{- if .Values.stackdriver.projectFilters }}
             - --google.projects.filter='{{ .Values.stackdriver.projectFilters }}'
             {{- end }}
             - --monitoring.metrics-interval={{ .Values.stackdriver.metrics.interval }}
             - --monitoring.metrics-offset={{ .Values.stackdriver.metrics.offset }}
-            {{- if .Values.stackdriver.metrics.prefixes }}
+            - --monitoring.descriptor-cache-ttl={{ .Values.stackdriver.metrics.descriptorCacheTTL }}
             {{- range .Values.stackdriver.metrics.prefixes }}
             - --monitoring.metrics-prefixes={{ . }}
-            {{- end }}
-            {{- else }}
-            - --monitoring.metrics-type-prefixes={{ .Values.stackdriver.metrics.typePrefixes | replace " " "" }}
             {{- end }}
             {{- range .Values.stackdriver.metrics.filters }}
             - --monitoring.filters={{ . }}

--- a/charts/prometheus-stackdriver-exporter/values.yaml
+++ b/charts/prometheus-stackdriver-exporter/values.yaml
@@ -68,8 +68,6 @@ secret:
   labels: {}
 
 stackdriver:
-  # DEPRECATED - The Google Project ID to gather metrics for
-  projectId: "FALSE"
   # The Google Project IDs to gather metrics for (requires 0.17.0+)
   projectIds: []
   # filter for selecting google projects
@@ -94,11 +92,9 @@ stackdriver:
   # Drop metrics from attached projects and fetch `project_id` only
   dropDelegatedProjects: false
   metrics:
-    # DEPRECATED - The prefixes to gather metrics for, we default to just CPU metrics.
-    typePrefixes: 'compute.googleapis.com/instance/cpu'
-    # The prefixes to gather metrics for (requires 0.17.0+)
-    prefixes: []
-      # - 'compute.googleapis.com/instance/cpu'
+    # The prefixes to gather metrics for
+    prefixes:
+      - 'compute.googleapis.com/instance/cpu'
     # The filters to refine the metrics query by using Filter objects that Google provides.
     # Filter objects: project, group.id, resource.type, resource.labels.[KEY], metric.type, metric.labels.[KEY]
     # https://cloud.google.com/monitoring/api/v3/filters
@@ -114,6 +110,8 @@ stackdriver:
     aggregateDeltas: false
     # How long should a delta metric continue to be exported after GCP stops producing a metric
     aggregateDeltasTTL: '30m'
+    # How long metric descriptors should be cached for
+    descriptorCacheTTL: '0s'
 
 web:
   # Port to listen on


### PR DESCRIPTION
#### What this PR does / why we need it

This PR updates the `prometheus-stackdriver-exporter` chart to:

* Add support for `--monitoring.descriptor-cache-ttl` via `stackdriver.metrics.descriptorCacheTTL`
* Remove the deprecated `stackdriver.projectId` value in favor of `stackdriver.projectIds`
* Remove the deprecated `stackdriver.metrics.typePrefixes` value in favor of `stackdriver.metrics.prefixes`
* Preserve the existing default metric prefix behavior
* Add `ci/descriptor-cache-values.yaml` to test a non-default descriptor cache TTL
* Bump the chart major version due to removal of deprecated values

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer

The new `descriptorCacheTTL` value defaults to `0s`, matching the exporter default.

#### Checklist

* [x] DCO signed
* [x] Chart Version bumped
* [x] Title of the PR starts with chart name
* [x] Add a helm unittest test case to cover this change
