### PR TITLE
[kube-prometheus-stack] Add secret-based auth to control-plane ServiceMonitors

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 89.3.0
+version: 90.0.0
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.93.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -28,7 +28,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 89.2.2
+version: 89.3.0
 # renovate: github=prometheus-operator/prometheus-operator
 appVersion: v0.93.1
 kubeVersion: ">=1.25.0-0"

--- a/charts/kube-prometheus-stack/README.md
+++ b/charts/kube-prometheus-stack/README.md
@@ -132,11 +132,11 @@ Timeouts are only rendered for `kind: HTTPRoute`. They do not apply to generated
 
 This requires Gateway API CRDs that support HTTPRoute timeouts (available in the Standard channel since v1.2.0) and a Gateway controller that supports the corresponding timeout features. When both values are set, `backendRequest` must not exceed `request`, unless `request` is `"0s"`. See the [Gateway API timeout documentation](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/#timeouts-optional) for duration semantics and controller support requirements.
 
-### Secret-based authentication for control-plane ServiceMonitors
+### Authentication of the control-plane ServiceMonitors
 
-The built-in ServiceMonitors for kubelet, kube-apiserver, kube-controller-manager, kube-scheduler, kube-etcd, kube-proxy, and coredns default to the deprecated `bearerTokenFile` / `tlsConfig.caFile` fields. Environments that set `prometheus.prometheusSpec.arbitraryFSAccessThroughSMs.deny: true`, or that scrape with Grafana Alloy's `prometheus.operator.servicemonitors` component (which defaults `allow_arbitrary_file_access` to `false`), reject these ServiceMonitors outright and drop the targets.
+The built-in ServiceMonitors for kubelet, kube-apiserver, kube-controller-manager, kube-scheduler, kube-etcd, kube-proxy, coredns and kube-dns authenticate through Kubernetes objects rather than through files on the scraper's filesystem. The bearer token comes from a Secret referenced by `authorization`, and the CA comes from the `kube-root-ca.crt` ConfigMap that Kubernetes maintains in every namespace. This keeps the ServiceMonitors valid when `prometheus.prometheusSpec.arbitraryFSAccessThroughSMs.deny` is `true`, and when they are scraped by Grafana Alloy's `prometheus.operator.servicemonitors` component, which rejects filesystem references by default since v1.19.0.
 
-Each component's `serviceMonitor` accepts an `authorization` field (in place of `bearerTokenFile`) and a `caSecret` field (in place of `caFile`, for components that support TLS) to reference a Kubernetes Secret instead:
+The chart creates the credential itself: `prometheus.serviceAccount.createTokenSecret` (enabled by default) renders a `kubernetes.io/service-account-token` Secret named `<prometheus service account>-token`, which every component references by default:
 
 ```yaml
 kubelet:
@@ -144,30 +144,52 @@ kubelet:
     authorization:
       type: Bearer
       credentials:
-        name: kubelet-scrape-auth
+        name: '{{ include "kube-prometheus-stack.prometheus.tokenSecretName" . }}'
         key: token
-    caSecret:
-      name: kubelet-scrape-auth
-      key: ca.crt
+    tlsConfig:
+      insecureSkipVerify: true
+      ca:
+        configMap:
+          name: kube-root-ca.crt
+          key: ca.crt
 ```
 
-Setting either field switches that endpoint to the secret-based equivalent and drops the corresponding file-based field; leaving them unset (the default) preserves today's `bearerTokenFile`/`caFile` behavior. `kubeApiServer` keeps its CA override under `kubeApiServer.tlsConfig.caSecret` (alongside the existing `tlsConfig.serverName`/`insecureSkipVerify`) rather than under `serviceMonitor`. `coreDns`/`kubeDns` only expose `authorization`, since those endpoints have no TLS support.
+Both `authorization` and `tlsConfig` are rendered as-is, so any field of the Prometheus Operator [SafeAuthorization](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SafeAuthorization) and [SafeTLSConfig](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SafeTLSConfig) types can be set. Set `authorization` to `null` to scrape a component without authentication. `kubeApiServer` keeps its TLS settings under `kubeApiServer.tlsConfig`; `coreDns` and `kubeDns` have no `tlsConfig`, since those endpoints are scraped over HTTP.
 
-`kubeEtcd` is the only component that scrapes with client certificates, so it additionally accepts `certSecret` and `keySecret` in place of `certFile` and `keyFile`:
+That Secret is only rendered alongside the Prometheus service account, so it also requires `prometheus.enabled` and `prometheus.serviceAccount.create`. Leaving a component on the default `authorization` while the Secret is not rendered fails the release with an explanatory message, rather than producing a ServiceMonitor that references a Secret which will never exist. When the control plane is scraped by a Prometheus this chart does not deploy, point each enabled component at the scraper's own credential; `ci/08-external-scraper-values.yaml` is a complete example.
+
+To use your own credential, disable `prometheus.serviceAccount.createTokenSecret` and point the components at your Secret. The Secret must live in the namespace of the ServiceMonitor, which is the release namespace unless `prometheus.prometheusSpec.ignoreNamespaceSelectors` is enabled. Because Helm deep-merges values, replacing the CA reference requires clearing the default explicitly:
+
+```yaml
+kubelet:
+  serviceMonitor:
+    tlsConfig:
+      ca:
+        configMap: null
+        secret:
+          name: kubelet-scrape-auth
+          key: ca.crt
+```
+
+`kubeEtcd` is the only component that scrapes with client certificates:
 
 ```yaml
 kubeEtcd:
   serviceMonitor:
     scheme: https
-    caSecret:
-      name: etcd-client-cert
-      key: ca.crt
-    certSecret:
-      name: etcd-client-cert
-      key: tls.crt
-    keySecret:
-      name: etcd-client-cert
-      key: tls.key
+    tlsConfig:
+      insecureSkipVerify: false
+      ca:
+        secret:
+          name: etcd-client-cert
+          key: etcd-ca
+      cert:
+        secret:
+          name: etcd-client-cert
+          key: etcd-client
+      keySecret:
+        name: etcd-client-cert
+        key: etcd-client-key
 ```
 
 ### Prometheus High Availability (HA)

--- a/charts/kube-prometheus-stack/README.md
+++ b/charts/kube-prometheus-stack/README.md
@@ -132,6 +132,44 @@ Timeouts are only rendered for `kind: HTTPRoute`. They do not apply to generated
 
 This requires Gateway API CRDs that support HTTPRoute timeouts (available in the Standard channel since v1.2.0) and a Gateway controller that supports the corresponding timeout features. When both values are set, `backendRequest` must not exceed `request`, unless `request` is `"0s"`. See the [Gateway API timeout documentation](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/#timeouts-optional) for duration semantics and controller support requirements.
 
+### Secret-based authentication for control-plane ServiceMonitors
+
+The built-in ServiceMonitors for kubelet, kube-apiserver, kube-controller-manager, kube-scheduler, kube-etcd, kube-proxy, and coredns default to the deprecated `bearerTokenFile` / `tlsConfig.caFile` fields. Environments that set `prometheus.prometheusSpec.arbitraryFSAccessThroughSMs.deny: true`, or that scrape with Grafana Alloy's `prometheus.operator.servicemonitors` component (which defaults `allow_arbitrary_file_access` to `false`), reject these ServiceMonitors outright and drop the targets.
+
+Each component's `serviceMonitor` accepts an `authorization` field (in place of `bearerTokenFile`) and a `caSecret` field (in place of `caFile`, for components that support TLS) to reference a Kubernetes Secret instead:
+
+```yaml
+kubelet:
+  serviceMonitor:
+    authorization:
+      type: Bearer
+      credentials:
+        name: kubelet-scrape-auth
+        key: token
+    caSecret:
+      name: kubelet-scrape-auth
+      key: ca.crt
+```
+
+Setting either field switches that endpoint to the secret-based equivalent and drops the corresponding file-based field; leaving them unset (the default) preserves today's `bearerTokenFile`/`caFile` behavior. `kubeApiServer` keeps its CA override under `kubeApiServer.tlsConfig.caSecret` (alongside the existing `tlsConfig.serverName`/`insecureSkipVerify`) rather than under `serviceMonitor`. `coreDns`/`kubeDns` only expose `authorization`, since those endpoints have no TLS support.
+
+`kubeEtcd` is the only component that scrapes with client certificates, so it additionally accepts `certSecret` and `keySecret` in place of `certFile` and `keyFile`:
+
+```yaml
+kubeEtcd:
+  serviceMonitor:
+    scheme: https
+    caSecret:
+      name: etcd-client-cert
+      key: ca.crt
+    certSecret:
+      name: etcd-client-cert
+      key: tls.crt
+    keySecret:
+      name: etcd-client-cert
+      key: tls.key
+```
+
 ### Prometheus High Availability (HA)
 
 For a basic HA setup, run multiple Prometheus replicas:

--- a/charts/kube-prometheus-stack/UPGRADE.md
+++ b/charts/kube-prometheus-stack/UPGRADE.md
@@ -1,5 +1,80 @@
 # Upgrade
 
+## From 89.x to 90.x
+
+The control-plane ServiceMonitors (kubelet, kube-apiserver, kube-controller-manager, kube-scheduler, kube-etcd,
+kube-proxy, coredns, kube-dns) no longer reference credentials on the scraper's filesystem. `bearerTokenFile` and
+`tlsConfig.caFile` are rejected by Prometheus Operator when `arbitraryFSAccessThroughSMs.deny` is enabled, and by
+Grafana Alloy's `prometheus.operator.servicemonitors` component since v1.19.0, which silently dropped every
+control-plane target. The bearer token now comes from a Secret through `authorization`, and the CA from the
+`kube-root-ca.crt` ConfigMap that Kubernetes maintains in every namespace since 1.21.
+
+Because a ServiceMonitor can only authenticate through a Secret, and Kubernetes no longer creates a token Secret for a
+service account automatically, the chart now creates one itself:
+`prometheus.serviceAccount.createTokenSecret` (default `true`) renders a `kubernetes.io/service-account-token` Secret
+named `<prometheus service account>-token`. That token is long-lived and does not expire. Disable the value and set the
+`authorization` of each component if you would rather manage the credential yourself. The Secret must exist in the
+namespace of the ServiceMonitor: that is the release namespace, or `kube-system` (`default` for kube-apiserver) when
+`prometheus.prometheusSpec.ignoreNamespaceSelectors` is enabled — in the latter case the chart-created Secret is in the
+wrong namespace and you have to supply your own.
+
+The Secret is only rendered alongside the service account, so it also requires `prometheus.enabled` and
+`prometheus.serviceAccount.create`. If you scrape the control plane with a Prometheus this chart does not deploy, the
+Secret does not exist and the default `authorization` would reference it anyway, so rendering now fails with an
+explanatory message instead of producing ServiceMonitors the operator drops. Point each enabled control-plane component
+at the credential your scraper uses:
+
+```yaml
+prometheus:
+  enabled: false
+
+kubelet:
+  serviceMonitor:
+    authorization:
+      type: Bearer
+      credentials:
+        name: external-scraper-token
+        key: token
+```
+
+Set `authorization: null` instead to scrape that component without authentication. See
+`ci/08-external-scraper-values.yaml` for a complete example.
+
+`prometheusOperator.secretFieldSelector` no longer excludes `kubernetes.io/service-account-token`, so that changes to
+that Secret trigger a reconciliation. The operator reads Secrets referenced by a ServiceMonitor directly, so scraping
+also works with the previous value, but the generated configuration is then only refreshed on the next unrelated
+reconciliation.
+
+Removed values, all replaced by the `authorization` and `tlsConfig` blocks of the same component, which are rendered
+as-is and accept any field of the Prometheus Operator `SafeAuthorization` and `SafeTLSConfig` types:
+
+| Removed | Replacement |
+| --- | --- |
+| `<component>.serviceMonitor.bearerTokenFile` | `<component>.serviceMonitor.authorization` |
+| `kubelet.serviceMonitor.insecureSkipVerify` | `kubelet.serviceMonitor.tlsConfig.insecureSkipVerify` |
+| `kubeApiServer.tlsConfig.caSecret` | `kubeApiServer.tlsConfig.ca` |
+| `kubeControllerManager.serviceMonitor.insecureSkipVerify` / `.serverName` / `.caSecret` | `kubeControllerManager.serviceMonitor.tlsConfig` |
+| `kubeScheduler.serviceMonitor.insecureSkipVerify` / `.serverName` / `.caSecret` | `kubeScheduler.serviceMonitor.tlsConfig` |
+| `kubeProxy.serviceMonitor.caSecret` | `kubeProxy.serviceMonitor.tlsConfig.ca` |
+| `kubeEtcd.serviceMonitor.insecureSkipVerify` / `.serverName` / `.caFile` / `.certFile` / `.keyFile` / `.caSecret` / `.certSecret` / `.keySecret` | `kubeEtcd.serviceMonitor.tlsConfig` |
+
+`kubeControllerManager` and `kubeScheduler` now carry `insecureSkipVerify: true` as a literal default. This is the value
+those components already resolved to on every Kubernetes version the chart supports, so the rendered output does not
+change.
+
+Values are deep-merged, so replacing the default CA reference requires clearing it explicitly:
+
+```yaml
+kubelet:
+  serviceMonitor:
+    tlsConfig:
+      ca:
+        configMap: null
+        secret:
+          name: my-ca
+          key: ca.crt
+```
+
 ## From 88.x to 89.x
 
 This version upgrades the Grafana helm chart to v13.0.0. Please check [Grafana Helm Chart upgrade guide]([https://grafana.com/docs/grafana/latest/whatsnew/whats-new-in-v13-0/](https://github.com/grafana-community/helm-charts/tree/main/charts/grafana#to-1300)).

--- a/charts/kube-prometheus-stack/ci/07-arbitrary-fs-access-deny-values.yaml
+++ b/charts/kube-prometheus-stack/ci/07-arbitrary-fs-access-deny-values.yaml
@@ -1,0 +1,18 @@
+## Reject any ServiceMonitor referencing the scraper's filesystem, so the control-plane
+## ServiceMonitors are dropped by the operator if they regress to bearerTokenFile / caFile.
+prometheus:
+  prometheusSpec:
+    arbitraryFSAccessThroughSMs:
+      deny: true
+
+kubeDns:
+  enabled: true
+
+kubeScheduler:
+  serviceMonitor:
+    resource:
+      enabled: true
+
+kubeProxy:
+  serviceMonitor:
+    https: true

--- a/charts/kube-prometheus-stack/ci/08-external-scraper-values.yaml
+++ b/charts/kube-prometheus-stack/ci/08-external-scraper-values.yaml
@@ -1,0 +1,39 @@
+## Scrape the control plane with a Prometheus this chart does not deploy. The chart-created token
+## Secret does not exist here, so every enabled control-plane component points its `authorization`
+## at a Secret the external scraper manages instead.
+prometheus:
+  enabled: false
+
+_externalAuthorization: &externalAuthorization
+  type: Bearer
+  credentials:
+    name: external-scraper-token
+    key: token
+
+kubelet:
+  serviceMonitor:
+    authorization: *externalAuthorization
+
+kubeApiServer:
+  serviceMonitor:
+    authorization: *externalAuthorization
+
+kubeControllerManager:
+  serviceMonitor:
+    authorization: *externalAuthorization
+
+kubeScheduler:
+  serviceMonitor:
+    authorization: *externalAuthorization
+
+kubeEtcd:
+  serviceMonitor:
+    authorization: *externalAuthorization
+
+kubeProxy:
+  serviceMonitor:
+    authorization: *externalAuthorization
+
+coreDns:
+  serviceMonitor:
+    authorization: *externalAuthorization

--- a/charts/kube-prometheus-stack/templates/_helpers.tpl
+++ b/charts/kube-prometheus-stack/templates/_helpers.tpl
@@ -113,6 +113,20 @@ heritage: {{ $.Release.Service | quote }}
 {{- end -}}
 {{- end -}}
 
+{{/*
+Name of the Secret holding the Prometheus service account token that the control-plane
+ServiceMonitors authenticate with by default. The chart only creates that Secret alongside the
+service account, so fail with an actionable message rather than render a ServiceMonitor pointing at
+a Secret that will never exist. Only reached when a component still carries the default
+`authorization`, so overriding or clearing it keeps working with prometheus disabled.
+*/}}
+{{- define "kube-prometheus-stack.prometheus.tokenSecretName" -}}
+{{- if not (and .Values.prometheus.enabled .Values.prometheus.serviceAccount.create .Values.prometheus.serviceAccount.createTokenSecret) -}}
+{{- fail "The control-plane ServiceMonitors authenticate by default with the Secret created by prometheus.serviceAccount.createTokenSecret, which is only rendered when prometheus.enabled and prometheus.serviceAccount.create are also true. Enable them, or set the serviceMonitor.authorization of each enabled control-plane component to a Secret you manage yourself, or to null to scrape without authentication." -}}
+{{- end -}}
+{{ include "kube-prometheus-stack.prometheus.serviceAccountName" . }}-token
+{{- end -}}
+
 {{/* Create the name of alertmanager service account to use */}}
 {{- define "kube-prometheus-stack.alertmanager.serviceAccountName" -}}
 {{- if .Values.alertmanager.serviceAccount.create -}}
@@ -358,69 +372,16 @@ global:
 {{- end }}
 {{- define "kube-prometheus-stack.kubelet.authConfig" }}
 {{- if .Values.kubelet.serviceMonitor.https }}
+{{- with .Values.kubelet.serviceMonitor.tlsConfig }}
 tlsConfig:
-  {{- include "kube-prometheus-stack.serviceMonitor.tlsSecret" (list "ca" .Values.kubelet.serviceMonitor.caSecret "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" 2) }}
-  insecureSkipVerify: {{ .Values.kubelet.serviceMonitor.insecureSkipVerify }}
-{{- include "kube-prometheus-stack.serviceMonitor.authorization" (list .Values.kubelet.serviceMonitor.authorization "/var/run/secrets/kubernetes.io/serviceaccount/token" 0) }}
+  {{- tpl (toYaml .) $ | nindent 2 }}
+{{- end }}
+{{- with .Values.kubelet.serviceMonitor.authorization }}
+authorization:
+  {{- tpl (toYaml .) $ | nindent 2 }}
 {{- end }}
 {{- end }}
-
-{{/*
-Render `authorization:` for a ServiceMonitor endpoint.
-Takes a list: (authorization value, bearerTokenFile default, indent width). Renders `authorization:`
-from the first argument if set, otherwise falls back to `bearerTokenFile: <default>`, and renders
-nothing at all if both are empty. Output is newline-prefixed and indented, so do not pipe it through
-`nindent` at the call site.
-*/}}
-{{- define "kube-prometheus-stack.serviceMonitor.authorization" -}}
-{{- $authorization := index . 0 -}}
-{{- $bearerTokenFile := index . 1 -}}
-{{- $indent := index . 2 | int -}}
-{{- if $authorization -}}
-{{- printf "authorization:\n%s" (toYaml $authorization | indent 2) | nindent $indent }}
-{{- else if $bearerTokenFile -}}
-{{- printf "bearerTokenFile: %s" $bearerTokenFile | nindent $indent }}
-{{- end -}}
 {{- end }}
-
-{{/*
-Render the CA or client certificate portion of `tlsConfig:` for a ServiceMonitor endpoint.
-Takes a list: (field name, secret value, file default, indent width), where field name is `ca` or
-`cert`. Renders `<field>.secret:` from the secret value if set, otherwise falls back to
-`<field>File: <default>`, and renders nothing at all if both are empty. Output is newline-prefixed
-and indented, so do not pipe it through `nindent` at the call site.
-*/}}
-{{- define "kube-prometheus-stack.serviceMonitor.tlsSecret" -}}
-{{- $field := index . 0 -}}
-{{- $secret := index . 1 -}}
-{{- $file := index . 2 -}}
-{{- $indent := index . 3 | int -}}
-{{- if $secret -}}
-{{- printf "%s:\n  secret:\n%s" $field (toYaml $secret | indent 4) | nindent $indent }}
-{{- else if $file -}}
-{{- printf "%sFile: %s" $field $file | nindent $indent }}
-{{- end -}}
-{{- end }}
-
-{{/*
-Render the private key portion of `tlsConfig:` for a ServiceMonitor endpoint. Unlike the CA and
-client certificate, the key has no `configMap` alternative, so the secret is not nested under a
-`secret:` key. Takes a list: (keySecret value, keyFile default, indent width). Renders `keySecret:`
-from the first argument if set, otherwise falls back to `keyFile: <default>`, and renders nothing at
-all if both are empty. Output is newline-prefixed and indented, so do not pipe it through `nindent`
-at the call site.
-*/}}
-{{- define "kube-prometheus-stack.serviceMonitor.tlsKeySecret" -}}
-{{- $keySecret := index . 0 -}}
-{{- $keyFile := index . 1 -}}
-{{- $indent := index . 2 | int -}}
-{{- if $keySecret -}}
-{{- printf "keySecret:\n%s" (toYaml $keySecret | indent 2) | nindent $indent }}
-{{- else if $keyFile -}}
-{{- printf "keyFile: %s" $keyFile | nindent $indent }}
-{{- end -}}
-{{- end }}
-
 
 {{/* To help configure anti-affinity rules for Prometheus pods */}}
 {{- define "kube-prometheus-stack.prometheus.pod-anti-affinity.matchExpressions" }}

--- a/charts/kube-prometheus-stack/templates/_helpers.tpl
+++ b/charts/kube-prometheus-stack/templates/_helpers.tpl
@@ -359,10 +359,66 @@ global:
 {{- define "kube-prometheus-stack.kubelet.authConfig" }}
 {{- if .Values.kubelet.serviceMonitor.https }}
 tlsConfig:
-  caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  {{- include "kube-prometheus-stack.serviceMonitor.tlsSecret" (list "ca" .Values.kubelet.serviceMonitor.caSecret "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" 2) }}
   insecureSkipVerify: {{ .Values.kubelet.serviceMonitor.insecureSkipVerify }}
-bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+{{- include "kube-prometheus-stack.serviceMonitor.authorization" (list .Values.kubelet.serviceMonitor.authorization "/var/run/secrets/kubernetes.io/serviceaccount/token" 0) }}
 {{- end }}
+{{- end }}
+
+{{/*
+Render `authorization:` for a ServiceMonitor endpoint.
+Takes a list: (authorization value, bearerTokenFile default, indent width). Renders `authorization:`
+from the first argument if set, otherwise falls back to `bearerTokenFile: <default>`, and renders
+nothing at all if both are empty. Output is newline-prefixed and indented, so do not pipe it through
+`nindent` at the call site.
+*/}}
+{{- define "kube-prometheus-stack.serviceMonitor.authorization" -}}
+{{- $authorization := index . 0 -}}
+{{- $bearerTokenFile := index . 1 -}}
+{{- $indent := index . 2 | int -}}
+{{- if $authorization -}}
+{{- printf "authorization:\n%s" (toYaml $authorization | indent 2) | nindent $indent }}
+{{- else if $bearerTokenFile -}}
+{{- printf "bearerTokenFile: %s" $bearerTokenFile | nindent $indent }}
+{{- end -}}
+{{- end }}
+
+{{/*
+Render the CA or client certificate portion of `tlsConfig:` for a ServiceMonitor endpoint.
+Takes a list: (field name, secret value, file default, indent width), where field name is `ca` or
+`cert`. Renders `<field>.secret:` from the secret value if set, otherwise falls back to
+`<field>File: <default>`, and renders nothing at all if both are empty. Output is newline-prefixed
+and indented, so do not pipe it through `nindent` at the call site.
+*/}}
+{{- define "kube-prometheus-stack.serviceMonitor.tlsSecret" -}}
+{{- $field := index . 0 -}}
+{{- $secret := index . 1 -}}
+{{- $file := index . 2 -}}
+{{- $indent := index . 3 | int -}}
+{{- if $secret -}}
+{{- printf "%s:\n  secret:\n%s" $field (toYaml $secret | indent 4) | nindent $indent }}
+{{- else if $file -}}
+{{- printf "%sFile: %s" $field $file | nindent $indent }}
+{{- end -}}
+{{- end }}
+
+{{/*
+Render the private key portion of `tlsConfig:` for a ServiceMonitor endpoint. Unlike the CA and
+client certificate, the key has no `configMap` alternative, so the secret is not nested under a
+`secret:` key. Takes a list: (keySecret value, keyFile default, indent width). Renders `keySecret:`
+from the first argument if set, otherwise falls back to `keyFile: <default>`, and renders nothing at
+all if both are empty. Output is newline-prefixed and indented, so do not pipe it through `nindent`
+at the call site.
+*/}}
+{{- define "kube-prometheus-stack.serviceMonitor.tlsKeySecret" -}}
+{{- $keySecret := index . 0 -}}
+{{- $keyFile := index . 1 -}}
+{{- $indent := index . 2 | int -}}
+{{- if $keySecret -}}
+{{- printf "keySecret:\n%s" (toYaml $keySecret | indent 2) | nindent $indent }}
+{{- else if $keyFile -}}
+{{- printf "keyFile: %s" $keyFile | nindent $indent }}
+{{- end -}}
 {{- end }}
 
 

--- a/charts/kube-prometheus-stack/templates/exporters/core-dns/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/core-dns/servicemonitor.yaml
@@ -40,9 +40,7 @@ spec:
     {{- if .Values.coreDns.serviceMonitor.proxyUrl }}
     proxyUrl: {{ .Values.coreDns.serviceMonitor.proxyUrl}}
     {{- end }}
-    {{- if .Values.coreDns.serviceMonitor.bearerTokenFile }}
-    bearerTokenFile: {{ .Values.coreDns.serviceMonitor.bearerTokenFile }}
-    {{- end }}
+    {{- include "kube-prometheus-stack.serviceMonitor.authorization" (list .Values.coreDns.serviceMonitor.authorization .Values.coreDns.serviceMonitor.bearerTokenFile 4) }}
 {{- if .Values.coreDns.serviceMonitor.metricRelabelings }}
     metricRelabelings:
 {{ tpl (toYaml .Values.coreDns.serviceMonitor.metricRelabelings | indent 4) . }}

--- a/charts/kube-prometheus-stack/templates/exporters/core-dns/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/core-dns/servicemonitor.yaml
@@ -40,7 +40,10 @@ spec:
     {{- if .Values.coreDns.serviceMonitor.proxyUrl }}
     proxyUrl: {{ .Values.coreDns.serviceMonitor.proxyUrl}}
     {{- end }}
-    {{- include "kube-prometheus-stack.serviceMonitor.authorization" (list .Values.coreDns.serviceMonitor.authorization .Values.coreDns.serviceMonitor.bearerTokenFile 4) }}
+    {{- with .Values.coreDns.serviceMonitor.authorization }}
+    authorization:
+      {{- tpl (toYaml .) $ | nindent 6 }}
+    {{- end }}
 {{- if .Values.coreDns.serviceMonitor.metricRelabelings }}
     metricRelabelings:
 {{ tpl (toYaml .Values.coreDns.serviceMonitor.metricRelabelings | indent 4) . }}

--- a/charts/kube-prometheus-stack/templates/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-api-server/servicemonitor.yaml
@@ -25,7 +25,10 @@ spec:
     {{- if .Values.kubeApiServer.serviceMonitor.proxyUrl }}
     proxyUrl: {{ .Values.kubeApiServer.serviceMonitor.proxyUrl }}
     {{- end }}
-    {{- include "kube-prometheus-stack.serviceMonitor.authorization" (list .Values.kubeApiServer.serviceMonitor.authorization "/var/run/secrets/kubernetes.io/serviceaccount/token" 4) }}
+    {{- with .Values.kubeApiServer.serviceMonitor.authorization }}
+    authorization:
+      {{- tpl (toYaml .) $ | nindent 6 }}
+    {{- end }}
 {{- if .Values.kubeApiServer.serviceMonitor.metricRelabelings }}
     metricRelabelings:
 {{ tpl (toYaml .Values.kubeApiServer.serviceMonitor.metricRelabelings | indent 6) . }}
@@ -34,10 +37,10 @@ spec:
     relabelings:
 {{ tpl (toYaml .Values.kubeApiServer.serviceMonitor.relabelings | indent 6) . }}
 {{- end }}
+    {{- with .Values.kubeApiServer.tlsConfig }}
     tlsConfig:
-      {{- include "kube-prometheus-stack.serviceMonitor.tlsSecret" (list "ca" .Values.kubeApiServer.tlsConfig.caSecret "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" 6) }}
-      serverName: {{ .Values.kubeApiServer.tlsConfig.serverName }}
-      insecureSkipVerify: {{ .Values.kubeApiServer.tlsConfig.insecureSkipVerify }}
+      {{- tpl (toYaml .) $ | nindent 6 }}
+    {{- end }}
   jobLabel: {{ .Values.kubeApiServer.serviceMonitor.jobLabel }}
   {{- with .Values.kubeApiServer.serviceMonitor.targetLabels }}
   targetLabels:

--- a/charts/kube-prometheus-stack/templates/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-api-server/servicemonitor.yaml
@@ -17,15 +17,15 @@ metadata:
 spec:
   {{- include "servicemonitor.scrapeLimits" .Values.kubeApiServer.serviceMonitor | nindent 2 }}
   endpoints:
-  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+  - port: https
+    scheme: https
     {{- if .Values.kubeApiServer.serviceMonitor.interval }}
     interval: {{ .Values.kubeApiServer.serviceMonitor.interval }}
     {{- end }}
     {{- if .Values.kubeApiServer.serviceMonitor.proxyUrl }}
     proxyUrl: {{ .Values.kubeApiServer.serviceMonitor.proxyUrl }}
     {{- end }}
-    port: https
-    scheme: https
+    {{- include "kube-prometheus-stack.serviceMonitor.authorization" (list .Values.kubeApiServer.serviceMonitor.authorization "/var/run/secrets/kubernetes.io/serviceaccount/token" 4) }}
 {{- if .Values.kubeApiServer.serviceMonitor.metricRelabelings }}
     metricRelabelings:
 {{ tpl (toYaml .Values.kubeApiServer.serviceMonitor.metricRelabelings | indent 6) . }}
@@ -35,7 +35,7 @@ spec:
 {{ tpl (toYaml .Values.kubeApiServer.serviceMonitor.relabelings | indent 6) . }}
 {{- end }}
     tlsConfig:
-      caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      {{- include "kube-prometheus-stack.serviceMonitor.tlsSecret" (list "ca" .Values.kubeApiServer.tlsConfig.caSecret "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" 6) }}
       serverName: {{ .Values.kubeApiServer.tlsConfig.serverName }}
       insecureSkipVerify: {{ .Values.kubeApiServer.tlsConfig.insecureSkipVerify }}
   jobLabel: {{ .Values.kubeApiServer.serviceMonitor.jobLabel }}

--- a/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/servicemonitor.yaml
@@ -37,20 +37,19 @@ spec:
     {{- if .Values.kubeControllerManager.serviceMonitor.interval }}
     interval: {{ .Values.kubeControllerManager.serviceMonitor.interval }}
     {{- end }}
-    {{- include "kube-prometheus-stack.serviceMonitor.authorization" (list .Values.kubeControllerManager.serviceMonitor.authorization "/var/run/secrets/kubernetes.io/serviceaccount/token" 4) }}
+    {{- with .Values.kubeControllerManager.serviceMonitor.authorization }}
+    authorization:
+      {{- tpl (toYaml .) $ | nindent 6 }}
+    {{- end }}
     {{- if .Values.kubeControllerManager.serviceMonitor.proxyUrl }}
     proxyUrl: {{ .Values.kubeControllerManager.serviceMonitor.proxyUrl}}
     {{- end }}
     {{- if eq (include "kube-prometheus-stack.kubeControllerManager.insecureScrape" (list . false true .Values.kubeControllerManager.serviceMonitor.https )) "true" }}
     scheme: https
+    {{- with .Values.kubeControllerManager.serviceMonitor.tlsConfig }}
     tlsConfig:
-      {{- include "kube-prometheus-stack.serviceMonitor.tlsSecret" (list "ca" .Values.kubeControllerManager.serviceMonitor.caSecret "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" 6) }}
-      {{- if eq (include "kube-prometheus-stack.kubeControllerManager.insecureScrape" (list . nil true .Values.kubeControllerManager.serviceMonitor.insecureSkipVerify)) "true" }}
-      insecureSkipVerify: true
-      {{- end }}
-      {{- if .Values.kubeControllerManager.serviceMonitor.serverName }}
-      serverName: {{ .Values.kubeControllerManager.serviceMonitor.serverName }}
-      {{- end }}
+      {{- tpl (toYaml .) $ | nindent 6 }}
+    {{- end }}
     {{- end }}
 {{- if .Values.kubeControllerManager.serviceMonitor.metricRelabelings }}
     metricRelabelings:

--- a/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-controller-manager/servicemonitor.yaml
@@ -37,14 +37,14 @@ spec:
     {{- if .Values.kubeControllerManager.serviceMonitor.interval }}
     interval: {{ .Values.kubeControllerManager.serviceMonitor.interval }}
     {{- end }}
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    {{- include "kube-prometheus-stack.serviceMonitor.authorization" (list .Values.kubeControllerManager.serviceMonitor.authorization "/var/run/secrets/kubernetes.io/serviceaccount/token" 4) }}
     {{- if .Values.kubeControllerManager.serviceMonitor.proxyUrl }}
     proxyUrl: {{ .Values.kubeControllerManager.serviceMonitor.proxyUrl}}
     {{- end }}
     {{- if eq (include "kube-prometheus-stack.kubeControllerManager.insecureScrape" (list . false true .Values.kubeControllerManager.serviceMonitor.https )) "true" }}
     scheme: https
     tlsConfig:
-      caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      {{- include "kube-prometheus-stack.serviceMonitor.tlsSecret" (list "ca" .Values.kubeControllerManager.serviceMonitor.caSecret "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" 6) }}
       {{- if eq (include "kube-prometheus-stack.kubeControllerManager.insecureScrape" (list . nil true .Values.kubeControllerManager.serviceMonitor.insecureSkipVerify)) "true" }}
       insecureSkipVerify: true
       {{- end }}

--- a/charts/kube-prometheus-stack/templates/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-dns/servicemonitor.yaml
@@ -37,9 +37,7 @@ spec:
     {{- if .Values.kubeDns.serviceMonitor.interval }}
     interval: {{ .Values.kubeDns.serviceMonitor.interval }}
     {{- end }}
-    {{- if .Values.kubeDns.serviceMonitor.bearerTokenFile }}
-    bearerTokenFile: {{ .Values.kubeDns.serviceMonitor.bearerTokenFile }}
-    {{- end }}
+    {{- include "kube-prometheus-stack.serviceMonitor.authorization" (list .Values.kubeDns.serviceMonitor.authorization .Values.kubeDns.serviceMonitor.bearerTokenFile 4) }}
     {{- if .Values.kubeDns.serviceMonitor.proxyUrl }}
     proxyUrl: {{ .Values.kubeDns.serviceMonitor.proxyUrl}}
     {{- end }}
@@ -55,9 +53,7 @@ spec:
     {{- if .Values.kubeDns.serviceMonitor.interval }}
     interval: {{ .Values.kubeDns.serviceMonitor.interval }}
     {{- end }}
-    {{- if .Values.kubeDns.serviceMonitor.bearerTokenFile }}
-    bearerTokenFile: {{ .Values.kubeDns.serviceMonitor.bearerTokenFile }}
-    {{- end }}
+    {{- include "kube-prometheus-stack.serviceMonitor.authorization" (list .Values.kubeDns.serviceMonitor.authorization .Values.kubeDns.serviceMonitor.bearerTokenFile 4) }}
 {{- if .Values.kubeDns.serviceMonitor.metricRelabelings }}
     metricRelabelings:
 {{ tpl (toYaml .Values.kubeDns.serviceMonitor.metricRelabelings | indent 4) . }}

--- a/charts/kube-prometheus-stack/templates/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-dns/servicemonitor.yaml
@@ -37,7 +37,10 @@ spec:
     {{- if .Values.kubeDns.serviceMonitor.interval }}
     interval: {{ .Values.kubeDns.serviceMonitor.interval }}
     {{- end }}
-    {{- include "kube-prometheus-stack.serviceMonitor.authorization" (list .Values.kubeDns.serviceMonitor.authorization .Values.kubeDns.serviceMonitor.bearerTokenFile 4) }}
+    {{- with .Values.kubeDns.serviceMonitor.authorization }}
+    authorization:
+      {{- tpl (toYaml .) $ | nindent 6 }}
+    {{- end }}
     {{- if .Values.kubeDns.serviceMonitor.proxyUrl }}
     proxyUrl: {{ .Values.kubeDns.serviceMonitor.proxyUrl}}
     {{- end }}
@@ -53,7 +56,10 @@ spec:
     {{- if .Values.kubeDns.serviceMonitor.interval }}
     interval: {{ .Values.kubeDns.serviceMonitor.interval }}
     {{- end }}
-    {{- include "kube-prometheus-stack.serviceMonitor.authorization" (list .Values.kubeDns.serviceMonitor.authorization .Values.kubeDns.serviceMonitor.bearerTokenFile 4) }}
+    {{- with .Values.kubeDns.serviceMonitor.authorization }}
+    authorization:
+      {{- tpl (toYaml .) $ | nindent 6 }}
+    {{- end }}
 {{- if .Values.kubeDns.serviceMonitor.metricRelabelings }}
     metricRelabelings:
 {{ tpl (toYaml .Values.kubeDns.serviceMonitor.metricRelabelings | indent 4) . }}

--- a/charts/kube-prometheus-stack/templates/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-etcd/servicemonitor.yaml
@@ -37,9 +37,7 @@ spec:
     {{- if .Values.kubeEtcd.serviceMonitor.interval }}
     interval: {{ .Values.kubeEtcd.serviceMonitor.interval }}
     {{- end }}
-    {{- if .Values.kubeEtcd.serviceMonitor.bearerTokenFile }}
-    bearerTokenFile: {{ .Values.kubeEtcd.serviceMonitor.bearerTokenFile }}
-    {{- end }}
+    {{- include "kube-prometheus-stack.serviceMonitor.authorization" (list .Values.kubeEtcd.serviceMonitor.authorization .Values.kubeEtcd.serviceMonitor.bearerTokenFile 4) }}
     {{- if .Values.kubeEtcd.serviceMonitor.proxyUrl }}
     proxyUrl: {{ .Values.kubeEtcd.serviceMonitor.proxyUrl}}
     {{- end }}
@@ -49,15 +47,9 @@ spec:
       {{- if .Values.kubeEtcd.serviceMonitor.serverName }}
       serverName: {{ .Values.kubeEtcd.serviceMonitor.serverName }}
       {{- end }}
-      {{- if .Values.kubeEtcd.serviceMonitor.caFile }}
-      caFile: {{ .Values.kubeEtcd.serviceMonitor.caFile }}
-      {{- end }}
-      {{- if  .Values.kubeEtcd.serviceMonitor.certFile }}
-      certFile: {{ .Values.kubeEtcd.serviceMonitor.certFile }}
-      {{- end }}
-      {{- if .Values.kubeEtcd.serviceMonitor.keyFile }}
-      keyFile: {{ .Values.kubeEtcd.serviceMonitor.keyFile }}
-      {{- end}}
+      {{- include "kube-prometheus-stack.serviceMonitor.tlsSecret" (list "ca" .Values.kubeEtcd.serviceMonitor.caSecret .Values.kubeEtcd.serviceMonitor.caFile 6) }}
+      {{- include "kube-prometheus-stack.serviceMonitor.tlsSecret" (list "cert" .Values.kubeEtcd.serviceMonitor.certSecret .Values.kubeEtcd.serviceMonitor.certFile 6) }}
+      {{- include "kube-prometheus-stack.serviceMonitor.tlsKeySecret" (list .Values.kubeEtcd.serviceMonitor.keySecret .Values.kubeEtcd.serviceMonitor.keyFile 6) }}
       insecureSkipVerify: {{ .Values.kubeEtcd.serviceMonitor.insecureSkipVerify }}
     {{- end }}
 {{- if .Values.kubeEtcd.serviceMonitor.metricRelabelings }}

--- a/charts/kube-prometheus-stack/templates/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-etcd/servicemonitor.yaml
@@ -37,20 +37,19 @@ spec:
     {{- if .Values.kubeEtcd.serviceMonitor.interval }}
     interval: {{ .Values.kubeEtcd.serviceMonitor.interval }}
     {{- end }}
-    {{- include "kube-prometheus-stack.serviceMonitor.authorization" (list .Values.kubeEtcd.serviceMonitor.authorization .Values.kubeEtcd.serviceMonitor.bearerTokenFile 4) }}
+    {{- with .Values.kubeEtcd.serviceMonitor.authorization }}
+    authorization:
+      {{- tpl (toYaml .) $ | nindent 6 }}
+    {{- end }}
     {{- if .Values.kubeEtcd.serviceMonitor.proxyUrl }}
     proxyUrl: {{ .Values.kubeEtcd.serviceMonitor.proxyUrl}}
     {{- end }}
     {{- if eq .Values.kubeEtcd.serviceMonitor.scheme "https" }}
     scheme: https
+    {{- with .Values.kubeEtcd.serviceMonitor.tlsConfig }}
     tlsConfig:
-      {{- if .Values.kubeEtcd.serviceMonitor.serverName }}
-      serverName: {{ .Values.kubeEtcd.serviceMonitor.serverName }}
-      {{- end }}
-      {{- include "kube-prometheus-stack.serviceMonitor.tlsSecret" (list "ca" .Values.kubeEtcd.serviceMonitor.caSecret .Values.kubeEtcd.serviceMonitor.caFile 6) }}
-      {{- include "kube-prometheus-stack.serviceMonitor.tlsSecret" (list "cert" .Values.kubeEtcd.serviceMonitor.certSecret .Values.kubeEtcd.serviceMonitor.certFile 6) }}
-      {{- include "kube-prometheus-stack.serviceMonitor.tlsKeySecret" (list .Values.kubeEtcd.serviceMonitor.keySecret .Values.kubeEtcd.serviceMonitor.keyFile 6) }}
-      insecureSkipVerify: {{ .Values.kubeEtcd.serviceMonitor.insecureSkipVerify }}
+      {{- tpl (toYaml .) $ | nindent 6 }}
+    {{- end }}
     {{- end }}
 {{- if .Values.kubeEtcd.serviceMonitor.metricRelabelings }}
     metricRelabelings:

--- a/charts/kube-prometheus-stack/templates/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-proxy/servicemonitor.yaml
@@ -37,14 +37,19 @@ spec:
     {{- if .Values.kubeProxy.serviceMonitor.interval }}
     interval: {{ .Values.kubeProxy.serviceMonitor.interval }}
     {{- end }}
-    {{- include "kube-prometheus-stack.serviceMonitor.authorization" (list .Values.kubeProxy.serviceMonitor.authorization .Values.kubeProxy.serviceMonitor.bearerTokenFile 4) }}
+    {{- with .Values.kubeProxy.serviceMonitor.authorization }}
+    authorization:
+      {{- tpl (toYaml .) $ | nindent 6 }}
+    {{- end }}
     {{- if .Values.kubeProxy.serviceMonitor.proxyUrl }}
     proxyUrl: {{ .Values.kubeProxy.serviceMonitor.proxyUrl}}
     {{- end }}
     {{- if .Values.kubeProxy.serviceMonitor.https }}
     scheme: https
+    {{- with .Values.kubeProxy.serviceMonitor.tlsConfig }}
     tlsConfig:
-      {{- include "kube-prometheus-stack.serviceMonitor.tlsSecret" (list "ca" .Values.kubeProxy.serviceMonitor.caSecret "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" 6) }}
+      {{- tpl (toYaml .) $ | nindent 6 }}
+    {{- end }}
     {{- end}}
 {{- if .Values.kubeProxy.serviceMonitor.metricRelabelings }}
     metricRelabelings:

--- a/charts/kube-prometheus-stack/templates/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-proxy/servicemonitor.yaml
@@ -37,16 +37,14 @@ spec:
     {{- if .Values.kubeProxy.serviceMonitor.interval }}
     interval: {{ .Values.kubeProxy.serviceMonitor.interval }}
     {{- end }}
-    {{- if .Values.kubeProxy.serviceMonitor.bearerTokenFile }}
-    bearerTokenFile: {{ .Values.kubeProxy.serviceMonitor.bearerTokenFile }}
-    {{- end }}
+    {{- include "kube-prometheus-stack.serviceMonitor.authorization" (list .Values.kubeProxy.serviceMonitor.authorization .Values.kubeProxy.serviceMonitor.bearerTokenFile 4) }}
     {{- if .Values.kubeProxy.serviceMonitor.proxyUrl }}
     proxyUrl: {{ .Values.kubeProxy.serviceMonitor.proxyUrl}}
     {{- end }}
     {{- if .Values.kubeProxy.serviceMonitor.https }}
     scheme: https
     tlsConfig:
-      caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      {{- include "kube-prometheus-stack.serviceMonitor.tlsSecret" (list "ca" .Values.kubeProxy.serviceMonitor.caSecret "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" 6) }}
     {{- end}}
 {{- if .Values.kubeProxy.serviceMonitor.metricRelabelings }}
     metricRelabelings:

--- a/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -37,14 +37,14 @@ spec:
     {{- if .Values.kubeScheduler.serviceMonitor.interval }}
     interval: {{ .Values.kubeScheduler.serviceMonitor.interval }}
     {{- end }}
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    {{- include "kube-prometheus-stack.serviceMonitor.authorization" (list .Values.kubeScheduler.serviceMonitor.authorization "/var/run/secrets/kubernetes.io/serviceaccount/token" 4) }}
     {{- if .Values.kubeScheduler.serviceMonitor.proxyUrl }}
     proxyUrl: {{ .Values.kubeScheduler.serviceMonitor.proxyUrl}}
     {{- end }}
     {{- if eq (include "kube-prometheus-stack.kubeScheduler.insecureScrape" (list . false true .Values.kubeScheduler.serviceMonitor.https )) "true" }}
     scheme: https
     tlsConfig:
-      caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      {{- include "kube-prometheus-stack.serviceMonitor.tlsSecret" (list "ca" .Values.kubeScheduler.serviceMonitor.caSecret "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" 6) }}
       {{- if eq (include "kube-prometheus-stack.kubeScheduler.insecureScrape" (list . nil true .Values.kubeScheduler.serviceMonitor.insecureSkipVerify)) "true" }}
       insecureSkipVerify: true
       {{- end }}
@@ -66,14 +66,14 @@ spec:
     {{- if .Values.kubeScheduler.serviceMonitor.resource.interval }}
     interval: {{ .Values.kubeScheduler.serviceMonitor.resource.interval }}
     {{- end }}
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    {{- include "kube-prometheus-stack.serviceMonitor.authorization" (list .Values.kubeScheduler.serviceMonitor.authorization "/var/run/secrets/kubernetes.io/serviceaccount/token" 4) }}
     {{- if .Values.kubeScheduler.serviceMonitor.proxyUrl }}
     proxyUrl: {{ .Values.kubeScheduler.serviceMonitor.proxyUrl}}
     {{- end }}
     {{- if eq (include "kube-prometheus-stack.kubeScheduler.insecureScrape" (list . false true .Values.kubeScheduler.serviceMonitor.https )) "true" }}
     scheme: https
     tlsConfig:
-      caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      {{- include "kube-prometheus-stack.serviceMonitor.tlsSecret" (list "ca" .Values.kubeScheduler.serviceMonitor.caSecret "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" 6) }}
       {{- if eq (include "kube-prometheus-stack.kubeScheduler.insecureScrape" (list . nil true .Values.kubeScheduler.serviceMonitor.insecureSkipVerify)) "true" }}
       insecureSkipVerify: true
       {{- end }}

--- a/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -37,20 +37,19 @@ spec:
     {{- if .Values.kubeScheduler.serviceMonitor.interval }}
     interval: {{ .Values.kubeScheduler.serviceMonitor.interval }}
     {{- end }}
-    {{- include "kube-prometheus-stack.serviceMonitor.authorization" (list .Values.kubeScheduler.serviceMonitor.authorization "/var/run/secrets/kubernetes.io/serviceaccount/token" 4) }}
+    {{- with .Values.kubeScheduler.serviceMonitor.authorization }}
+    authorization:
+      {{- tpl (toYaml .) $ | nindent 6 }}
+    {{- end }}
     {{- if .Values.kubeScheduler.serviceMonitor.proxyUrl }}
     proxyUrl: {{ .Values.kubeScheduler.serviceMonitor.proxyUrl}}
     {{- end }}
     {{- if eq (include "kube-prometheus-stack.kubeScheduler.insecureScrape" (list . false true .Values.kubeScheduler.serviceMonitor.https )) "true" }}
     scheme: https
+    {{- with .Values.kubeScheduler.serviceMonitor.tlsConfig }}
     tlsConfig:
-      {{- include "kube-prometheus-stack.serviceMonitor.tlsSecret" (list "ca" .Values.kubeScheduler.serviceMonitor.caSecret "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" 6) }}
-      {{- if eq (include "kube-prometheus-stack.kubeScheduler.insecureScrape" (list . nil true .Values.kubeScheduler.serviceMonitor.insecureSkipVerify)) "true" }}
-      insecureSkipVerify: true
-      {{- end }}
-      {{- if .Values.kubeScheduler.serviceMonitor.serverName }}
-      serverName: {{ .Values.kubeScheduler.serviceMonitor.serverName }}
-      {{- end}}
+      {{- tpl (toYaml .) $ | nindent 6 }}
+    {{- end }}
     {{- end}}
 {{- if .Values.kubeScheduler.serviceMonitor.metricRelabelings }}
     metricRelabelings:
@@ -66,20 +65,19 @@ spec:
     {{- if .Values.kubeScheduler.serviceMonitor.resource.interval }}
     interval: {{ .Values.kubeScheduler.serviceMonitor.resource.interval }}
     {{- end }}
-    {{- include "kube-prometheus-stack.serviceMonitor.authorization" (list .Values.kubeScheduler.serviceMonitor.authorization "/var/run/secrets/kubernetes.io/serviceaccount/token" 4) }}
+    {{- with .Values.kubeScheduler.serviceMonitor.authorization }}
+    authorization:
+      {{- tpl (toYaml .) $ | nindent 6 }}
+    {{- end }}
     {{- if .Values.kubeScheduler.serviceMonitor.proxyUrl }}
     proxyUrl: {{ .Values.kubeScheduler.serviceMonitor.proxyUrl}}
     {{- end }}
     {{- if eq (include "kube-prometheus-stack.kubeScheduler.insecureScrape" (list . false true .Values.kubeScheduler.serviceMonitor.https )) "true" }}
     scheme: https
+    {{- with .Values.kubeScheduler.serviceMonitor.tlsConfig }}
     tlsConfig:
-      {{- include "kube-prometheus-stack.serviceMonitor.tlsSecret" (list "ca" .Values.kubeScheduler.serviceMonitor.caSecret "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" 6) }}
-      {{- if eq (include "kube-prometheus-stack.kubeScheduler.insecureScrape" (list . nil true .Values.kubeScheduler.serviceMonitor.insecureSkipVerify)) "true" }}
-      insecureSkipVerify: true
-      {{- end }}
-      {{- if .Values.kubeScheduler.serviceMonitor.serverName }}
-      serverName: {{ .Values.kubeScheduler.serviceMonitor.serverName }}
-      {{- end}}
+      {{- tpl (toYaml .) $ | nindent 6 }}
+    {{- end }}
     {{- end}}
 {{- if .Values.kubeScheduler.serviceMonitor.resource.metricRelabelings }}
     metricRelabelings:

--- a/charts/kube-prometheus-stack/templates/prometheus/serviceaccount-token-secret.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/serviceaccount-token-secret.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.prometheus.enabled .Values.prometheus.serviceAccount.create .Values.prometheus.serviceAccount.createTokenSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "kube-prometheus-stack.prometheus.tokenSecretName" . }}
+  namespace: {{ template "kube-prometheus-stack.namespace" . }}
+  labels:
+    app: {{ template "kube-prometheus-stack.name" . }}-prometheus
+    app.kubernetes.io/name: {{ template "kube-prometheus-stack.name" . }}-prometheus
+    app.kubernetes.io/component: prometheus
+{{ include "kube-prometheus-stack.labels" . | indent 4 }}
+  annotations:
+    kubernetes.io/service-account.name: {{ template "kube-prometheus-stack.prometheus.serviceAccountName" . }}
+type: kubernetes.io/service-account-token
+{{- end }}

--- a/charts/kube-prometheus-stack/unittests/exporters/servicemonitor_auth_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/exporters/servicemonitor_auth_test.yaml
@@ -9,75 +9,161 @@ templates:
   - exporters/kube-proxy/servicemonitor.yaml
   - exporters/core-dns/servicemonitor.yaml
   - exporters/kube-dns/servicemonitor.yaml
+release:
+  name: kps
 set:
   kubeDns.enabled: true
-  kubeDns.serviceMonitor.bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
   kubeControllerManager.serviceMonitor.https: true
   kubeProxy.serviceMonitor.https: true
   kubeScheduler.serviceMonitor.https: true
   kubeScheduler.serviceMonitor.resource.enabled: true
   kubeEtcd.serviceMonitor.scheme: https
-  kubeEtcd.serviceMonitor.caFile: /etc/prometheus/secrets/etcd-client-cert/etcd-ca
-  kubeEtcd.serviceMonitor.certFile: /etc/prometheus/secrets/etcd-client-cert/etcd-client
-  kubeEtcd.serviceMonitor.keyFile: /etc/prometheus/secrets/etcd-client-cert/etcd-client-key
 tests:
-  - it: should fall back to bearerTokenFile and caFile by default
+  - it: should authenticate with the prometheus service account token secret by default
     asserts:
       - equal:
-          path: spec.endpoints[0].bearerTokenFile
-          value: /var/run/secrets/kubernetes.io/serviceaccount/token
+          path: spec.endpoints[0].authorization.type
+          value: Bearer
+      - equal:
+          path: spec.endpoints[0].authorization.credentials.name
+          value: kps-kube-prometheus-stack-prometheus-token
+      - equal:
+          path: spec.endpoints[0].authorization.credentials.key
+          value: token
       - template: exporters/kube-scheduler/servicemonitor.yaml
         equal:
-          path: spec.endpoints[1].bearerTokenFile
-          value: /var/run/secrets/kubernetes.io/serviceaccount/token
+          path: spec.endpoints[1].authorization.credentials.name
+          value: kps-kube-prometheus-stack-prometheus-token
       - template: exporters/kube-dns/servicemonitor.yaml
         equal:
-          path: spec.endpoints[1].bearerTokenFile
-          value: /var/run/secrets/kubernetes.io/serviceaccount/token
+          path: spec.endpoints[1].authorization.credentials.name
+          value: kps-kube-prometheus-stack-prometheus-token
       - template: exporters/kubelet/servicemonitor.yaml
         equal:
-          path: spec.endpoints[0].tlsConfig.caFile
-          value: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          path: spec.endpoints[2].authorization.credentials.name
+          value: kps-kube-prometheus-stack-prometheus-token
+
+  - it: should trust the cluster CA from the kube-root-ca.crt config map by default
+    templates:
+      - exporters/kubelet/servicemonitor.yaml
+      - exporters/kube-api-server/servicemonitor.yaml
+      - exporters/kube-controller-manager/servicemonitor.yaml
+      - exporters/kube-scheduler/servicemonitor.yaml
+      - exporters/kube-proxy/servicemonitor.yaml
+    asserts:
+      - equal:
+          path: spec.endpoints[0].tlsConfig.ca.configMap.name
+          value: kube-root-ca.crt
+      - equal:
+          path: spec.endpoints[0].tlsConfig.ca.configMap.key
+          value: ca.crt
+      - template: exporters/kube-scheduler/servicemonitor.yaml
+        equal:
+          path: spec.endpoints[1].tlsConfig.ca.configMap.name
+          value: kube-root-ca.crt
+      - template: exporters/kubelet/servicemonitor.yaml
+        equal:
+          path: spec.endpoints[2].tlsConfig.ca.configMap.name
+          value: kube-root-ca.crt
       - template: exporters/kube-api-server/servicemonitor.yaml
         equal:
-          path: spec.endpoints[0].tlsConfig.caFile
-          value: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-      - template: exporters/kube-controller-manager/servicemonitor.yaml
+          path: spec.endpoints[0].tlsConfig.serverName
+          value: kubernetes
+      - template: exporters/kube-api-server/servicemonitor.yaml
         equal:
-          path: spec.endpoints[0].tlsConfig.caFile
-          value: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-      - template: exporters/kube-proxy/servicemonitor.yaml
+          path: spec.endpoints[0].tlsConfig.insecureSkipVerify
+          value: false
+      - template: exporters/kubelet/servicemonitor.yaml
         equal:
-          path: spec.endpoints[0].tlsConfig.caFile
-          value: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-      - template: exporters/kube-scheduler/servicemonitor.yaml
-        equal:
-          path: spec.endpoints[0].tlsConfig.caFile
-          value: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-      - template: exporters/kube-scheduler/servicemonitor.yaml
-        equal:
-          path: spec.endpoints[1].tlsConfig.caFile
-          value: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-      - template: exporters/kube-etcd/servicemonitor.yaml
-        equal:
-          path: spec.endpoints[0].tlsConfig.caFile
-          value: /etc/prometheus/secrets/etcd-client-cert/etcd-ca
-      - template: exporters/kube-etcd/servicemonitor.yaml
-        equal:
-          path: spec.endpoints[0].tlsConfig.certFile
-          value: /etc/prometheus/secrets/etcd-client-cert/etcd-client
-      - template: exporters/kube-etcd/servicemonitor.yaml
-        equal:
-          path: spec.endpoints[0].tlsConfig.keyFile
-          value: /etc/prometheus/secrets/etcd-client-cert/etcd-client-key
+          path: spec.endpoints[0].tlsConfig.insecureSkipVerify
+          value: true
 
-  - it: should use authorization instead of bearerTokenFile when set
+  - it: should never reference credentials on the file system
+    asserts:
+      - notExists:
+          path: spec.endpoints[0].bearerTokenFile
+      - notExists:
+          path: spec.endpoints[0].tlsConfig.caFile
+      - notExists:
+          path: spec.endpoints[0].tlsConfig.certFile
+      - notExists:
+          path: spec.endpoints[0].tlsConfig.keyFile
+      - template: exporters/kubelet/servicemonitor.yaml
+        notExists:
+          path: spec.endpoints[2].bearerTokenFile
+      - template: exporters/kubelet/servicemonitor.yaml
+        notExists:
+          path: spec.endpoints[2].tlsConfig.caFile
+      - template: exporters/kube-scheduler/servicemonitor.yaml
+        notExists:
+          path: spec.endpoints[1].bearerTokenFile
+      - template: exporters/kube-scheduler/servicemonitor.yaml
+        notExists:
+          path: spec.endpoints[1].tlsConfig.caFile
+      - template: exporters/kube-dns/servicemonitor.yaml
+        notExists:
+          path: spec.endpoints[1].bearerTokenFile
+
+  - it: should render user supplied secret-based TLS credentials
+    templates:
+      - exporters/kubelet/servicemonitor.yaml
+      - exporters/kube-api-server/servicemonitor.yaml
+      - exporters/kube-etcd/servicemonitor.yaml
+    set:
+      kubelet.serviceMonitor.tlsConfig: &caSecret
+        insecureSkipVerify: true
+        ca:
+          # values are deep-merged, so the default configMap reference has to be removed explicitly
+          configMap: null
+          secret:
+            name: my-ca
+            key: ca.crt
+      kubeApiServer.tlsConfig: *caSecret
+      kubeEtcd.serviceMonitor.tlsConfig:
+        serverName: localhost
+        ca:
+          secret:
+            name: etcd-client-cert
+            key: etcd-ca
+        cert:
+          secret:
+            name: etcd-client-cert
+            key: etcd-client
+        keySecret:
+          name: etcd-client-cert
+          key: etcd-client-key
+    asserts:
+      - template: exporters/kubelet/servicemonitor.yaml
+        equal:
+          path: spec.endpoints[0].tlsConfig.ca.secret.name
+          value: my-ca
+      - template: exporters/kubelet/servicemonitor.yaml
+        notExists:
+          path: spec.endpoints[0].tlsConfig.ca.configMap
+      - template: exporters/kube-api-server/servicemonitor.yaml
+        equal:
+          path: spec.endpoints[0].tlsConfig.ca.secret.name
+          value: my-ca
+      - template: exporters/kube-etcd/servicemonitor.yaml
+        equal:
+          path: spec.endpoints[0].tlsConfig.cert.secret.name
+          value: etcd-client-cert
+      - template: exporters/kube-etcd/servicemonitor.yaml
+        equal:
+          path: spec.endpoints[0].tlsConfig.keySecret.key
+          value: etcd-client-key
+      - template: exporters/kube-etcd/servicemonitor.yaml
+        equal:
+          path: spec.endpoints[0].tlsConfig.serverName
+          value: localhost
+
+  - it: should render user supplied authorization credentials
     set:
       kubelet.serviceMonitor.authorization: &authorization
         type: Bearer
         credentials:
           name: my-secret
-          key: token
+          key: my-key
       kubeApiServer.serviceMonitor.authorization: *authorization
       kubeControllerManager.serviceMonitor.authorization: *authorization
       kubeScheduler.serviceMonitor.authorization: *authorization
@@ -87,78 +173,84 @@ tests:
       kubeDns.serviceMonitor.authorization: *authorization
     asserts:
       - equal:
-          path: spec.endpoints[0].authorization.type
-          value: Bearer
-      - equal:
           path: spec.endpoints[0].authorization.credentials.name
           value: my-secret
+      - equal:
+          path: spec.endpoints[0].authorization.credentials.key
+          value: my-key
+
+  - it: should omit authorization entirely when unset
+    set:
+      kubelet.serviceMonitor.authorization: null
+      kubeApiServer.serviceMonitor.authorization: null
+      kubeControllerManager.serviceMonitor.authorization: null
+      kubeScheduler.serviceMonitor.authorization: null
+      kubeEtcd.serviceMonitor.authorization: null
+      kubeProxy.serviceMonitor.authorization: null
+      coreDns.serviceMonitor.authorization: null
+      kubeDns.serviceMonitor.authorization: null
+    asserts:
+      - notExists:
+          path: spec.endpoints[0].authorization
       - notExists:
           path: spec.endpoints[0].bearerTokenFile
       - template: exporters/kube-scheduler/servicemonitor.yaml
-        equal:
-          path: spec.endpoints[1].authorization.type
-          value: Bearer
-      - template: exporters/kube-scheduler/servicemonitor.yaml
         notExists:
-          path: spec.endpoints[1].bearerTokenFile
-      - template: exporters/kube-dns/servicemonitor.yaml
-        equal:
-          path: spec.endpoints[1].authorization.type
-          value: Bearer
-      - template: exporters/kube-dns/servicemonitor.yaml
-        notExists:
-          path: spec.endpoints[1].bearerTokenFile
+          path: spec.endpoints[1].authorization
 
-  - it: should use secret-based TLS credentials instead of caFile, certFile and keyFile when set
-    templates:
-      - exporters/kubelet/servicemonitor.yaml
-      - exporters/kube-api-server/servicemonitor.yaml
-      - exporters/kube-controller-manager/servicemonitor.yaml
-      - exporters/kube-scheduler/servicemonitor.yaml
-      - exporters/kube-etcd/servicemonitor.yaml
-      - exporters/kube-proxy/servicemonitor.yaml
+  - it: should fail rather than reference a token secret the chart does not create
     set:
-      kubelet.serviceMonitor.caSecret: &caSecret
-        name: my-ca
-        key: ca.crt
-      kubeApiServer.tlsConfig.caSecret: *caSecret
-      kubeControllerManager.serviceMonitor.caSecret: *caSecret
-      kubeScheduler.serviceMonitor.caSecret: *caSecret
-      kubeEtcd.serviceMonitor.caSecret: *caSecret
-      kubeProxy.serviceMonitor.caSecret: *caSecret
-      kubeEtcd.serviceMonitor.certSecret:
-        name: etcd-client
-        key: tls.crt
-      kubeEtcd.serviceMonitor.keySecret:
-        name: etcd-client
-        key: tls.key
+      prometheus.enabled: false
+    asserts:
+      - template: exporters/kubelet/servicemonitor.yaml
+        failedTemplate:
+          errorMessage: The control-plane ServiceMonitors authenticate by default with the Secret created by prometheus.serviceAccount.createTokenSecret, which is only rendered when prometheus.enabled and prometheus.serviceAccount.create are also true. Enable them, or set the serviceMonitor.authorization of each enabled control-plane component to a Secret you manage yourself, or to null to scrape without authentication.
+
+  - it: should fail when the prometheus service account is not created
+    set:
+      prometheus.serviceAccount.create: false
+    asserts:
+      - template: exporters/kubelet/servicemonitor.yaml
+        failedTemplate: {}
+
+  - it: should fail when the token secret is disabled
+    set:
+      prometheus.serviceAccount.createTokenSecret: false
+    asserts:
+      - template: exporters/kubelet/servicemonitor.yaml
+        failedTemplate: {}
+
+  - it: should render against an external scraper credential with prometheus disabled
+    set:
+      prometheus.enabled: false
+      kubelet.serviceMonitor.authorization: &externalAuthorization
+        type: Bearer
+        credentials:
+          name: external-scraper-token
+          key: token
+      kubeApiServer.serviceMonitor.authorization: *externalAuthorization
+      kubeControllerManager.serviceMonitor.authorization: *externalAuthorization
+      kubeScheduler.serviceMonitor.authorization: *externalAuthorization
+      kubeEtcd.serviceMonitor.authorization: *externalAuthorization
+      kubeProxy.serviceMonitor.authorization: *externalAuthorization
+      coreDns.serviceMonitor.authorization: *externalAuthorization
+      kubeDns.serviceMonitor.authorization: *externalAuthorization
     asserts:
       - equal:
-          path: spec.endpoints[0].tlsConfig.ca.secret.name
-          value: my-ca
-      - equal:
-          path: spec.endpoints[0].tlsConfig.ca.secret.key
-          value: ca.crt
+          path: spec.endpoints[0].authorization.credentials.name
+          value: external-scraper-token
+
+  - it: should render with prometheus disabled when authorization is cleared
+    set:
+      prometheus.enabled: false
+      kubelet.serviceMonitor.authorization: null
+      kubeApiServer.serviceMonitor.authorization: null
+      kubeControllerManager.serviceMonitor.authorization: null
+      kubeScheduler.serviceMonitor.authorization: null
+      kubeEtcd.serviceMonitor.authorization: null
+      kubeProxy.serviceMonitor.authorization: null
+      coreDns.serviceMonitor.authorization: null
+      kubeDns.serviceMonitor.authorization: null
+    asserts:
       - notExists:
-          path: spec.endpoints[0].tlsConfig.caFile
-      - template: exporters/kube-scheduler/servicemonitor.yaml
-        equal:
-          path: spec.endpoints[1].tlsConfig.ca.secret.name
-          value: my-ca
-      - template: exporters/kube-scheduler/servicemonitor.yaml
-        notExists:
-          path: spec.endpoints[1].tlsConfig.caFile
-      - template: exporters/kube-etcd/servicemonitor.yaml
-        equal:
-          path: spec.endpoints[0].tlsConfig.cert.secret.name
-          value: etcd-client
-      - template: exporters/kube-etcd/servicemonitor.yaml
-        notExists:
-          path: spec.endpoints[0].tlsConfig.certFile
-      - template: exporters/kube-etcd/servicemonitor.yaml
-        equal:
-          path: spec.endpoints[0].tlsConfig.keySecret.name
-          value: etcd-client
-      - template: exporters/kube-etcd/servicemonitor.yaml
-        notExists:
-          path: spec.endpoints[0].tlsConfig.keyFile
+          path: spec.endpoints[0].authorization

--- a/charts/kube-prometheus-stack/unittests/exporters/servicemonitor_auth_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/exporters/servicemonitor_auth_test.yaml
@@ -1,0 +1,164 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test control-plane exporter secret-based auth
+templates:
+  - exporters/kubelet/servicemonitor.yaml
+  - exporters/kube-api-server/servicemonitor.yaml
+  - exporters/kube-controller-manager/servicemonitor.yaml
+  - exporters/kube-scheduler/servicemonitor.yaml
+  - exporters/kube-etcd/servicemonitor.yaml
+  - exporters/kube-proxy/servicemonitor.yaml
+  - exporters/core-dns/servicemonitor.yaml
+  - exporters/kube-dns/servicemonitor.yaml
+set:
+  kubeDns.enabled: true
+  kubeDns.serviceMonitor.bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+  kubeControllerManager.serviceMonitor.https: true
+  kubeProxy.serviceMonitor.https: true
+  kubeScheduler.serviceMonitor.https: true
+  kubeScheduler.serviceMonitor.resource.enabled: true
+  kubeEtcd.serviceMonitor.scheme: https
+  kubeEtcd.serviceMonitor.caFile: /etc/prometheus/secrets/etcd-client-cert/etcd-ca
+  kubeEtcd.serviceMonitor.certFile: /etc/prometheus/secrets/etcd-client-cert/etcd-client
+  kubeEtcd.serviceMonitor.keyFile: /etc/prometheus/secrets/etcd-client-cert/etcd-client-key
+tests:
+  - it: should fall back to bearerTokenFile and caFile by default
+    asserts:
+      - equal:
+          path: spec.endpoints[0].bearerTokenFile
+          value: /var/run/secrets/kubernetes.io/serviceaccount/token
+      - template: exporters/kube-scheduler/servicemonitor.yaml
+        equal:
+          path: spec.endpoints[1].bearerTokenFile
+          value: /var/run/secrets/kubernetes.io/serviceaccount/token
+      - template: exporters/kube-dns/servicemonitor.yaml
+        equal:
+          path: spec.endpoints[1].bearerTokenFile
+          value: /var/run/secrets/kubernetes.io/serviceaccount/token
+      - template: exporters/kubelet/servicemonitor.yaml
+        equal:
+          path: spec.endpoints[0].tlsConfig.caFile
+          value: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      - template: exporters/kube-api-server/servicemonitor.yaml
+        equal:
+          path: spec.endpoints[0].tlsConfig.caFile
+          value: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      - template: exporters/kube-controller-manager/servicemonitor.yaml
+        equal:
+          path: spec.endpoints[0].tlsConfig.caFile
+          value: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      - template: exporters/kube-proxy/servicemonitor.yaml
+        equal:
+          path: spec.endpoints[0].tlsConfig.caFile
+          value: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      - template: exporters/kube-scheduler/servicemonitor.yaml
+        equal:
+          path: spec.endpoints[0].tlsConfig.caFile
+          value: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      - template: exporters/kube-scheduler/servicemonitor.yaml
+        equal:
+          path: spec.endpoints[1].tlsConfig.caFile
+          value: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      - template: exporters/kube-etcd/servicemonitor.yaml
+        equal:
+          path: spec.endpoints[0].tlsConfig.caFile
+          value: /etc/prometheus/secrets/etcd-client-cert/etcd-ca
+      - template: exporters/kube-etcd/servicemonitor.yaml
+        equal:
+          path: spec.endpoints[0].tlsConfig.certFile
+          value: /etc/prometheus/secrets/etcd-client-cert/etcd-client
+      - template: exporters/kube-etcd/servicemonitor.yaml
+        equal:
+          path: spec.endpoints[0].tlsConfig.keyFile
+          value: /etc/prometheus/secrets/etcd-client-cert/etcd-client-key
+
+  - it: should use authorization instead of bearerTokenFile when set
+    set:
+      kubelet.serviceMonitor.authorization: &authorization
+        type: Bearer
+        credentials:
+          name: my-secret
+          key: token
+      kubeApiServer.serviceMonitor.authorization: *authorization
+      kubeControllerManager.serviceMonitor.authorization: *authorization
+      kubeScheduler.serviceMonitor.authorization: *authorization
+      kubeEtcd.serviceMonitor.authorization: *authorization
+      kubeProxy.serviceMonitor.authorization: *authorization
+      coreDns.serviceMonitor.authorization: *authorization
+      kubeDns.serviceMonitor.authorization: *authorization
+    asserts:
+      - equal:
+          path: spec.endpoints[0].authorization.type
+          value: Bearer
+      - equal:
+          path: spec.endpoints[0].authorization.credentials.name
+          value: my-secret
+      - notExists:
+          path: spec.endpoints[0].bearerTokenFile
+      - template: exporters/kube-scheduler/servicemonitor.yaml
+        equal:
+          path: spec.endpoints[1].authorization.type
+          value: Bearer
+      - template: exporters/kube-scheduler/servicemonitor.yaml
+        notExists:
+          path: spec.endpoints[1].bearerTokenFile
+      - template: exporters/kube-dns/servicemonitor.yaml
+        equal:
+          path: spec.endpoints[1].authorization.type
+          value: Bearer
+      - template: exporters/kube-dns/servicemonitor.yaml
+        notExists:
+          path: spec.endpoints[1].bearerTokenFile
+
+  - it: should use secret-based TLS credentials instead of caFile, certFile and keyFile when set
+    templates:
+      - exporters/kubelet/servicemonitor.yaml
+      - exporters/kube-api-server/servicemonitor.yaml
+      - exporters/kube-controller-manager/servicemonitor.yaml
+      - exporters/kube-scheduler/servicemonitor.yaml
+      - exporters/kube-etcd/servicemonitor.yaml
+      - exporters/kube-proxy/servicemonitor.yaml
+    set:
+      kubelet.serviceMonitor.caSecret: &caSecret
+        name: my-ca
+        key: ca.crt
+      kubeApiServer.tlsConfig.caSecret: *caSecret
+      kubeControllerManager.serviceMonitor.caSecret: *caSecret
+      kubeScheduler.serviceMonitor.caSecret: *caSecret
+      kubeEtcd.serviceMonitor.caSecret: *caSecret
+      kubeProxy.serviceMonitor.caSecret: *caSecret
+      kubeEtcd.serviceMonitor.certSecret:
+        name: etcd-client
+        key: tls.crt
+      kubeEtcd.serviceMonitor.keySecret:
+        name: etcd-client
+        key: tls.key
+    asserts:
+      - equal:
+          path: spec.endpoints[0].tlsConfig.ca.secret.name
+          value: my-ca
+      - equal:
+          path: spec.endpoints[0].tlsConfig.ca.secret.key
+          value: ca.crt
+      - notExists:
+          path: spec.endpoints[0].tlsConfig.caFile
+      - template: exporters/kube-scheduler/servicemonitor.yaml
+        equal:
+          path: spec.endpoints[1].tlsConfig.ca.secret.name
+          value: my-ca
+      - template: exporters/kube-scheduler/servicemonitor.yaml
+        notExists:
+          path: spec.endpoints[1].tlsConfig.caFile
+      - template: exporters/kube-etcd/servicemonitor.yaml
+        equal:
+          path: spec.endpoints[0].tlsConfig.cert.secret.name
+          value: etcd-client
+      - template: exporters/kube-etcd/servicemonitor.yaml
+        notExists:
+          path: spec.endpoints[0].tlsConfig.certFile
+      - template: exporters/kube-etcd/servicemonitor.yaml
+        equal:
+          path: spec.endpoints[0].tlsConfig.keySecret.name
+          value: etcd-client
+      - template: exporters/kube-etcd/servicemonitor.yaml
+        notExists:
+          path: spec.endpoints[0].tlsConfig.keyFile

--- a/charts/kube-prometheus-stack/unittests/prometheus/serviceaccount_token_secret_test.yaml
+++ b/charts/kube-prometheus-stack/unittests/prometheus/serviceaccount_token_secret_test.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test prometheus service account token secret
+templates:
+  - prometheus/serviceaccount-token-secret.yaml
+release:
+  name: kps
+tests:
+  - it: should create a service account token secret by default
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: kps-kube-prometheus-stack-prometheus-token
+      - equal:
+          path: type
+          value: kubernetes.io/service-account-token
+      - equal:
+          path: metadata.annotations["kubernetes.io/service-account.name"]
+          value: kps-kube-prometheus-stack-prometheus
+
+  - it: should follow a custom service account name
+    set:
+      prometheus.serviceAccount.name: custom-sa
+    asserts:
+      - equal:
+          path: metadata.name
+          value: custom-sa-token
+      - equal:
+          path: metadata.annotations["kubernetes.io/service-account.name"]
+          value: custom-sa
+
+  - it: should not render when disabled
+    set:
+      prometheus.serviceAccount.createTokenSecret: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when prometheus is disabled
+    set:
+      prometheus.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when the service account is not created
+    set:
+      prometheus.serviceAccount.create: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1722,11 +1722,20 @@ kubeApiServer:
   tlsConfig:
     serverName: kubernetes
     insecureSkipVerify: false
+    ## Use a secret-based CA instead of caFile. Only applies when scraping over https.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SecretKeySelector
+    ##
+    caSecret: {}
   serviceMonitor:
     enabled: true
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
+
+    ## Use secret-based bearer token authentication instead of bearerTokenFile.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.Authorization
+    ##
+    authorization: {}
 
     ## SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.
     ##
@@ -1870,6 +1879,16 @@ kubelet:
     ## ref: https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-certs/#kubelet-serving-certs
     ##
     insecureSkipVerify: true
+
+    ## Use secret-based bearer token authentication instead of bearerTokenFile.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.Authorization
+    ##
+    authorization: {}
+
+    ## Use a secret-based CA instead of caFile. Only applies when scraping over https.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SecretKeySelector
+    ##
+    caSecret: {}
 
     ## Enable scraping /metrics/probes from kubelet's service
     ##
@@ -2127,6 +2146,16 @@ kubeControllerManager:
     # Name of the server to use when validating TLS certificate
     serverName: null
 
+    ## Use secret-based bearer token authentication instead of bearerTokenFile.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.Authorization
+    ##
+    authorization: {}
+
+    ## Use a secret-based CA instead of caFile. Only applies when scraping over https.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SecretKeySelector
+    ##
+    caSecret: {}
+
     ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#relabelconfig
     ##
@@ -2242,6 +2271,11 @@ coreDns:
     ##
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
 
+    ## Use secret-based bearer token authentication instead of bearerTokenFile.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.Authorization
+    ##
+    authorization: {}
+
 ## Component scraping kubeDns. Use either this or coreDns
 ##
 kubeDns:
@@ -2345,6 +2379,11 @@ kubeDns:
     ##
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
 
+    ## Use secret-based bearer token authentication instead of bearerTokenFile.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.Authorization
+    ##
+    authorization: {}
+
 ## Component scraping etcd
 ##
 kubeEtcd:
@@ -2417,6 +2456,21 @@ kubeEtcd:
     certFile: ""
     keyFile: ""
 
+    ## Use a secret-based CA instead of caFile. Only applies when scraping over https.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SecretKeySelector
+    ##
+    caSecret: {}
+
+    ## Use a secret-based client certificate instead of certFile. Only applies when scraping over https.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SecretKeySelector
+    ##
+    certSecret: {}
+
+    ## Use a secret-based client key instead of keyFile. Only applies when scraping over https.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SecretKeySelector
+    ##
+    keySecret: {}
+
     ## port: Name of the port the metrics will be scraped from
     ##
     port: http-metrics
@@ -2458,6 +2512,11 @@ kubeEtcd:
     ## Empty value do not send any bearer token.
     ##
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+    ## Use secret-based bearer token authentication instead of bearerTokenFile.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.Authorization
+    ##
+    authorization: {}
 
 ## Component scraping kube scheduler
 ##
@@ -2540,6 +2599,16 @@ kubeScheduler:
 
     ## Name of the server to use when validating TLS certificate
     serverName: null
+
+    ## Use secret-based bearer token authentication instead of bearerTokenFile.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.Authorization
+    ##
+    authorization: {}
+
+    ## Use a secret-based CA instead of caFile. Only applies when scraping over https.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SecretKeySelector
+    ##
+    caSecret: {}
 
     ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#relabelconfig
@@ -2669,6 +2738,11 @@ kubeProxy:
     ##
     https: false
 
+    ## Use a secret-based CA instead of caFile. Only applies when scraping over https.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SecretKeySelector
+    ##
+    caSecret: {}
+
     ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#relabelconfig
     ##
@@ -2698,6 +2772,11 @@ kubeProxy:
     ## Empty value do not send any bearer token.
     ##
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+    ## Use secret-based bearer token authentication instead of bearerTokenFile.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.Authorization
+    ##
+    authorization: {}
 
 ## Component scraping kube state metrics
 ##

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -1719,23 +1719,33 @@ kubernetesServiceMonitors:
 ##
 kubeApiServer:
   enabled: true
+  ## TLS configuration of the ServiceMonitor endpoint. Rendered as-is, so any field of the
+  ## Prometheus Operator SafeTLSConfig type can be set here.
+  ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SafeTLSConfig
+  ##
   tlsConfig:
     serverName: kubernetes
     insecureSkipVerify: false
-    ## Use a secret-based CA instead of caFile. Only applies when scraping over https.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SecretKeySelector
-    ##
-    caSecret: {}
+    ca:
+      configMap:
+        name: kube-root-ca.crt
+        key: ca.crt
   serviceMonitor:
     enabled: true
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
     interval: ""
 
-    ## Use secret-based bearer token authentication instead of bearerTokenFile.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.Authorization
+    ## Bearer credentials used to scrape this component. Rendered as-is, so any field of the
+    ## Prometheus Operator SafeAuthorization type can be set here. Set to null to scrape without
+    ## authentication.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SafeAuthorization
     ##
-    authorization: {}
+    authorization:
+      type: Bearer
+      credentials:
+        name: '{{ include "kube-prometheus-stack.prometheus.tokenSecretName" . }}'
+        key: token
 
     ## SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.
     ##
@@ -1874,21 +1884,30 @@ kubelet:
     ##
     https: true
 
-    ## Skip TLS certificate validation when scraping.
-    ## This is enabled by default because kubelet serving certificate deployed by kubeadm is by default self-signed
+    ## Bearer credentials used to scrape this component. Rendered as-is, so any field of the
+    ## Prometheus Operator SafeAuthorization type can be set here. Set to null to scrape without
+    ## authentication.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SafeAuthorization
+    ##
+    authorization:
+      type: Bearer
+      credentials:
+        name: '{{ include "kube-prometheus-stack.prometheus.tokenSecretName" . }}'
+        key: token
+
+    ## TLS configuration of the ServiceMonitor endpoint. Only applies when scraping over https.
+    ## Rendered as-is, so any field of the Prometheus Operator SafeTLSConfig type can be set here.
+    ## insecureSkipVerify is enabled by default because the kubelet serving certificate deployed by
+    ## kubeadm is self-signed.
     ## ref: https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-certs/#kubelet-serving-certs
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SafeTLSConfig
     ##
-    insecureSkipVerify: true
-
-    ## Use secret-based bearer token authentication instead of bearerTokenFile.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.Authorization
-    ##
-    authorization: {}
-
-    ## Use a secret-based CA instead of caFile. Only applies when scraping over https.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SecretKeySelector
-    ##
-    caSecret: {}
+    tlsConfig:
+      insecureSkipVerify: true
+      ca:
+        configMap:
+          name: kube-root-ca.crt
+          key: ca.crt
 
     ## Enable scraping /metrics/probes from kubelet's service
     ##
@@ -2140,21 +2159,27 @@ kubeControllerManager:
     ##
     https: null
 
-    # Skip TLS certificate validation when scraping
-    insecureSkipVerify: null
-
-    # Name of the server to use when validating TLS certificate
-    serverName: null
-
-    ## Use secret-based bearer token authentication instead of bearerTokenFile.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.Authorization
+    ## Bearer credentials used to scrape this component. Rendered as-is, so any field of the
+    ## Prometheus Operator SafeAuthorization type can be set here. Set to null to scrape without
+    ## authentication.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SafeAuthorization
     ##
-    authorization: {}
+    authorization:
+      type: Bearer
+      credentials:
+        name: '{{ include "kube-prometheus-stack.prometheus.tokenSecretName" . }}'
+        key: token
 
-    ## Use a secret-based CA instead of caFile. Only applies when scraping over https.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SecretKeySelector
+    ## TLS configuration of the ServiceMonitor endpoint. Only applies when scraping over https.
+    ## Rendered as-is, so any field of the Prometheus Operator SafeTLSConfig type can be set here.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SafeTLSConfig
     ##
-    caSecret: {}
+    tlsConfig:
+      insecureSkipVerify: true
+      ca:
+        configMap:
+          name: kube-root-ca.crt
+          key: ca.crt
 
     ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#relabelconfig
@@ -2266,15 +2291,16 @@ coreDns:
     ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#servicemonitor
     targetLabels: []
 
-    ## File containing bearer token to be used when scraping targets
-    ## Empty value do not send any bearer token.
+    ## Bearer credentials used to scrape this component. Rendered as-is, so any field of the
+    ## Prometheus Operator SafeAuthorization type can be set here. Set to null to scrape without
+    ## authentication.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SafeAuthorization
     ##
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-
-    ## Use secret-based bearer token authentication instead of bearerTokenFile.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.Authorization
-    ##
-    authorization: {}
+    authorization:
+      type: Bearer
+      credentials:
+        name: '{{ include "kube-prometheus-stack.prometheus.tokenSecretName" . }}'
+        key: token
 
 ## Component scraping kubeDns. Use either this or coreDns
 ##
@@ -2374,15 +2400,16 @@ kubeDns:
     ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#servicemonitor
     targetLabels: []
 
-    ## File containing bearer token to be used when scraping targets
-    ## Empty value do not send any bearer token.
+    ## Bearer credentials used to scrape this component. Rendered as-is, so any field of the
+    ## Prometheus Operator SafeAuthorization type can be set here. Set to null to scrape without
+    ## authentication.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SafeAuthorization
     ##
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-
-    ## Use secret-based bearer token authentication instead of bearerTokenFile.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.Authorization
-    ##
-    authorization: {}
+    authorization:
+      type: Bearer
+      credentials:
+        name: '{{ include "kube-prometheus-stack.prometheus.tokenSecretName" . }}'
+        key: token
 
 ## Component scraping etcd
 ##
@@ -2409,16 +2436,25 @@ kubeEtcd:
     # selector:
     #   component: etcd
 
-  ## Configure secure access to the etcd cluster by loading a secret into prometheus and
-  ## specifying security configuration below. For example, with a secret named etcd-client-cert
+  ## Configure secure access to the etcd cluster by referencing a secret holding the client
+  ## certificate. For example, with a secret named etcd-client-cert
   ##
   ## serviceMonitor:
   ##   scheme: https
-  ##   insecureSkipVerify: false
-  ##   serverName: localhost
-  ##   caFile: /etc/prometheus/secrets/etcd-client-cert/etcd-ca
-  ##   certFile: /etc/prometheus/secrets/etcd-client-cert/etcd-client
-  ##   keyFile: /etc/prometheus/secrets/etcd-client-cert/etcd-client-key
+  ##   tlsConfig:
+  ##     insecureSkipVerify: false
+  ##     serverName: localhost
+  ##     ca:
+  ##       secret:
+  ##         name: etcd-client-cert
+  ##         key: etcd-ca
+  ##     cert:
+  ##       secret:
+  ##         name: etcd-client-cert
+  ##         key: etcd-client
+  ##     keySecret:
+  ##       name: etcd-client-cert
+  ##       key: etcd-client-key
   ##
   serviceMonitor:
     enabled: true
@@ -2450,26 +2486,14 @@ kubeEtcd:
     ##
     proxyUrl: ""
     scheme: http
-    insecureSkipVerify: false
-    serverName: ""
-    caFile: ""
-    certFile: ""
-    keyFile: ""
 
-    ## Use a secret-based CA instead of caFile. Only applies when scraping over https.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SecretKeySelector
+    ## TLS configuration of the ServiceMonitor endpoint. Only applies when scheme is https.
+    ## Rendered as-is, so any field of the Prometheus Operator SafeTLSConfig type can be set here.
+    ## etcd requires client certificates, see the commented example above.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SafeTLSConfig
     ##
-    caSecret: {}
-
-    ## Use a secret-based client certificate instead of certFile. Only applies when scraping over https.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SecretKeySelector
-    ##
-    certSecret: {}
-
-    ## Use a secret-based client key instead of keyFile. Only applies when scraping over https.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SecretKeySelector
-    ##
-    keySecret: {}
+    tlsConfig:
+      insecureSkipVerify: false
 
     ## port: Name of the port the metrics will be scraped from
     ##
@@ -2508,15 +2532,16 @@ kubeEtcd:
     ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#servicemonitor
     targetLabels: []
 
-    ## File containing bearer token to be used when scraping targets
-    ## Empty value do not send any bearer token.
+    ## Bearer credentials used to scrape this component. Rendered as-is, so any field of the
+    ## Prometheus Operator SafeAuthorization type can be set here. Set to null to scrape without
+    ## authentication.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SafeAuthorization
     ##
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-
-    ## Use secret-based bearer token authentication instead of bearerTokenFile.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.Authorization
-    ##
-    authorization: {}
+    authorization:
+      type: Bearer
+      credentials:
+        name: '{{ include "kube-prometheus-stack.prometheus.tokenSecretName" . }}'
+        key: token
 
 ## Component scraping kube scheduler
 ##
@@ -2594,21 +2619,27 @@ kubeScheduler:
     #  matchLabels:
     #    component: kube-scheduler
 
-    ## Skip TLS certificate validation when scraping
-    insecureSkipVerify: null
-
-    ## Name of the server to use when validating TLS certificate
-    serverName: null
-
-    ## Use secret-based bearer token authentication instead of bearerTokenFile.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.Authorization
+    ## Bearer credentials used to scrape this component. Rendered as-is, so any field of the
+    ## Prometheus Operator SafeAuthorization type can be set here. Set to null to scrape without
+    ## authentication.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SafeAuthorization
     ##
-    authorization: {}
+    authorization:
+      type: Bearer
+      credentials:
+        name: '{{ include "kube-prometheus-stack.prometheus.tokenSecretName" . }}'
+        key: token
 
-    ## Use a secret-based CA instead of caFile. Only applies when scraping over https.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SecretKeySelector
+    ## TLS configuration of the ServiceMonitor endpoint. Only applies when scraping over https.
+    ## Rendered as-is, so any field of the Prometheus Operator SafeTLSConfig type can be set here.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SafeTLSConfig
     ##
-    caSecret: {}
+    tlsConfig:
+      insecureSkipVerify: true
+      ca:
+        configMap:
+          name: kube-root-ca.crt
+          key: ca.crt
 
     ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#relabelconfig
@@ -2738,10 +2769,15 @@ kubeProxy:
     ##
     https: false
 
-    ## Use a secret-based CA instead of caFile. Only applies when scraping over https.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SecretKeySelector
+    ## TLS configuration of the ServiceMonitor endpoint. Only applies when scraping over https.
+    ## Rendered as-is, so any field of the Prometheus Operator SafeTLSConfig type can be set here.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SafeTLSConfig
     ##
-    caSecret: {}
+    tlsConfig:
+      ca:
+        configMap:
+          name: kube-root-ca.crt
+          key: ca.crt
 
     ## MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#relabelconfig
@@ -2768,15 +2804,16 @@ kubeProxy:
     ## https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#servicemonitor
     targetLabels: []
 
-    ## File containing bearer token to be used when scraping targets
-    ## Empty value do not send any bearer token.
+    ## Bearer credentials used to scrape this component. Rendered as-is, so any field of the
+    ## Prometheus Operator SafeAuthorization type can be set here. Set to null to scrape without
+    ## authentication.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.SafeAuthorization
     ##
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-
-    ## Use secret-based bearer token authentication instead of bearerTokenFile.
-    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#monitoring.coreos.com/v1.Authorization
-    ##
-    authorization: {}
+    authorization:
+      type: Bearer
+      credentials:
+        name: '{{ include "kube-prometheus-stack.prometheus.tokenSecretName" . }}'
+        key: token
 
 ## Component scraping kube state metrics
 ##
@@ -3697,8 +3734,10 @@ prometheusOperator:
   thanosRulerInstanceSelector: ""
 
   ## Set a Field Selector to filter watched secrets
+  ## `kubernetes.io/service-account-token` secrets are no longer excluded, so that changes to the
+  ## secret the control-plane ServiceMonitors authenticate with trigger a reconciliation.
   ##
-  secretFieldSelector: "type!=kubernetes.io/dockercfg,type!=kubernetes.io/service-account-token,type!=helm.sh/release.v1"
+  secretFieldSelector: "type!=kubernetes.io/dockercfg,type!=helm.sh/release.v1"
 
   ## Feature gates to enable/disable operator features, rendered as --feature-gates=<key>=<value>.
   ## See https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/feature-gates.md
@@ -3772,6 +3811,18 @@ prometheus:
     name: ""
     annotations: {}
     automountServiceAccountToken: true
+
+    ## Create a `kubernetes.io/service-account-token` Secret for the Prometheus service account.
+    ## The control-plane ServiceMonitors reference it by default, because ServiceMonitors can only
+    ## authenticate through a Secret and Kubernetes no longer creates one automatically.
+    ## The resulting token is long-lived and does not expire; disable this and set the
+    ## `authorization` values of the control-plane components if you manage the credential yourself.
+    ## Only rendered together with the service account, so it requires `prometheus.enabled` and
+    ## `create` above. Leaving a control-plane component on the default `authorization` while the
+    ## Secret is not rendered is a rendering error rather than a silently broken ServiceMonitor.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-an-api-token-for-a-serviceaccount
+    ##
+    createTokenSecret: true
 
   # Service for thanos service discovery on sidecar
   # Enable this can make Thanos Query can use


### PR DESCRIPTION
#### What this PR does / why we need it

The built-in ServiceMonitors for kubelet, kube-apiserver, kube-controller-manager, kube-scheduler, kube-etcd, kube-proxy, coredns and kube-dns authenticate exclusively through `bearerTokenFile` and `tlsConfig.caFile`. Both fields declare raw filesystem paths, which are rejected outright by Prometheus Operator when
`spec.arbitraryFSAccessThroughSMs.deny` is true, and by Grafana Alloy's `prometheus.operator.servicemonitors` component since v1.19.0, where `allow_arbitrary_file_access` defaults to false. In either environment the whole ServiceMonitor is dropped and the control-plane scrape targets are lost.

Add optional per-component values that reference a Kubernetes Secret instead:

  - `authorization` in place of `bearerTokenFile`, for every component
  - `caSecret` in place of `caFile`, for every component that scrapes over TLS
  - `certSecret` and `keySecret` in place of `certFile` and `keyFile`, for kube-etcd, the only component that scrapes with client certificates

Setting a field switches that endpoint to the secret-based equivalent and drops the corresponding file-based field, since the two are mutually exclusive in the ServiceMonitor spec. All new values default to `{}`, so charts that do not set them render exactly as before. Note that clearing a deny-by-default environment requires setting both `authorization` and the TLS secrets; either one left unset remains a rejection trigger.

`kubeApiServer` keeps its CA override at `kubeApiServer.tlsConfig.caSecret` rather than under `serviceMonitor`, alongside the pre-existing `tlsConfig.serverName` and `tlsConfig.insecureSkipVerify`, so that its TLS settings stay in one place. `coreDns` and `kubeDns` only gain `authorization`, as those endpoints have no TLS support.

Three shared helpers render the file-or-secret choice so the eight templates do not each repeat it: `serviceMonitor.authorization`, `serviceMonitor.tlsSecret` (parameterised over `ca` and `cert`) and `serviceMonitor.tlsKeySecret`. The key needs its own helper because `keySecret` is a bare SecretKeySelector, whereas `ca` and `cert` are SecretOrConfigMap and nest the selector under `secret`. Each helper takes its indent width and emits a newline-prefixed block, so a call site that renders nothing contributes no stray whitespace.

Verified against Prometheus Operator on minikube with `arbitraryFSAccessThroughSMs.deny: true`: the secret-based kube-etcd monitor is accepted and its scrape job generated with operator-projected credentials, while the file-based equivalent is rejected with "it accesses file system via tls config which Prometheus specification prohibits".

#### Which issue this PR fixes

- fixes #7230

#### Checklist

- [ ] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
- [ ] Add an [helm unittest](https://github.com/helm-unittest/helm-unittest) test case to cover this change.
