### PR TITLE
[prometheus-node-exporter] keep the chart version out of the pod labels

### DIFF
--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - prometheus
   - exporter
 type: application
-version: 4.56.3
+version: 4.56.4
 # renovate: github=prometheus/node_exporter
 appVersion: 1.12.1
 home: https://github.com/prometheus/node_exporter/

--- a/charts/prometheus-node-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-node-exporter/templates/_helpers.tpl
@@ -54,6 +54,21 @@ release: {{ .Release.Name }}
 {{/*
 Selector labels
 */}}
+{{/*
+Pod labels: the common labels without helm.sh/chart. That label carries the chart version, so
+including it in the pod template restarts the DaemonSet on every chart upgrade, on every node,
+even when nothing about the workload changed.
+*/}}
+{{- define "prometheus-node-exporter.podLabels" -}}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: metrics
+app.kubernetes.io/part-of: {{ include "prometheus-node-exporter.name" . }}
+{{ include "prometheus-node-exporter.selectorLabels" . }}
+{{- with .Chart.AppVersion }}
+app.kubernetes.io/version: {{ . | quote }}
+{{- end }}
+{{- end }}
+
 {{- define "prometheus-node-exporter.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "prometheus-node-exporter.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -25,7 +25,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "prometheus-node-exporter.labels" . | nindent 8 }}
+        {{- include "prometheus-node-exporter.podLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}

--- a/charts/prometheus-node-exporter/unittests/daemonset_test.yaml
+++ b/charts/prometheus-node-exporter/unittests/daemonset_test.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test daemonset pod labels
+templates:
+  - daemonset.yaml
+tests:
+  - it: should not put the chart version in the pod labels
+    asserts:
+      - notExists:
+          path: spec.template.metadata.labels["helm.sh/chart"]
+      - exists:
+          path: metadata.labels["helm.sh/chart"]
+
+  - it: should keep the pod template identical when only the chart version changes
+    chart:
+      version: 99.99.99
+    asserts:
+      - isSubset:
+          path: spec.template.metadata.labels
+          content:
+            app.kubernetes.io/name: prometheus-node-exporter
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/component: metrics
+            app.kubernetes.io/part-of: prometheus-node-exporter
+            app.kubernetes.io/managed-by: Helm
+      - notExists:
+          path: spec.template.metadata.labels["helm.sh/chart"]
+
+  - it: should still render user supplied pod labels
+    set:
+      podLabels:
+        team: platform
+    asserts:
+      - isSubset:
+          path: spec.template.metadata.labels
+          content:
+            team: platform


### PR DESCRIPTION
#### What this PR does / why we need it

`prometheus-node-exporter.labels` includes `helm.sh/chart`, and the DaemonSet applies it to the pod template as well as to the object. That value changes on every chart version bump, so every node-exporter pod on every node is recreated on `helm upgrade` even when nothing about the workload changed — image, args and config identical.

This adds a `prometheus-node-exporter.podLabels` helper, the same label set without `helm.sh/chart`, and uses it in the pod template. The DaemonSet object keeps the full set, so the chart version is still visible where it belongs, and pods keep name, instance, component, part-of, managed-by and `app.kubernetes.io/version`.

Rendered 4.56.4 against a bumped version: the pod template is byte-identical, and the only differences are the object-level labels. All the values files under `ci/` still render and `helm lint` passes.

#### Which issue this PR fixes

#### Special notes for your reviewer

This is the first `unittests/` suite for this chart — three cases: the chart label is absent from the pod template but present on the object, the pod labels are unchanged under an overridden chart version, and user-supplied `podLabels` still render.

The same change was recently made in the argo-cd chart (argoproj/argo-helm#4044 covers the related checksum case) and is in flight for kargo (akuity/kargo#7192).

This PR was prepared with AI assistance (Claude), reviewed and tested by me before opening.

#### Checklist

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
- [x] Add an [helm unittest](https://github.com/helm-unittest/helm-unittest) test case to cover this change.