### PR TITLE
[prometheus-stackdriver-exporter] Support optional google.universe-domain flag

### DIFF
--- a/charts/prometheus-stackdriver-exporter/Chart.yaml
+++ b/charts/prometheus-stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: prometheus-stackdriver-exporter
-version: 5.0.1
+version: 5.1.0
 appVersion: v0.19.0
 home: https://www.stackdriver.com/
 sources:

--- a/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
@@ -86,6 +86,9 @@ spec:
             {{- if .Values.stackdriver.projectFilters }}
             - --google.projects.filter='{{ .Values.stackdriver.projectFilters }}'
             {{- end }}
+            {{- if .Values.stackdriver.universeDomain }}
+            - --google.universe-domain={{ .Values.stackdriver.universeDomain }}
+            {{- end }}
             - --monitoring.metrics-interval={{ .Values.stackdriver.metrics.interval }}
             - --monitoring.metrics-offset={{ .Values.stackdriver.metrics.offset }}
             - --monitoring.descriptor-cache-ttl={{ .Values.stackdriver.metrics.descriptorCacheTTL }}

--- a/charts/prometheus-stackdriver-exporter/unittests/deployment_universe_domain_test.yaml
+++ b/charts/prometheus-stackdriver-exporter/unittests/deployment_universe_domain_test.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: deployment universe domain
+templates:
+  - deployment.yaml
+tests:
+  - it: does not set google.universe-domain flag by default
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --google.universe-domain=googleapis.com
+
+  - it: sets google.universe-domain flag when configured
+    set:
+      stackdriver:
+        universeDomain: googleapis.com
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --google.universe-domain=googleapis.com

--- a/charts/prometheus-stackdriver-exporter/values.yaml
+++ b/charts/prometheus-stackdriver-exporter/values.yaml
@@ -84,6 +84,8 @@ stackdriver:
   serviceAccountKey: ""
   # Max number of retries that should be attempted on 503 errors from Stackdriver
   maxRetries: 0
+  # The Google Cloud universe domain to use (requires stackdriver_exporter 0.19.0+)
+  universeDomain: ""
   # How long should Stackdriver_exporter wait for a result from the Stackdriver API
   httpTimeout: 10s
   # Max time between each request in an exp backoff scenario


### PR DESCRIPTION

Exposes stackdriver.universeDomain to set the --google.universe-domain flag added upstream in stackdriver_exporter 0.19.0, allowing use of a non-default Google Cloud universe.


#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
- [x] Add an [helm unittest](https://github.com/helm-unittest/helm-unittest) test case to cover this change.
