### PR TITLE
[prometheus-stackdriver-exporter] Support multiple stackdriver.retryStatuses

### DIFF
--- a/charts/prometheus-stackdriver-exporter/Chart.yaml
+++ b/charts/prometheus-stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: prometheus-stackdriver-exporter
-version: 5.1.0
+version: 5.2.0
 appVersion: v0.19.0
 home: https://www.stackdriver.com/
 sources:

--- a/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
+++ b/charts/prometheus-stackdriver-exporter/templates/deployment.yaml
@@ -102,7 +102,13 @@ spec:
             - --stackdriver.http-timeout={{ .Values.stackdriver.httpTimeout }}
             - --stackdriver.max-backoff={{ .Values.stackdriver.maxBackoff }}
             - --stackdriver.max-retries={{ .Values.stackdriver.maxRetries }}
+            {{- if kindIs "slice" .Values.stackdriver.retryStatuses }}
+            {{- range .Values.stackdriver.retryStatuses }}
+            - --stackdriver.retry-statuses={{ . }}
+            {{- end }}
+            {{- else }}
             - --stackdriver.retry-statuses={{ .Values.stackdriver.retryStatuses }}
+            {{- end }}
             - --web.listen-address={{ .Values.web.listenAddress }}
             - --web.telemetry-path={{ .Values.web.telemetryPath }}
             - --web.stackdriver-telemetry-path={{ .Values.web.stackdriverTelemetryPath }}

--- a/charts/prometheus-stackdriver-exporter/unittests/deployment_retry_statuses_test.yaml
+++ b/charts/prometheus-stackdriver-exporter/unittests/deployment_retry_statuses_test.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: deployment retry statuses
+templates:
+  - deployment.yaml
+tests:
+  - it: renders the default retry status
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --stackdriver.retry-statuses=503
+
+  - it: renders one flag per configured retry status
+    set:
+      stackdriver:
+        maxRetries: 3
+        retryStatuses:
+          - 503
+          - 500
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --stackdriver.max-retries=3
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --stackdriver.retry-statuses=503
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --stackdriver.retry-statuses=500
+
+  - it: supports the legacy scalar retry status
+    set:
+      stackdriver:
+        retryStatuses: 503
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --stackdriver.retry-statuses=503
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --stackdriver.retry-statuses=[503]

--- a/charts/prometheus-stackdriver-exporter/values.yaml
+++ b/charts/prometheus-stackdriver-exporter/values.yaml
@@ -82,7 +82,7 @@ stackdriver:
   serviceAccountSecretKey: ""
   # A service account key JSON file. Must be provided when no existing secret is used, in this case a new secret will be created holding this service account
   serviceAccountKey: ""
-  # Max number of retries that should be attempted on 503 errors from Stackdriver
+  # Max number of retries that should be attempted for configured retry statuses
   maxRetries: 0
   # The Google Cloud universe domain to use (requires stackdriver_exporter 0.19.0+)
   universeDomain: ""
@@ -93,7 +93,8 @@ stackdriver:
   # The amount of jitter to introduce in an exp backoff scenario
   backoffJitter: 1s
   # The HTTP statuses that should trigger a retry
-  retryStatuses: 503
+  retryStatuses:
+    - 503
   # Drop metrics from attached projects and fetch `project_id` only
   dropDelegatedProjects: false
   metrics:


### PR DESCRIPTION
The exporter accepts --stackdriver.retry-statuses as a repeatable flag, but the chart only rendered a single occurrence from a scalar value, so multiple retry statuses could not be configured.

Make stackdriver.retryStatuses a list and render one flag per entry. Scalar values (legacy format) are still supported so existing installations keep working, which keeps this a minor release rather than a breaking change.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
- [x] Add an [helm unittest](https://github.com/helm-unittest/helm-unittest) test case to cover this change.