### PR TITLE
[kube-prometheus-stack] Fix multiline annotation overrides

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 88.6.2
+version: 88.6.3
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.93.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/hack/sync_prometheus_rules.py
+++ b/charts/kube-prometheus-stack/hack/sync_prometheus_rules.py
@@ -506,7 +506,7 @@ def add_custom_annotations(rules, group, indent=4):
     rule_group_annotations = get_rule_group_condition(condition_map.get(group['name'], ''), 'additionalRuleGroupAnnotations')
     annotations = "      annotations:"
     annotations_len = len(annotations) + 1
-    description_pattern = r'(?m)^([ \t]+)description: (.+)$'
+    description_pattern = r'(?ms)^([ \t]+)description: (.*?)(?=\n\1(?:runbook_url|summary):)'
     runbook_pattern = r'(?m)^([ \t]+)runbook_url: (.+)$'
     summary_pattern = r'(?m)^([ \t]+)summary: (.+)$'
 

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/config-reloaders.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/config-reloaders.yaml
@@ -35,9 +35,9 @@ spec:
 {{- end }}
         {{- if not (hasKey $additionalAnnotations "description") }}
         description: 'Errors encountered while the {{`{{`}}$labels.pod{{`}}`}} config-reloader sidecar attempts to sync config in {{`{{`}}$labels.namespace{{`}}`}} namespace.
-        {{- end }}
 
           As a result, configuration for service running in {{`{{`}}$labels.pod{{`}}`}} may be stale and cannot be updated anymore.'
+        {{- end }}
         {{- if not (hasKey $additionalAnnotations "runbook_url") }}
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus-operator/configreloadersidecarerrors
         {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/general.rules.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/general.rules.yaml
@@ -69,7 +69,6 @@ spec:
 {{- end }}
         {{- if not (hasKey $additionalAnnotations "description") }}
         description: 'This is an alert meant to ensure that the entire alerting pipeline is functional.
-        {{- end }}
 
           This alert is always firing, therefore it should always be firing in Alertmanager
 
@@ -80,6 +79,7 @@ spec:
           "DeadMansSnitch" integration in PagerDuty.
 
           '
+        {{- end }}
         {{- if not (hasKey $additionalAnnotations "runbook_url") }}
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/general/watchdog
         {{- end }}
@@ -109,7 +109,6 @@ spec:
 {{- end }}
         {{- if not (hasKey $additionalAnnotations "description") }}
         description: 'This is an alert that is used to inhibit info alerts.
-        {{- end }}
 
           By themselves, the info-level alerts are sometimes very noisy, but they are relevant when combined with
 
@@ -122,6 +121,7 @@ spec:
           This alert should be routed to a null receiver and configured to inhibit alerts with severity="info".
 
           '
+        {{- end }}
         {{- if not (hasKey $additionalAnnotations "runbook_url") }}
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/general/infoinhibitor
         {{- end }}

--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-exporter.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-exporter.yaml
@@ -703,9 +703,9 @@ spec:
 {{- end }}
         {{- if not (hasKey $additionalAnnotations "description") }}
         description: 'CPU usage at {{`{{`}} $labels.instance {{`}}`}} has been above 90% for the last 15 minutes, is currently at {{`{{`}} printf "%.2f" $value {{`}}`}}%.
-        {{- end }}
 
           '
+        {{- end }}
         {{- if not (hasKey $additionalAnnotations "runbook_url") }}
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodecpuhighusage
         {{- end }}
@@ -739,11 +739,11 @@ spec:
 {{- end }}
         {{- if not (hasKey $additionalAnnotations "description") }}
         description: 'System load per core at {{`{{`}} $labels.instance {{`}}`}} has been above 2 for the last 15 minutes, is currently at {{`{{`}} printf "%.2f" $value {{`}}`}}.
-        {{- end }}
 
           This might indicate this instance resources saturation and can cause it becoming unresponsive.
 
           '
+        {{- end }}
         {{- if not (hasKey $additionalAnnotations "runbook_url") }}
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodesystemsaturation
         {{- end }}
@@ -779,11 +779,11 @@ spec:
 {{- end }}
         {{- if not (hasKey $additionalAnnotations "description") }}
         description: 'Memory major pages are occurring at very high rate at {{`{{`}} $labels.instance {{`}}`}}, 500 major page faults per second for the last 15 minutes, is currently at {{`{{`}} printf "%.2f" $value {{`}}`}}.
-        {{- end }}
 
           Please check that there is enough memory available at this instance.
 
           '
+        {{- end }}
         {{- if not (hasKey $additionalAnnotations "runbook_url") }}
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodememorymajorpagesfaults
         {{- end }}
@@ -817,9 +817,9 @@ spec:
 {{- end }}
         {{- if not (hasKey $additionalAnnotations "description") }}
         description: 'Memory is filling up at {{`{{`}} $labels.instance {{`}}`}}, has been above 90% for the last 15 minutes, is currently at {{`{{`}} printf "%.2f" $value {{`}}`}}%.
-        {{- end }}
 
           '
+        {{- end }}
         {{- if not (hasKey $additionalAnnotations "runbook_url") }}
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodememoryhighutilization
         {{- end }}
@@ -853,11 +853,11 @@ spec:
 {{- end }}
         {{- if not (hasKey $additionalAnnotations "description") }}
         description: 'Disk IO queue (aqu-sq) is high on {{`{{`}} $labels.device {{`}}`}} at {{`{{`}} $labels.instance {{`}}`}}, has been above 10 for the last 30 minutes, is currently at {{`{{`}} printf "%.2f" $value {{`}}`}}.
-        {{- end }}
 
           This symptom might indicate disk saturation.
 
           '
+        {{- end }}
         {{- if not (hasKey $additionalAnnotations "runbook_url") }}
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/node/nodediskiosaturation
         {{- end }}

--- a/charts/kube-prometheus-stack/unittests/prometheus/additional_rule_annotations_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/prometheus/additional_rule_annotations_test.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test additionalRuleAnnotations
+
+templates:
+  - prometheus/rules-1.14/node-exporter.yaml
+
+tests:
+  - it: should fully override multiline default annotations
+    set:
+      defaultRules.additionalRuleAnnotations.NodeSystemSaturation.summary: Custom summary
+      defaultRules.additionalRuleAnnotations.NodeSystemSaturation.description: Custom description
+    asserts:
+      - isSubset:
+          path: spec.groups[0].rules[?(@.alert == "NodeSystemSaturation")].annotations
+          content:
+            summary: Custom summary
+            description: Custom description


### PR DESCRIPTION
#### What this PR does / why we need it

When a multiline default alert description is overridden through `defaultRules.additionalRuleAnnotations`, the generated template closes the conditional block after the first line. The remaining lines are rendered unconditionally, which can produce incorrect annotation content after Helm rendering.

This change updates the rule generator to match the complete multiline description block, regenerates the affected PrometheusRule templates, and adds a regression test for NodeSystemSaturation.

#### Which issue this PR fixes

fixes #7227

#### Special notes for your reviewer

The chart version was bumped from 88.6.2 to 88.6.3.

Validation completed:

- helm unittest --strict --file 'unittests/**/*.yaml' charts/kube-prometheus-stack
- 24 test suites passed
- 108 tests passed

#### Checklist

- [x] DCO signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name
- [x] Added a helm-unittest test case for this change