### PR TITLE
[kube-prometheus-stack] Set a default commonName for prometheus cert-…

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 89.2.0
+version: 89.2.1
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.93.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/templates/prometheus-operator/certmanager.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus-operator/certmanager.yaml
@@ -47,6 +47,7 @@ metadata:
 spec:
   secretName: {{ template "kube-prometheus-stack.fullname" . }}-admission
   duration: {{ .Values.prometheusOperator.admissionWebhooks.certManager.admissionCert.duration | default "8760h0m0s" | quote }}
+  commonName: {{ template "kube-prometheus-stack.operator.fullname" . }}
   {{- with .Values.prometheusOperator.admissionWebhooks.certManager.admissionCert.revisionHistoryLimit }}
   revisionHistoryLimit: {{ . }}
   {{- end }}


### PR DESCRIPTION
## Summary

Set a default `commonName` in the Prometheus Operator cert-manager `Certificate`, equal to the Prometheus Operator service name.

## Motivation

Some PKI certificate issuers require the `commonName` field to be set explicitly. Without it, the certificate request fails during signing.

For example, when using a Vault-backed issuer, the certificate request fails with the following error:

> Warning  Failed     44s   cert-manager-certificates-issuing          The certificate request has failed to complete and will be retried: Vault failed to sign certificate: failed to sign certificate by vault: Error making API request.
> Code: 400. Errors:
> * the common_name field is required, or must be provided in a CSR with "use_csr_common_name" set to true, unless "require_cn" is set to false

Setting the `commonName` to the Prometheus Operator service name ensures the certificate request satisfies these issuers and completes successfully.